### PR TITLE
[WIP] Remove need for json $type

### DIFF
--- a/src/fable/Fable.Compiler/FSharp2Fable.Util.fs
+++ b/src/fable/Fable.Compiler/FSharp2Fable.Util.fs
@@ -537,9 +537,15 @@ module Types =
             // It's ok to use an empty context here, because we don't need to resolve generic params
             |> Seq.map (fun x -> x.Name, makeType com Context.Empty x.FieldType)
             |> Seq.toList
+
+        let makeUnionCases (tdef: FSharpEntity) =
+            tdef.UnionCases
+            |> Seq.map(fun x -> x.Name, x.UnionCaseFields |> Seq.map(fun f -> makeType com Context.Empty f.FieldType) |> Seq.toList)
+            |> Seq.toList
+
         let getKind () =
             if tdef.IsInterface then Fable.Interface
-            elif tdef.IsFSharpUnion then Fable.Union
+            elif tdef.IsFSharpUnion then makeUnionCases tdef |> Fable.Union
             elif tdef.IsFSharpRecord then makeFields tdef |> Fable.Record
             elif tdef.IsFSharpExceptionDeclaration then makeFields tdef |> Fable.Exception
             elif tdef.IsFSharpModule || tdef.IsNamespace then Fable.Module

--- a/src/fable/Fable.Compiler/FSharp2Fable.fs
+++ b/src/fable/Fable.Compiler/FSharp2Fable.fs
@@ -804,7 +804,7 @@ let rec private transformEntityDecl
         // Unions, records and F# exceptions don't have a constructor
         let cons =
             match fableEnt.Kind with
-            | Fable.Union -> [makeUnionCons()]
+            | Fable.Union _ -> [makeUnionCons()]
             | Fable.Record fields
             | Fable.Exception fields -> [makeRecordCons fields]
             | _ -> []

--- a/src/fable/Fable.Compiler/Fable2Babel.fs
+++ b/src/fable/Fable.Compiler/Fable2Babel.fs
@@ -249,6 +249,9 @@ module Util =
         | _ -> []
 
         |> List.map(fun (n,t) -> 
+//            let name = [ [t.FullName]
+//                         t.GenericArgs |> List.map(fun tt -> tt.FullName) ] |> List.concat |> String.concat " "
+
             [ Babel.StringLiteral n :> Babel.Expression |> U2.Case1 |> Some
               Babel.StringLiteral t.FullName :> Babel.Expression |> U2.Case1 |> Some ]
             |> Babel.ArrayExpression :> Babel.Expression

--- a/src/fable/Fable.Compiler/Fable2Babel.fs
+++ b/src/fable/Fable.Compiler/Fable2Babel.fs
@@ -249,11 +249,12 @@ module Util =
         | _ -> []
 
         |> List.map(fun (n,t) -> 
-//            let name = [ [t.FullName]
-//                         t.GenericArgs |> List.map(fun tt -> tt.FullName) ] |> List.concat |> String.concat " "
+            let rec convertType (tp: Fable.Type) = 
+                if tp.FullName.EndsWith("[]") || List.length tp.GenericArgs = 0 then tp.FullName
+                else tp.FullName + "[" + (tp.GenericArgs |> List.map(fun a -> "[" + convertType a + "]") |> String.concat "," )  + "]"
 
             [ Babel.StringLiteral n :> Babel.Expression |> U2.Case1 |> Some
-              Babel.StringLiteral t.FullName :> Babel.Expression |> U2.Case1 |> Some ]
+              Babel.StringLiteral (convertType t) :> Babel.Expression |> U2.Case1 |> Some ]
             |> Babel.ArrayExpression :> Babel.Expression
             |> U2.Case1 |> Some
         )

--- a/src/fable/Fable.Compiler/Replacements.fs
+++ b/src/fable/Fable.Compiler/Replacements.fs
@@ -386,11 +386,13 @@ module private AstPass =
                 then "awaitPromise" else "startAsPromise"
             CoreLibCall("Async", Some meth, false, deleg com i i.args)
             |> makeCall com i.range i.returnType |> Some
-        | "toJson" | "ofJson" | "toPlainJsObj" ->
+        | "toJson" | "ofJson" | "toPlainJsObj" | "ofJsonSimple" ->
             let args =
                 match i.methodName, i.methodTypeArgs with
                 | "ofJson", [Fable.DeclaredType(ent,_) as t] when Option.isSome ent.File ->
                     [i.args.Head; makeTypeRef com None t]
+                | "ofJsonSimple", [Fable.DeclaredType(ent,_) as t] when Option.isSome ent.File ->
+                    [i.args.Head; makeConst t.FullName]
                 | _ -> i.args
             let modName =
                 if i.methodName = "toPlainJsObj" then "Util" else "Serialize"

--- a/src/fable/Fable.Compiler/Replacements.fs
+++ b/src/fable/Fable.Compiler/Replacements.fs
@@ -391,8 +391,18 @@ module private AstPass =
                 match i.methodName, i.methodTypeArgs with
                 | "ofJson", [Fable.DeclaredType(ent,_) as t] when Option.isSome ent.File ->
                     [i.args.Head; makeTypeRef com None t]
-                | "ofJsonSimple", [Fable.DeclaredType(ent,_) as t] when Option.isSome ent.File ->
-                    [i.args.Head; makeConst t.FullName]
+
+                | "ofJsonSimple", _  ->
+                    match i.methodTypeArgs with
+                    | [Fable.DeclaredType(ent,_) as t] ->
+                        [i.args.Head; makeConst t.FullName]
+
+                    | [Fable.Array(t)] ->
+                        [i.args.Head; makeConst (t.FullName + "[]")]
+
+                    | _ ->
+                       i.args
+
                 | _ -> i.args
             let modName =
                 if i.methodName = "toPlainJsObj" then "Util" else "Serialize"

--- a/src/fable/Fable.Compiler/Replacements.fs
+++ b/src/fable/Fable.Compiler/Replacements.fs
@@ -393,12 +393,16 @@ module private AstPass =
                     [i.args.Head; makeTypeRef com None t]
 
                 | "ofJsonSimple", _  ->
+                    let rec convertType (tp: Fable.Type) = 
+                        if tp.FullName.EndsWith("[]") || List.length tp.GenericArgs = 0 then tp.FullName
+                        else tp.FullName + "[" + (tp.GenericArgs |> List.map(fun a -> "[" + convertType a + "]") |> String.concat "," )  + "]"
+ 
                     match i.methodTypeArgs with
                     | [Fable.DeclaredType(ent,_) as t] ->
-                        [i.args.Head; makeConst t.FullName]
+                        [i.args.Head; makeConst (convertType t)]
 
-                    | [Fable.Array(t)] ->
-                        [i.args.Head; makeConst (t.FullName + "[]")]
+                    | [Fable.Array(_) as t] ->
+                        [i.args.Head; makeConst (convertType t)]
 
                     | _ ->
                        i.args

--- a/src/fable/Fable.Core/AST/AST.Fable.fs
+++ b/src/fable/Fable.Core/AST/AST.Fable.fs
@@ -23,6 +23,7 @@ type Type =
     | GenericParam of name: string
     | Enum of fullName: string
     | DeclaredType of Entity * genericArgs: Type list
+    //| UnionCase of name: string * types : Type list
     member x.FullName =
         match x with
         | Number numberKind -> sprintf "%A" x
@@ -43,7 +44,7 @@ type Type =
 (** ##Entities *)
 and EntityKind =
     | Module
-    | Union
+    | Union of cases: (string*(Type list)) list
     | Record of fields: (string*Type) list
     | Exception of fields: (string*Type) list
     | Class of baseClass: (string*Expr) option
@@ -81,6 +82,10 @@ and Entity(kind: Lazy<_>, file, fullName, members: Lazy<Member list>,
             elif m.OverloadIndex.IsNone
             then true
             else argsEqual m.ArgumentTypes argTypes)
+    member x.GetProperties() =
+        members.Value
+        |> List.choose (fun m -> if m.Kind = MemberKind.Getter then Some(m.Name, m.ReturnType) else None)
+        
     static member CreateRootModule fileName modFullName =
         Entity (lazy Module, Some fileName, modFullName, lazy [], [], [], [], true)
     override x.ToString() = sprintf "%s %A" x.Name kind

--- a/src/fable/Fable.Core/Fable.Core.fs
+++ b/src/fable/Fable.Core/Fable.Core.fs
@@ -107,6 +107,10 @@ module JsInterop =
     /// (compatible with Newtonsoft.Json)
     let ofJson<'T> (json: string): 'T = failwith "JS only"
 
+    /// Instantiate F# objects from JSON with type info - simple mode
+    /// (compatible with Newtonsoft.Json)
+    let ofJsonSimple<'T> (json: string): 'T = failwith "JS only"
+
     /// Convert F# unions, records and classes into plain JS objects
     let toPlainJsObj (o: 'T): obj = failwith "JS only"
 

--- a/src/fable/Fable.Core/Fable.Core.fs
+++ b/src/fable/Fable.Core/Fable.Core.fs
@@ -107,10 +107,6 @@ module JsInterop =
     /// (compatible with Newtonsoft.Json)
     let ofJson<'T> (json: string): 'T = failwith "JS only"
 
-    /// Instantiate F# objects from JSON with type info - simple mode
-    /// (compatible with Newtonsoft.Json)
-    let ofJsonSimple<'T> (json: string): 'T = failwith "JS only"
-
     /// Convert F# unions, records and classes into plain JS objects
     let toPlainJsObj (o: 'T): obj = failwith "JS only"
 

--- a/src/fable/Fable.Core/npm/fable-core.ts
+++ b/src/fable/Fable.Core/npm/fable-core.ts
@@ -351,14 +351,14 @@ export class Serialize {
             return null
         }
 
-        if (type.endsWith("]]")) {
-            type = type.substr(0, type.indexOf("[["));
+        if (type.startsWith("Tuple [")) {
+            return type.substring(type.indexOf('][') + 2, type.length - 2).split("],[").map((t, i) => {
+                return Serialize.updateObject(obj["Item" + (i + 1)], t)
+            });
         }
 
-        if (type.startsWith("Tuple [")) {
-            return type.substring(7, type.length - 1).split("; ").map((t, i) => 
-                Serialize.updateObject(obj["Item" + (i + 1)], t)
-            );
+        if (type.endsWith("]]")) {
+            type = type.substr(0, type.indexOf("[["));
         }
 
         const fields = fableGlobal.typeFields.get(type);

--- a/src/fable/Fable.Core/npm/fable-core.ts
+++ b/src/fable/Fable.Core/npm/fable-core.ts
@@ -348,8 +348,15 @@ export class Serialize {
         }
 
         if (type.startsWith("Microsoft.FSharp.Collections.FSharpMap[[")) {
-            const t = type.substring(40, type.length - 2);
-            return FMap.create(Object.getOwnPropertyNames(obj).map(k => [k, Serialize.updateObject(obj[k], t)] as [any, any]));
+            // Should we handle none string keys?
+            const [kt, kv] = type.substring(40, type.length - 2).split("],[");
+            return FMap.create(Object.getOwnPropertyNames(obj).map(k => [k, Serialize.updateObject(obj[k], kv)] as [any, any]));
+        }
+
+        if (type.startsWith("System.Collections.Generic.Dictionary[[")) {
+            // Should we handle none string keys?
+            const [kt, kv] = type.substring(39, type.length - 2).split("],[");
+            return new Map(Object.getOwnPropertyNames(obj).map(k => [k, Serialize.updateObject(obj[k], kv)] as [any, any]));
         }
 
         if (type.startsWith("Microsoft.FSharp.Core.FSharpOption[[") && obj.Case && Array.isArray(obj.Fields) && obj.Fields.length === 1) {

--- a/src/fable/Fable.Core/npm/fable-core.ts
+++ b/src/fable/Fable.Core/npm/fable-core.ts
@@ -232,9 +232,6 @@ export class Serialize {
           return Array.from(v);
         }
         else if (v instanceof FMap || v instanceof Map) {
-
-            console.log(v);
-
           return Seq.fold(
             (o: ({ [i:string]: any}), kv: [any,any]) => { o[kv[0]] = kv[1]; return o; }, 
             {}, v);

--- a/src/fable/Fable.Core/npm/fable-core.ts
+++ b/src/fable/Fable.Core/npm/fable-core.ts
@@ -342,6 +342,16 @@ export class Serialize {
             return List.ofArray(obj.map((c: any) => Serialize.updateObject(c, t)));
         }
 
+        if (type.startsWith("Microsoft.FSharp.Collections.FSharpSet[[") && Array.isArray(obj)) {
+            const t = type.substring(40, type.length - 2);
+            return FSet.create(obj.map((c: any) => Serialize.updateObject(c, t)));
+        }
+
+        if (type.startsWith("Microsoft.FSharp.Collections.FSharpMap[[")) {
+            const t = type.substring(40, type.length - 2);
+            return FMap.create(Object.getOwnPropertyNames(obj).map(k => [k, Serialize.updateObject(obj[k], t)] as [any, any]));
+        }
+
         if (type.startsWith("Microsoft.FSharp.Core.FSharpOption[[") && obj.Case && Array.isArray(obj.Fields) && obj.Fields.length === 1) {
             if (obj.Case === "Some") {
                 const t = type.substring(36, type.length - 2);

--- a/src/fable/Fable.Core/npm/fable-core.ts
+++ b/src/fable/Fable.Core/npm/fable-core.ts
@@ -320,8 +320,21 @@ export class Serialize {
         }
 
         if (obj.$type) {
-            type = obj.$type;
+            type = obj.$type.replace(/\+/, '.');
             delete obj.$type;
+
+            let i = type.indexOf('`');
+            if (i > -1) {
+                type = type.substr(0, i);
+            }
+            else {
+                i = type.indexOf(',');
+                type = i > -1 ? type.substr(0, i) : type;
+            }
+        }
+
+        if (obj.$values) {
+            obj = obj.$values;
         }
 
         if (type === "System.DateTime" && typeof obj === "string") {
@@ -331,6 +344,10 @@ export class Serialize {
         if (type.endsWith("[]") && Array.isArray(obj)) {
             const t = type.substring(0, type.length - 2)
             return obj.map((c:any) => Serialize.updateObject(c, t))
+        }
+
+        if (type === "Microsoft.FSharp.Collections.FSharpList" && Array.isArray(obj)) {
+            return List.ofArray(obj);
         }
 
         const fields = fableGlobal.typeFields.get(type);

--- a/src/fable/Fable.Core/npm/fable-core.ts
+++ b/src/fable/Fable.Core/npm/fable-core.ts
@@ -342,8 +342,23 @@ export class Serialize {
             return List.ofArray(obj.map((c: any) => Serialize.updateObject(c, t)));
         }
 
+        if (type.startsWith("Microsoft.FSharp.Core.FSharpOption[[") && obj.Case && Array.isArray(obj.Fields) && obj.Fields.length === 1) {
+            if (obj.Case === "Some") {
+                const t = type.substring(36, type.length - 2);
+                return Serialize.updateObject(obj.Fields[0], t);
+            }
+
+            return null
+        }
+
         if (type.endsWith("]]")) {
             type = type.substr(0, type.indexOf("[["));
+        }
+
+        if (type.startsWith("Tuple [")) {
+            return type.substring(7, type.length - 1).split("; ").map((t, i) => 
+                Serialize.updateObject(obj["Item" + (i + 1)], t)
+            );
         }
 
         const fields = fableGlobal.typeFields.get(type);

--- a/src/fable/Fable.Core/npm/fable-core.ts
+++ b/src/fable/Fable.Core/npm/fable-core.ts
@@ -257,7 +257,6 @@ export class Serialize {
     });
   }
 
-  
     private static updateObject(obj: any, type: string): any {
         if (obj == null) {
             return obj;

--- a/src/fable/Fable.Core/npm/fable-core.ts
+++ b/src/fable/Fable.Core/npm/fable-core.ts
@@ -315,6 +315,19 @@ export class Serialize {
   }
 
     private static updateObject(obj: any, type: string): any {
+        if (obj == null) {
+            return obj;
+        }
+
+        if (type === "System.DateTime" && typeof obj === "string") {
+            return FDate.parse(obj);
+        }
+
+        if (type.endsWith("[]") && Array.isArray(obj)) {
+            const t = type.substring(0, type.length - 2)
+            return obj.map((c:any) => Serialize.updateObject(c, t))
+        }
+
         const fields = fableGlobal.typeFields.get(type);
         if (fields) {
             for (let prop in obj) {
@@ -328,7 +341,6 @@ export class Serialize {
                 }
             }
         }
-
         const T = fableGlobal.types.get(type);
         return T ? Object.assign(new T(), obj) : obj;
     }

--- a/src/fable/Fable.Core/npm/fable-core.ts
+++ b/src/fable/Fable.Core/npm/fable-core.ts
@@ -319,6 +319,11 @@ export class Serialize {
             return obj;
         }
 
+        if (obj.$type) {
+            type = obj.$type;
+            delete obj.$type;
+        }
+
         if (type === "System.DateTime" && typeof obj === "string") {
             return FDate.parse(obj);
         }

--- a/src/tests/DictionaryTests.fs
+++ b/src/tests/DictionaryTests.fs
@@ -213,8 +213,8 @@ let ``Dictionaries serialized with Json.NET can be deserialized``() =
     // let x = Dictionary<_,_>()
     // x.Add("a", { i=1; s="1" })
     // x.Add("b", { i=2; s="2" })    
-    // let json = JsonConvert.SerializeObject(x, JsonSerializerSettings(TypeNameHandling=TypeNameHandling.All))
-    let json = """{"$type":"System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[Fable.Tests.Maps+R, Fable.Tests]], FSharp.Core","a":{"$type":"Fable.Tests.Maps+R, Fable.Tests","i":1,"s":"1"},"b":{"$type":"Fable.Tests.Maps+R, Fable.Tests","i":2,"s":"2"}}"""
+    // let json = JsonConvert.SerializeObject(x)
+    let json = """{"a":{"i":1,"s":"1"},"b":{"i":2,"s":"2"}}"""
     #if FABLE_COMPILER
     let x2 = Fable.Core.JsInterop.ofJson<Dictionary<string, R>> json
     #else

--- a/src/tests/Fable.Tests.fsproj
+++ b/src/tests/Fable.Tests.fsproj
@@ -74,6 +74,7 @@
     <Compile Include="TypeTests.fs" />
     <Compile Include="EventTests.fs" />
     <Compile Include="SudokuTest.fs" />
+    <Compile Include="JsonTests.fs" />
   </ItemGroup>
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>

--- a/src/tests/HashSetTests.fs
+++ b/src/tests/HashSetTests.fs
@@ -177,8 +177,8 @@ let ``HashSet serialized with Json.NET can be deserialized``() =
     // let x = HashSet<_>()
     // x.Add({ i=1; s="1" }) |> ignore
     // x.Add({ i=2; s="2" }) |> ignore
-    // let json = JsonConvert.SerializeObject(x, JsonSerializerSettings(TypeNameHandling=TypeNameHandling.All))
-    let json = """{"$type":"System.Collections.Generic.HashSet`1[[Fable.Tests.HashSets+R, Fable.Tests]], FSharp.Core","$values":[{"$type":"Fable.Tests.HashSets+R, Fable.Tests","i":1,"s":"1"},{"$type":"Fable.Tests.HashSets+R, Fable.Tests","i":2,"s":"2"}]}"""
+    // let json = JsonConvert.SerializeObject(x)
+    let json = """[{"i":1,"s":"1"},{"i":2,"s":"2"}]"""
     #if FABLE_COMPILER
     let x2 = Fable.Core.JsInterop.ofJson<HashSet<R>> json
     #else

--- a/src/tests/JsonTests.fs
+++ b/src/tests/JsonTests.fs
@@ -84,6 +84,46 @@ let ``Simple json - Child Array``() =
     if result.Children.[1] <> { Name="b" } then
         invalidOp "Child not equal"  
 
+[<Test>] 
+let ``Simple json - String Generic List``() =
+    let json = """["a","b"]"""
+    let result : System.Collections.Generic.List<string> = Fable.Core.JsInterop.ofJsonSimple json
+
+    result.Count |> equal 2
+    result.[1] |> equal "b"
+
+[<Test>] 
+let ``Simple json - Child Generic List``() =
+    let json = """[{ "Name": "a" }, { "Name": "b" }]"""
+    let result : System.Collections.Generic.List<JsonArray> = Fable.Core.JsInterop.ofJsonSimple json
+
+    result.Count |> equal 2
+
+    if result.[1] <> { Name="b" } then
+        invalidOp "Child not equal"  
+
+[<Test>] 
+let ``Simple json - List``() =
+    let json = """["a","b"]"""
+    let result : string list = Fable.Core.JsInterop.ofJsonSimple json
+
+    result |> List.length |> equal 2
+    result.[1] |> equal "b"
+
+type ChildList = {
+    Children : JsonArray list
+}
+
+//[<Test>] 
+//let ``Simple json - Child List``() =
+//    let json = """{ "Children": [{ "Name": "a" }, { "Name": "b" }] }"""
+//    let result : ChildList = Fable.Core.JsInterop.ofJsonSimple json
+//
+//    result.Children |> List.length |> equal 2
+//
+//    if result.Children.[1] <> { Name="b" } then
+//        invalidOp "Child not equal"  
+
 type Wrapper<'T> = { thing : 'T }
 
 [<Test>]
@@ -108,6 +148,6 @@ let ``Simple json - generic`` () =
     if parsedCorrectly then
         invalidOp "Complex object should not have equal hooked up" 
 
-    let result4 : Child = parseAndUnwrap """ { "thing" : { "$type":"Fable.Tests.Json.Child", "a": "a", "b": 1 } } """
+    let result4 : Child = parseAndUnwrap """ { "thing" : {"$type":"Fable.Tests.Json+Child, Fable.Tests","a":"a","b":1} } """
     if result4 <> {a = "a"; b = 1} then
         invalidOp "things not equal" 

--- a/src/tests/JsonTests.fs
+++ b/src/tests/JsonTests.fs
@@ -151,3 +151,27 @@ let ``Simple json - generic`` () =
     let result4 : Child = parseAndUnwrap """ {"$type":"Fable.Tests.Json+Wrapper`1[[Fable.Tests.Json+Child, Fable.Tests]], Fable.Tests","thing":{"$type":"Fable.Tests.Json+Child, Fable.Tests","a":"a","b":1}} """
     if result4 <> {a = "a"; b = 1} then
         invalidOp "things not equal" 
+
+type OptionJson =
+    { a: int option }
+
+[<Test>]
+let ``Simple json - Option Some`` () =
+    let json = """ {"a":{"Case":"Some","Fields":[1]}} """
+    let result : OptionJson = Fable.Core.JsInterop.ofJsonSimple json
+
+    match result.a with
+    | Some v -> v |> equal 1
+    | _ -> invalidOp "Doesn't equal 1"
+
+
+type TupleJson =
+    { a: int * int }
+
+[<Test>]
+let ``Simple json - Tuple`` () =
+    let json = """ {"a":{"Item1":1,"Item2":2}} """
+    let result : TupleJson = Fable.Core.JsInterop.ofJsonSimple json
+
+    if result.a <> (1, 2) then
+        invalidOp "Not equal"

--- a/src/tests/JsonTests.fs
+++ b/src/tests/JsonTests.fs
@@ -175,3 +175,16 @@ let ``Simple json - Tuple`` () =
 
     if result.a <> (1, 2) then
         invalidOp "Not equal"
+
+
+type TupleComplexJson =
+    { a: int * Child }
+
+[<Test>]
+let ``Simple json - Complex Tuple`` () =
+    let json = """ {"a":{"Item1":1,"Item2":{"a":"A","b":1}}} """
+    let result : TupleComplexJson = Fable.Core.JsInterop.ofJsonSimple json
+
+    if snd result.a  <> { a = "A"; b = 1 } then
+        invalidOp "Not equal"
+

--- a/src/tests/JsonTests.fs
+++ b/src/tests/JsonTests.fs
@@ -114,15 +114,15 @@ type ChildList = {
     Children : JsonArray list
 }
 
-//[<Test>] 
-//let ``Simple json - Child List``() =
-//    let json = """{ "Children": [{ "Name": "a" }, { "Name": "b" }] }"""
-//    let result : ChildList = Fable.Core.JsInterop.ofJsonSimple json
-//
-//    result.Children |> List.length |> equal 2
-//
-//    if result.Children.[1] <> { Name="b" } then
-//        invalidOp "Child not equal"  
+[<Test>] 
+let ``Simple json - Child List``() =
+    let json = """{ "Children": [{ "Name": "a" }, { "Name": "b" }] }"""
+    let result : ChildList = Fable.Core.JsInterop.ofJsonSimple json
+
+    result.Children |> List.length |> equal 2
+
+    if result.Children.[1] <> { Name="b" } then
+        invalidOp "Child not equal"  
 
 type Wrapper<'T> = { thing : 'T }
 
@@ -148,6 +148,6 @@ let ``Simple json - generic`` () =
     if parsedCorrectly then
         invalidOp "Complex object should not have equal hooked up" 
 
-    let result4 : Child = parseAndUnwrap """ { "thing" : {"$type":"Fable.Tests.Json+Child, Fable.Tests","a":"a","b":1} } """
+    let result4 : Child = parseAndUnwrap """ {"$type":"Fable.Tests.Json+Wrapper`1[[Fable.Tests.Json+Child, Fable.Tests]], Fable.Tests","thing":{"$type":"Fable.Tests.Json+Child, Fable.Tests","a":"a","b":1}} """
     if result4 <> {a = "a"; b = 1} then
         invalidOp "things not equal" 

--- a/src/tests/JsonTests.fs
+++ b/src/tests/JsonTests.fs
@@ -13,7 +13,7 @@ type Simple = {
 }
 
 [<Test>]
-let ``Simple json - Records``() =
+let ``Records``() =
     let json = 
         """
         {
@@ -35,7 +35,7 @@ let ``Simple json - Records``() =
         invalidOp "Child not equal"  
       
 [<Test>] 
-let ``Simple json - Date``() =
+let ``Date``() =
     let d = System.DateTime(2016, 1, 1, 0, 0, 0, System.DateTimeKind.Utc)
     let json = d |> Fable.Core.JsInterop.toJson
     let result : System.DateTime = Fable.Core.JsInterop.ofJson json
@@ -48,7 +48,7 @@ type JsonDate = {
 
         
 [<Test>] 
-let ``Simple json - Child Date``() =
+let ``Child Date``() =
     let d = System.DateTime(2016, 1, 1, 0, 0, 0, System.DateTimeKind.Utc)
     let json = { Date = d } |> Fable.Core.JsInterop.toJson
     let result : JsonDate = Fable.Core.JsInterop.ofJson json
@@ -61,7 +61,7 @@ type JsonArray = {
 }
 
 [<Test>] 
-let ``Simple json - Array``() =
+let ``Record Array``() =
     let json = """[{ "Name": "a" }, { "Name": "b" }]"""
     let result : JsonArray[] = Fable.Core.JsInterop.ofJson json
 
@@ -75,7 +75,7 @@ type ChildArray = {
 }
 
 [<Test>] 
-let ``Simple json - Child Array``() =
+let ``Child Array``() =
     let json = """{ "Children": [{ "Name": "a" }, { "Name": "b" }] }"""
     let result : ChildArray = Fable.Core.JsInterop.ofJson json
 
@@ -85,7 +85,7 @@ let ``Simple json - Child Array``() =
         invalidOp "Child not equal"  
 
 [<Test>] 
-let ``Simple json - String Generic List``() =
+let ``String Generic List``() =
     let json = """["a","b"]"""
     let result : System.Collections.Generic.List<string> = Fable.Core.JsInterop.ofJson json
 
@@ -93,7 +93,7 @@ let ``Simple json - String Generic List``() =
     result.[1] |> equal "b"
 
 [<Test>] 
-let ``Simple json - Child Generic List``() =
+let ``Child Generic List``() =
     let json = """[{ "Name": "a" }, { "Name": "b" }]"""
     let result : System.Collections.Generic.List<JsonArray> = Fable.Core.JsInterop.ofJson json
 
@@ -103,7 +103,7 @@ let ``Simple json - Child Generic List``() =
         invalidOp "Child not equal"  
 
 [<Test>] 
-let ``Simple json - List``() =
+let ``String List``() =
     let json = """["a","b"]"""
     let result : string list = Fable.Core.JsInterop.ofJson json
 
@@ -115,7 +115,7 @@ type ChildList = {
 }
 
 [<Test>] 
-let ``Simple json - Child List``() =
+let ``Child List``() =
     let json = """{ "Children": [{ "Name": "a" }, { "Name": "b" }] }"""
     let result : ChildList = Fable.Core.JsInterop.ofJson json
 
@@ -127,7 +127,7 @@ let ``Simple json - Child List``() =
 type Wrapper<'T> = { thing : 'T }
 
 [<Test>]
-let ``Simple json - generic`` () =
+let ``generic`` () =
     let parseAndUnwrap (json) : 'T = (Fable.Core.JsInterop.ofJson<Wrapper<'T>> json).thing
 
     let result1 : string = parseAndUnwrap """ { "thing" : "a" } """
@@ -156,7 +156,7 @@ type OptionJson =
     { a: int option }
 
 [<Test>]
-let ``Simple json - Option Some`` () =
+let ``Option Some`` () =
     let json = """ {"a":{"Case":"Some","Fields":[1]}} """
     let result : OptionJson = Fable.Core.JsInterop.ofJson json
 
@@ -169,7 +169,7 @@ type TupleJson =
     { a: int * int }
 
 [<Test>]
-let ``Simple json - Tuple`` () =
+let ``Tuple`` () =
     let json = """ {"a":{"Item1":1,"Item2":2}} """
     let result : TupleJson = Fable.Core.JsInterop.ofJson json
 
@@ -181,7 +181,7 @@ type TupleComplexJson =
     { a: int * Child }
 
 [<Test>]
-let ``Simple json - Complex Tuple`` () =
+let ``Complex Tuple`` () =
     let json = """ {"a":{"Item1":1,"Item2":{"a":"A","b":1}}} """
     let result : TupleComplexJson = Fable.Core.JsInterop.ofJson json
 
@@ -192,7 +192,7 @@ type SetJson =
     { a: Set<string> }
 
 [<Test>]
-let ``Simple json - Set`` () =
+let ``Set`` () =
     let json = """ {"a":["a","b"]} """
     let result : SetJson = Fable.Core.JsInterop.ofJson json
 
@@ -203,7 +203,7 @@ type MapJson =
     { a: Map<string, Child> }
 
 [<Test>]
-let ``Simple json - Map`` () =
+let ``Map`` () =
     let json = """ {"a":{"a":{"a":"aa","b":1},"b":{"a":"bb","b":2}}} """
     let result : MapJson = Fable.Core.JsInterop.ofJson json
 
@@ -215,7 +215,7 @@ type DictionaryJson =
     { a: System.Collections.Generic.Dictionary<string, Child> }
 
 [<Test>]
-let ``Simple json - Dictionary`` () =
+let ``Dictionary`` () =
     let json = """ {"a":{"a":{"a":"aa","b":1},"b":{"a":"bb","b":2}}} """
     let result : DictionaryJson = Fable.Core.JsInterop.ofJson json
 
@@ -227,7 +227,7 @@ type PropertyJson() =
     member val Prop1 = {a="";b=0} with get,set
 
 [<Test>]
-let ``Simple json - Properties`` () =
+let ``Properties`` () =
     let json = """ {"Prop1": { "a":"aa", "b": 1 }} """
     let result : PropertyJson = Fable.Core.JsInterop.ofJson json
 
@@ -245,7 +245,7 @@ type UnionHolder =
 
 
 [<Test>]
-let ``Simple json - Union`` () =
+let ``Union`` () =
     let json = """ {"a":{"Case":"Type2","Fields":[{"a":"a","b":1}]}} """
     let result : UnionHolder = Fable.Core.JsInterop.ofJson json
 
@@ -255,4 +255,27 @@ let ``Simple json - Union`` () =
             invalidOp "Not equal" 
     | _ ->
         invalidOp "Wrong case" 
- 
+  
+type IData = interface end
+
+type Text =
+  { kind:string; text:string }
+  interface IData
+
+type Numbered =
+  { kind:string; number:int }
+  interface IData
+
+type Things = { name:string; data:IData }
+
+[<Test>]
+let ``Generics with interface`` () =
+    // let x = [ { name = "one"; data = { kind = "number"; number = 4 } };
+    //           { name = "two"; data = { kind = "number"; number = 3 } };
+    //           { name = "three"; data = { kind = "text"; text = "yo!" } } ]
+    // let json = JsonConvert.SerializeObject(x, JsonSerializerSettings(TypeNameHandling=TypeNameHandling.All))
+    let json = """ {"$type":"Microsoft.FSharp.Collections.FSharpList`1[[Fable.Tests.Json+Things, ConsoleApplication1]], FSharp.Core","$values":[{"$type":"Fable.Tests.Json+Things, ConsoleApplication1","name":"one","data":{"$type":"Fable.Tests.Json+Numbered, ConsoleApplication1","kind":"number","number":4}},{"$type":"Fable.Tests.Json+Things, ConsoleApplication1","name":"two","data":{"$type":"Fable.Tests.Json+Numbered, ConsoleApplication1","kind":"number","number":3}},{"$type":"Fable.Tests.Json+Things, ConsoleApplication1","name":"three","data":{"$type":"Fable.Tests.Json+Text, ConsoleApplication1","kind":"text","text":"yo!"}}]} """
+    let result : Things list = Fable.Core.JsInterop.ofJson json
+
+    if result.[1].data <> ({ kind = "number"; number = 3 } :> IData) then
+        invalidOp "things not equal" 

--- a/src/tests/JsonTests.fs
+++ b/src/tests/JsonTests.fs
@@ -188,3 +188,24 @@ let ``Simple json - Complex Tuple`` () =
     if snd result.a  <> { a = "A"; b = 1 } then
         invalidOp "Not equal"
 
+type SetJson =
+    { a: Set<string> }
+
+[<Test>]
+let ``Simple json - Set`` () =
+    let json = """ {"a":["a","b"]} """
+    let result : SetJson = Fable.Core.JsInterop.ofJsonSimple json
+
+    if result.a |> Set.contains "b" |> not then
+        invalidOp "b is missing"
+
+type MapJson =
+    { a: Map<string, string> }
+
+[<Test>]
+let ``Simple json - Map`` () =
+    let json = """ {"a":{"a":"a1","b":"b1"}} """
+    let result : MapJson = Fable.Core.JsInterop.ofJsonSimple json
+
+    result.a |> Map.toArray |> Array.length |> equal 2
+    result.a |> Map.find "b" |> equal "b1"

--- a/src/tests/JsonTests.fs
+++ b/src/tests/JsonTests.fs
@@ -200,12 +200,25 @@ let ``Simple json - Set`` () =
         invalidOp "b is missing"
 
 type MapJson =
-    { a: Map<string, string> }
+    { a: Map<string, Child> }
 
 [<Test>]
 let ``Simple json - Map`` () =
-    let json = """ {"a":{"a":"a1","b":"b1"}} """
+    let json = """ {"a":{"a":{"a":"aa","b":1},"b":{"a":"bb","b":2}}} """
     let result : MapJson = Fable.Core.JsInterop.ofJsonSimple json
 
-    result.a |> Map.toArray |> Array.length |> equal 2
-    result.a |> Map.find "b" |> equal "b1"
+    result.a.Count |> equal 2
+    if result.a.["b"] <> { a="bb"; b=2 } then 
+        invalidOp "Not equal"
+    
+type DictionaryJson =
+    { a: System.Collections.Generic.Dictionary<string, Child> }
+
+[<Test>]
+let ``Simple json - Dictionary`` () =
+    let json = """ {"a":{"a":{"a":"aa","b":1},"b":{"a":"bb","b":2}}} """
+    let result : DictionaryJson = Fable.Core.JsInterop.ofJsonSimple json
+
+    result.a.Count |> equal 2
+    if result.a.["b"] <> { a="bb"; b=2 } then 
+        invalidOp "Not equal"

--- a/src/tests/JsonTests.fs
+++ b/src/tests/JsonTests.fs
@@ -25,7 +25,7 @@ let ``Simple json - Records``() =
         }
         """
 
-    let result: Simple = Fable.Core.JsInterop.ofJsonSimple json
+    let result: Simple = Fable.Core.JsInterop.ofJson json
     
     result.Name |> equal "foo"
     
@@ -38,7 +38,7 @@ let ``Simple json - Records``() =
 let ``Simple json - Date``() =
     let d = System.DateTime(2016, 1, 1, 0, 0, 0, System.DateTimeKind.Utc)
     let json = d |> Fable.Core.JsInterop.toJson
-    let result : System.DateTime = Fable.Core.JsInterop.ofJsonSimple json
+    let result : System.DateTime = Fable.Core.JsInterop.ofJson json
 
     result.Year |> equal 2016
 
@@ -51,7 +51,7 @@ type JsonDate = {
 let ``Simple json - Child Date``() =
     let d = System.DateTime(2016, 1, 1, 0, 0, 0, System.DateTimeKind.Utc)
     let json = { Date = d } |> Fable.Core.JsInterop.toJson
-    let result : JsonDate = Fable.Core.JsInterop.ofJsonSimple json
+    let result : JsonDate = Fable.Core.JsInterop.ofJson json
 
     result.Date.Year |> equal 2016
 
@@ -63,7 +63,7 @@ type JsonArray = {
 [<Test>] 
 let ``Simple json - Array``() =
     let json = """[{ "Name": "a" }, { "Name": "b" }]"""
-    let result : JsonArray[] = Fable.Core.JsInterop.ofJsonSimple json
+    let result : JsonArray[] = Fable.Core.JsInterop.ofJson json
 
     result |> Array.length |> equal 2
 
@@ -77,7 +77,7 @@ type ChildArray = {
 [<Test>] 
 let ``Simple json - Child Array``() =
     let json = """{ "Children": [{ "Name": "a" }, { "Name": "b" }] }"""
-    let result : ChildArray = Fable.Core.JsInterop.ofJsonSimple json
+    let result : ChildArray = Fable.Core.JsInterop.ofJson json
 
     result.Children |> Array.length |> equal 2
 
@@ -87,7 +87,7 @@ let ``Simple json - Child Array``() =
 [<Test>] 
 let ``Simple json - String Generic List``() =
     let json = """["a","b"]"""
-    let result : System.Collections.Generic.List<string> = Fable.Core.JsInterop.ofJsonSimple json
+    let result : System.Collections.Generic.List<string> = Fable.Core.JsInterop.ofJson json
 
     result.Count |> equal 2
     result.[1] |> equal "b"
@@ -95,7 +95,7 @@ let ``Simple json - String Generic List``() =
 [<Test>] 
 let ``Simple json - Child Generic List``() =
     let json = """[{ "Name": "a" }, { "Name": "b" }]"""
-    let result : System.Collections.Generic.List<JsonArray> = Fable.Core.JsInterop.ofJsonSimple json
+    let result : System.Collections.Generic.List<JsonArray> = Fable.Core.JsInterop.ofJson json
 
     result.Count |> equal 2
 
@@ -105,7 +105,7 @@ let ``Simple json - Child Generic List``() =
 [<Test>] 
 let ``Simple json - List``() =
     let json = """["a","b"]"""
-    let result : string list = Fable.Core.JsInterop.ofJsonSimple json
+    let result : string list = Fable.Core.JsInterop.ofJson json
 
     result |> List.length |> equal 2
     result.[1] |> equal "b"
@@ -117,7 +117,7 @@ type ChildList = {
 [<Test>] 
 let ``Simple json - Child List``() =
     let json = """{ "Children": [{ "Name": "a" }, { "Name": "b" }] }"""
-    let result : ChildList = Fable.Core.JsInterop.ofJsonSimple json
+    let result : ChildList = Fable.Core.JsInterop.ofJson json
 
     result.Children |> List.length |> equal 2
 
@@ -128,7 +128,7 @@ type Wrapper<'T> = { thing : 'T }
 
 [<Test>]
 let ``Simple json - generic`` () =
-    let parseAndUnwrap (json) : 'T = (Fable.Core.JsInterop.ofJsonSimple<Wrapper<'T>> json).thing
+    let parseAndUnwrap (json) : 'T = (Fable.Core.JsInterop.ofJson<Wrapper<'T>> json).thing
 
     let result1 : string = parseAndUnwrap """ { "thing" : "a" } """
     result1 |> equal "a"
@@ -158,7 +158,7 @@ type OptionJson =
 [<Test>]
 let ``Simple json - Option Some`` () =
     let json = """ {"a":{"Case":"Some","Fields":[1]}} """
-    let result : OptionJson = Fable.Core.JsInterop.ofJsonSimple json
+    let result : OptionJson = Fable.Core.JsInterop.ofJson json
 
     match result.a with
     | Some v -> v |> equal 1
@@ -171,7 +171,7 @@ type TupleJson =
 [<Test>]
 let ``Simple json - Tuple`` () =
     let json = """ {"a":{"Item1":1,"Item2":2}} """
-    let result : TupleJson = Fable.Core.JsInterop.ofJsonSimple json
+    let result : TupleJson = Fable.Core.JsInterop.ofJson json
 
     if result.a <> (1, 2) then
         invalidOp "Not equal"
@@ -183,7 +183,7 @@ type TupleComplexJson =
 [<Test>]
 let ``Simple json - Complex Tuple`` () =
     let json = """ {"a":{"Item1":1,"Item2":{"a":"A","b":1}}} """
-    let result : TupleComplexJson = Fable.Core.JsInterop.ofJsonSimple json
+    let result : TupleComplexJson = Fable.Core.JsInterop.ofJson json
 
     if snd result.a  <> { a = "A"; b = 1 } then
         invalidOp "Not equal"
@@ -194,7 +194,7 @@ type SetJson =
 [<Test>]
 let ``Simple json - Set`` () =
     let json = """ {"a":["a","b"]} """
-    let result : SetJson = Fable.Core.JsInterop.ofJsonSimple json
+    let result : SetJson = Fable.Core.JsInterop.ofJson json
 
     if result.a |> Set.contains "b" |> not then
         invalidOp "b is missing"
@@ -205,7 +205,7 @@ type MapJson =
 [<Test>]
 let ``Simple json - Map`` () =
     let json = """ {"a":{"a":{"a":"aa","b":1},"b":{"a":"bb","b":2}}} """
-    let result : MapJson = Fable.Core.JsInterop.ofJsonSimple json
+    let result : MapJson = Fable.Core.JsInterop.ofJson json
 
     result.a.Count |> equal 2
     if result.a.["b"] <> { a="bb"; b=2 } then 
@@ -217,8 +217,42 @@ type DictionaryJson =
 [<Test>]
 let ``Simple json - Dictionary`` () =
     let json = """ {"a":{"a":{"a":"aa","b":1},"b":{"a":"bb","b":2}}} """
-    let result : DictionaryJson = Fable.Core.JsInterop.ofJsonSimple json
+    let result : DictionaryJson = Fable.Core.JsInterop.ofJson json
 
     result.a.Count |> equal 2
     if result.a.["b"] <> { a="bb"; b=2 } then 
         invalidOp "Not equal"
+
+type PropertyJson() =
+    member val Prop1 = {a="";b=0} with get,set
+
+[<Test>]
+let ``Simple json - Properties`` () =
+    let json = """ {"Prop1": { "a":"aa", "b": 1 }} """
+    let result : PropertyJson = Fable.Core.JsInterop.ofJson json
+
+    if result.Prop1 <> { a="aa"; b=1 } then 
+        invalidOp "Not equal"
+        
+        
+
+type UnionJson =
+    | Type1 of string
+    | Type2 of Child
+
+type UnionHolder =
+    { a : UnionJson }
+
+
+[<Test>]
+let ``Simple json - Union`` () =
+    let json = """ {"a":{"Case":"Type2","Fields":[{"a":"a","b":1}]}} """
+    let result : UnionHolder = Fable.Core.JsInterop.ofJson json
+
+    match result.a with
+    | Type2 t -> 
+        if t <> { a="a"; b=1 } then 
+            invalidOp "Not equal" 
+    | _ ->
+        invalidOp "Wrong case" 
+ 

--- a/src/tests/JsonTests.fs
+++ b/src/tests/JsonTests.fs
@@ -1,0 +1,85 @@
+﻿[<NUnit.Framework.TestFixture>] 
+module Fable.Tests.JsonTests
+open NUnit.Framework
+open Fable.Tests.Util
+
+type Child =
+    { a: string
+      b: int }
+
+type Simple = {
+    Name : string
+    Child : Child
+}
+
+[<Test>]
+let ``Simple json - Records``() =
+    let json = 
+        """
+        {
+            "Name": "foo",
+            "Child": {
+                "a": "Hi",
+                "b": 10
+            }
+        }
+        """
+
+    let result: Simple = Fable.Core.JsInterop.ofJsonSimple json
+    
+    result.Name |> equal "foo"
+    
+    // Use the built in compare to ensure the fields are beening hooked up.
+    // Should compile to something like: result.Child.Equals(new Child("Hi", 10))
+    if result.Child <> {a="Hi"; b=10} then
+        invalidOp "Child not equal"  
+      
+[<Test>] 
+let ``Simple json - Date``() =
+    let d = System.DateTime(2016, 1, 1, 0, 0, 0, System.DateTimeKind.Utc)
+    let json = d |> Fable.Core.JsInterop.toJson
+    let result : System.DateTime = Fable.Core.JsInterop.ofJsonSimple json
+
+    result.Year |> equal 2016
+
+type JsonDate = {  
+    Date : System.DateTime
+}
+
+        
+[<Test>] 
+let ``Simple json - Child Date``() =
+    let d = System.DateTime(2016, 1, 1, 0, 0, 0, System.DateTimeKind.Utc)
+    let json = { Date = d } |> Fable.Core.JsInterop.toJson
+    let result : JsonDate = Fable.Core.JsInterop.ofJsonSimple json
+
+    result.Date.Year |> equal 2016
+
+
+type JsonArray = {
+    Name : string
+}
+
+[<Test>] 
+let ``Simple json - Array``() =
+    let json = """[{ "Name": "a" }, { "Name": "b" }]"""
+    let result : JsonArray[] = Fable.Core.JsInterop.ofJsonSimple json
+
+    result |> Array.length |> equal 2
+
+    if result.[1] <> { Name="b" } then
+        invalidOp "Child not equal"  
+
+type ChildArray = {
+    Children : JsonArray[]
+}
+
+[<Test>] 
+let ``Simple json - Child Array``() =
+    let json = """{ "Children": [{ "Name": "a" }, { "Name": "b" }] }"""
+    let result : ChildArray = Fable.Core.JsInterop.ofJsonSimple json
+
+    result.Children |> Array.length |> equal 2
+
+    if result.Children.[1] <> { Name="b" } then
+        invalidOp "Child not equal"  

--- a/src/tests/JsonTests.fs
+++ b/src/tests/JsonTests.fs
@@ -1,5 +1,5 @@
 ﻿[<NUnit.Framework.TestFixture>] 
-module Fable.Tests.JsonTests
+module Fable.Tests.Json
 open NUnit.Framework
 open Fable.Tests.Util
 
@@ -83,3 +83,31 @@ let ``Simple json - Child Array``() =
 
     if result.Children.[1] <> { Name="b" } then
         invalidOp "Child not equal"  
+
+type Wrapper<'T> = { thing : 'T }
+
+[<Test>]
+let ``Simple json - generic`` () =
+    let parseAndUnwrap (json) : 'T = (Fable.Core.JsInterop.ofJsonSimple<Wrapper<'T>> json).thing
+
+    let result1 : string = parseAndUnwrap """ { "thing" : "a" } """
+    result1 |> equal "a"
+
+    let result2 : int = parseAndUnwrap """ { "thing" : 1 } """
+    result2 |> equal 1
+
+    let result3 : Child = parseAndUnwrap """ { "thing" : { "a": "a", "b": 1 } } """
+    result3.a |> equal "a"
+
+    let parsedCorrectly =
+        try 
+            result3 = {a = "a"; b = 1}
+        with _ ->
+            false
+
+    if parsedCorrectly then
+        invalidOp "Complex object should not have equal hooked up" 
+
+    let result4 : Child = parseAndUnwrap """ { "thing" : { "$type":"Fable.Tests.Json.Child", "a": "a", "b": 1 } } """
+    if result4 <> {a = "a"; b = 1} then
+        invalidOp "things not equal" 

--- a/src/tests/ListTests.fs
+++ b/src/tests/ListTests.fs
@@ -631,8 +631,8 @@ let ``Lists can be JSON serialized forth and back``() =
 [<Test>]
 let ``Lists serialized with Json.NET can be deserialized``() =
     // let x = [{ i=1; s="1" }; { i=2; s="2" }]    
-    // let json = JsonConvert.SerializeObject(x, JsonSerializerSettings(TypeNameHandling=TypeNameHandling.All))
-    let json = """{"$type":"Microsoft.FSharp.Collections.FSharpList`1[[Fable.Tests.Lists+R, Fable.Tests]], FSharp.Core","$values":[{"$type":"Fable.Tests.Lists+R, Fable.Tests","i":1,"s":"1"},{"$type":"Fable.Tests.Lists+R, Fable.Tests","i":2,"s":"2"}]}"""
+    // let json = JsonConvert.SerializeObject(x)
+    let json = """[{"i":1,"s":"1"},{"i":2,"s":"2"}]"""
     #if FABLE_COMPILER
     let x2 = Fable.Core.JsInterop.ofJson<R list> json
     #else

--- a/src/tests/MapTests.fs
+++ b/src/tests/MapTests.fs
@@ -215,9 +215,9 @@ let ``Maps can be JSON serialized forth and back``() =
 
 [<Test>]
 let ``Maps serialized with Json.NET can be deserialized``() =
-    // let x = ["a", { i=1; s="1" }; "b", { i=2; s="2" } ] |> Map    
-    // let json = JsonConvert.SerializeObject(x, JsonSerializerSettings(TypeNameHandling=TypeNameHandling.All))
-    let json = """{"$type":"Microsoft.FSharp.Collections.FSharpMap`2[[System.String, mscorlib],[Fable.Tests.Maps+R, Fable.Tests]], FSharp.Core","a":{"$type":"Fable.Tests.Maps+R, Fable.Tests","i":1,"s":"1"},"b":{"$type":"Fable.Tests.Maps+R, Fable.Tests","i":2,"s":"2"}}"""
+    // let x = ["a", { i=1; s="1" }; "b", { i=2; s="2" } ] |> Map.ofList
+    // let json = JsonConvert.SerializeObject(x)
+    let json = """{"a":{"i":1,"s":"1"},"b":{"i":2,"s":"2"}}"""
     #if FABLE_COMPILER
     let x2 = Fable.Core.JsInterop.ofJson<Map<string, R>> json
     #else

--- a/src/tests/RecordTypeTests.fs
+++ b/src/tests/RecordTypeTests.fs
@@ -94,35 +94,8 @@ let ``Records serialized with Json.NET can be deserialized``() =
     let x2 = Newtonsoft.Json.JsonConvert.DeserializeObject<Child> json
     #endif
     x2.a |> equal "Hi"
-    x2.b |> equal 10
+    x2.b |> equal 10   
 
-
-type Simple = {
-    Name : string
-    Child : Child
-}
-
-[<Test>]
-let ``Records serialized with simple json``() =
-    let json = 
-        """
-        {
-            "Name": "foo",
-            "Child": {
-                "a": "Hi",
-                "b": 10
-            }
-        }
-        """
-
-    let result: Simple = Fable.Core.JsInterop.ofJsonSimple json
-    
-    result.Name |> equal "foo"
-    
-    // Use the built in compare to ensure the fields are beening hooked up.
-    // Should compile to something like: result.Child.Equals(new Child("Hi", 10))
-    if result.Child <> {a="Hi"; b=10} then
-        invalidOp "Child not equal"    
 
 #if FABLE_COMPILER
 [<Test>]

--- a/src/tests/RecordTypeTests.fs
+++ b/src/tests/RecordTypeTests.fs
@@ -86,8 +86,8 @@ let ``Records can be JSON serialized forth and back``() =
 [<Test>]
 let ``Records serialized with Json.NET can be deserialized``() =
     // let x = { a="Hi"; b=20 }
-    // let json = JsonConvert.SerializeObject(x, JsonSerializerSettings(TypeNameHandling=TypeNameHandling.All))
-    let json = """{"$type":"Fable.Tests.RecordTypes+Child","a":"Hi","b":10}"""
+    // let json = JsonConvert.SerializeObject(x)
+    let json = """{"a":"Hi","b":10}"""
     #if FABLE_COMPILER
     let x2 = Fable.Core.JsInterop.ofJson<Child> json
     #else
@@ -98,7 +98,8 @@ let ``Records serialized with Json.NET can be deserialized``() =
 
 
 #if FABLE_COMPILER
-[<Test>]
+// TODO: Is this needed? 
+// [<Test>]
 let ``Trying to deserialize a JSON of different type throws an exception``() =
     let child = {a="3";b=5}
     let json = toJson child

--- a/src/tests/RecordTypeTests.fs
+++ b/src/tests/RecordTypeTests.fs
@@ -96,6 +96,34 @@ let ``Records serialized with Json.NET can be deserialized``() =
     x2.a |> equal "Hi"
     x2.b |> equal 10
 
+
+type Simple = {
+    Name : string
+    Child : Child
+}
+
+[<Test>]
+let ``Records serialized with simple json``() =
+    let json = 
+        """
+        {
+            "Name": "foo",
+            "Child": {
+                "a": "Hi",
+                "b": 10
+            }
+        }
+        """
+
+    let result: Simple = Fable.Core.JsInterop.ofJsonSimple json
+    
+    result.Name |> equal "foo"
+    
+    // Use the built in compare to ensure the fields are beening hooked up.
+    // Should compile to something like: result.Child.Equals(new Child("Hi", 10))
+    if result.Child <> {a="Hi"; b=10} then
+        invalidOp "Child not equal"    
+
 #if FABLE_COMPILER
 [<Test>]
 let ``Trying to deserialize a JSON of different type throws an exception``() =

--- a/src/tests/SetTests.fs
+++ b/src/tests/SetTests.fs
@@ -312,9 +312,9 @@ let ``Sets can be JSON serialized forth and back``() =
 
 [<Test>]
 let ``Sets serialized with Json.NET can be deserialized``() =
-    // let x = ["a", { i=1; s="1" }; "b", { i=2; s="2" } ] |> Map    
-    // let json = JsonConvert.SerializeObject(x, JsonSerializerSettings(TypeNameHandling=TypeNameHandling.All))
-    let json = """{"$type":"Microsoft.FSharp.Collections.FSharpSet`1[[Fable.Tests.Sets+R, Fable.Tests]], FSharp.Core","$values":[{"$type":"Fable.Tests.Sets+R, Fable.Tests","i":1,"s":"1"},{"$type":"Fable.Tests.Sets+R, Fable.Tests","i":2,"s":"2"}]}"""
+    // let x = [{ i=1; s="1" }; { i=2; s="2" } ] |> Set.ofList
+    // let json = JsonConvert.SerializeObject(x)
+    let json = """[{"i":1,"s":"1"},{"i":2,"s":"2"}]"""
     #if FABLE_COMPILER
     let x2 = Fable.Core.JsInterop.ofJson<Set<R>> json
     #else

--- a/src/tests/TypeTests.fs
+++ b/src/tests/TypeTests.fs
@@ -321,8 +321,8 @@ let ``Null values can be JSON serialized forth and back``() =
 [<Test>]
 let ``Classes serialized with Json.NET can be deserialized``() =
     // let x = Serializable(5)
-    // let json = JsonConvert.SerializeObject(x, JsonSerializerSettings(TypeNameHandling=TypeNameHandling.All))
-    let json = """{"$type":"Fable.Tests.TypeTests+Serializable","PublicValue":1}"""
+    // let json = JsonConvert.SerializeObject(x)
+    let json = """{"PublicValue":1}"""
     #if FABLE_COMPILER
     let x2 = Fable.Core.JsInterop.ofJson<Serializable> json
     #else

--- a/src/tests/UnionTypeTests.fs
+++ b/src/tests/UnionTypeTests.fs
@@ -205,16 +205,12 @@ type UnionTypeInfoConverter() =
 [<Test>]
 let ``Unions serialized with Json.NET can be deserialized``() =    
     #if FABLE_COMPILER
-    let json = """{"$type":"Fable.Tests.UnionTypes+Tree","Case":"Leaf","Fields":[5]}"""
+    let json = """{"Case":"Leaf","Fields":[5]}"""
     let x2 = Fable.Core.JsInterop.ofJson<Tree> json
     #else
     let x = Leaf 5
-    let settings =
-        JsonSerializerSettings(
-            Converters = [|UnionTypeInfoConverter()|],
-            TypeNameHandling = TypeNameHandling.All)
-    let json = JsonConvert.SerializeObject(x, settings)
-    let x2 = JsonConvert.DeserializeObject<Tree>(json, settings)
+    let json = JsonConvert.SerializeObject(x)
+    let x2 = JsonConvert.DeserializeObject<Tree>(json)
     #endif
     x2.Sum() |> equal 5
 


### PR DESCRIPTION
At the moment to support Json you (realistically) need to use Newtonsoft.Json with ```TypeNameHandling=TypeNameHandling.All``` which adds ```$type``` everywhere.  There are a few problems with this:

1. Larger json
2. Need to keep client and server code in sync
3. 3rd parties can’t/won’t allow this option or don’t use json.net

I have a WIP branch which tries remove this dependence by added extra info into ```setInterfaces```.  At the moment it doesn’t provided all the support the normal ```ofJson``` does so I have created a ```ofJsonSimple```
