### PR TITLE
Implement ResizeArray.FindAll

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -474,6 +474,11 @@ Target "PublishDocs" (fun _ ->
     if exit <> 0 then failwith "Publishing documentation failed"
 )
 
+Target "PublishStaticPages" (fun _ ->
+    let exit = Fake.executeFAKEWithOutput "docs" "docs.fsx" "" ["target", "PublishStaticPages"]
+    if exit <> 0 then failwith "Publishing documentation failed"
+)
+
 Target "All" ignore
 
 // Build order

--- a/docs/docs.fsx
+++ b/docs/docs.fsx
@@ -377,7 +377,7 @@ Target "BrowseDocs" (fun _ ->
     System.Threading.Thread.Sleep(-1)
 )
 
-Target "PublishDocs" (fun _ ->
+let publishDocs() =
   CleanDir temp
   Repository.cloneSingleBranch "" (githubLink + ".git") publishBranch temp
 
@@ -385,6 +385,14 @@ Target "PublishDocs" (fun _ ->
   StageAll temp
   Git.Commit.Commit temp (sprintf "Update site (%s)" (DateTime.Now.ToShortDateString()))
   Branches.push temp
+
+Target "PublishDocs" (fun _ ->
+    publishDocs()
+)
+
+Target "PublishStaticPages" (fun _ ->
+    generateStaticPages publishSite true ()
+    publishDocs()
 )
 
 // --------------------------------------------------------------------------------------

--- a/docs/source/index.html
+++ b/docs/source/index.html
@@ -139,7 +139,7 @@
 
       <h2>Recent news about Fable</h2>
       <ul>
-        <li><a href="http://red-green-rewrite.github.io/2016/09/14/Maze-generator-with-Fable/">Maze generator with Fable<a> - Milosz Krajewski<li>
+        <li><a href="http://red-green-rewrite.github.io/2016/09/14/Maze-generator-with-Fable/">Maze generator with Fable<a> - Milosz Krajewski</li>
         <li><a href="http://katade.com/fable-compilador-spain/">Fable, an F# to JS compiler "made in Spain"</a> (Spanish) - Lucía El Asri</li>
         <li><a href="https://thoughtspam.wordpress.com/2016/09/05/cross-platform-uis-with-f-and-fable/">Cross-Platform UIs with F# and Fable</a> - Eugene Tolmachev</li>
         <li><a href="https://www.infoq.com/news/2016/08/fsharp-fable-javascript">Transcompiling F# to Javascript with Fable</a> - Pierre-Luc Maheu, InfoQ (<a href="https://www.infoq.com/jp/news/2016/09/fsharp-fable-javascript">Japanese version</a>)</li>

--- a/src/fable/Fable.Compiler/Replacements.fs
+++ b/src/fable/Fable.Compiler/Replacements.fs
@@ -1129,6 +1129,8 @@ module private AstPass =
         | "find" when Option.isSome c ->
             let defaultValue = defaultof i.calleeTypeArgs.Head 
             ccall "Seq" "tryFind" [args.Head;c.Value;defaultValue] |> Some
+        | "findAll" when Option.isSome c ->
+            ccall "Seq" "filter" [args.Head;c.Value] |> Some
         | "findLast" when Option.isSome c ->
             let defaultValue = defaultof i.calleeTypeArgs.Head 
             ccall "Seq" "tryFindBack" [args.Head;c.Value;defaultValue] |> Some

--- a/src/fable/Fable.Compiler/Replacements.fs
+++ b/src/fable/Fable.Compiler/Replacements.fs
@@ -1130,7 +1130,7 @@ module private AstPass =
             let defaultValue = defaultof i.calleeTypeArgs.Head 
             ccall "Seq" "tryFind" [args.Head;c.Value;defaultValue] |> Some
         | "findAll" when Option.isSome c ->
-            ccall "Seq" "filter" [args.Head;c.Value] |> Some
+            ccall "Seq" "filter" [args.Head;c.Value] |> toArray com i |> Some
         | "findLast" when Option.isSome c ->
             let defaultValue = defaultof i.calleeTypeArgs.Head 
             ccall "Seq" "tryFindBack" [args.Head;c.Value;defaultValue] |> Some

--- a/src/tests/ResizeArrayTests.fs
+++ b/src/tests/ResizeArrayTests.fs
@@ -71,6 +71,18 @@ let ``ResizeArray.Find works``() =
     System.Predicate<_> (fun x -> x = -1.) |> li.Find |> equal 0.
 
 [<Test>]
+let ``ResizeArray.FindAll using ResizeArray.Count works``() =
+    let xs = ResizeArray<_> [1.; 2.; 3.; 4.]
+    System.Predicate<_> (fun x -> x <= 3.) |> xs.FindAll |> (fun l -> l.Count) |> equal 3
+    System.Predicate<_> (fun x -> x = 5.) |> xs.FindAll |> (fun l -> l.Count) |> equal 0
+
+[<Test>]
+let ``ResizeArray.FindAll using Seq.length works``() =
+    let xs = ResizeArray<_> [1.; 2.; 3.; 4.]
+    System.Predicate<_> (fun x -> x <= 3.) |> xs.FindAll |> Seq.length |> equal 3
+    System.Predicate<_> (fun x -> x = 5.) |> xs.FindAll |> Seq.length |> equal 0
+
+[<Test>]
 let ``ResizeArray.FindLast works``() =
     let li = ResizeArray<_>()
     li.Add(1.,0.); li.Add(2.,0.); li.Add(3.,0.); li.Add(4.,0.); li.Add(5.,0.); li.Add(1.,1.)

--- a/src/tests/ResizeArrayTests.fs
+++ b/src/tests/ResizeArrayTests.fs
@@ -71,16 +71,10 @@ let ``ResizeArray.Find works``() =
     System.Predicate<_> (fun x -> x = -1.) |> li.Find |> equal 0.
 
 [<Test>]
-let ``ResizeArray.FindAll using ResizeArray.Count works``() =
+let ``ResizeArray.FindAll works``() =
     let xs = ResizeArray<_> [1.; 2.; 3.; 4.]
     System.Predicate<_> (fun x -> x <= 3.) |> xs.FindAll |> (fun l -> l.Count) |> equal 3
     System.Predicate<_> (fun x -> x = 5.) |> xs.FindAll |> (fun l -> l.Count) |> equal 0
-
-[<Test>]
-let ``ResizeArray.FindAll using Seq.length works``() =
-    let xs = ResizeArray<_> [1.; 2.; 3.; 4.]
-    System.Predicate<_> (fun x -> x <= 3.) |> xs.FindAll |> Seq.length |> equal 3
-    System.Predicate<_> (fun x -> x = 5.) |> xs.FindAll |> Seq.length |> equal 0
 
 [<Test>]
 let ``ResizeArray.FindLast works``() =


### PR DESCRIPTION
Problem - the test that uses
~~~
Seq.length
... producing js:
    var xs = Array.from(_fableCore.List.ofArray([1, 2, 3, 4]));
    (0, _Util.equal)(3, _fableCore.Seq.count(function (arg00) {
      return _fableCore.Seq.filter(arg00, xs);
    }(function (x) {
      return x <= 3;
    })));
~~~
to count the result passes, but the test that uses
~~~
(fun l -> l.Count)
... producing js:
    var xs = Array.from(_fableCore.List.ofArray([1, 2, 3, 4]));
    (0, _Util.equal)(3, function (l) {
      return l.length;
    }(function (arg00) {
      return _fableCore.Seq.filter(arg00, xs);
    }(function (x) {
      return x <= 3;
    })));
~~~
fails with:
~~~
  1) ResizeArrays ResizeArray.FindAll using ResizeArray.Count works:
     AssertionError: 3 == undefined
 ~~~
The call to (ResizeArray) Count is compiled as js property .length, which seems to be undefined for the output js array. There are tests that show .Count works for ResizeArrays that are constructed by literals and by Add, so it must be that my implementation is not producing a well-formed output array. I am using an approach similar to ResizeArray.Find, but apparently I'm missing something.