### PR TITLE
Fix #402: Switch optimization 

### DIFF
--- a/src/fable/Fable.Compiler/FSharp2Fable.Util.fs
+++ b/src/fable/Fable.Compiler/FSharp2Fable.Util.fs
@@ -78,8 +78,11 @@ module Helpers =
 
     let isUnit (typ: FSharpType) =
         let typ = nonAbbreviatedType typ
-        typ.HasTypeDefinition
-        && typ.TypeDefinition.CompiledName = "Microsoft.FSharp.Core.Unit"
+        let fullName =
+            if typ.HasTypeDefinition
+            then typ.TypeDefinition.TryFullName
+            else None
+        fullName = Some "Microsoft.FSharp.Core.Unit"
 
     let makeRange (r: Range.range) = {
         start = { line = r.StartLine; column = r.StartColumn }

--- a/src/fable/Fable.Core/AST/AST.Fable.fs
+++ b/src/fable/Fable.Core/AST/AST.Fable.fs
@@ -238,6 +238,7 @@ and Expr =
     | Set of callee: Expr * property: Expr option * value: Expr * range: SourceLocation option
     | Sequential of Expr list * range: SourceLocation option
     | TryCatch of body: Expr * catch: (Ident * Expr) option * finalizer: Expr option * range: SourceLocation option
+    | Switch of matchValue: Expr * cases: (Expr list * Expr) list * defaultCase: Expr option * typ: Type * range: SourceLocation option
 
     // This wraps expressions with a different type for compile-time checkings
     // E.g. enums, ignored expressions so they don't trigger a return in functions
@@ -266,6 +267,7 @@ and Expr =
             | exprs -> (Seq.last exprs).Type
         | TryCatch (body,_,_,_)
         | Label(_, body, _)-> body.Type
+        | Switch (_,_,_,t,_) -> t
         | Break _
         | Continue _
         | Return _ -> Unit
@@ -285,6 +287,7 @@ and Expr =
         | Set (_,_,_,range)
         | Sequential (_,range)
         | TryCatch (_,_,_,range)
+        | Switch (_,_,_,_,range)
         | Label (_, _, range)
         | Break (_, range)
         | Continue (_, range) 

--- a/src/tests/MiscTests.fs
+++ b/src/tests/MiscTests.fs
@@ -643,3 +643,60 @@ let ``Unchecked.defaultof works`` () =
     Unchecked.defaultof<int> |> equal 0
     Unchecked.defaultof<bool> |> equal false
     Unchecked.defaultof<string> |> equal null
+
+type MyEnum =
+    | One = 1
+    | Two = 2
+
+[<Test>]
+let ``Pattern matching optimization works (switch statement)``() =
+    let mutable x = ""
+    let i = 4
+    match i with
+    | 1 -> x <- "1"
+    | 2 -> x <- "2"
+    | 3 | 4 -> x <- "3" // Multiple cases are allowed
+    // | 5 | 6 as j -> x <- string j // This prevents the optimization
+    | 4 -> x <- "4" // Unreachable cases are removed
+    | _ -> x <- "?"
+    equal "3" x
+
+    match "Bye" with
+    | "Hi" -> x <- "Bye"
+    | "Bye" -> let h = "Hi" in x <- sprintf "%s there!" h
+    | _ -> x <- "?"
+    equal "Hi there!" x
+
+    // Pattern matching with boolean is not converted to switch
+    match false with
+    | true -> x <- "True"
+    | false -> x <- "False"
+    equal "False" x
+
+    match MyEnum.One with
+    | MyEnum.One -> x <- "One"
+    | MyEnum.Two -> x <- "Two"
+    | _ -> failwith "never"
+    equal "One" x
+
+[<Test>]
+let ``Pattern matching optimization works (switch expression)``() =
+    let i = 4
+    match i with
+    | 1 -> "1"
+    | 2 -> "2"
+    | 3 | 4 -> "3"
+    | _ -> "?"
+    |> equal "3"
+
+    match "Bye" with
+    | "Hi" -> "Bye"
+    | "Bye" -> let h = "Hi" in sprintf "%s there!" h
+    | _ -> "?"
+    |> equal "Hi there!"
+
+    match MyEnum.One with
+    | MyEnum.One -> "One"
+    | MyEnum.Two -> "Two"
+    | _ -> failwith "never"
+    |> equal "One"


### PR DESCRIPTION
Optimise pattern matching with string and number literals by converting them into switch clauses.