### PR TITLE
Allow trailing carriage return in Fable console output

### DIFF
--- a/src/fable/Fable.Client.Node/js/fable.js
+++ b/src/fable/Fable.Client.Node/js/fable.js
@@ -389,7 +389,7 @@ function build(opts) {
                 txt = txt.substring(newLine + 1);
                 buffer = "";
 
-                var buildFinished = /^\[SIG(SUCCESS|FAIL)\]$/.exec(json);
+                var buildFinished = /^\[SIG(SUCCESS|FAIL)\]\r?$/.exec(json);
                 if (buildFinished) {
                     postbuild(opts, buildFinished[1] === "SUCCESS", fableProc);
                 }


### PR DESCRIPTION
On Windows, you get `\r\n` and so we need to allow `\r` at the end of `[SIGSUCCESS]`.