### PR TITLE
[WIP] Uniqueness records

### DIFF
--- a/RELEASE_NOTES_COMPILER.md
+++ b/RELEASE_NOTES_COMPILER.md
@@ -1,3 +1,6 @@
+### 0.7.0
+
+
 ### 0.6.12
 
 * Now fableconfig.json can be in JSON5 format (comments!)

--- a/RELEASE_NOTES_COMPILER.md
+++ b/RELEASE_NOTES_COMPILER.md
@@ -1,5 +1,8 @@
 ### 0.7.0
 
+* Add type info to JS constructors: cases (unions) and properties (records and classes)
+* Extend type references with generic info when calling `typeof`
+* Add `GenericParamAttribute` to implicitly pass type info of generic parameters
 
 ### 0.6.12
 

--- a/RELEASE_NOTES_CORE.md
+++ b/RELEASE_NOTES_CORE.md
@@ -1,3 +1,6 @@
+### 0.7.0
+
+
 ### 0.6.8
 
 * Fix #459: Seq.filter doesn't blow the stack with long sequences

--- a/RELEASE_NOTES_CORE.md
+++ b/RELEASE_NOTES_CORE.md
@@ -1,5 +1,6 @@
 ### 0.7.0
 
+* Serialize.ofJson doesn't need JSON to contain `$type` info any more
 
 ### 0.6.8
 

--- a/src/fable/Fable.Client.Node/AssemblyInfo.fs
+++ b/src/fable/Fable.Client.Node/AssemblyInfo.fs
@@ -2,10 +2,10 @@
 namespace System
 open System.Reflection
 
-[<assembly: AssemblyVersionAttribute("0.6.12")>]
-[<assembly: AssemblyMetadataAttribute("fableCoreVersion","0.6.8")>]
+[<assembly: AssemblyVersionAttribute("0.7.0")>]
+[<assembly: AssemblyMetadataAttribute("fableCoreVersion","0.7.0")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "0.6.12"
-    let [<Literal>] InformationalVersion = "0.6.12"
+    let [<Literal>] Version = "0.7.0"
+    let [<Literal>] InformationalVersion = "0.7.0"

--- a/src/fable/Fable.Client.Suave/Main.fs
+++ b/src/fable/Fable.Client.Suave/Main.fs
@@ -242,8 +242,8 @@ let rec formatFSharpTypeSig = function
     | FableType.Unit -> "unit"
     | FableType.Boolean -> "bool"
     | FableType.String -> "string"
-    | FableType.Regex -> "System.Text.RegularExpressions.Regex"
     | FableType.Number n -> formatFSharpNumber n
+    | FableType.Option t -> formatFSharpTypeSig t + "option"
     | FableType.Array t -> formatFSharpTypeSig t + "[]"
     | FableType.Tuple ts ->  "(" + (List.map formatFSharpTypeSig ts |> String.concat " * ") + ")"
     | FableType.Function(ts, tr) -> 

--- a/src/fable/Fable.Compiler/AssemblyInfo.fs
+++ b/src/fable/Fable.Compiler/AssemblyInfo.fs
@@ -2,9 +2,9 @@
 namespace System
 open System.Reflection
 
-[<assembly: AssemblyVersionAttribute("0.6.12")>]
+[<assembly: AssemblyVersionAttribute("0.7.0")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "0.6.12"
-    let [<Literal>] InformationalVersion = "0.6.12"
+    let [<Literal>] Version = "0.7.0"
+    let [<Literal>] InformationalVersion = "0.7.0"

--- a/src/fable/Fable.Compiler/FSharp2Fable.Util.fs
+++ b/src/fable/Fable.Compiler/FSharp2Fable.Util.fs
@@ -33,9 +33,19 @@ type Context =
     thisAvailability: ThisAvailability
     }
     static member Empty =
+<<<<<<< HEAD
         { fileName="unknown"; scope=[]; typeArgs=[]; baseClass=None;
           decisionTargets=Map.empty<_,_>; thisAvailability=ThisUnavailable }
     
+=======
+        { fileName="unknown"; scope=[]; typeArgs=[]; decisionTargets=Map.empty<_,_>; baseClass=None }
+
+type Role =
+    | AppliedArgument
+    // For now we're only interested in applied arguments
+    | UnknownRole
+
+>>>>>>> Prepare types
 type IFableCompiler =
     inherit ICompiler
     abstract Transform: Context -> FSharpExpr -> Fable.Expr
@@ -671,10 +681,10 @@ module Identifiers =
         let sanitizedName = tentativeName |> Naming.sanitizeIdent (fun x ->
             List.exists (fun (_,x') ->
                 match x' with
-                | Fable.Value (Fable.IdentValue {name=name}) -> x = name
+                | Fable.Value (Fable.IdentValue i) -> x = i.Name
                 | _ -> false) ctx.scope)
         com.AddUsedVarName sanitizedName
-        let ident: Fable.Ident = { name=sanitizedName; typ=typ}
+        let ident = Fable.Ident(sanitizedName, typ)
         let identValue = Fable.Value (Fable.IdentValue ident)
         { ctx with scope = (fsRef, identValue)::ctx.scope}, ident
 
@@ -687,7 +697,13 @@ module Identifiers =
     let tryGetBoundExpr (ctx: Context) (fsRef: FSharpMemberOrFunctionOrValue) =
         ctx.scope
         |> List.tryFind (fst >> function Some fsRef' -> obj.Equals(fsRef, fsRef') | None -> false)
-        |> function Some (_,boundExpr) -> Some boundExpr | None -> None
+        |> function
+            | Some(_, (Fable.Value(Fable.IdentValue i) as boundExpr)) ->
+                // TODO: Check if value is uniqueness type
+                // if i.IsConsumed then failwithf "Value %s has already been consumed" i.Name
+                Some boundExpr
+            | Some(_, boundExpr) -> Some boundExpr
+            | None -> None
 
     /// Get corresponding identifier to F# value in current scope
     let getBoundExpr (ctx: Context) (fsRef: FSharpMemberOrFunctionOrValue) =
@@ -695,6 +711,13 @@ module Identifiers =
         | Some boundExpr -> boundExpr
         | None -> failwithf "Detected non-bound identifier: %s in %O"
                     fsRef.CompiledName (getRefLocation fsRef |> makeRange)
+
+    let tryConsumeBoundExpr (ctx: Context) (fsRef: FSharpMemberOrFunctionOrValue) =
+        tryGetBoundExpr ctx fsRef
+        |> Option.map (function
+            | Fable.Value(Fable.IdentValue i) as e ->
+                i.Consume(); e
+            | e -> e)
 
 module Util =
     open Helpers
@@ -1012,7 +1035,7 @@ module Util =
          // TODO: This shouldn't happen, throw exception?
         | ThisUnavailable -> Fable.Value Fable.This
 
-    let makeValueFrom com ctx r typ (v: FSharpMemberOrFunctionOrValue) =
+    let makeValueFrom com ctx r typ role (v: FSharpMemberOrFunctionOrValue) =
         if not v.IsModuleValueOrMember
         then
             if typ = Fable.Unit
@@ -1023,10 +1046,11 @@ module Util =
         elif isReplaceCandidate com v.EnclosingEntity
         then wrapInLambda com ctx r typ v
         else
-            match v with
-            | Emitted com ctx r typ ([], []) (None, []) emitted -> emitted
-            | Imported com ctx r typ [] imported -> imported
-            | Try (tryGetBoundExpr ctx) e -> e 
+            match role, v with
+            | _, Emitted com ctx r typ ([], []) (None, []) emitted -> emitted
+            | _, Imported com ctx r typ [] imported -> imported
+            | AppliedArgument, Try (tryConsumeBoundExpr ctx) e -> e 
+            | _, Try (tryGetBoundExpr ctx) e -> e 
             | _ ->
                 let typeRef =
                     makeTypeFromDef com ctx v.EnclosingEntity []

--- a/src/fable/Fable.Compiler/FSharp2Fable.fs
+++ b/src/fable/Fable.Compiler/FSharp2Fable.fs
@@ -217,7 +217,7 @@ and private transformExprWithRole (role: Role) (com: IFableCompiler) ctx fsExpr 
             Fable.DeclaredType(ent, [Fable.Any; Fable.Any])
         Fable.Wrapped(expr, appType)
 
-    | RecordUpdate(NonAbbreviatedType fsType, record, updatedFields) ->
+    | RecordMutatingUpdate(NonAbbreviatedType fsType, record, updatedFields) ->
         let r, typ = makeRangeFrom fsExpr, makeType com ctx fsType
         // TODO: Use a different role type?
         let record = makeValueFrom com ctx r typ AppliedArgument record
@@ -352,7 +352,7 @@ and private transformExprWithRole (role: Role) (com: IFableCompiler) ctx fsExpr 
             if flags.IsInstance
             then transformExpr com ctx argExprs.Head,
                  List.map (transformExprWithRole AppliedArgument com ctx) argExprs.Tail
-            else makeTypeRef com range sourceType,
+            else makeTypeRef com range false sourceType,
                  List.map (transformExprWithRole AppliedArgument com ctx) argExprs
         let argTypes = List.map (makeType com ctx) argTypes
         let methName =

--- a/src/fable/Fable.Compiler/FSharp2Fable.fs
+++ b/src/fable/Fable.Compiler/FSharp2Fable.fs
@@ -218,8 +218,8 @@ and private transformExprWithRole (role: Role) (com: IFableCompiler) ctx fsExpr 
         Fable.Wrapped(expr, appType)
 
     | RecordUpdate(NonAbbreviatedType fsType, record, updatedFields) ->
-        // TODO: Use a different role type?
         let r, typ = makeRangeFrom fsExpr, makeType com ctx fsType
+        // TODO: Use a different role type?
         let record = makeValueFrom com ctx r typ AppliedArgument record
         let assignments =
             ([record], updatedFields)

--- a/src/fable/Fable.Compiler/FSharp2Fable.fs
+++ b/src/fable/Fable.Compiler/FSharp2Fable.fs
@@ -154,6 +154,9 @@ and private transformComposableExpr com ctx fsExpr argExprs =
     | _ -> failwith "ComposableExpr expected"
 
 and private transformExpr (com: IFableCompiler) ctx fsExpr =
+    transformExprWithRole UnknownRole com ctx fsExpr
+
+and private transformExprWithRole (role: Role) (com: IFableCompiler) ctx fsExpr =
     match fsExpr with
     (** ## Custom patterns *)
     | SpecialValue com ctx replacement ->
@@ -165,27 +168,28 @@ and private transformExpr (com: IFableCompiler) ctx fsExpr =
         |> makeLoop (makeRangeFrom fsExpr)
         
     | ErasableLambda (expr, argExprs) ->
-        List.map (com.Transform ctx) argExprs
+        List.map (transformExprWithRole AppliedArgument com ctx) argExprs
         |> transformComposableExpr com ctx expr
 
     // Pipe must come after ErasableLambda
     | Pipe (Transform com ctx callee, args) ->
         let typ, range = makeType com ctx fsExpr.Type, makeRangeFrom fsExpr
-        makeApply range typ callee (List.map (transformExpr com ctx) args)
+        makeApply range typ callee (List.map (transformExprWithRole AppliedArgument com ctx) args)
         
     | Composition (expr1, args1, expr2, args2) ->
         let lambdaArg = com.GetUniqueVar() |> makeIdent
         let r, typ = makeRangeFrom fsExpr, makeType com ctx fsExpr.Type
         let expr1 =
-            (List.map (com.Transform ctx) args1)@[Fable.Value (Fable.IdentValue lambdaArg)]
+            (List.map (transformExprWithRole AppliedArgument com ctx) args1)
+                @ [Fable.Value (Fable.IdentValue lambdaArg)]
             |> transformComposableExpr com ctx expr1
         let expr2 =
-            (List.map (com.Transform ctx) args2)@[expr1]
+            (List.map (transformExprWithRole AppliedArgument com ctx) args2)@[expr1]
             |> transformComposableExpr com ctx expr2
         makeLambdaExpr [lambdaArg] expr2             
 
     | BaseCons com ctx (meth, args) ->
-        let args = List.map (com.Transform ctx) args
+        let args = List.map (transformExprWithRole AppliedArgument com ctx) args
         let typ, range = makeType com ctx fsExpr.Type, makeRangeFrom fsExpr
         Fable.Apply(Fable.Value Fable.Super, args, Fable.ApplyMeth, typ, range)
 
@@ -263,7 +267,7 @@ and private transformExpr (com: IFableCompiler) ctx fsExpr =
 
     | BasicPatterns.Value v ->
         let r, typ = makeRangeFrom fsExpr, makeType com ctx fsExpr.Type
-        makeValueFrom com ctx r typ v
+        makeValueFrom com ctx r typ role v
 
     | BasicPatterns.DefaultValue (FableType com ctx typ) ->
         let valueKind =
@@ -334,8 +338,10 @@ and private transformExpr (com: IFableCompiler) ctx fsExpr =
         let range, typ = makeRangeFrom fsExpr, makeType com ctx fsExpr.Type
         let callee, args =
             if flags.IsInstance
-            then transformExpr com ctx argExprs.Head, List.map (transformExpr com ctx) argExprs.Tail
-            else makeTypeRef com range false sourceType, List.map (transformExpr com ctx) argExprs
+            then transformExpr com ctx argExprs.Head,
+                 List.map (transformExprWithRole AppliedArgument com ctx) argExprs.Tail
+            else makeTypeRef com range sourceType,
+                 List.map (transformExprWithRole AppliedArgument com ctx) argExprs
         let argTypes = List.map (makeType com ctx) argTypes
         let methName =
             match sourceType with
@@ -347,12 +353,13 @@ and private transformExpr (com: IFableCompiler) ctx fsExpr =
         |> fun m -> Fable.Apply (m, args, Fable.ApplyMeth, typ, range)
 
     | BasicPatterns.Call(callee, meth, typArgs, methTypArgs, args) ->
-        let callee, args = Option.map (com.Transform ctx) callee, List.map (com.Transform ctx) args
+        let callee = Option.map (com.Transform ctx) callee
+        let args = List.map (transformExprWithRole AppliedArgument com ctx) args
         let r, typ = makeRangeFrom fsExpr, makeType com ctx fsExpr.Type
         makeCallFrom com ctx r typ meth (typArgs, methTypArgs) callee args
 
     | BasicPatterns.Application(Transform com ctx callee, _typeArgs, args) ->
-        let args = List.map (transformExpr com ctx) args
+        let args = List.map (transformExprWithRole AppliedArgument com ctx) args
         let typ, range = makeType com ctx fsExpr.Type, makeRangeFrom fsExpr
         match callee.Type.FullName, args with
         | "Fable.Core.Applicable", args ->
@@ -433,7 +440,7 @@ and private transformExpr (com: IFableCompiler) ctx fsExpr =
 
     | BasicPatterns.ValueSet (valToSet, Transform com ctx valueExpr) ->
         let r, typ = makeRangeFrom fsExpr, makeType com ctx valToSet.FullType
-        let valToSet = makeValueFrom com ctx r typ valToSet
+        let valToSet = makeValueFrom com ctx r typ UnknownRole valToSet
         Fable.Set (valToSet, None, valueExpr, r)
 
     (** Instantiation *)
@@ -598,8 +605,8 @@ and private transformExpr (com: IFableCompiler) ctx fsExpr =
             let defaultCase = transformBody defaultCase
             cases, defaultCase
         let matchValue =
-            makeType com ctx matchValue.FullType
-            |> makeValueFrom com ctx None <| matchValue
+            let t = makeType com ctx matchValue.FullType
+            makeValueFrom com ctx None t UnknownRole matchValue
         let r, typ = makeRangeFrom fsExpr, makeType com ctx fsExpr.Type
         match typ with
         | Fable.Unit ->
@@ -780,7 +787,7 @@ let private transformMemberDecl (com: IFableCompiler) ctx (declInfo: DeclInfo)
             if meth.EnclosingEntity.IsFSharpModule then
                 let typ = makeType com ctx meth.FullType
                 let ctx, privateName = bindIdent com ctx typ (Some meth) memberName
-                ctx, Some (privateName.name)
+                ctx, Some (privateName.Name)
             else ctx, None
         let args, body =
             bindMemberArgs com ctx meth.IsInstanceMember args
@@ -868,7 +875,7 @@ let rec private transformEntityDecl
             // Bind entity name to context to prevent name
             // clashes (it will become a variable in JS)
             let ctx, ident = sanitizeEntityName ent |> bindIdent com ctx Fable.Any None
-            declInfo.AddChild(com, ent, ident.name, childDecls)
+            declInfo.AddChild(com, ent, ident.Name, childDecls)
             declInfo, ctx
 
 and private transformDeclarations (com: IFableCompiler) ctx init decls =

--- a/src/fable/Fable.Compiler/Fable2Babel.fs
+++ b/src/fable/Fable.Compiler/Fable2Babel.fs
@@ -69,7 +69,7 @@ module Util =
     let identFromName name =
         let name = Naming.sanitizeIdent (fun _ -> false) name
         Babel.Identifier name
-        
+
     let sanitizeName propName: Babel.Expression * bool =
         if Naming.identForbiddenCharsRegex.IsMatch propName
         then upcast Babel.StringLiteral propName, true
@@ -85,6 +85,11 @@ module Util =
         com.Options.coreLib
         |> Path.getExternalImportPath com ctx.fixedFileName
         |> com.GetImportExpr ctx None coreModule
+
+    let getSymbol com ctx name =
+        Babel.MemberExpression(
+                getCoreLibImport com ctx "Symbol",
+                Babel.Identifier name) :> Babel.Expression
 
     let get left propName =
         let expr, computed = sanitizeName propName
@@ -124,10 +129,8 @@ module Util =
                 (match memb with Some memb -> [memb] | None ->  [])
         match ent.File with
         | None ->
-            match Map.tryFind ent.FullName Replacements.coreLibMappedTypes with
-            | Some mappedType ->
-                Path.getExternalImportPath com ctx.fixedFileName com.Options.coreLib
-                |> com.GetImportExpr ctx None mappedType
+            match Replacements.tryReplaceEntity com ent with
+            | Some expr -> com.TransformExpr ctx expr
             | None -> failwithf "Cannot access type: %s" ent.FullName
         | Some file when ctx.file.FileName <> file ->
             let proj, ns = com.GetProjectAndNamespace file
@@ -165,7 +168,6 @@ module Util =
         | Fable.Unit -> upcast Babel.VoidTypeAnnotation()
         | Fable.Boolean -> upcast Babel.BooleanTypeAnnotation()
         | Fable.String -> upcast Babel.StringTypeAnnotation()
-        | Fable.Regex -> upcast Babel.GenericTypeAnnotation(Babel.Identifier("RegExp"))
         | Fable.Number _ -> upcast Babel.NumberTypeAnnotation()
         // TODO: Typed arrays?
         | Fable.Array genArg ->
@@ -191,19 +193,21 @@ module Util =
         // TODO: Make union type annotation?
         | Fable.Enum _ ->
             upcast Babel.NumberTypeAnnotation()
-        | Fable.DeclaredType(FullName "Microsoft.FSharp.Core.FSharpOption", [genArg]) ->
+        | Fable.Option genArg ->
             upcast Babel.NullableTypeAnnotation(typeAnnotation com ctx genArg)
         | Fable.DeclaredType(FullName "System.Collections.Generic.IEnumerable", [genArg]) ->
             upcast Babel.GenericTypeAnnotation(
                 Babel.Identifier("Iterable"),
                 Babel.TypeParameterInstantiation([typeAnnotation com ctx genArg]))
-        | Fable.DeclaredType(FullName "System.DateTime", _) ->
-            upcast Babel.GenericTypeAnnotation(Babel.Identifier("Date"))
-        | Fable.DeclaredType(FullName "System.TimeSpan", _) ->
-            upcast Babel.NumberTypeAnnotation()
         | Fable.DeclaredType(ent, genArgs) ->
             try
                 match typeRef com ctx ent None with
+                | :? Babel.StringLiteral as str ->
+                    match str.value with
+                    | "number" -> upcast Babel.NumberTypeAnnotation()
+                    | "boolean" -> upcast Babel.BooleanTypeAnnotation()
+                    | "string" -> upcast Babel.StringTypeAnnotation()
+                    | _ -> upcast Babel.AnyTypeAnnotation()
                 | :? Babel.Identifier as id ->
                     let typeParams =
                         match List.map (typeAnnotation com ctx) genArgs  with
@@ -367,11 +371,11 @@ module Util =
                 match interfaces with
                 | [] -> props
                 | interfaces ->
-                    let ifcsSymbol =
-                        getCoreLibImport com ctx "Symbol" 
-                        |> get <| "interfaces"
-                    Babel.ObjectProperty(ifcsSymbol, buildStringArray interfaces, computed=true)
-                    |> U3.Case1 |> consBack props
+                    let body =
+                        [buildStringArray interfaces |> Babel.ExpressionStatement :> Babel.Statement]
+                        |> Babel.BlockStatement
+                    Babel.ObjectMethod(Babel.ObjectMeth, getSymbol com ctx "interfaces", [], body, computed=true)
+                    |> U3.Case2 |> consBack props
             |> fun props ->
                 upcast Babel.ObjectExpression(props, ?loc=range)
 
@@ -692,8 +696,12 @@ module Util =
             let typ = Babel.TypeAnnotation(typeAnnotation com ctx typ)
             Babel.ClassProperty(Babel.Identifier(name), typeAnnotation=typ)
             |> U2<Babel.ClassMethod,_>.Case2
-        let declareMethod range kind name args (body: Fable.Expr) typeParams hasRestParams isStatic =
-            let name, computed = sanitizeName name
+        let declareMethod range kind name args (body: Fable.Expr)
+                          typeParams hasRestParams isStatic isSymbol =
+            let name, computed =
+                if isSymbol
+                then getSymbol com ctx name, true
+                else sanitizeName name
             let args, body, returnType, typeParams =
                 getMemberArgs com ctx args body typeParams hasRestParams
             Babel.ClassMethod(kind, name, args, body, computed, isStatic,
@@ -703,18 +711,18 @@ module Util =
         decls
         |> List.map (function
             | Fable.MemberDeclaration(m, _, args, body, range) ->
-                let kind, name, isStatic, body =
+                let kind, name, isStatic, isSymbol, body =
                     match m.Kind with
                     | Fable.Constructor ->
                         let body =
                             match ent with
-                            | Some(EntKind(Fable.Class(Some _))) -> checkBaseCall body
+                            | Some(EntKind(Fable.Class(Some _, _))) -> checkBaseCall body
                             | _ -> body
-                        Babel.ClassConstructor, "constructor", false, body
-                    | Fable.Method -> Babel.ClassFunction, m.OverloadName, m.IsStatic, body
-                    | Fable.Getter | Fable.Field -> Babel.ClassGetter, m.Name, m.IsStatic, body
-                    | Fable.Setter -> Babel.ClassSetter, m.Name, m.IsStatic, body
-                declareMethod range kind name args body m.GenericParameters m.HasRestParams isStatic
+                        Babel.ClassConstructor, "constructor", false, false, body
+                    | Fable.Method -> Babel.ClassFunction, m.OverloadName, m.IsStatic, m.IsSymbol, body
+                    | Fable.Getter | Fable.Field -> Babel.ClassGetter, m.Name, m.IsStatic, m.IsSymbol, body
+                    | Fable.Setter -> Babel.ClassSetter, m.Name, m.IsStatic, m.IsSymbol, body
+                declareMethod range kind name args body m.GenericParameters m.HasRestParams isStatic isSymbol
             | Fable.ActionDeclaration _
             | Fable.EntityDeclaration _ as decl ->
                 failwithf "Unexpected declaration in class: %A" decl)
@@ -729,7 +737,7 @@ module Util =
                         |> Babel.TypeParameterDeclaration |> Some
                     let props =
                         match ent.Kind with
-                        | Fable.Union ->
+                        | Fable.Union _ ->
                             ["Case", Fable.String; "Fields", Fable.Array Fable.Any]
                             |> List.map (fun (name, typ) -> declareProperty com ctx name typ)
                         | Fable.Record fields | Fable.Exception fields ->
@@ -739,28 +747,6 @@ module Util =
                 | _ -> None, members
             Babel.ClassExpression(Babel.ClassBody(members, ?loc=range),
                     ?id=id, ?typeParams=typeParams, ?super=baseClass, ?loc=range)
-
-    let declareInterfaces (com: IBabelCompiler) ctx (ent: Fable.Entity) isClass =
-        ent.Interfaces
-        |> Seq.tryFind (Naming.replacedInterfaces.Contains)
-        |> Option.iter (fun i ->
-            failwithf "Fable doesn't support custom implementations of %s (%s)" i ent.FullName)
-        let interfaces =
-            match ent.Kind with
-            | Fable.Union -> "FSharpUnion"::ent.Interfaces
-            | Fable.Record _ -> "FSharpRecord"::ent.Interfaces
-            | Fable.Exception _ -> "FSharpException"::ent.Interfaces
-            | _ -> ent.Interfaces
-        [ getCoreLibImport com ctx "Util"
-          typeRef com ctx ent None
-          buildStringArray interfaces
-          upcast Babel.StringLiteral ent.FullName ]
-        |> fun args ->
-            // "$0.setInterfaces($1.prototype, $2, $3)"
-            Babel.CallExpression(
-                get args.[0] "setInterfaces",
-                [get args.[1] "prototype"; args.[2]; args.[3]] |> List.map U2.Case1)
-        |> Babel.ExpressionStatement :> Babel.Statement
 
     let declareEntryPoint com ctx (funcExpr: Babel.Expression) =
         let argv = macroExpression None "process.argv.slice(2)" []
@@ -851,9 +837,6 @@ module Util =
             // Don't create a new context for class declarations
             transformClass com ctx (Some entRange) (Some ent) baseClass entDecls
             |> declareMember entRange ent.Name (Some privateName) ent.IsPublic false modIdent
-        let classDecl =
-            declareInterfaces com ctx ent isClass
-            |> fun ifcDecl -> (U2.Case1 ifcDecl)::classDecl
         // Check if there's a static constructor
         entDecls |> Seq.exists (function
             | Fable.MemberDeclaration(m,_,_,_,_) ->
@@ -905,12 +888,12 @@ module Util =
                 match ent.Kind with
                 | Fable.Interface ->
                     (declareInterfaceEntity com ent)@acc
-                | Fable.Class baseClass ->
+                | Fable.Class(baseClass, _) ->
                     let baseClass = Option.map snd baseClass
                     declareClass com ctx declareMember modIdent
                         ent privateName entDecls entRange baseClass true
                     |> List.append <| acc
-                | Fable.Union | Fable.Record _ | Fable.Exception _ ->                
+                | Fable.Union _ | Fable.Record _ | Fable.Exception _ ->                
                     declareClass com ctx declareMember modIdent
                         ent privateName entDecls entRange None false
                     |> List.append <| acc

--- a/src/fable/Fable.Compiler/Fable2Babel.fs
+++ b/src/fable/Fable.Compiler/Fable2Babel.fs
@@ -64,7 +64,7 @@ module Util =
             | expr -> com.TransformExpr ctx expr |> U2.Case1)
         
     let ident (id: Fable.Ident) =
-        Babel.Identifier id.name
+        Babel.Identifier id.Name
 
     let identFromName name =
         let name = Naming.sanitizeIdent (fun _ -> false) name
@@ -292,7 +292,7 @@ module Util =
                     match arg with
                     | :? Babel.Identifier as id ->
                         Babel.Identifier(id.name,
-                            Babel.TypeAnnotation(typeAnnotation com ctx args.[i].typ))
+                            Babel.TypeAnnotation(typeAnnotation com ctx args.[i].Type))
                         :> Babel.Pattern
                     | arg -> arg),
                 Babel.TypeAnnotation(typeAnnotation com ctx body.Type) |> Some,
@@ -320,7 +320,7 @@ module Util =
         | Fable.This -> upcast Babel.ThisExpression ()
         | Fable.Super -> upcast Babel.Super ()
         | Fable.Null -> upcast Babel.NullLiteral ()
-        | Fable.IdentValue {name=name} -> upcast Babel.Identifier (name)
+        | Fable.IdentValue i -> upcast Babel.Identifier (i.Name)
         | Fable.NumberConst (x,_) -> upcast Babel.NumericLiteral x
         | Fable.StringConst x -> upcast Babel.StringLiteral (x)
         | Fable.BoolConst x -> upcast Babel.BooleanLiteral (x)
@@ -496,7 +496,7 @@ module Util =
             com.TransformExprAndResolve ctx ret value
 
         | Fable.VarDeclaration (var, Fable.Value(Fable.ImportRef(Naming.placeholder, path)), isMutable) ->
-            let value = com.GetImportExpr ctx None var.name path
+            let value = com.GetImportExpr ctx None var.Name path
             varDeclaration expr.Range (ident var) isMutable value :> Babel.Statement
 
         | Fable.VarDeclaration (var, TransformExpr com ctx value, isMutable) ->

--- a/src/fable/Fable.Compiler/Replacements.fs
+++ b/src/fable/Fable.Compiler/Replacements.fs
@@ -119,11 +119,11 @@ module Util =
     let toString com (i: Fable.ApplyInfo) (arg: Fable.Expr) =
         match arg.Type with
         | Fable.String -> arg
-        | Fable.Unit | Fable.Boolean | Fable.Regex | Fable.Number _
+        | Fable.Unit | Fable.Boolean | Fable.Number _
         | Fable.Array _ | Fable.Tuple _ | Fable.Function _ | Fable.Enum _ ->
             GlobalCall ("String", None, false, [arg])
             |> makeCall com i.range i.returnType
-        | _ ->
+        | Fable.Any | Fable.GenericParam _ | Fable.DeclaredType _ | Fable.Option _ -> 
             CoreLibCall ("Util", Some "toString", false, [arg])
             |> makeCall com i.range i.returnType
 
@@ -249,7 +249,7 @@ module Util =
             if equal then expr
             else makeUnOp i.range i.returnType [expr] UnaryNot
         match args.Head.Type with
-        | Fable.Any | Fable.Unit | Fable.Boolean | Fable.String | Fable.Regex
+        | Fable.Any | Fable.Unit | Fable.Boolean | Fable.String
         | Fable.Number _ | Fable.Function _ | Fable.Enum _ ->
             Fable.Apply(op equal, args, Fable.ApplyMeth, i.returnType, i.range) |> Some
         | EntFullName "System.DateTime" ->
@@ -257,15 +257,14 @@ module Util =
             |> makeCall com i.range i.returnType |> is equal |> Some
         | Fable.DeclaredType(ent, _)
             when (ent.HasInterface "System.IEquatable"
-                    && ent.FullName <> "System.TimeSpan"
-                    && ent.FullName <> "Microsoft.FSharp.Core.FSharpOption")
+                    && ent.FullName <> "System.TimeSpan")
                 || ent.FullName = "Microsoft.FSharp.Collections.FSharpList"
                 || ent.FullName = "Microsoft.FSharp.Collections.FSharpMap"
                 || ent.FullName = "Microsoft.FSharp.Collections.FSharpSet" ->
             InstanceCall(args.Head, "Equals", args.Tail)
             |> makeCall com i.range i.returnType |> is equal |> Some
         | Fable.Array _ | Fable.Tuple _
-        | Fable.DeclaredType _ | Fable.GenericParam _ ->
+        | Fable.DeclaredType _ | Fable.GenericParam _ | Fable.Option _ ->
             CoreLibCall("Util", Some "equals", false, args)
             |> makeCall com i.range i.returnType |> is equal |> Some
 
@@ -277,12 +276,11 @@ module Util =
             | None -> comparison
             | Some op -> makeEqOp r [comparison; makeConst 0] op
         match args.Head.Type with
-        | Fable.Any | Fable.Unit | Fable.Boolean | Fable.String | Fable.Regex
+        | Fable.Any | Fable.Unit | Fable.Boolean | Fable.String
         | Fable.Number _ | Fable.Function _ | Fable.Enum _ when Option.isSome op ->
             makeEqOp r args op.Value
         | Fable.DeclaredType(ent, _)
             when ent.HasInterface "System.IComparable"
-                && ent.FullName <> "Microsoft.FSharp.Core.FSharpOption"
                 && ent.FullName <> "System.TimeSpan"
                 && ent.FullName <> "System.DateTime" ->
             InstanceCall(args.Head, "CompareTo", args.Tail)
@@ -294,8 +292,7 @@ module Util =
     let makeComparer com (typArg: Fable.Type option) =
         match typArg with
         | None
-        | Some(EntFullName "Microsoft.FSharp.Core.FSharpOption")
-        | Some(Fable.Array _ | Fable.Tuple _) ->
+        | Some(Fable.Option _) | Some(Fable.Array _ | Fable.Tuple _) ->
             [makeCoreRef com "Util" (Some "compare")]
         | Some(Fable.DeclaredType(ent, _))
             when ent.HasInterface "System.IComparable"
@@ -388,14 +385,9 @@ module private AstPass =
             CoreLibCall("Async", Some meth, false, deleg com i i.args)
             |> makeCall com i.range i.returnType |> Some
         | "toJson" | "ofJson" | "toPlainJsObj" ->
-            let args =
-                match i.methodName, i.methodTypeArgs with
-                | "ofJson", [Fable.DeclaredType(ent,_) as t] when Option.isSome ent.File ->
-                    [i.args.Head; makeTypeRef com None t]
-                | _ -> i.args
             let modName =
                 if i.methodName = "toPlainJsObj" then "Util" else "Serialize"
-            CoreLibCall(modName, Some i.methodName, false, args)
+            CoreLibCall(modName, Some i.methodName, false, i.args)
             |> makeCall com i.range i.returnType |> Some
         | _ -> None
 
@@ -534,7 +526,7 @@ module private AstPass =
             Fable.Throw (args.Head, typ, r) |> Some
         // Type ref
         | "typeOf" ->
-            makeTypeRef com info.range info.methodTypeArgs.Head |> Some
+            makeTypeRef com info.range true info.methodTypeArgs.Head |> Some
         // Concatenates two lists
         | "op_Append" ->
           CoreLibCall("List", Some "append", false, args)
@@ -739,7 +731,7 @@ module private AstPass =
         | "typeTestGeneric", (None, [expr]) ->
             makeTypeTest com i.range i.methodTypeArgs.Head expr |> Some
         | "createInstance", (None, _) ->
-            let typRef, args = makeTypeRef com i.range i.methodTypeArgs.Head, []
+            let typRef, args = makeTypeRef com i.range false i.methodTypeArgs.Head, []
             Fable.Apply (typRef, args, Fable.ApplyCons, i.returnType, i.range) |> Some
         | _ -> None
 
@@ -857,7 +849,7 @@ module private AstPass =
         match i.methodName with
         | ".ctor" ->
             match i.calleeTypeArgs.Head with
-            | DeclaredKind(Fable.Record _) | DeclaredKind(Fable.Union) ->
+            | DeclaredKind(Fable.Record _) | DeclaredKind(Fable.Union _) ->
                 "Structural equality is not supported for Dictionary keys, please use F# Map"
                 |> addWarning com i
             | _ -> ()
@@ -895,7 +887,7 @@ module private AstPass =
         match i.methodName with
         | ".ctor" ->
             match i.calleeTypeArgs.Head with
-            | DeclaredKind(Fable.Record _) | DeclaredKind(Fable.Union) ->
+            | DeclaredKind(Fable.Record _) | DeclaredKind(Fable.Union _) ->
                 "Structural equality is not supported for HashSet, please use F# Set"
                 |> addWarning com i
             | _ -> ()
@@ -1340,24 +1332,24 @@ module private AstPass =
         | _ -> None
 
     let types com (info: Fable.ApplyInfo) =
-        let makeString = Fable.StringConst >> Fable.Value >> Some
+        let str x = Fable.Value(Fable.StringConst x)
         match info.callee with
         | Some(Fable.Value(Fable.TypeRef t)) ->
             match info.methodName with
-            | "namespace" -> makeString t.Namespace
-            | "fullName" -> makeString t.FullName
-            | "name" -> makeString t.Name
+            | "namespace" -> str t.Namespace |> Some
+            | "fullName" -> str t.FullName |> Some
+            | "name" -> str t.Name |> Some
             | _ -> None
         | _ ->
             match info.methodName with
-            | "namespace" -> Some "getTypeNamespace"
-            | "fullName" -> Some "getTypeFullName"
-            | "name" -> Some "getTypeName"
+            | "fullName" -> Some [info.callee.Value]
+            | "name" -> Some [info.callee.Value; str "name"]
+            | "namespace" -> Some [info.callee.Value; str "namespace"]
             | _ -> None
-            |> Option.map (fun meth ->
-                CoreLibCall("Util", Some meth, false, [info.callee.Value])
+            |> Option.map (fun args ->
+                CoreLibCall("Reflection", Some "getTypeFullName", false, args)
                 |> makeCall com info.range info.returnType)
-
+        
     let unchecked com (info: Fable.ApplyInfo) =
         match info.methodName with
         | "defaultOf" ->
@@ -1482,7 +1474,7 @@ module private AstPass =
         | "Microsoft.FSharp.Core.Operators"
         | "Microsoft.FSharp.Core.ExtraTopLevelOperators" -> operators com info
         | "Microsoft.FSharp.Core.FSharpRef" -> references com info
-        | "System.Activator" -> activator com info
+        | "System.Activator" -> activator com info        
         | "Microsoft.FSharp.Core.LanguagePrimitives" -> languagePrimitives com info
         | "Microsoft.FSharp.Core.LanguagePrimitives.IntrinsicFunctions"
         | "Microsoft.FSharp.Core.Operators.OperatorIntrinsics" -> intrinsicFunctions com info
@@ -1601,11 +1593,20 @@ let tryReplace (com: ICompiler) (info: Fable.ApplyInfo) =
     | ex -> failwithf "Cannot replace %s.%s: %s"
                 info.ownerFullName info.methodName ex.Message
 
-let coreLibMappedTypes =
-    Map [
-        fsharp + "Control.FSharpAsync" => "Async"
-        fsharp + "Collections.FSharpSet" => "Set"
-        fsharp + "Collections.FSharpMap" => "Map"
-        fsharp + "Collections.FSharpList" => "List"
-        fsharp + "Core.FSharpChoice" => "Choice"
-    ]
+let tryReplaceEntity (com: ICompiler) (ent: Fable.Entity) =
+    let coreLibType name =
+        Fable.ImportRef(name, com.Options.coreLib)
+        |> Fable.Value |> Some
+    match ent.FullName with
+    | "System.TimeSpan" -> Fable.StringConst "number" |> Fable.Value |> Some
+    | "System.DateTime" -> makeIdentExpr "Date" |> Some
+    | "System.Collections.Generic.Dictionary" -> makeIdentExpr "Map" |> Some
+    | "System.Collections.Generic.HashSet" -> makeIdentExpr "Set" |> Some
+    | "System.Text.RegularExpressions.Regex" -> makeIdentExpr "RegExp" |> Some
+    | "Microsoft.FSharp.Control.FSharpAsync" -> coreLibType "Async"
+    | "Microsoft.FSharp.Collections.FSharpSet" -> coreLibType "Set"
+    | "Microsoft.FSharp.Collections.FSharpMap" -> coreLibType "Map"
+    | "Microsoft.FSharp.Collections.FSharpList" -> coreLibType "List"
+    | "Microsoft.FSharp.Core.FSharpChoice" -> coreLibType "Choice"
+    | "System.Timers.Timer" -> coreLibType "Timer"
+    | _ -> None

--- a/src/fable/Fable.Core/AST/AST.Fable.Util.fs
+++ b/src/fable/Fable.Core/AST/AST.Fable.Util.fs
@@ -23,8 +23,8 @@ let getSymbol (com: ICompiler) name =
     Apply (import, [Value(StringConst name)], ApplyGet, Any, None)
 
 let makeLoop range loopKind = Loop (loopKind, range)
-let makeIdent name: Ident = {name=name; typ=Any}
-let makeTypedIdent name typ: Ident = {name=name; typ=typ}
+let makeIdent name = Ident(name)
+let makeTypedIdent name typ = Ident(name, typ)
 let makeIdentExpr name = makeIdent name |> IdentValue |> Value
 let makeLambdaExpr args body = Value(Lambda(args, body))
 
@@ -210,7 +210,7 @@ let rec makeTypeTest com range (typ: Type) expr =
         |> attachRange range |> failwith
 
 let makeUnionCons () =
-    let args = [{name="caseName"; typ=String}; {name="fields"; typ=Array Any}]
+    let args = [Ident("caseName", String); Ident("fields", Array Any)]
     let argTypes = List.map Ident.getType args
     let emit = Emit "this.Case=caseName; this.Fields = fields;" |> Value
     let body = Apply (emit, [], ApplyMeth, Unit, None)
@@ -221,8 +221,8 @@ let makeRecordCons (props: (string*Type) list) =
         ([], props) ||> List.fold (fun args (name, typ) ->
             let name =
                 Naming.lowerFirst name |> Naming.sanitizeIdent (fun x ->
-                    List.exists (fun (y: Ident) -> y.name = x) args)
-            {name=name; typ=typ}::args)
+                    List.exists (fun (y: Ident) -> y.Name = x) args)
+            (Ident(name, typ))::args)
         |> List.rev
     let body =
         Seq.zip args props
@@ -231,17 +231,17 @@ let makeRecordCons (props: (string*Type) list) =
                 if Naming.identForbiddenCharsRegex.IsMatch propName
                 then "['" + (propName.Replace("'", "\\'")) + "']"
                 else "." + propName
-            "this" + propName + "=" + arg.name)
+            "this" + propName + "=" + arg.Name)
         |> String.concat ";"
         |> fun body -> makeEmit None Unit [] body
     MemberDeclaration(Member(".ctor", Constructor, List.map Ident.getType args, Any), None, args, body, SourceLocation.Empty)
 
 let private makeMeth com argType returnType name coreMeth =
-    let arg = {name="other"; typ=argType}
+    let arg = Ident("other", argType)
     let body =
         CoreLibCall("Util", Some coreMeth, false, [Value This; Value(IdentValue arg)])
         |> makeCall com None returnType
-    MemberDeclaration(Member(name, Method, [arg.typ], returnType), None, [arg], body, SourceLocation.Empty)
+    MemberDeclaration(Member(name, Method, [arg.Type], returnType), None, [arg], body, SourceLocation.Empty)
 
 let makeUnionEqualMethod com argType = makeMeth com argType Boolean "Equals" "equalsUnions"
 let makeRecordEqualMethod com argType = makeMeth com argType Boolean "Equals" "equalsRecords"
@@ -297,8 +297,7 @@ let makeDelegate (com: ICompiler) arity (expr: Expr) =
         match arity with
         | Some arity when arity > 1 ->
             let lambdaArgs =
-                [for i=1 to arity do
-                    yield {name=com.GetUniqueVar(); typ=Any}]
+                [for i=1 to arity do yield Ident(com.GetUniqueVar(), Any)]
             let lambdaBody =
                 (expr, lambdaArgs)
                 ||> List.fold (fun callee arg ->

--- a/src/fable/Fable.Core/AST/AST.Fable.Util.fs
+++ b/src/fable/Fable.Core/AST/AST.Fable.Util.fs
@@ -18,6 +18,10 @@ type CallKind =
     | CoreLibCall of modName: string * meth: string option * isCons: bool * args: Expr list
     | GlobalCall of modName: string * meth: string option * isCons: bool * args: Expr list
 
+let getSymbol (com: ICompiler) name =
+    let import = Value(ImportRef("Symbol", com.Options.coreLib))
+    Apply (import, [Value(StringConst name)], ApplyGet, Any, None)
+
 let makeLoop range loopKind = Loop (loopKind, range)
 let makeIdent name: Ident = {name=name; typ=Any}
 let makeTypedIdent name typ: Ident = {name=name; typ=typ}
@@ -97,22 +101,55 @@ let tryImported com name (decs: #seq<Decorator>) =
             | _ -> failwith "Import attributes must contain two string arguments"
         | _ -> None)
 
-let makeTypeRef com (range: SourceLocation option) typ =
+let makeJsObject range (props: (string * Expr) list) =
+    let decls = props |> List.map (fun (name, body) ->
+        MemberDeclaration(Member(name, Field, [], body.Type), None, [], body, range))
+    ObjExpr(decls, [], None, Some range)
+
+let rec makeTypeRef (com: ICompiler) (range: SourceLocation option) generics typ =
+    let str s = Value(StringConst s)
+    let makeInfo (kind: TypeKind) arg =
+        let kind = Value(NumberConst(U2.Case1(int kind), Int32))
+        match arg with
+        | None -> [kind]
+        | Some arg -> [kind; arg]
+        |> makeArray Any
+    let makeGenInfo (kind: TypeKind) genArgs =
+        match genArgs with
+        | [genArg] -> makeTypeRef com range generics genArg
+        | genArgs ->
+            let genArgs = List.map (makeTypeRef com range generics) genArgs
+            ArrayConst(ArrayValues genArgs, Any) |> Value
+        |> Some |> makeInfo kind
     match typ with
-    | DeclaredType(ent, _) ->
+    | Boolean -> str "boolean"
+    | String -> str "string"
+    | Number _ | Enum _ -> str "number"
+    | Function _ -> str "function"
+    | Any -> makeInfo TypeKind.Any None
+    | Unit -> makeInfo TypeKind.Unit None
+    | Array genArg -> makeGenInfo TypeKind.Array [genArg]
+    | Option genArg -> makeGenInfo TypeKind.Option [genArg]
+    | Tuple genArgs -> makeGenInfo TypeKind.Tuple genArgs
+    | GenericParam name ->
+        str name |> Some |> makeInfo TypeKind.GenericParam
+    | DeclaredType(ent, _) when ent.Kind = Interface ->
+        str ent.FullName |> Some |> makeInfo TypeKind.Interface
+    | DeclaredType(ent, genArgs) ->
+        // Imported types come from JS so they don't need to be made generic
         match tryImported com ent.Name ent.Decorators with
         | Some expr -> expr
-        | None -> Value (TypeRef ent)
-    | GenericParam name ->
-        "Cannot reference generic parameter " + name
-        + ". Try to make function inline."
-        |> attachRange range |> failwith
-    | _ ->
-        // TODO: Reference JS objects? Object, String, Number...
-        sprintf "Cannot reference type %s" typ.FullName
-        |> attachRange range |> failwith
+        | None when not generics || List.isEmpty genArgs ->
+            Value (TypeRef ent)
+        | None ->
+            let genArgs =
+                List.map (makeTypeRef com range generics) genArgs
+                |> List.zip ent.GenericParameters
+                |> makeJsObject SourceLocation.Empty
+            CoreLibCall("Util", Some "makeGeneric", false, [Value (TypeRef ent); genArgs])
+            |> makeCall com range Any
 
-let makeCall com range typ kind =
+and makeCall com range typ kind =
     let getCallee meth args returnType owner =
         match meth with
         | None -> owner
@@ -144,7 +181,7 @@ let makeCall com range typ kind =
 let makeEmit r t args macro =
     Apply(Value(Emit macro), args, ApplyMeth, t, r) 
 
-let makeTypeTest com range (typ: Type) expr =
+let rec makeTypeTest com range (typ: Type) expr =
     let jsTypeof (primitiveType: string) expr =
         let typof = makeUnOp None String [expr] UnaryTypeof
         makeBinOp range Boolean [typof; makeConst primitiveType] BinaryEqualStrict
@@ -152,26 +189,25 @@ let makeTypeTest com range (typ: Type) expr =
         makeBinOp None Boolean [expr; typeRef] BinaryInstanceOf
     match typ with
     | String _ -> jsTypeof "string" expr
-    | Number _ -> jsTypeof "number" expr
+    | Number _ | Enum _ -> jsTypeof "number" expr
     | Boolean -> jsTypeof "boolean" expr
     | Unit -> makeBinOp range Boolean [expr; Value Null] BinaryEqual
     | Function _ -> jsTypeof "function" expr
-    | Regex ->
-        let typeRef = makeIdent "RegExp" |> IdentValue |> Value
-        jsInstanceOf typeRef expr
-    | Array _ ->
+    | Array _ | Tuple _ ->
         "Array.isArray($0) || ArrayBuffer.isView($0)"
         |> makeEmit range Boolean [expr] 
     | Any -> makeConst true
+    | Option typ -> makeTypeTest com range typ expr
     | DeclaredType(typEnt, _) ->
         match typEnt.Kind with
         | Interface ->
             CoreLibCall ("Util", Some "hasInterface", false, [expr; makeConst typEnt.FullName])
             |> makeCall com range Boolean
         | _ ->
-            makeBinOp range Boolean [expr; makeTypeRef com range typ] BinaryInstanceOf
-    | _ -> "Unsupported type test: " + typ.FullName
-            |> attachRange range |> failwith
+            makeBinOp range Boolean [expr; makeTypeRef com range false typ] BinaryInstanceOf
+    | GenericParam name ->
+        "Cannot type test generic parameter " + name
+        |> attachRange range |> failwith
 
 let makeUnionCons () =
     let args = [{name="caseName"; typ=String}; {name="fields"; typ=Array Any}]
@@ -211,6 +247,43 @@ let makeUnionEqualMethod com argType = makeMeth com argType Boolean "Equals" "eq
 let makeRecordEqualMethod com argType = makeMeth com argType Boolean "Equals" "equalsRecords"
 let makeUnionCompareMethod com argType = makeMeth com argType (Number Int32) "CompareTo" "compareUnions"
 let makeRecordCompareMethod com argType = makeMeth com argType (Number Int32) "CompareTo" "compareRecords"
+
+let makeTypeNameMeth com typeFullName =
+    let typeFullName = Value(StringConst typeFullName)
+    MemberDeclaration(Member("typeName", Method, [], String, isSymbol=true),
+                        None, [], typeFullName, SourceLocation.Empty)
+
+let makeInterfacesMethod com extend interfaces =
+    let interfaces: Expr =
+        let interfaces = List.map (StringConst >> Value) interfaces
+        ArrayConst(ArrayValues interfaces, String) |> Value
+    let interfaces =
+        if not extend then interfaces else
+        CoreLibCall("Util", Some "extendInfo", false, [interfaces; Value Super; makeConst "interfaces"])
+        |> makeCall com None Any
+    MemberDeclaration(Member("interfaces", Method, [], Array String, isSymbol=true),
+                        None, [], interfaces, SourceLocation.Empty)
+
+let makePropertiesMethod com extend properties =
+    let body =
+        properties |> List.map (fun (name, typ) ->
+            MemberDeclaration(Member(name, Field, [], Any), None, [], makeTypeRef com None true typ, SourceLocation.Empty))
+        |> fun decls -> ObjExpr(decls, [], None, None)
+    let body =
+        if not extend then body else
+        CoreLibCall("Util", Some "extendInfo", false, [body; Value Super; makeConst "properties"])
+        |> makeCall com None Any
+    MemberDeclaration(Member("properties", Method, [], Any, isSymbol=true),
+                        None, [], body, SourceLocation.Empty)
+
+let makeCasesMethod com (cases: Map<string, Type list>) =
+    let body =
+        cases |> Seq.map (fun kv ->
+            let typs = kv.Value |> List.map (makeTypeRef com None true)
+            let typs = Fable.ArrayConst(Fable.ArrayValues typs, Any) |> Fable.Value
+            MemberDeclaration(Member(kv.Key, Field, [], Any), None, [], typs, SourceLocation.Empty))
+        |> fun decls -> ObjExpr(Seq.toList decls, [], None, None)
+    MemberDeclaration(Member("cases", Method, [], Any, isSymbol=true), None, [], body, SourceLocation.Empty)
 
 let makeDelegate (com: ICompiler) arity (expr: Expr) =
     let rec flattenLambda (arity: int option) accArgs = function
@@ -255,11 +328,6 @@ let makeApply range typ callee exprs =
         let typ' = if i = lasti then typ else makeUnknownFnType (i+1)
         i + 1, Apply (callee, [expr], ApplyMeth, typ', range))
     |> snd    
-
-let makeJsObject range (props: (string * Expr) list) =
-    let decls = props |> List.map (fun (name, body) ->
-        MemberDeclaration(Member(name, Field, [], body.Type), None, [], body, range))
-    ObjExpr(decls, [], None, Some range)
 
 let getTypedArrayName (com: ICompiler) numberKind =
     match numberKind with

--- a/src/fable/Fable.Core/AST/AST.Fable.fs
+++ b/src/fable/Fable.Core/AST/AST.Fable.fs
@@ -192,9 +192,13 @@ and ArrayConsKind =
     | ArrayValues of Expr list
     | ArrayAlloc of Expr
 
-and Ident =
-    { name: string; typ: Type }
-    static member getType (i: Ident) = i.typ
+and Ident(name: string, ?typ: Type) =
+    let mutable consumed = false
+    member x.Name = name
+    member x.Type = defaultArg typ Any
+    member x.IsConsumed = consumed
+    member x.Consume() = consumed <- true
+    static member getType (i: Ident) = i.Type
 
 and ValueKind =
     | Null
@@ -219,7 +223,7 @@ and ValueKind =
         match x with
         | Null -> Any
         | Spread x -> x.Type
-        | IdentValue {typ=typ} -> typ
+        | IdentValue i -> i.Type
         | This | Super | ImportRef _ | TypeRef _ | Emit _ -> Any
         | NumberConst (_,kind) -> Number kind
         | StringConst _ -> String

--- a/src/fable/Fable.Core/AST/AST.Fable.fs
+++ b/src/fable/Fable.Core/AST/AST.Fable.fs
@@ -15,8 +15,8 @@ type Type =
     | Unit
     | Boolean
     | String
-    | Regex
     | Number of NumberKind
+    | Option of genericArg: Type
     | Array of genericArg: Type
     | Tuple of genericArgs: Type list
     | Function of argTypes: Type list * returnType: Type
@@ -40,17 +40,33 @@ type Type =
         | DeclaredType(_, genArgs) -> genArgs
         | _ -> []
 
+and TypeKind =
+    // | Boolean | String | Number _ | Enum _
+    // | Function _ | DeclaredType _
+    | Other = 0
+    | Any = 1
+    | Unit = 2
+    | Option = 3
+    | Array = 4
+    | Tuple = 5
+    | GenericParam = 6
+    | Interface = 7
+
 (** ##Entities *)
 and EntityKind =
     | Module
-    | Union
+    | Union of cases: Map<string, Type list>
     | Record of fields: (string*Type) list
     | Exception of fields: (string*Type) list
-    | Class of baseClass: (string*Expr) option
+    | Class of baseClass: (string*Expr) option * properties: (string*Type) list
     | Interface
 
 and Entity(kind: Lazy<_>, file, fullName, members: Lazy<Member list>,
-           genParams, interfaces, decorators, isPublic) =
+           ?genParams, ?interfaces, ?decorators, ?isPublic) =
+    let genParams = defaultArg genParams []
+    let decorators = defaultArg decorators []
+    let interfaces = defaultArg interfaces []
+    let isPublic = defaultArg isPublic true
     member x.Kind: EntityKind = kind.Value
     member x.File: string option = file
     member x.FullName: string = fullName
@@ -105,7 +121,7 @@ and MemberKind =
     | Field
 
 and Member(name, kind, argTypes, returnType, ?originalType, ?genParams, ?decorators,
-           ?isPublic, ?isMutable, ?isStatic, ?hasRestParams, ?overloadIndex) =
+           ?isPublic, ?isMutable, ?isStatic, ?isSymbol, ?hasRestParams, ?overloadIndex) =
     member x.Name: string = name
     member x.Kind: MemberKind = kind
     member x.ArgumentTypes: Type list = argTypes
@@ -116,6 +132,7 @@ and Member(name, kind, argTypes, returnType, ?originalType, ?genParams, ?decorat
     member x.IsPublic: bool = defaultArg isPublic true
     member x.IsMutable: bool = defaultArg isMutable false
     member x.IsStatic: bool = defaultArg isStatic false
+    member x.IsSymbol: bool = defaultArg isSymbol false
     member x.HasRestParams: bool = defaultArg hasRestParams false
     member x.OverloadIndex: int option = overloadIndex
     member x.OverloadName: string =
@@ -206,7 +223,9 @@ and ValueKind =
         | This | Super | ImportRef _ | TypeRef _ | Emit _ -> Any
         | NumberConst (_,kind) -> Number kind
         | StringConst _ -> String
-        | RegexConst _ -> Regex
+        | RegexConst _ ->
+            let fullName = "System.Text.RegularExpressions.Regex"
+            DeclaredType(Entity(lazy Class(None, []), None, fullName, lazy []), [])        
         | BoolConst _ -> Boolean
         | ArrayConst (_, typ) -> Array typ
         | TupleConst exprs -> List.map Expr.getType exprs |> Tuple

--- a/src/fable/Fable.Core/AssemblyInfo.fs
+++ b/src/fable/Fable.Core/AssemblyInfo.fs
@@ -2,9 +2,9 @@
 namespace System
 open System.Reflection
 
-[<assembly: AssemblyVersionAttribute("0.6.8")>]
+[<assembly: AssemblyVersionAttribute("0.7.0")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "0.6.8"
-    let [<Literal>] InformationalVersion = "0.6.8"
+    let [<Literal>] Version = "0.7.0"
+    let [<Literal>] InformationalVersion = "0.7.0"

--- a/src/fable/Fable.Core/Fable.Core.fs
+++ b/src/fable/Fable.Core/Fable.Core.fs
@@ -30,13 +30,21 @@ type EmitAttribute private () =
 
 /// Compile union case lists as JS object literals.
 /// More info: http://fable-compiler.github.io/docs/interacting.html#KeyValueList-attribute
+[<AttributeUsage(AttributeTargets.Class)>]
 type KeyValueListAttribute() =
     inherit Attribute()
 
 /// Compile union types as string literals.
 /// More info: http://fable-compiler.github.io/docs/interacting.html#StringEnum-attribute
+[<AttributeUsage(AttributeTargets.Class)>]
 type StringEnumAttribute() =
-    inherit Attribute()    
+    inherit Attribute()
+
+/// When set on a optional System.Type parameter, Fable will pass the type
+/// of the generic parameter of that name if omitted by the user. 
+[<AttributeUsage(AttributeTargets.Parameter)>]
+type GenericParamAttribute(name: string) =
+    inherit Attribute()
 
 /// Erased union type to represent one of two possible values.
 /// More info: http://fable-compiler.github.io/docs/interacting.html#Erase-attribute
@@ -60,6 +68,13 @@ type [<Erase>] U6<'a, 'b, 'c, 'd, 'e, 'f> = Case1 of 'a | Case2 of 'b | Case3 of
 
 /// DO NOT USE: Internal type for Fable dynamic operations
 type Applicable = obj->obj
+
+type Serialize =
+    /// Serialize F# objects to JSON
+    static member toJson(o: 'T): string = jsNative
+
+    /// Instantiate F# objects from JSON
+    static member ofJson<'T> (json: string, [<GenericParam("T")>]?t: Type): 'T = jsNative
 
 module JsInterop =
     /// Dynamically access a property of an arbitrary object.
@@ -104,13 +119,6 @@ module JsInterop =
     /// F#: let myLib = importAll<obj> "myLib"
     /// JS: import * as myLib from "myLib"
     let importAll<'T> (path: string):'T = jsNative
-
-    /// Serialize F# objects to JSON with type info
-    let toJson (o: 'T): string = jsNative
-
-    /// Instantiate F# objects from JSON with type info
-    /// (compatible with Newtonsoft.Json)
-    let ofJson<'T> (json: string): 'T = jsNative
 
     /// Convert F# unions, records and classes into plain JS objects
     let toPlainJsObj (o: 'T): obj = jsNative

--- a/src/fable/Fable.Core/Fable.Core.fs
+++ b/src/fable/Fable.Core/Fable.Core.fs
@@ -46,6 +46,12 @@ type StringEnumAttribute() =
 type GenericParamAttribute(name: string) =
     inherit Attribute()
 
+/// [EXPERIMENTAL] Record updates will be compiled as mutations: { x with a = 5 }
+/// Fable will fail if the original value is used after being updated or passed to a function.
+/// More info: http://fable-compiler.github.io/docs/interacting.html#Uniqueness-attribute
+type UniquenessAttribute() =
+    inherit Attribute()      
+
 /// Erased union type to represent one of two possible values.
 /// More info: http://fable-compiler.github.io/docs/interacting.html#Erase-attribute
 type [<Erase>] U2<'a, 'b> = Case1 of 'a | Case2 of 'b

--- a/src/fable/Fable.Core/Fable.Core.fs
+++ b/src/fable/Fable.Core/Fable.Core.fs
@@ -7,35 +7,35 @@ module Exceptions =
     let jsNative<'T> : 'T = failwith "JS only"
 
 /// Used for erased union types and to ignore modules in JS compilation.
-/// More info: http://fable-compiler.github.io/docs/interacting.html#Erase-attribute
+/// More info: http://fable.io/docs/interacting.html#Erase-attribute
 type EraseAttribute() =
     inherit Attribute()
 
 /// The module, type, function... is globally accessible in JS.
-/// More info: http://fable-compiler.github.io/docs/interacting.html#Import-attribute
+/// More info: http://fable.io/docs/interacting.html#Import-attribute
 type GlobalAttribute() =
     inherit Attribute()
 
 /// References to the module, type, function... will be replaced by import statements.
-/// More info: http://fable-compiler.github.io/docs/interacting.html#Import-attribute
+/// More info: http://fable.io/docs/interacting.html#Import-attribute
 type ImportAttribute(get: string, from: string) =
     inherit Attribute()
 
 /// Function calls will be replaced by inlined JS code.
-/// More info: http://fable-compiler.github.io/docs/interacting.html#Import-attribute
+/// More info: http://fable.io/docs/interacting.html#Import-attribute
 type EmitAttribute private () =
     inherit Attribute()
     new (macro: string) = EmitAttribute()
     new (emitterType: Type, methodName: string) = EmitAttribute()
 
 /// Compile union case lists as JS object literals.
-/// More info: http://fable-compiler.github.io/docs/interacting.html#KeyValueList-attribute
+/// More info: http://fable.io/docs/interacting.html#KeyValueList-attribute
 [<AttributeUsage(AttributeTargets.Class)>]
 type KeyValueListAttribute() =
     inherit Attribute()
 
 /// Compile union types as string literals.
-/// More info: http://fable-compiler.github.io/docs/interacting.html#StringEnum-attribute
+/// More info: http://fable.io/docs/interacting.html#StringEnum-attribute
 [<AttributeUsage(AttributeTargets.Class)>]
 type StringEnumAttribute() =
     inherit Attribute()
@@ -48,28 +48,29 @@ type GenericParamAttribute(name: string) =
 
 /// [EXPERIMENTAL] Record updates will be compiled as mutations: { x with a = 5 }
 /// Fable will fail if the original value is used after being updated or passed to a function.
-/// More info: http://fable-compiler.github.io/docs/interacting.html#Uniqueness-attribute
-type UniquenessAttribute() =
+/// More info: http://fable.io/docs/interacting.html#MutatingUpdate-attribute
+[<AttributeUsage(AttributeTargets.Class)>]
+type MutatingUpdateAttribute() =
     inherit Attribute()      
 
 /// Erased union type to represent one of two possible values.
-/// More info: http://fable-compiler.github.io/docs/interacting.html#Erase-attribute
+/// More info: http://fable.io/docs/interacting.html#Erase-attribute
 type [<Erase>] U2<'a, 'b> = Case1 of 'a | Case2 of 'b
 
 /// Erased union type to represent one of three possible values.
-/// More info: http://fable-compiler.github.io/docs/interacting.html#Erase-attribute
+/// More info: http://fable.io/docs/interacting.html#Erase-attribute
 type [<Erase>] U3<'a, 'b, 'c> = Case1 of 'a | Case2 of 'b | Case3 of 'c    
 
 /// Erased union type to represent one of four possible values.
-/// More info: http://fable-compiler.github.io/docs/interacting.html#Erase-attribute
+/// More info: http://fable.io/docs/interacting.html#Erase-attribute
 type [<Erase>] U4<'a, 'b, 'c, 'd> = Case1 of 'a | Case2 of 'b | Case3 of 'c | Case4 of 'd    
 
 /// Erased union type to represent one of five possible values.
-/// More info: http://fable-compiler.github.io/docs/interacting.html#Erase-attribute
+/// More info: http://fable.io/docs/interacting.html#Erase-attribute
 type [<Erase>] U5<'a, 'b, 'c, 'd, 'e> = Case1 of 'a | Case2 of 'b | Case3 of 'c | Case4 of 'd | Case5 of 'e    
 
 /// Erased union type to represent one of six possible values.
-/// More info: http://fable-compiler.github.io/docs/interacting.html#Erase-attribute
+/// More info: http://fable.io/docs/interacting.html#Erase-attribute
 type [<Erase>] U6<'a, 'b, 'c, 'd, 'e, 'f> = Case1 of 'a | Case2 of 'b | Case3 of 'c | Case4 of 'd | Case5 of 'e | Case6 of 'f    
 
 /// DO NOT USE: Internal type for Fable dynamic operations

--- a/src/fable/Fable.Core/npm/package.json
+++ b/src/fable/Fable.Core/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fable-core",
-  "version": "0.6.8",
+  "version": "0.7.0",
   "description": "Fable core lib & bindings for native JS objects, browser and node APIs",
   "main": "fable-core.js",
   "typings": "fable-core.d.ts",

--- a/src/tests/ComparisonTests.fs
+++ b/src/tests/ComparisonTests.fs
@@ -6,14 +6,28 @@ open Fable.Tests.Util
 open System.Collections.Generic
 
 [<Test>]
-let ``Array equality works``() =  
+let ``Typed array equality works``() =  
     let xs1 = [| 1; 2; 3 |]
     let xs2 = [| 1; 2; 3 |]
     let xs3 = [| 1; 2; 4 |]
+    let xs4 = [| 1; 2 |]
     equal true (xs1 = xs2)
     equal false (xs1 = xs3)
     equal true (xs1 <> xs3)
     equal false (xs1 <> xs2)
+    equal true (xs1 <> xs4)
+
+[<Test>]
+let ``Array equality works``() =  
+    let xs1 = [| "1"; "2"; "3" |]
+    let xs2 = [| "1"; "2"; "3" |]
+    let xs3 = [| "1"; "2"; "4" |]
+    let xs4 = [| "1"; "2" |]
+    equal true (xs1 = xs2)
+    equal false (xs1 = xs3)
+    equal true (xs1 <> xs3)
+    equal false (xs1 <> xs2)
+    equal true (xs1 <> xs4)
 
 [<Test>]
 let ``Tuple equality works``() =  
@@ -170,13 +184,31 @@ let ``Equality with objects implementing IEquatable works``() =
     Object.ReferenceEquals(c1, c2) |> equal false
 
 [<Test>]
-let ``Array comparison works``() =  
+let ``Typed array comparison works``() =  
     let xs1 = [| 1; 2; 3 |]
     let xs2 = [| 1; 2; 3 |]
     let xs3 = [| 1; 2; 4 |]
     let xs4 = [| 1; 2; 2 |]
     let xs5 = [| 1; 2 |]
     let xs6 = [| 1; 2; 3; 1 |]
+    equal 0 (compare xs1 xs2)
+    equal -1 (compare xs1 xs3)
+    equal true (xs1 < xs3)
+    equal 1 (compare xs1 xs4)
+    equal false (xs1 < xs4)
+    equal 1 (compare xs1 xs5)
+    equal true (xs1 > xs5)
+    equal -1 (compare xs1 xs6)
+    equal false (xs1 > xs6)
+
+[<Test>]
+let ``Array comparison works``() =  
+    let xs1 = [| "1"; "2"; "3" |]
+    let xs2 = [| "1"; "2"; "3" |]
+    let xs3 = [| "1"; "2"; "4" |]
+    let xs4 = [| "1"; "2"; "2" |]
+    let xs5 = [| "1"; "2" |]
+    let xs6 = [| "1"; "2"; "3"; "1" |]
     equal 0 (compare xs1 xs2)
     equal -1 (compare xs1 xs3)
     equal true (xs1 < xs3)

--- a/src/tests/DateTimeTests.fs
+++ b/src/tests/DateTimeTests.fs
@@ -40,8 +40,8 @@ let ``DateTime.ToString with format works``() =
 let ``DateTime can be JSON serialized forth and back``() =
     let utc = DateTime(2016, 8, 4, 17, 30, 0, DateTimeKind.Utc)
     #if FABLE_COMPILER
-    let json = Fable.Core.JsInterop.toJson utc
-    let utc = Fable.Core.JsInterop.ofJson<DateTime> json
+    let json = Fable.Core.Serialize.toJson utc
+    let utc = Fable.Core.Serialize.ofJson<DateTime> json
     #else
     let json = Newtonsoft.Json.JsonConvert.SerializeObject utc
     let utc = Newtonsoft.Json.JsonConvert.DeserializeObject<DateTime> json

--- a/src/tests/DictionaryTests.fs
+++ b/src/tests/DictionaryTests.fs
@@ -199,8 +199,8 @@ let ``Dictionaries can be JSON serialized forth and back``() =
     x.Add("a", { i=1; s="1" })
     x.Add("b", { i=2; s="2" })    
     #if FABLE_COMPILER
-    let json = Fable.Core.JsInterop.toJson x
-    let x2 = Fable.Core.JsInterop.ofJson<Dictionary<string, R>> json
+    let json = Fable.Core.Serialize.toJson x
+    let x2 = Fable.Core.Serialize.ofJson<Dictionary<string, R>> json
     #else
     let json = Newtonsoft.Json.JsonConvert.SerializeObject x
     let x2 = Newtonsoft.Json.JsonConvert.DeserializeObject<Dictionary<string, R>> json
@@ -208,17 +208,17 @@ let ``Dictionaries can be JSON serialized forth and back``() =
     (0, x2) ||> Seq.fold (fun acc kv -> acc + kv.Value.i)
     |> equal 3
 
-[<Test>]
-let ``Dictionaries serialized with Json.NET can be deserialized``() =
-    // let x = Dictionary<_,_>()
-    // x.Add("a", { i=1; s="1" })
-    // x.Add("b", { i=2; s="2" })    
-    // let json = JsonConvert.SerializeObject(x, JsonSerializerSettings(TypeNameHandling=TypeNameHandling.All))
-    let json = """{"$type":"System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[Fable.Tests.Maps+R, Fable.Tests]], FSharp.Core","a":{"$type":"Fable.Tests.Maps+R, Fable.Tests","i":1,"s":"1"},"b":{"$type":"Fable.Tests.Maps+R, Fable.Tests","i":2,"s":"2"}}"""
-    #if FABLE_COMPILER
-    let x2 = Fable.Core.JsInterop.ofJson<Dictionary<string, R>> json
-    #else
-    let x2 = Newtonsoft.Json.JsonConvert.DeserializeObject<Dictionary<string, R>> json
-    #endif
-    (0, x2) ||> Seq.fold (fun acc kv -> acc + kv.Value.i)
-    |> equal 3
+// [<Test>]
+// let ``Dictionaries serialized with Json.NET can be deserialized``() =
+//     // let x = Dictionary<_,_>()
+//     // x.Add("a", { i=1; s="1" })
+//     // x.Add("b", { i=2; s="2" })    
+//     // let json = JsonConvert.SerializeObject(x, JsonSerializerSettings(TypeNameHandling=TypeNameHandling.All))
+//     let json = """{"$type":"System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[Fable.Tests.Maps+R, Fable.Tests]], FSharp.Core","a":{"$type":"Fable.Tests.Maps+R, Fable.Tests","i":1,"s":"1"},"b":{"$type":"Fable.Tests.Maps+R, Fable.Tests","i":2,"s":"2"}}"""
+//     #if FABLE_COMPILER
+//     let x2 = Fable.Core.Serialize.ofJson<Dictionary<string, R>> json
+//     #else
+//     let x2 = Newtonsoft.Json.JsonConvert.DeserializeObject<Dictionary<string, R>> json
+//     #endif
+//     (0, x2) ||> Seq.fold (fun acc kv -> acc + kv.Value.i)
+//     |> equal 3

--- a/src/tests/Fable.Tests.fsproj
+++ b/src/tests/Fable.Tests.fsproj
@@ -58,6 +58,7 @@
     <Compile Include="DateTimeTests.fs" />
     <Compile Include="DictionaryTests.fs" />
     <Compile Include="EnumTests.fs" />
+    <Compile Include="JsonTests.fs" />
     <Compile Include="ListTests.fs" />
     <Compile Include="MapTests.fs" />
     <Compile Include="MiscTests.fs" />

--- a/src/tests/HashSetTests.fs
+++ b/src/tests/HashSetTests.fs
@@ -163,8 +163,8 @@ let ``HashSet can be JSON serialized forth and back``() =
     x.Add(1) |> ignore
     x.Add(2) |> ignore
     #if FABLE_COMPILER
-    let json = Fable.Core.JsInterop.toJson x
-    let x2 = Fable.Core.JsInterop.ofJson<HashSet<int>> json
+    let json = Fable.Core.Serialize.toJson x
+    let x2 = Fable.Core.Serialize.ofJson<HashSet<int>> json
     #else
     let json = Newtonsoft.Json.JsonConvert.SerializeObject x
     let x2 = Newtonsoft.Json.JsonConvert.DeserializeObject<HashSet<int>> json
@@ -172,18 +172,18 @@ let ``HashSet can be JSON serialized forth and back``() =
     x2.IsSubsetOf x |> equal true
     (0, x2) ||> Seq.fold (fun acc v -> acc + v) |> equal 3
 
-[<Test>]
-let ``HashSet serialized with Json.NET can be deserialized``() =
-    // let x = HashSet<_>()
-    // x.Add({ i=1; s="1" }) |> ignore
-    // x.Add({ i=2; s="2" }) |> ignore
-    // let json = JsonConvert.SerializeObject(x, JsonSerializerSettings(TypeNameHandling=TypeNameHandling.All))
-    let json = """{"$type":"System.Collections.Generic.HashSet`1[[Fable.Tests.HashSets+R, Fable.Tests]], FSharp.Core","$values":[{"$type":"Fable.Tests.HashSets+R, Fable.Tests","i":1,"s":"1"},{"$type":"Fable.Tests.HashSets+R, Fable.Tests","i":2,"s":"2"}]}"""
-    #if FABLE_COMPILER
-    let x2 = Fable.Core.JsInterop.ofJson<HashSet<R>> json
-    #else
-    let x2 = Newtonsoft.Json.JsonConvert.DeserializeObject<HashSet<R>> json
-    #endif
-    (0, x2) ||> Seq.fold (fun acc v -> acc + v.i) |> equal 3
+// [<Test>]
+// let ``HashSet serialized with Json.NET can be deserialized``() =
+//     // let x = HashSet<_>()
+//     // x.Add({ i=1; s="1" }) |> ignore
+//     // x.Add({ i=2; s="2" }) |> ignore
+//     // let json = JsonConvert.SerializeObject(x, JsonSerializerSettings(TypeNameHandling=TypeNameHandling.All))
+//     let json = """{"$type":"System.Collections.Generic.HashSet`1[[Fable.Tests.HashSets+R, Fable.Tests]], FSharp.Core","$values":[{"$type":"Fable.Tests.HashSets+R, Fable.Tests","i":1,"s":"1"},{"$type":"Fable.Tests.HashSets+R, Fable.Tests","i":2,"s":"2"}]}"""
+//     #if FABLE_COMPILER
+//     let x2 = Fable.Core.Serialize.ofJson<HashSet<R>> json
+//     #else
+//     let x2 = Newtonsoft.Json.JsonConvert.DeserializeObject<HashSet<R>> json
+//     #endif
+//     (0, x2) ||> Seq.fold (fun acc v -> acc + v.i) |> equal 3
 
 

--- a/src/tests/JsonTests.fs
+++ b/src/tests/JsonTests.fs
@@ -1,0 +1,298 @@
+[<NUnit.Framework.TestFixture>] 
+module Fable.Tests.Json
+open NUnit.Framework
+open Fable.Tests.Util
+
+type S =
+#if FABLE_COMPILER
+    static member toJson(x) = Fable.Core.Serialize.toJson(x)
+    static member ofJson<'T>(x, [<Fable.Core.GenericParam("T")>]?t) =
+        Fable.Core.Serialize.ofJson<'T>(x, ?t=t)
+#else
+    static member toJson x = Newtonsoft.Json.JsonConvert.SerializeObject x
+    static member ofJson<'T> x = Newtonsoft.Json.JsonConvert.DeserializeObject<'T> x
+#endif
+
+type Child =
+    { a: string
+      b: int }
+
+type Simple = {
+    Name : string
+    Child : Child
+}
+
+type U =
+    | CaseA of int
+    | CaseB of Simple list
+
+type R() =
+    member __.Foo() = "foo"
+
+type A<'U> = {a: 'U}
+type B<'J> = {b: A<'J>}
+type C<'T> = {c: B<'T>}
+
+[<Test>]
+let ``Nested generics``() =
+    let x = { c={ b={ a=R() } } }
+    let json = S.toJson x
+    let x2 = S.ofJson<C<R>> json
+    x2.c.b.a.Foo() |> equal "foo"
+
+[<Test>]
+let ``Records``() =
+    let json = 
+        """
+        {
+            "Name": "foo",
+            "Child": {
+                "a": "Hi",
+                "b": 10
+            }
+        }
+        """
+    let result: Simple = S.ofJson json
+    result.Name |> equal "foo"
+    // Use the built in compare to ensure the fields are being hooked up.
+    // Should compile to something like: result.Child.Equals(new Child("Hi", 10))
+    result.Child = {a="Hi"; b=10} |> equal true  
+
+[<Test>]
+let ``Unions``() =
+    let u = CaseB [{Name="Sarah";Child={a="John";b=14}}]
+    // Providing type parameters when treating method as a first class value
+    // isn't supported in AppVeyor, see http://stackoverflow.com/a/2743479
+    let json = S.toJson u
+    let u2: U = S.ofJson json
+    u = u2 |> equal true
+    let u3: U = S.ofJson """{"Case":"CaseB","Fields":[[{"Name":"Sarah","Child":{"a":"John","b":14}}]]}"""
+    u = u3 |> equal true
+
+[<Test>] 
+let ``Date``() =
+    let d = System.DateTime(2016, 1, 1, 0, 0, 0, System.DateTimeKind.Utc)
+    let json = d |> S.toJson
+    let result : System.DateTime = S.ofJson json
+    result.Year |> equal 2016
+
+type JsonDate = {  
+    Date : System.DateTime
+}
+        
+[<Test>] 
+let ``Child Date``() =
+    let d = System.DateTime(2016, 1, 1, 0, 0, 0, System.DateTimeKind.Utc)
+    let json = { Date = d } |> S.toJson
+    let result : JsonDate = S.ofJson json
+    result.Date.Year |> equal 2016
+
+type JsonArray = {
+    Name : string
+}
+
+[<Test>] 
+let ``Arrays``() =
+    let json = """[{ "Name": "a" }, { "Name": "b" }]"""
+    let result : JsonArray[] = S.ofJson json
+    result |> Array.length |> equal 2
+    result.[1] = { Name="b" } |> equal true  
+
+type ChildArray = {
+    Children : JsonArray[]
+}
+
+[<Test>] 
+let ``Child Array``() =
+    let json = """{ "Children": [{ "Name": "a" }, { "Name": "b" }] }"""
+    let result : ChildArray = S.ofJson json
+    result.Children |> Array.length |> equal 2
+    result.Children.[1] = { Name="b" } |> equal true
+
+[<Test>] 
+let ``String Generic List``() =
+    let json = """["a","b"]"""
+    let result : System.Collections.Generic.List<string> = S.ofJson json
+    result.Count |> equal 2
+    result.[1] |> equal "b"
+
+[<Test>] 
+let ``Child Generic List``() =
+    let json = """[{ "Name": "a" }, { "Name": "b" }]"""
+    let result : System.Collections.Generic.List<JsonArray> = S.ofJson json
+    result.Count |> equal 2
+    result.[1] = { Name="b" } |> equal true  
+
+[<Test>] 
+let ``Lists``() =
+    let json = """["a","b"]"""
+    let result : string list = S.ofJson json
+    result |> List.length |> equal 2
+    result.Tail |> List.length |> equal 1
+    result.[1] |> equal "b"
+    result.Head |> equal "a"
+
+
+type ChildList = {
+    Children : JsonArray list
+}
+
+[<Test>] 
+let ``Child List``() =
+    let json = """{ "Children": [{ "Name": "a" }, { "Name": "b" }] }"""
+    let result : ChildList = S.ofJson json
+    result.Children |> List.length |> equal 2
+    result.Children.[1] = { Name="b" } |> equal true
+
+type Wrapper<'T> = { thing : 'T }
+
+let inline parseAndUnwrap json: 'T = (S.ofJson<Wrapper<'T>> json).thing
+
+[<Test>]
+let ``generic`` () =
+    let result1 : string = parseAndUnwrap """ { "thing" : "a" } """
+    result1 |> equal "a"
+    let result2 : int = parseAndUnwrap """ { "thing" : 1 } """
+    result2 |> equal 1
+    let result3 : Child = parseAndUnwrap """ { "thing" : { "a": "a", "b": 1 } } """
+    result3.a |> equal "a"
+    result3 = {a = "a"; b = 1} |> equal true
+    // let result4 : Child = parseAndUnwrap """ {"$type":"Fable.Tests.Json+Wrapper`1[[Fable.Tests.Json+Child, Fable.Tests]], Fable.Tests","thing":{"$type":"Fable.Tests.Json+Child, Fable.Tests","a":"a","b":1}} """
+    // if result4 <> {a = "a"; b = 1} then
+    //     invalidOp "things not equal" 
+
+// Tuples and options are serialized differently
+// in Fable and Json.NET
+#if FABLE_COMPILER
+type OptionJson =
+    { a: int option }
+
+[<Test>]
+let ``Option Some`` () =
+    // TODO: Deserialize also options as normal union cases?
+    // let json = """ {"a":{"Case":"Some","Fields":[1]}} """
+    let json1 = """ {"a":1 } """
+    let result1 : OptionJson = S.ofJson json1
+    let json2 = """ {"a":null } """
+    let result2 : OptionJson = S.ofJson json2
+    match result1.a, result2.a with
+    | Some v, None -> v
+    | _ -> -1
+    |> equal 1
+
+type ComplexOptionJson =
+    { a: Child option }
+
+[<Test>]
+let ``Complex Option Some`` () =
+    let json = """ {"a":{"a":"John","b":14}} """
+    let result : ComplexOptionJson = S.ofJson json
+    match result.a with
+    | Some v -> v = {a="John";b=14}
+    | None -> false
+    |> equal true
+
+type TupleJson =
+    { a: int * int }
+
+[<Test>]
+let ``Tuple`` () =
+    // TODO: Deserialize also tuples as objects?
+    // let json = """ {"a":{"Item1":1,"Item2":2}} """
+    let json = """ {"a":[1,2]} """
+    let result : TupleJson = S.ofJson json
+    result.a = (1, 2) |> equal true
+
+type TupleComplexJson =
+    { a: int * Child }
+
+[<Test>]
+let ``Complex Tuple`` () =
+    // TODO: Deserialize also tuples as objects?
+    // let json = """ {"a":{"Item1":1,"Item2":{"a":"A","b":1}}} """
+    let json = """ {"a":[1,{"a":"A","b":1}]} """
+    let result : TupleComplexJson = S.ofJson json
+    snd result.a = { a = "A"; b = 1 } |> equal true
+#endif
+
+type SetJson =
+    { a: Set<string> }
+
+[<Test>]
+let ``Sets`` () =
+    let json = """ {"a":["a","b"]} """
+    let result : SetJson = S.ofJson json
+    result.a |> Set.contains "b" |> equal true
+
+type MapJson =
+    { a: Map<string, Child> }
+
+[<Test>]
+let ``Maps`` () =
+    let json = """ {"a":{"a":{"a":"aa","b":1},"b":{"a":"bb","b":2}}} """
+    let result : MapJson = S.ofJson json
+    result.a.Count |> equal 2
+    result.a.["b"] = { a="bb"; b=2 } |> equal true
+    
+type DictionaryJson =
+    { a: System.Collections.Generic.Dictionary<string, Child> }
+
+[<Test>]
+let ``Dictionaries`` () =
+    let json = """ {"a":{"a":{"a":"aa","b":1},"b":{"a":"bb","b":2}}} """
+    let result : DictionaryJson = S.ofJson json
+    result.a.Count |> equal 2
+    result.a.["b"] = { a="bb"; b=2 } |> equal true
+
+// Dunno why, but this tests is not working with Json.NET
+#if FABLE_COMPILER
+type PropertyJson() =
+    member val Prop1 = {a="";b=0} with get,set
+
+[<Test>]
+let ``Properties`` () =
+    let json = """ {"Prop1": { "a":"aa", "b": 1 }} """
+    let result : PropertyJson = S.ofJson json
+    result.Prop1.a |> equal "aa"
+    result.Prop1.b |> equal 1
+#endif
+
+type UnionJson =
+    | Type1 of string
+    | Type2 of Child
+
+type UnionHolder =
+    { a : UnionJson }
+
+[<Test>]
+let ``Union`` () =
+    let json = """ {"a":{"Case":"Type2","Fields":[{"a":"a","b":1}]}} """
+    let result : UnionHolder = S.ofJson json
+    match result.a with
+    | Type2 t -> t = { a="a"; b=1 }
+    | Type1 _ -> false
+    |> equal true 
+  
+// type IData = interface end
+
+// type Text =
+//   { kind:string; text:string }
+//   interface IData
+
+// type Numbered =
+//   { kind:string; number:int }
+//   interface IData
+
+// type Things = { name:string; data:IData }
+
+// [<Test>]
+// let ``Generics with interface`` () =
+//     // let x = [ { name = "one"; data = { kind = "number"; number = 4 } };
+//     //            { name = "two"; data = { kind = "number"; number = 3 } };
+//     //            { name = "three"; data = { kind = "text"; text = "yo!" } } ]
+//     // let json = Newtonsoft.Json.JsonConvert.SerializeObject(x, Newtonsoft.Json.JsonSerializerSettings(TypeNameHandling=Newtonsoft.Json.TypeNameHandling.All))
+
+//     let json = """ {"$type":"Microsoft.FSharp.Collections.FSharpList`1[[Fable.Tests.Json+Things, Fable.Tests]], FSharp.Core","$values":[{"$type":"Fable.Tests.Json+Things, Fable.Tests","name":"one","data":{"$type":"Fable.Tests.Json+Numbered, Fable.Tests","kind":"number","number":4}},{"$type":"Fable.Tests.Json+Things, Fable.Tests","name":"two","data":{"$type":"Fable.Tests.Json+Numbered, Fable.Tests","kind":"number","number":3}},{"$type":"Fable.Tests.Json+Things, Fable.Tests","name":"three","data":{"$type":"Fable.Tests.Json+Text, Fable.Tests","kind":"text","text":"yo!"}}]} """
+//     let result : Things list = S.ofJson json
+
+//     result.[1].data = ({ kind = "number"; number = 3 } :> IData) |> equal true

--- a/src/tests/ListTests.fs
+++ b/src/tests/ListTests.fs
@@ -635,8 +635,8 @@ type R = { i: int; s: string }
 let ``Lists can be JSON serialized forth and back``() =
     let x = [{ i=1; s="1" }; { i=2; s="2" }]
     #if FABLE_COMPILER
-    let json = Fable.Core.JsInterop.toJson x
-    let x2 = Fable.Core.JsInterop.ofJson<R list> json
+    let json = Fable.Core.Serialize.toJson x
+    let x2 = Fable.Core.Serialize.ofJson<R list> json
     #else
     let json = Newtonsoft.Json.JsonConvert.SerializeObject x
     let x2 = Newtonsoft.Json.JsonConvert.DeserializeObject<R list> json
@@ -646,20 +646,20 @@ let ``Lists can be JSON serialized forth and back``() =
     | _ -> false
     |> equal true
 
-[<Test>]
-let ``Lists serialized with Json.NET can be deserialized``() =
-    // let x = [{ i=1; s="1" }; { i=2; s="2" }]    
-    // let json = JsonConvert.SerializeObject(x, JsonSerializerSettings(TypeNameHandling=TypeNameHandling.All))
-    let json = """{"$type":"Microsoft.FSharp.Collections.FSharpList`1[[Fable.Tests.Lists+R, Fable.Tests]], FSharp.Core","$values":[{"$type":"Fable.Tests.Lists+R, Fable.Tests","i":1,"s":"1"},{"$type":"Fable.Tests.Lists+R, Fable.Tests","i":2,"s":"2"}]}"""
-    #if FABLE_COMPILER
-    let x2 = Fable.Core.JsInterop.ofJson<R list> json
-    #else
-    let x2 = Newtonsoft.Json.JsonConvert.DeserializeObject<R list> json
-    #endif
-    match x2 with
-    | _::[{ i=2; s="2" }] -> true
-    | _ -> false
-    |> equal true
+// [<Test>]
+// let ``Lists serialized with Json.NET can be deserialized``() =
+//     // let x = [{ i=1; s="1" }; { i=2; s="2" }]    
+//     // let json = JsonConvert.SerializeObject(x, JsonSerializerSettings(TypeNameHandling=TypeNameHandling.All))
+//     let json = """{"$type":"Microsoft.FSharp.Collections.FSharpList`1[[Fable.Tests.Lists+R, Fable.Tests]], FSharp.Core","$values":[{"$type":"Fable.Tests.Lists+R, Fable.Tests","i":1,"s":"1"},{"$type":"Fable.Tests.Lists+R, Fable.Tests","i":2,"s":"2"}]}"""
+//     #if FABLE_COMPILER
+//     let x2 = Fable.Core.Serialize.ofJson<R list> json
+//     #else
+//     let x2 = Newtonsoft.Json.JsonConvert.DeserializeObject<R list> json
+//     #endif
+//     match x2 with
+//     | _::[{ i=2; s="2" }] -> true
+//     | _ -> false
+//     |> equal true
 
 type List(x: int) =
     member val Value = x

--- a/src/tests/MapTests.fs
+++ b/src/tests/MapTests.fs
@@ -204,8 +204,8 @@ type R = { i: int; s: string }
 let ``Maps can be JSON serialized forth and back``() =
     let x = ["a", { i=1; s="1" }; "b", { i=2; s="2" } ] |> Map
     #if FABLE_COMPILER
-    let json = Fable.Core.JsInterop.toJson x
-    let x2 = Fable.Core.JsInterop.ofJson<Map<string, R>> json
+    let json = Fable.Core.Serialize.toJson x
+    let x2 = Fable.Core.Serialize.ofJson<Map<string, R>> json
     #else
     let json = Newtonsoft.Json.JsonConvert.SerializeObject x
     let x2 = Newtonsoft.Json.JsonConvert.DeserializeObject<Map<string, R>> json
@@ -213,15 +213,15 @@ let ``Maps can be JSON serialized forth and back``() =
     (0, x2) ||> Map.fold (fun acc k v -> acc + v.i)
     |> equal 3
 
-[<Test>]
-let ``Maps serialized with Json.NET can be deserialized``() =
-    // let x = ["a", { i=1; s="1" }; "b", { i=2; s="2" } ] |> Map    
-    // let json = JsonConvert.SerializeObject(x, JsonSerializerSettings(TypeNameHandling=TypeNameHandling.All))
-    let json = """{"$type":"Microsoft.FSharp.Collections.FSharpMap`2[[System.String, mscorlib],[Fable.Tests.Maps+R, Fable.Tests]], FSharp.Core","a":{"$type":"Fable.Tests.Maps+R, Fable.Tests","i":1,"s":"1"},"b":{"$type":"Fable.Tests.Maps+R, Fable.Tests","i":2,"s":"2"}}"""
-    #if FABLE_COMPILER
-    let x2 = Fable.Core.JsInterop.ofJson<Map<string, R>> json
-    #else
-    let x2 = Newtonsoft.Json.JsonConvert.DeserializeObject<Map<string, R>> json
-    #endif
-    (0, x2) ||> Map.fold (fun acc k v -> acc + v.i)
-    |> equal 3
+// [<Test>]
+// let ``Maps serialized with Json.NET can be deserialized``() =
+//     // let x = ["a", { i=1; s="1" }; "b", { i=2; s="2" } ] |> Map    
+//     // let json = JsonConvert.SerializeObject(x, JsonSerializerSettings(TypeNameHandling=TypeNameHandling.All))
+//     let json = """{"$type":"Microsoft.FSharp.Collections.FSharpMap`2[[System.String, mscorlib],[Fable.Tests.Maps+R, Fable.Tests]], FSharp.Core","a":{"$type":"Fable.Tests.Maps+R, Fable.Tests","i":1,"s":"1"},"b":{"$type":"Fable.Tests.Maps+R, Fable.Tests","i":2,"s":"2"}}"""
+//     #if FABLE_COMPILER
+//     let x2 = Fable.Core.Serialize.ofJson<Map<string, R>> json
+//     #else
+//     let x2 = Newtonsoft.Json.JsonConvert.DeserializeObject<Map<string, R>> json
+//     #endif
+//     (0, x2) ||> Map.fold (fun acc k v -> acc + v.i)
+//     |> equal 3

--- a/src/tests/RecordTypeTests.fs
+++ b/src/tests/RecordTypeTests.fs
@@ -63,18 +63,13 @@ type Parent =
     { children: Child[] }
     member x.Sum() = x.children |> Seq.sumBy (fun c -> c.Sum())
 
-#if FABLE_COMPILER
-open Fable.Core
-open Fable.Core.JsInterop
-#endif
-
 [<Test>]
 let ``Records can be JSON serialized forth and back``() =
     let parent = { children=[|{a="3";b=5}; {b=7;a="1"} |] }
     let sum1 = parent.Sum() 
     #if FABLE_COMPILER
-    let json = toJson parent
-    let parent2 = ofJson<Parent> json
+    let json = Fable.Core.Serialize.toJson parent
+    let parent2 = Fable.Core.Serialize.ofJson<Parent> json
     #else
     let json = Newtonsoft.Json.JsonConvert.SerializeObject parent
     let parent2 = Newtonsoft.Json.JsonConvert.DeserializeObject<Parent> json    
@@ -83,29 +78,29 @@ let ``Records can be JSON serialized forth and back``() =
     equal true (box parent2 :? Parent) // Type is kept
     equal true (sum1 = sum2) // Prototype methods can be accessed
 
-[<Test>]
-let ``Records serialized with Json.NET can be deserialized``() =
-    // let x = { a="Hi"; b=20 }
-    // let json = JsonConvert.SerializeObject(x, JsonSerializerSettings(TypeNameHandling=TypeNameHandling.All))
-    let json = """{"$type":"Fable.Tests.RecordTypes+Child","a":"Hi","b":10}"""
-    #if FABLE_COMPILER
-    let x2 = Fable.Core.JsInterop.ofJson<Child> json
-    #else
-    let x2 = Newtonsoft.Json.JsonConvert.DeserializeObject<Child> json
-    #endif
-    x2.a |> equal "Hi"
-    x2.b |> equal 10
+// [<Test>]
+// let ``Records serialized with Json.NET can be deserialized``() =
+//     // let x = { a="Hi"; b=20 }
+//     // let json = JsonConvert.SerializeObject(x, JsonSerializerSettings(TypeNameHandling=TypeNameHandling.All))
+//     let json = """{"$type":"Fable.Tests.RecordTypes+Child","a":"Hi","b":10}"""
+//     #if FABLE_COMPILER
+//     let x2 = Fable.Core.Serialize.ofJson<Child> json
+//     #else
+//     let x2 = Newtonsoft.Json.JsonConvert.DeserializeObject<Child> json
+//     #endif
+//     x2.a |> equal "Hi"
+//     x2.b |> equal 10
 
-#if FABLE_COMPILER
-[<Test>]
-let ``Trying to deserialize a JSON of different type throws an exception``() =
-    let child = {a="3";b=5}
-    let json = toJson child
-    let success =
-        try
-            ofJson<Parent> json |> ignore
-            true
-        with
-        | _ -> false
-    equal false success
-#endif
+// #if FABLE_COMPILER
+// [<Test>]
+// let ``Trying to deserialize a JSON of different type throws an exception``() =
+//     let child = {a="3";b=5}
+//     let json = Fable.Core.Serialize.toJson child
+//     let success =
+//         try
+//             Fable.Core.Serialize.ofJson<Parent> json |> ignore
+//             true
+//         with
+//         | _ -> false
+//     equal false success
+// #endif

--- a/src/tests/RecordTypeTests.fs
+++ b/src/tests/RecordTypeTests.fs
@@ -104,3 +104,19 @@ let ``Records can be JSON serialized forth and back``() =
 //         | _ -> false
 //     equal false success
 // #endif
+
+#if FABLE_COMPILER
+[<Fable.Core.Uniqueness>]
+#endif
+type UniquenessRecord =
+    { uniqueA: int; uniqueB: int }
+
+[<Test>]
+let ``Uniqueness records work``() =
+    let x = { uniqueA = 10; uniqueB = 20 }
+    equal 10 x.uniqueA
+    equal 20 x.uniqueB
+    let x' = { x with uniqueB = -20 }
+    // equal 10 x.uniqueA // This would make Fable compilation fail
+    equal 10 x'.uniqueA
+    equal -20 x'.uniqueB

--- a/src/tests/RecordTypeTests.fs
+++ b/src/tests/RecordTypeTests.fs
@@ -116,7 +116,11 @@ let ``Uniqueness records work``() =
     let x = { uniqueA = 10; uniqueB = 20 }
     equal 10 x.uniqueA
     equal 20 x.uniqueB
-    let x' = { x with uniqueB = -20 }
+    let uniqueB' = -x.uniqueB
+    let x' = { x with uniqueB = uniqueB' }
     // equal 10 x.uniqueA // This would make Fable compilation fail
     equal 10 x'.uniqueA
     equal -20 x'.uniqueB
+    let x'' = { x with uniqueA = -10 }
+    equal -10 x''.uniqueA
+    equal 20 x''.uniqueB

--- a/src/tests/RecordTypeTests.fs
+++ b/src/tests/RecordTypeTests.fs
@@ -106,13 +106,13 @@ let ``Records can be JSON serialized forth and back``() =
 // #endif
 
 #if FABLE_COMPILER
-[<Fable.Core.Uniqueness>]
+[<Fable.Core.MutatingUpdate>]
 #endif
-type UniquenessRecord =
+type MutatingRecord =
     { uniqueA: int; uniqueB: int }
 
 [<Test>]
-let ``Uniqueness records work``() =
+let ``Mutating records work``() =
     let x = { uniqueA = 10; uniqueB = 20 }
     equal 10 x.uniqueA
     equal 20 x.uniqueB

--- a/src/tests/RecordTypeTests.fs
+++ b/src/tests/RecordTypeTests.fs
@@ -121,6 +121,6 @@ let ``Uniqueness records work``() =
     // equal 10 x.uniqueA // This would make Fable compilation fail
     equal 10 x'.uniqueA
     equal -20 x'.uniqueB
-    let x'' = { x with uniqueA = -10 }
+    let x'' = { x' with uniqueA = -10 }
     equal -10 x''.uniqueA
-    equal 20 x''.uniqueB
+    equal -20 x''.uniqueB

--- a/src/tests/SetTests.fs
+++ b/src/tests/SetTests.fs
@@ -300,8 +300,8 @@ type R = { i: int; s: string }
 let ``Sets can be JSON serialized forth and back``() =
     let x = [{ i=1; s="1" }; { i=2; s="2" } ] |> set
     #if FABLE_COMPILER
-    let json = Fable.Core.JsInterop.toJson x
-    let x2 = Fable.Core.JsInterop.ofJson<Set<R>> json
+    let json = Fable.Core.Serialize.toJson x
+    let x2 = Fable.Core.Serialize.ofJson<Set<R>> json
     #else
     let json = Newtonsoft.Json.JsonConvert.SerializeObject x
     let x2 = Newtonsoft.Json.JsonConvert.DeserializeObject<Set<R>> json
@@ -310,16 +310,16 @@ let ``Sets can be JSON serialized forth and back``() =
     (0, x2) ||> Set.fold (fun acc v -> acc + v.i)
     |> equal 3
 
-[<Test>]
-let ``Sets serialized with Json.NET can be deserialized``() =
-    // let x = ["a", { i=1; s="1" }; "b", { i=2; s="2" } ] |> Map    
-    // let json = JsonConvert.SerializeObject(x, JsonSerializerSettings(TypeNameHandling=TypeNameHandling.All))
-    let json = """{"$type":"Microsoft.FSharp.Collections.FSharpSet`1[[Fable.Tests.Sets+R, Fable.Tests]], FSharp.Core","$values":[{"$type":"Fable.Tests.Sets+R, Fable.Tests","i":1,"s":"1"},{"$type":"Fable.Tests.Sets+R, Fable.Tests","i":2,"s":"2"}]}"""
-    #if FABLE_COMPILER
-    let x2 = Fable.Core.JsInterop.ofJson<Set<R>> json
-    #else
-    let x2 = Newtonsoft.Json.JsonConvert.DeserializeObject<Set<R>> json
-    #endif
-    (0, x2) ||> Set.fold (fun acc v -> acc + v.i)
-    |> equal 3
+// [<Test>]
+// let ``Sets serialized with Json.NET can be deserialized``() =
+//     // let x = ["a", { i=1; s="1" }; "b", { i=2; s="2" } ] |> Map    
+//     // let json = JsonConvert.SerializeObject(x, JsonSerializerSettings(TypeNameHandling=TypeNameHandling.All))
+//     let json = """{"$type":"Microsoft.FSharp.Collections.FSharpSet`1[[Fable.Tests.Sets+R, Fable.Tests]], FSharp.Core","$values":[{"$type":"Fable.Tests.Sets+R, Fable.Tests","i":1,"s":"1"},{"$type":"Fable.Tests.Sets+R, Fable.Tests","i":2,"s":"2"}]}"""
+//     #if FABLE_COMPILER
+//     let x2 = Fable.Core.Serialize.ofJson<Set<R>> json
+//     #else
+//     let x2 = Newtonsoft.Json.JsonConvert.DeserializeObject<Set<R>> json
+//     #endif
+//     (0, x2) ||> Set.fold (fun acc v -> acc + v.i)
+//     |> equal 3
     

--- a/src/tests/TypeTests.fs
+++ b/src/tests/TypeTests.fs
@@ -297,8 +297,8 @@ type Serializable(?i: int) =
 let ``Classes can be JSON serialized forth and back``() =
     let x = Serializable(5)
     #if FABLE_COMPILER
-    let json = Fable.Core.JsInterop.toJson x
-    let x2 = Fable.Core.JsInterop.ofJson<Serializable> json
+    let json = Fable.Core.Serialize.toJson x
+    let x2 = Fable.Core.Serialize.ofJson<Serializable> json
     #else
     let json = Newtonsoft.Json.JsonConvert.SerializeObject x
     let x2 = Newtonsoft.Json.JsonConvert.DeserializeObject<Serializable> json
@@ -310,8 +310,8 @@ let ``Classes can be JSON serialized forth and back``() =
 let ``Null values can be JSON serialized forth and back``() =
     let x: Serializable = null
     #if FABLE_COMPILER
-    let json = Fable.Core.JsInterop.toJson x
-    let x2 = Fable.Core.JsInterop.ofJson<Serializable> json
+    let json = Fable.Core.Serialize.toJson x
+    let x2 = Fable.Core.Serialize.ofJson<Serializable> json
     #else
     let json = Newtonsoft.Json.JsonConvert.SerializeObject x
     let x2 = Newtonsoft.Json.JsonConvert.DeserializeObject<Serializable> json
@@ -324,7 +324,7 @@ let ``Classes serialized with Json.NET can be deserialized``() =
     // let json = JsonConvert.SerializeObject(x, JsonSerializerSettings(TypeNameHandling=TypeNameHandling.All))
     let json = """{"$type":"Fable.Tests.TypeTests+Serializable","PublicValue":1}"""
     #if FABLE_COMPILER
-    let x2 = Fable.Core.JsInterop.ofJson<Serializable> json
+    let x2 = Fable.Core.Serialize.ofJson<Serializable> json
     #else
     let x2 = Newtonsoft.Json.JsonConvert.DeserializeObject<Serializable> json
     #endif
@@ -354,3 +354,18 @@ let ``Multiple constructors work``() =
     equal 5 m1.Value
     equal 9 m2.Value
     equal 14 m3.Value
+
+#if FABLE_COMPILER
+open Fable.Core
+type GenericParamTest =
+    static member Foo<'T>(x: int, [<GenericParam("T")>] ?t: Type) = t.Value
+    static member Bar<'T,'U>([<GenericParam("U")>] ?t1: Type, [<GenericParam("T")>] ?t2: Type) = t1.Value, t2.Value
+
+[<Test>]
+let ``GenericParamAttribute works``() =
+    let t = GenericParamTest.Foo<string>(5)
+    let t1, t2 = GenericParamTest.Bar<TestType, bool>()
+    box t |> equal (box "string")
+    box t1 |> equal (box "boolean")
+    box t2 |> equal (box typeof<TestType>)
+#endif

--- a/src/tests/UnionTypeTests.fs
+++ b/src/tests/UnionTypeTests.fs
@@ -95,7 +95,6 @@ let ``Active patterns can be combined with union case matching``() = // See #306
 
 #if FABLE_COMPILER
 open Fable.Core
-open Fable.Core.JsInterop
 
 type JsonTypeInner = {
     Prop1: string
@@ -161,8 +160,8 @@ let ``Unions can be JSON serialized forth and back``() =
     let tree = Branch [|Leaf 1; Leaf 2; Branch [|Leaf 3; Leaf 4|]|]
     let sum1 = tree.Sum()
     #if FABLE_COMPILER
-    let json = toJson tree
-    let tree2 = ofJson<Tree> json
+    let json = Fable.Core.Serialize.toJson tree
+    let tree2 = Fable.Core.Serialize.ofJson<Tree> json
     #else
     let json = Newtonsoft.Json.JsonConvert.SerializeObject tree
     let tree2 = Newtonsoft.Json.JsonConvert.DeserializeObject<Tree> json
@@ -206,7 +205,7 @@ type UnionTypeInfoConverter() =
 let ``Unions serialized with Json.NET can be deserialized``() =    
     #if FABLE_COMPILER
     let json = """{"$type":"Fable.Tests.UnionTypes+Tree","Case":"Leaf","Fields":[5]}"""
-    let x2 = Fable.Core.JsInterop.ofJson<Tree> json
+    let x2 = Fable.Core.Serialize.ofJson<Tree> json
     #else
     let x = Leaf 5
     let settings =


### PR DESCRIPTION
This is me trying to look smart at ICFP :) I was already thinking of something similar beforehand but one of the talks has inspired me to implement [uniqueness types](https://en.wikipedia.org/wiki/Uniqueness_type) (sort of) in Fable. The idea is to compile updates of records with `UniquenessAttribute` as mutations. For example:

```fsharp
[<Uniqueness>]
type A = { a: int; b: int; c: int }

let transform a =
    printfn "%i" a.a
    let a2 = {a with b = -2; c = -3}
    // printfn "%i" a.a
    a2

{a=1; b=2; c=3} |> transform
```

Compiles to this:

```js
function transform(a) {
  _fableCore.String.fsFormat("%i")(function (x) { console.log(x); })(a.a);

  var a2 = (a.b = -2, a.c = -3, a);

  return a2;
}

transform(new A(1, 2, 3));
```

Which prevents allocation and helps performance (particularly in games with frequent updates of multiple objects) while keeping our code functional and elegant.

Of course, this means it's not safe to use the original value after update (uniqueness types can only be consumed once) and this will be checked by the Fable compiler. In the sample above, if we remove the comment from the second `printfn` we'll get a compilation error :+1:

> Note: at the moment, the PR is considering a value being consumed when being updated or passed as an argument to a function.

I'd love to hear some feedback before merging this. Maybe @tpetricek could give some advice?