### PR TITLE
fix #329 - sprintf percent symbols

### DIFF
--- a/src/fable/Fable.Core/npm/fable-core.ts
+++ b/src/fable/Fable.Core/npm/fable-core.ts
@@ -774,7 +774,8 @@ class FString {
           const ch = pad >= 0 && flags.indexOf("0") >= 0 ? "0" : " ";
           rep = FString.padLeft(rep, Math.abs(pad) - (plusPrefix ? 1 : 0), ch, pad < 0);
         }
-        return prefix + (plusPrefix ? "+" + rep : rep);
+        let once = prefix + (plusPrefix ? "+" + rep : rep);
+        return once.replace(/%/g, "%%");
       });
     }
 

--- a/src/tests/StringTests.fs
+++ b/src/tests/StringTests.fs
@@ -34,11 +34,15 @@ let ``sprintf with escaped percent symbols works``() = // See #195
       |> equal "Ratio1: 21.38% Ratio2: 79.99%"
 
 [<Test>]
-let ``String slicing works``() =
-      let s = "cat and dog"
-      sprintf "%s" s.[2..8] |> equal "t and d"
-      sprintf "%s" s.[2..] |> equal "t and dog"
-      sprintf "%s" s.[..8] |> equal "cat and d"
+let ``sprintf with percent symbols in arguments works``() = // See #329
+      let same s = sprintf "%s" s |> equal s
+      same "%"
+      same "%%"
+      same "%%%"
+      same "%%%%"
+      same "% %"
+      same "%% %%"
+      same "%% % % %%"
 
 #if FABLE_COMPILER
 open Fable.Core.JsInterop
@@ -49,6 +53,13 @@ let ``sprintf "%A" with circular references doesn't crash``() = // See #338
       o?self <- o
       sprintf "%A" o |> ignore
 #endif
+
+[<Test>]
+let ``String slicing works``() =
+      let s = "cat and dog"
+      sprintf "%s" s.[2..8] |> equal "t and d"
+      sprintf "%s" s.[2..] |> equal "t and dog"
+      sprintf "%s" s.[..8] |> equal "cat and d"
 
 [<Test>]
 let ``String.Format works``() =


### PR DESCRIPTION
* percent symbols in arguments are now copied literally into the output