### PR TITLE
Pixi sample: fix compile error

### DIFF
--- a/samples/browser/pixi/pixi.fsx
+++ b/samples/browser/pixi/pixi.fsx
@@ -5,6 +5,7 @@
 open Fable.Core
 open Fable.Import
 open Fable.Import.Browser
+open Fable.Core.JsInterop
 
 // You can use either `new PIXI.WebGLRenderer`, `new PIXI.CanvasRenderer`, or `PIXI.autoDetectRenderer`
 // which will try to choose the best renderer for the environment you are in.


### PR DESCRIPTION
? operator is no longer automatically supported, will cause error when compiling

    bunny <- PIXI.Sprite(unbox resources?bunny?texture)

unless JsInterop is included.