### PR TITLE
Ease of use change

### DIFF
--- a/samples/browser/react-tutorial/README.md
+++ b/samples/browser/react-tutorial/README.md
@@ -3,7 +3,11 @@
 This is just an adaptation of [React tutorial]() and [react-hot-boilerplate](https://github.com/gaearon/react-hot-boilerplate)
 to show how the workflow of building a React app with Fable would be.
 
-> Remember to run `npm install` before the first compilation!
+Use `fable -d` to build the project with the `debug` target and wait a few seconds until the
+server launches. Visit `http://localhost:8080/` and then try modifying the `render`
+function of one of the components in `public/components.fs`. See how the page loads new 
+code **without refreshing** on file saving. It's magic! The necessary configuration is defined
+in `fableconfig.json` and `webpack.config.js`
 
 ## Server
 
@@ -18,16 +22,8 @@ share code like business models (see `public/models.fs`). The project includes
 a ReactHelper API with a DSL to make it easier to build React components from F#.
 Check `public/components.fs`.
 
-> The React DSL (`Fable.ReactHelper.fs`) is still subject to changes. 
-After stabilization, it will be distributed through npm.
-
 ## Hot Module Reloading
 The app uses [webpack](https://webpack.github.io) and a variation of [react-hot-loader](https://www.npmjs.com/package/react-hot-loader)
-to allow HMR and improve the debug process. The necessary configuration is already defined
-in `fableconfig.json` and `webpack.config.js`, so you just need to build the
-project with the `debug` target (`fable -d` for short) and wait a few seconds until
-the server launches. Visit `http://localhost:8080/` and then try modifying the `render`
-function of one of the components in `public/components.fs`. See how the page loads
-new code **without refreshing** on file saving. It's magic!
+to allow HMR and improve the debug process. 
 
 > Give also a try to [React Developer Tools](https://github.com/facebook/react-devtools)!


### PR DESCRIPTION
I didn't have to run npm install explicitly as that gets run when I did `fable -d`.  Running fable a few times thinking I had done something wrong, and then having to read through the whole document to find out the correct way to build this was a pain point for something which is otherwise impressively painless. Fable.ReactHelper.fs is not currently in this directory, so I also removed references to it in the readme.

I tried to put an emphasis on getting the developer up and running before explaining why it's running.