### PR TITLE
[ON HOLD] Compile F# lambdas as delegates (functions with multiple arguments) 

### DIFF
--- a/src/fable/Fable.Compiler/FSharp2Fable.Util.fs
+++ b/src/fable/Fable.Compiler/FSharp2Fable.Util.fs
@@ -800,7 +800,7 @@ module Util =
                      (typArgs, methTypArgs) callee args =
         let argTypes = getArgTypes com meth.CurriedParameterGroups                     
         let args =
-            let args = ensureArity argTypes args
+            let args = ensureArity com argTypes args
             if hasRestParams meth then
                 let args = List.rev args
                 match args.Head with

--- a/src/fable/Fable.Compiler/FSharp2Fable.Util.fs
+++ b/src/fable/Fable.Compiler/FSharp2Fable.Util.fs
@@ -458,13 +458,6 @@ module Types =
         | args -> List.concat args |> List.map (fun x -> makeType com Context.Empty x.Type)            
 
     and getMembers com (tdef: FSharpEntity) =
-        let getArgTypes com (args: IList<IList<FSharpParameter>>) =
-            // FSharpParameters don't contain the `this` arg
-            match args |> Seq.map Seq.toList |> Seq.toList with
-            | [] -> []
-            | [[singleArg]] when isUnit singleArg.Type -> []
-            // The F# compiler "untuples" the args in methods
-            | args -> List.concat args |> List.map (fun x -> makeType com Context.Empty x.Type)
         let isOverloadable =
             // TODO: Use overload index for interfaces too? (See overloadIndex below too)
             not(tdef.IsInterface || isImported tdef || isReplaceCandidate com tdef)

--- a/src/fable/Fable.Compiler/FSharp2Fable.Util.fs
+++ b/src/fable/Fable.Compiler/FSharp2Fable.Util.fs
@@ -424,19 +424,18 @@ module Types =
             ?overloadIndex = overloadIndex,
             hasRestParams = hasRestParams meth)
 
+    and getArgTypes com (args: IList<IList<FSharpParameter>>) =
+        // FSharpParameters don't contain the `this` arg
+        match args |> Seq.map Seq.toList |> Seq.toList with
+        | [] -> []
+        | [[singleArg]] when isUnit singleArg.Type -> []
+        // The F# compiler "untuples" the args in methods
+        | args -> List.concat args |> List.map (fun x -> makeType com Context.Empty x.Type)            
+
     and getMembers com (tdef: FSharpEntity) =
-        let getArgTypes com isInstance (args: IList<IList<FSharpParameter>>) =
-            match args |> Seq.map Seq.toList |> Seq.toList with
-            | [_thisArg]::args when isInstance -> args
-            | args -> args
-            |> function
-            | [] -> []
-            | [[singleArg]] when isUnit singleArg.Type -> []
-            // The F# compiler "untuples" the args in methods
-            | args -> args |> List.collect (fun tupledArg ->
-                tupledArg |> List.map (fun x -> makeType com Context.Empty x.Type))
         let isOverloadable =
-            not(isImported tdef || isReplaceCandidate com tdef)
+            // TODO: Use overload index for interfaces too? (See overloadIndex below too)
+            not(tdef.IsInterface || isImported tdef || isReplaceCandidate com tdef)
         let getMembers' isInstance (tdef: FSharpEntity) =
             tdef.MembersFunctionsAndValues
             |> Seq.filter (fun x ->
@@ -449,9 +448,11 @@ module Types =
                 let members = List.ofSeq members
                 let isOverloaded = isOverloadable && members.Length > 1
                 members |> List.mapi (fun i (_, meth) ->
-                    let argTypes = getArgTypes com (isInstance && not meth.IsExtensionMember) meth.CurriedParameterGroups
+                    let argTypes = getArgTypes com meth.CurriedParameterGroups
                     let returnType = makeType com Context.Empty meth.ReturnParameter.Type
-                    let overloadIndex = if isOverloaded then Some i else None
+                    let overloadIndex =
+                        if isOverloaded && (not meth.IsExplicitInterfaceImplementation)
+                        then Some i else None
                     makeMethodFrom com name kind argTypes returnType overloadIndex meth
             ))
             |> Seq.toList
@@ -601,11 +602,14 @@ module Util =
     open Identifiers
 
     let makeLambdaArgs com ctx (vars: FSharpMemberOrFunctionOrValue list) =
-        List.foldBack (fun var (ctx, accArgs) ->
-            let newContext, arg = bindIdentFrom com ctx var
-            newContext, arg::accArgs) vars (ctx, [])
+        let ctx, args =
+            ((ctx, []), vars)
+            ||> List.fold (fun (ctx, accArgs) var ->
+                let newContext, arg = bindIdentFrom com ctx var
+                newContext, arg::accArgs)
+        ctx, List.rev args
 
-    let getMethodArgs com ctx isInstance (args: FSharpMemberOrFunctionOrValue list list) =
+    let bindMemberArgs com ctx isInstance (args: FSharpMemberOrFunctionOrValue list list) =
         let ctx, args =
             match args with
             | [thisArg]::args when isInstance ->
@@ -614,12 +618,11 @@ module Util =
         match args with
         | [] -> ctx, []
         | [[singleArg]] when isUnit singleArg.FullType -> ctx, []
+        // The F# compiler "untuples" the args in methods
         | args ->
-            List.foldBack (fun tupledArg (ctx, accArgs) ->
-                // The F# compiler "untuples" the args in methods
-                let ctx, untupledArg = makeLambdaArgs com ctx tupledArg
-                ctx, untupledArg@accArgs
-            ) args (ctx, [])
+            let ctx, args = makeLambdaArgs com ctx args
+            // The F# compiler "untuples" the args in methods
+            ctx, List.concat args
 
     let makeTryCatch com ctx (fsExpr: FSharpExpr) (Transform com ctx body) catchClause finalBody =
         let catchClause =
@@ -756,8 +759,7 @@ module Util =
         | Some (vars, fsExpr) ->
             let args = match callee with Some x -> x::args | None -> args
             let ctx =
-                (Context.Empty, vars, args)
-                |||> Seq.fold2 (fun ctx var arg ->
+                (ctx, vars, args) |||> Seq.fold2 (fun ctx var arg ->
                     { ctx with scope = (Some var, arg)::ctx.scope })
             let ctx =
                 let typeArgs =
@@ -777,6 +779,7 @@ module Util =
     let makeCallFrom (com: IFableCompiler) ctx r typ
                      (meth: FSharpMemberOrFunctionOrValue)
                      (typArgs, methTypArgs) callee args =
+        let argTypes = getArgTypes com meth.CurriedParameterGroups                     
         let args =
             if hasRestParams meth then
                 let args = List.rev args
@@ -785,8 +788,6 @@ module Util =
                     (List.rev args.Tail)@items
                 | _ ->
                     (Fable.Spread args.Head |> Fable.Value)::args.Tail |> List.rev
-            // At the moment, null args are being cleaned in Fable2Babel, but see #231
-            // elif getArgCount meth = 0 then []
             else args
         match meth with
         (** -Check for replacements, emits... *)
@@ -803,11 +804,8 @@ module Util =
                 let typRef = makeTypeFromDef com ctx meth.EnclosingEntity []
                              |> makeTypeRef com r
                 let methName =
-                    let typArgs = List.map (makeType com ctx) typArgs
-                    let methTypArgs = List.map (makeType com ctx) methTypArgs
-                    let argTypes = List.map Fable.Expr.getType args
                     let ent = makeEntity com meth.EnclosingEntity
-                    ent.TryGetMember(methName, methKind, typArgs, methTypArgs, argTypes, not meth.IsInstanceMember)
+                    ent.TryGetMember(methName, methKind, not meth.IsInstanceMember, argTypes)
                     |> function Some m -> m.OverloadName | None -> methName
                 let ext = makeGet r Fable.Any typRef (makeConst methName)
                 let bind = Fable.Emit("$0.bind($1)($2...)") |> Fable.Value
@@ -836,12 +834,9 @@ module Util =
                     match tryGetBoundExpr ctx meth with
                     | Some e -> e
                     | _ ->
-                        let argTypes = List.map Fable.Expr.getType args
                         let methName =
-                            let typArgs = List.map (makeType com ctx) typArgs
-                            let methTypArgs = List.map (makeType com ctx) methTypArgs
                             let ent = makeEntity com meth.EnclosingEntity
-                            ent.TryGetMember(methName, methKind, typArgs, methTypArgs, argTypes, isStatic)
+                            ent.TryGetMember(methName, methKind, isStatic, argTypes)
                             |> function Some m -> m.OverloadName | None -> methName
                         let calleeType = Fable.Function(argTypes, typ)
                         makeGet r calleeType callee (makeConst methName)
@@ -854,10 +849,10 @@ module Util =
             | _ -> failwithf "Expecting a function value but got %s" meth.FullName
         let lambdaArgs =
             [for i=1 to arity do yield Naming.getUniqueVar() |> makeIdent]
-        let lambdaBody =
-            let args = lambdaArgs |> List.map (Fable.IdentValue >> Fable.Value)
-            makeCallFrom com ctx r typ meth ([],[]) None args
-        Fable.Lambda (lambdaArgs, lambdaBody) |> Fable.Value
+        lambdaArgs
+        |> List.map (Fable.IdentValue >> Fable.Value)
+        |> makeCallFrom com ctx r typ meth ([],[]) None
+        |> makeLambdaExpr lambdaArgs
 
     let makeValueFrom com ctx r typ (v: FSharpMemberOrFunctionOrValue) =
         if not v.IsModuleValueOrMember

--- a/src/fable/Fable.Compiler/FSharp2Fable.fs
+++ b/src/fable/Fable.Compiler/FSharp2Fable.fs
@@ -323,7 +323,7 @@ and private transformExpr (com: IFableCompiler) ctx fsExpr =
                 ent.TryGetMember(traitName, Fable.Method, not flags.IsInstance, argTypes, argsEqual)
                 |> function Some m -> m.OverloadName | None -> traitName
             | _ -> traitName
-        makeGet range (Fable.Function(List.map List.singleton argTypes, typ)) callee (makeConst methName)
+        makeGet range (Fable.Function(argTypes, typ)) callee (makeConst methName)
         |> fun m -> Fable.Apply (m, args, Fable.ApplyMeth, typ, range)
 
     | BasicPatterns.Call(callee, meth, typArgs, methTypArgs, args) ->
@@ -365,23 +365,20 @@ and private transformExpr (com: IFableCompiler) ctx fsExpr =
     //    let ctx, args = makeLambdaArgs com ctx [var]
     //    Fable.Lambda (args, transformExpr com ctx body) |> Fable.Value
 
-    | FlattenedLambda(args, body) ->
+    | FlattenedLambda(args, destructs, body) ->
         let ctx, args = makeLambdaArgs com ctx args
-        Fable.Lambda(args, transformExpr com ctx body) |> Fable.Value
-        // match transformExpr com ctx body with
-        // | Fable.Apply(Fable.Apply(_,_, Fable.ApplyGet,_,_) as callee, args', Fable.ApplyMeth,_,_) as e ->
-        //     let args = List.concat args
-        //     if args.Length = args'.Length then
-        //         (true, List.zip args args')
-        //         ||> List.fold (fun equal (a, a') ->
-        //             match equal, a' with
-        //             | false, _ -> false
-        //             | true, Fable.Value(Fable.IdentValue a') -> a = a'
-        //             | _ -> false)
-        //         |> function true -> callee | false -> e
-        //     else e
-        // | body ->
-        //     Fable.Lambda(args, body) |> Fable.Value
+        let ctx, assignments =
+            ((ctx, []), destructs)
+            ||> List.fold (fun (ctx, assignments) (var, i, arg) ->
+                let ctx, ident = bindIdentFrom com ctx var
+                let tupleGet = Fable.Apply(getBoundExpr ctx arg, [makeConst i], Fable.ApplyGet, ident.typ, None)
+                let assignment = Fable.VarDeclaration(ident, tupleGet, false)
+                ctx, (assignment::assignments))
+        let body = transformExpr com ctx body
+        match assignments with
+        | [] -> body
+        | decls -> makeSequential (makeRangeFrom fsExpr) ((List.rev assignments)@[body])
+        |> makeLambdaExpr args
 
     | BasicPatterns.NewDelegate(_delegateType, Transform com ctx delegateBodyExpr) ->
         delegateBodyExpr

--- a/src/fable/Fable.Compiler/FSharp2Fable.fs
+++ b/src/fable/Fable.Compiler/FSharp2Fable.fs
@@ -166,7 +166,7 @@ and private transformExpr (com: IFableCompiler) ctx fsExpr =
     // Pipe must come after ErasableLambda
     | Pipe (Transform com ctx callee, args) ->
         let typ, range = makeType com ctx fsExpr.Type, makeRangeFrom fsExpr
-        makeApply range typ callee (List.map (transformExpr com ctx) args)
+        makeApply com range typ callee (List.map (transformExpr com ctx) args)
         
     | Composition (expr1, args1, expr2, args2) ->
         let lambdaArg = Naming.getUniqueVar() |> makeIdent
@@ -343,7 +343,7 @@ and private transformExpr (com: IFableCompiler) ctx fsExpr =
                 | [Fable.Value(Fable.TupleConst args)] -> args
                 | _ -> args
             Fable.Apply(callee, args, Fable.ApplyMeth, typ, range)
-        | _ -> makeApply range typ callee args
+        | _ -> makeApply com range typ callee args
         
     | BasicPatterns.IfThenElse (Transform com ctx guardExpr, Transform com ctx thenExpr, Transform com ctx elseExpr) ->
         Fable.IfThenElse (guardExpr, thenExpr, elseExpr, makeRangeFrom fsExpr)

--- a/src/fable/Fable.Compiler/FSharp2Fable.fs
+++ b/src/fable/Fable.Compiler/FSharp2Fable.fs
@@ -166,7 +166,7 @@ and private transformExpr (com: IFableCompiler) ctx fsExpr =
     // Pipe must come after ErasableLambda
     | Pipe (Transform com ctx callee, args) ->
         let typ, range = makeType com ctx fsExpr.Type, makeRangeFrom fsExpr
-        makeApply com range typ callee (List.map (transformExpr com ctx) args)
+        makeApply range typ callee (List.map (transformExpr com ctx) args)
         
     | Composition (expr1, args1, expr2, args2) ->
         let lambdaArg = Naming.getUniqueVar() |> makeIdent
@@ -331,7 +331,7 @@ and private transformExpr (com: IFableCompiler) ctx fsExpr =
         let r, typ = makeRangeFrom fsExpr, makeType com ctx fsExpr.Type
         makeCallFrom com ctx r typ meth (typArgs, methTypArgs) callee args
 
-    | BasicPatterns.Application(Transform com ctx callee, _typeArgs, args) ->
+    | FlattenedApplication(Transform com ctx callee, args) ->
         // So far I've only seen application without arguments when accessing None values
         if args.Length = 0 then callee else
         let args = List.map (transformExpr com ctx) args
@@ -343,7 +343,7 @@ and private transformExpr (com: IFableCompiler) ctx fsExpr =
                 | [Fable.Value(Fable.TupleConst args)] -> args
                 | _ -> args
             Fable.Apply(callee, args, Fable.ApplyMeth, typ, range)
-        | _ -> makeApply com range typ callee args
+        | _ -> makeApply range typ callee args
         
     | BasicPatterns.IfThenElse (Transform com ctx guardExpr, Transform com ctx thenExpr, Transform com ctx elseExpr) ->
         Fable.IfThenElse (guardExpr, thenExpr, elseExpr, makeRangeFrom fsExpr)

--- a/src/fable/Fable.Compiler/Fable2Babel.fs
+++ b/src/fable/Fable.Compiler/Fable2Babel.fs
@@ -188,7 +188,7 @@ module Util =
             |> Babel.TupleTypeAnnotation
             :> Babel.TypeAnnotationInfo
         | Fable.Function(argTypes, returnType) ->
-            List.concat argTypes
+            argTypes
             |> List.mapi (fun i argType ->
                 Babel.FunctionTypeParam(
                     Babel.Identifier("arg" + (string i)),
@@ -332,7 +332,7 @@ module Util =
         | Fable.BoolConst x -> upcast Babel.BooleanLiteral (x)
         | Fable.RegexConst (source, flags) -> upcast Babel.RegExpLiteral (source, flags)
         | Fable.Lambda (args, body) ->
-            let args, body = com.TransformFunction ctx (List.concat args) body
+            let args, body = com.TransformFunction ctx args body
             // It's important to use arrow functions to lexically bind `this`
             upcast Babel.ArrowFunctionExpression (args, body, ?loc=r)
         | Fable.ArrayConst (cons, typ) -> buildArray com ctx cons typ

--- a/src/fable/Fable.Compiler/Fable2Babel.fs
+++ b/src/fable/Fable.Compiler/Fable2Babel.fs
@@ -188,7 +188,7 @@ module Util =
             |> Babel.TupleTypeAnnotation
             :> Babel.TypeAnnotationInfo
         | Fable.Function(argTypes, returnType) ->
-            argTypes
+            List.concat argTypes
             |> List.mapi (fun i argType ->
                 Babel.FunctionTypeParam(
                     Babel.Identifier("arg" + (string i)),
@@ -332,7 +332,7 @@ module Util =
         | Fable.BoolConst x -> upcast Babel.BooleanLiteral (x)
         | Fable.RegexConst (source, flags) -> upcast Babel.RegExpLiteral (source, flags)
         | Fable.Lambda (args, body) ->
-            let args, body = com.TransformFunction ctx args body
+            let args, body = com.TransformFunction ctx (List.concat args) body
             // It's important to use arrow functions to lexically bind `this`
             upcast Babel.ArrowFunctionExpression (args, body, ?loc=r)
         | Fable.ArrayConst (cons, typ) -> buildArray com ctx cons typ

--- a/src/fable/Fable.Compiler/Replacements.fs
+++ b/src/fable/Fable.Compiler/Replacements.fs
@@ -60,13 +60,6 @@ module Util =
         | Int8 | UInt8 | Int16 | UInt16 | Int32 | UInt32 -> Integer
         | Float32 | Float64 -> Float
 
-    // The core lib expects non-curried lambdas
-    let deleg (info: Fable.ApplyInfo) args =
-        if info.lambdaArgArity > 1
-        then List.mapi (fun i x ->
-            if i=0 then (makeDelegate (Some info.lambdaArgArity) x) else x) args
-        else args
-
     let instanceArgs (callee: Fable.Expr option) (args: Fable.Expr list) =
         match callee with
         | Some callee -> (callee, args)
@@ -334,7 +327,7 @@ module private AstPass =
             let meth =
                 if i.methodName = "async.AwaitPromise.Static"
                 then "awaitPromise" else "startAsPromise"
-            CoreLibCall("Async", Some meth, false, deleg i i.args)
+            CoreLibCall("Async", Some meth, false, i.args)
             |> makeCall com i.range i.returnType |> Some
         | "toJson" | "ofJson" | "toPlainJsObj" ->
             CoreLibCall("Util", Some i.methodName, false, i.args)
@@ -516,10 +509,10 @@ module private AstPass =
             InstanceCall(i.callee.Value, "split", [makeConst ""])
             |> makeCall com i.range i.returnType |> Some
         | "iterate" | "iterateIndexed" | "forAll" | "exists" ->
-            CoreLibCall("Seq", Some i.methodName, false, deleg i i.args)
+            CoreLibCall("Seq", Some i.methodName, false, i.args)
             |> makeCall com i.range i.returnType |> Some
         | "map" | "mapIndexed" | "collect"  ->
-            CoreLibCall("Seq", Some i.methodName, false, deleg i i.args)
+            CoreLibCall("Seq", Some i.methodName, false, i.args)
             |> makeCall com i.range Fable.Any
             |> List.singleton
             |> emit i "Array.from($0).join('')"
@@ -692,7 +685,7 @@ module private AstPass =
                 let args = List.rev i.args
                 wrapInLet (fun e -> toArray i.range e) args.Head
                 |> fun argsHead -> List.rev (argsHead::args.Tail)
-            CoreLibCall("Seq", Some meth, false, deleg i args)
+            CoreLibCall("Seq", Some meth, false, args)
             |> makeCall com i.range i.returnType |> Some
 
     let timeSpans com (i: Fable.ApplyInfo) =
@@ -852,7 +845,7 @@ module private AstPass =
         | "exists" | "fold" | "foldBack" | "forAll" | "iterate"
         | "filter" | "map" | "partition"
         | "findKey" | "tryFindKey" | "pick" | "tryPick" -> // Map-only
-            CoreLibCall(modName, Some i.methodName, false, deleg i i.args)
+            CoreLibCall(modName, Some i.methodName, false, i.args)
             |> makeCall com i.range i.returnType |> Some
         // Set only static methods
         | "singleton" ->
@@ -970,7 +963,7 @@ module private AstPass =
             | Some c, _ ->
                 match args with
                 | [] -> icall "sort" (c, [compareFn]) |> Some
-                | [Type (Fable.Function _)] -> icall "sort" (c, deleg i args) |> Some
+                | [Type (Fable.Function _)] -> icall "sort" (c, args) |> Some
                 | _ -> None
             | None, Seq -> ccall "Seq" "sortWith" (compareFn::args) |> Some
             | None, List -> ccall "Seq" "sortWith" (compareFn::args) |> toList com i |> Some
@@ -1070,7 +1063,7 @@ module private AstPass =
                 else emitNoInfo "((f,add)=>(x,y)=>add(x,f(y)))($0,$1)" [args.Head;addFn], args.Tail.Head
                 |> fun (f, xs) -> ccall "Seq" "fold" [f; zero; xs] |> Some
             | _ ->
-                ccall "Seq" meth (deleg i args) |> Some
+                ccall "Seq" meth args |> Some
         | "min" | "minBy" | "max" | "maxBy" ->
             let reduce macro macroArgs xs =
                 ccall "Seq" "reduce" [emitNoInfo macro macroArgs; xs] |> Some
@@ -1085,15 +1078,15 @@ module private AstPass =
                 reduce "(f=>(x,y)=>f(x)<f(y)?x:y)($0)" [args.Head] args.Tail.Head
             | "maxBy", [_;Fable.Number _] ->
                 reduce "(f=>(x,y)=>f(x)>f(y)?x:y)($0)" [args.Head] args.Tail.Head
-            | _ -> ccall "Seq" meth (deleg i args) |> Some
+            | _ -> ccall "Seq" meth args |> Some
         // Default to Seq implementation in core lib
         | Patterns.SetContains implementedSeqNonBuildFunctions meth ->
-            ccall "Seq" meth (deleg i args) |> Some
+            ccall "Seq" meth args |> Some
         | Patterns.SetContains implementedSeqBuildFunctions meth ->
             match kind with
-            | Seq -> ccall "Seq" meth (deleg i args)
-            | List -> ccall "Seq" meth (deleg i args) |> toList com i
-            | Array -> ccall "Seq" meth (deleg i args) |> toArray com i
+            | Seq -> ccall "Seq" meth args
+            | List -> ccall "Seq" meth args |> toList com i
+            | Array -> ccall "Seq" meth args |> toArray com i
             |> Some
         | _ -> None
 
@@ -1107,7 +1100,7 @@ module private AstPass =
             match i.methodName with
             | "getSlice" -> icall "slice" (i.callee.Value, i.args)
             | Patterns.SetContains implementedListFunctions meth ->
-                CoreLibCall ("List", Some meth, false, deleg i i.args)
+                CoreLibCall ("List", Some meth, false, i.args)
                 |> makeCall com i.range i.returnType |> Some
             | _ -> None
         | Array ->
@@ -1132,20 +1125,20 @@ module private AstPass =
                 // the final result (see #120, #171)
                 | Fable.Any::_ | Fable.GenericParam _::_ -> None
                 | NumberType(Some _) as tin::[tout] when tin = tout ->
-                    icall "map" (i.args.[1], deleg i [i.args.[0]])
+                    icall "map" (i.args.[1], [i.args.[0]])
                 | NumberType None::[NumberType None] ->
-                    icall "map" (i.args.[1], deleg i [i.args.[0]])
+                    icall "map" (i.args.[1], [i.args.[0]])
                 | _ -> None
             | "append" ->
                 match i.methodTypeArgs with
                 | [Fable.Any] | [NumberType(Some _)] -> None
                 | _ -> icall "concat" (i.args.Head, i.args.Tail)
             | Patterns.SetContains implementedArrayFunctions meth ->
-                CoreLibCall ("Array", Some meth, false, deleg i i.args)
+                CoreLibCall ("Array", Some meth, false, i.args)
                 |> makeCall com i.range i.returnType |> Some
             | Patterns.DicContains nativeArrayFunctions meth ->
                 let revArgs = List.rev i.args
-                icall meth (revArgs.Head, deleg i (List.rev revArgs.Tail))
+                icall meth (revArgs.Head, List.rev revArgs.Tail)
             | _ -> None
         | _ -> None
         |> function None -> collectionsSecondPass com i kind | someExpr -> someExpr
@@ -1419,7 +1412,7 @@ let private coreLibPass com (info: Fable.ApplyInfo) =
         | CoreLibPass.Both ->
             match info.methodName, info.methodKind, info.callee with
             | ".ctor", _, None | _, Fable.Constructor, None ->
-                CoreLibCall(modName, None, true, deleg info info.args)
+                CoreLibCall(modName, None, true, info.args)
                 |> makeCall com info.range info.returnType |> Some
             | _, Fable.Getter _, Some callee ->
                 let prop = Naming.upperFirst info.methodName |> makeConst
@@ -1428,15 +1421,15 @@ let private coreLibPass com (info: Fable.ApplyInfo) =
                 let prop = Naming.upperFirst info.methodName |> makeConst
                 Fable.Set(callee, Some prop, info.args.Head, info.range) |> Some
             | _, _, Some callee ->
-                InstanceCall (callee, Naming.upperFirst info.methodName, deleg info info.args)
+                InstanceCall (callee, Naming.upperFirst info.methodName, info.args)
                 |> makeCall com info.range info.returnType |> Some
             | _, _, None ->
-                CoreLibCall(modName, Some info.methodName, false, staticArgs info.callee info.args |> deleg info)
+                CoreLibCall(modName, Some info.methodName, false, staticArgs info.callee info.args)
                 |> makeCall com info.range info.returnType |> Some
         | CoreLibPass.Static ->
             let meth =
                 if info.methodName = ".ctor" then "create" else info.methodName
-            CoreLibCall(modName, Some meth, false, staticArgs info.callee info.args |> deleg info)
+            CoreLibCall(modName, Some meth, false, staticArgs info.callee info.args)
             |> makeCall com info.range info.returnType |> Some
     | _ -> None
 

--- a/src/fable/Fable.Compiler/Replacements.fs
+++ b/src/fable/Fable.Compiler/Replacements.fs
@@ -92,8 +92,8 @@ module Util =
         Fable.Wrapped (expr, typ)
 
     let wrapInLambda args f =
-        let argValues = List.map (Fable.IdentValue >> Fable.Value) args
-        Fable.Lambda(args, f argValues) |> Fable.Value
+        List.map (Fable.IdentValue >> Fable.Value) args
+        |> f |> makeLambdaExpr args
 
     let genArg (t: Fable.Type) =
         match t.GenericArgs with
@@ -153,7 +153,7 @@ module Util =
             set [ "System.TimeSpan"; "System.DateTime"; "Microsoft.FSharp.Collections.FSharpSet" ]
         let (|CustomOp|_|) meth argTypes (ent: Fable.Entity) =
             if replacedEntities.Contains ent.FullName then None else
-            ent.TryGetMember(meth, Fable.Method, i.calleeTypeArgs, i.methodTypeArgs, argTypes, true)
+            ent.TryGetMember(meth, Fable.Method, true, argTypes)
             |> function None -> None | Some m -> Some(ent, m)
         let apply op args =
             Fable.Apply(Fable.Value op, args, Fable.ApplyMeth, i.returnType, i.range)
@@ -676,7 +676,7 @@ module private AstPass =
             | Fable.Boolean _ -> Some comp
             // Hack to fix instance member calls (e.g., myOpt.IsSome)
             // For some reason, F# compiler expects it to be applicable
-            | _ -> Fable.Lambda([], comp) |> Fable.Value |> Some
+            | _ -> makeLambdaExpr [] comp |> Some
         | "map" | "bind" ->
             // emit i "$1 != null ? $0($1) : $1" i.args |> Some
             let f, arg = i.args.Head, i.args.Tail.Head
@@ -964,7 +964,7 @@ module private AstPass =
                     if meth = "sortDescending" || meth = "sortByDescending"
                     then makeUnOp None (Fable.Number Int32) [comparison] UnaryMinus
                     else comparison
-                Fable.Lambda(fnArgs, comparison) |> Fable.Value
+                makeLambdaExpr fnArgs comparison
             match c, kind with
             // This is for calls to instance `Sort` member on ResizeArrays
             | Some c, _ ->
@@ -1218,7 +1218,7 @@ module private AstPass =
 
     let unchecked com (info: Fable.ApplyInfo) =
         match info.methodName with
-        | "defaultof" ->
+        | "defaultOf" ->
             match info.methodTypeArgs with
             | [Fable.Number _] -> makeConst 0
             | [Fable.Boolean _] -> makeConst false

--- a/src/fable/Fable.Core/AST/AST.Fable.fs
+++ b/src/fable/Fable.Core/AST/AST.Fable.fs
@@ -19,7 +19,7 @@ type Type =
     | Number of NumberKind
     | Array of genericArg: Type
     | Tuple of genericArgs: Type list
-    | Function of curriedParamGroups: Type list list * returnType: Type
+    | Function of argTypes: Type list * returnType: Type
     | GenericParam of name: string
     | Enum of fullName: string
     | DeclaredType of Entity * genericArgs: Type list
@@ -29,14 +29,14 @@ type Type =
         | Enum fullName -> fullName
         | Array typ -> typ.FullName + "[]"
         | Function (argTypes, returnType) ->
-            "(" + (Seq.concat argTypes |> Seq.map (fun x -> x.FullName) |> String.concat ", ") + ")=>" + returnType.FullName
+            "(" + (argTypes |> Seq.map (fun x -> x.FullName) |> String.concat ", ") + ")=>" + returnType.FullName
         | DeclaredType(ent,_) -> ent.FullName
         | _ -> sprintf "%A" x
     member x.GenericArgs =
         match x with
         | Array genArg -> [genArg]
         | Tuple genArgs -> genArgs
-        | Function(argTypes, returnType) -> (List.concat argTypes)@[returnType]
+        | Function(argTypes, returnType) -> argTypes@[returnType]
         | DeclaredType(_, genArgs) -> genArgs
         | _ -> []
 
@@ -191,7 +191,7 @@ and ValueKind =
     | UnaryOp of UnaryOperator
     | BinaryOp of BinaryOperator
     | LogicalOp of LogicalOperator
-    | Lambda of curriedParamGroups: Ident list list * body: Expr
+    | Lambda of args: Ident list * body: Expr
     | Emit of string
     member x.Type =
         match x with
@@ -205,9 +205,9 @@ and ValueKind =
         | BoolConst _ -> Boolean
         | ArrayConst (_, typ) -> Array typ
         | TupleConst exprs -> List.map Expr.getType exprs |> Tuple
-        | UnaryOp _ -> Function([[Any]], Any)
-        | BinaryOp _ | LogicalOp _ -> Function([[Any]; [Any]], Any)
-        | Lambda (args, body) -> Function(List.map (List.map Ident.getType) args, body.Type)
+        | UnaryOp _ -> Function([Any], Any)
+        | BinaryOp _ | LogicalOp _ -> Function([Any; Any], Any)
+        | Lambda (args, body) -> Function(List.map Ident.getType args, body.Type)
     member x.Range: SourceLocation option =
         match x with
         | Lambda (_,body) -> body.Range

--- a/src/fable/Fable.Core/npm/fable-core.ts
+++ b/src/fable/Fable.Core/npm/fable-core.ts
@@ -743,8 +743,10 @@ class FString {
     function isObject(x: any) {
       return x !== null && typeof x === "object" && !(x instanceof Number) && !(x instanceof String) && !(x instanceof Boolean);
     }
-    return (cont: any) => {
-      return (...args: any[]) => {
+    return (cont: any, immediate?: boolean) => {
+      return immediate
+        ? cont(str.replace(/%%/g, "%"))
+        : (...args: any[]) => {
         let i = 0;
         const str2 = str.replace(FString.fsFormatRegExp, function (_: any, prefix: any, flags: any, pad: any, precision: any, format: any) {
           let rep = args[i++];

--- a/src/tests/ComparisonTests.fs
+++ b/src/tests/ComparisonTests.fs
@@ -90,6 +90,7 @@ type UTest2 =
             | :? UTest2 as y ->
                 match x, y with
                 | String s1, String s2 -> compare (s1 + s1) s2
+            | _ -> -1
 
 [<Test>]
 let ``Union custom equality works``() =  

--- a/src/tests/MiscTests.fs
+++ b/src/tests/MiscTests.fs
@@ -585,3 +585,9 @@ let ``Root members with JS non-valid chars work``() = // See #207
     Lib.引く 3 2 |> equal 1
     Lib.モジュール.ファンクション 0 |> equal false
 #endif
+
+[<Test>]
+let ``Unchecked.defaultof works`` () =
+    Unchecked.defaultof<int> |> equal 0
+    Unchecked.defaultof<bool> |> equal false
+    Unchecked.defaultof<string> |> equal null

--- a/src/tests/StringTests.fs
+++ b/src/tests/StringTests.fs
@@ -19,6 +19,10 @@ let ``sprintf works``() =
       printer "evening" |> equal "Hi Alfonso, good evening!"
 
 [<Test>]
+let ``sprintf withour arguments works``() =
+      sprintf "hello" |> equal "hello"
+
+[<Test>]
 let ``sprintf with escaped percent symbols works``() = // See #195
       let r, r1, r2 = "Ratio", 0.213849, 0.799898
       sprintf "%s1: %.2f%% %s2: %.2f%%" r (r1*100.) r (r2*100.)

--- a/src/tests/TypeTests.fs
+++ b/src/tests/TypeTests.fs
@@ -308,3 +308,28 @@ let ``Classes serialized with Json.NET can be deserialized``() =
     let x2 = Newtonsoft.Json.JsonConvert.DeserializeObject<Serializable> json
     #endif
     string x2 |> equal "Public: 1 - Private: 0 - Deserialized: true"
+
+type SecondaryCons(x: int) =
+    new () = SecondaryCons(5)
+    member __.Value = x
+
+[<Test>]
+let ``Secondary constructors work``() =
+    let s1 = SecondaryCons(3)
+    let s2 = SecondaryCons()
+    equal 3 s1.Value
+    equal 5 s2.Value
+
+type MultipleCons(x: int, y: int) =
+    new () = MultipleCons(2,3)
+    new (x:int) = MultipleCons(x,4)
+    member __.Value = x + y
+
+[<Test>]
+let ``Multiple constructors work``() =
+    let m1 = MultipleCons()
+    let m2 = MultipleCons(5)
+    let m3 = MultipleCons(7,7)
+    equal 5 m1.Value
+    equal 9 m2.Value
+    equal 14 m3.Value


### PR DESCRIPTION
- [ ] Write application tests
- [ ] Update docs

So far it seems the biggest source of confusion for developers when interacting with native JS code is how F# lambdas are represented in JS. At the moment, Fable doesn't do any special treatment to lambdas and their representation is very faithful to what can be seen in the AST generated by the F# compiler. One of the trickiest parts is that type and module methods have a very "classic" representation (`__.Foo(x, y)` and `__.Bar x y` compile both to an uncurried method with two arguments) and the F# compiler takes care of adding the necessary manipulations to make the methods work as expected in F#. For example, if you pass a tuple to `Foo`, it will be destructured before calling the method, and if you apply partially `Bar`, the method call will be wrapped in a lambda.

``` fsharp
typ A() =
  member __.Foo(x, y) = x + y   // function Foo(x, y) { return x + y }
  member __.Bar x y = x + y      // function Bar(x, y) { return x + y }

let a = A()
let t = 2, 3
a.Foo t       // var x = t[0], y = t[1]; a.Foo(x, y)
a.Bar 5       // var x = 5; function (arg00) { return a.Bar(x, arg00); }
```

However, lambdas do compile to what you expect in F#: anonymous function with always a single argument (that can be tupled) and which return another function in the case of curried arguments. I've tried to explain all of this and how to interact with JS by converting the functions to delegates here:
http://fsprojects.github.io/Fable/docs/interacting.html#Calling-F-code-from-JavaScript

``` fsharp
fun x y -> x + y      //  function(x) { return (y) { return x + y } }
fun (x, y) -> x + y  //  function(tupleArg) { var x = tupleArg[0], y = tupleArg[1]; return x + y }
```

It'd be ideal if Fable could do with lambdas the same thing as it does with type and module methods: represent them as "classic" delegates and let the compiler make the conversions when needed (wrapping in a lambda in partial applications, etc). First I tried flattening lambdas with `CurriedParameterGroups` as methods are represented in F# AST. So lambdas would compile as follows and in applications Fable would destruct tuples or wrap the call in another lambda for partial application:

``` fsharp
fun x y -> x + y                                       //  function(x, y) { return x + y }
fun (x, y) -> x + y                                   //  function(x, y) { return x + y }
fun (t: (int*int)) -> let x, y = t in x + y   // function(t) { var x = t[0], y = t[1]; return x + y }
```

Flattening lambdas:
https://github.com/fsprojects/Fable/blob/bf576bab16f65efe00ca98bb67ff2e305d014f87/src/fable/Fable.Compiler/FSharp2Fable.Util.fs#L308-L322

Applications:
https://github.com/fsprojects/Fable/blob/bf576bab16f65efe00ca98bb67ff2e305d014f87/src/fable/Fable.Core/AST/AST.Fable.Util.fs#L209-L242

But this fails in many situations where the lambda accepts a tuple argument and Fable thinks it must be destructured.

``` fsharp
Seq.fold (fun (a, b) x -> if a then (a, x::b) else (a, b))
// flableCore.Seq.fold(function (a, b, x) { ... })
```

So I tried then to ignore tupled arguments and transform curried lambdas as if they all were converted to delegates:

``` fsharp
fun x y -> x + y
// function(x, y) { return x + y }

fun (x, y) -> x + y
// function(tupleArg) { var x = tupleArg[0], y = tupleArg[1]; return x + y }

fun (t: (int*int)) -> let x, y = t in x + y
// function(t) { var x = t[0], y = t[1]; return x + y }
```

Then I only need to deal with partial applications:
https://github.com/fsprojects/Fable/blob/3a2b4c8b1c7781c0911a4589369c845409ef8350/src/fable/Fable.Core/AST/AST.Fable.Util.fs#L202-L210

With this, all Fable tests are passing (we've more than 800) but one:

``` fsharp
    let a = [| "a"; "b"; "c" |]
    let concaters1 = a |> Array.map (fun x y -> y + x)
    concaters1.[0] "x" |> equal "xa"
```

Compiled as follows (in the experimental branch):

``` js
    var a = ["a", "b", "c"];
    var concaters1 = a.map(function (x, y) {
      return y + x;
    });
    (0, _Util.equal)("xa", concaters1[0]("x"));
```

The solution to this problem is adding an [arity check](https://github.com/fsprojects/Fable/blob/flatten-lambdas/src/fable/Fable.Core/AST/AST.Fable.Util.fs#L192) for all method calls and applications, so when you pass a function with a higher arity than expected, Fable wraps it to prevent the unexpected behaviour. The previous sample code `[| "a"; "b"; "c" |] |> Array.map (fun x y -> y + x)` now compiles to:

``` js
  ["a", "b", "c"].map(function ($var1) {
    return function ($var2) {
      return function (x, y) {
        return x + y;
      }($var1, $var2);
    };
  });
```

Now all tests pass! 🎉 I just hope there're no other plausible scenarios where this can fail 🙏 If someone can build the branch and give it a try with their own projects to be sure everything works fine that'd be much appreciated.
