### PR TITLE
Problem with WebSocket constructor

### DIFF
--- a/src/fable/Fable.Core/Import/Fable.Import.Browser.fs
+++ b/src/fable/Fable.Core/Import/Fable.Import.Browser.fs
@@ -9563,6 +9563,7 @@ module Browser =
         abstract CLOSING: float with get, set
         abstract CONNECTING: float with get, set
         abstract OPEN: float with get, set
+        [<Emit("new $0($1)")>] abstract Create: url: string -> WebSocket
         [<Emit("new $0($1...)")>] abstract Create: url: string * ?protocols: U2<string, ResizeArray<string>> -> WebSocket
 
     and [<AllowNullLiteral>] WheelEvent =


### PR DESCRIPTION
I was testing websockets, essentially porting the code to Fable from https://github.com/SuaveIO/suave/blob/master/examples/WebSocket/index.html

I got this error in Chrome 52.0.2743.116:
"Error during WebSocket handshake: Sent non-empty 'Sec-WebSocket-Protocol' header but no response was received"

And the cause seems to be calling the websocket constructor as: new WebSocket(address, null);

If I manually changed it to new WebSocket(address) then it worked correctly.

This PR adds an overload to the constructor to prevent emitting null as the second parameter. 