### PR TITLE
Include NUnitTest during CI on Travis and AppVeyor

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -488,6 +488,8 @@ Target "All" ignore
   ==> "CompileFableImportTests"
   ==> "Plugins"
   ==> "MochaTest"
+  =?> ("NUnitTest", environVar "APPVEYOR" = "True")
+  =?> ("NUnitTest", environVar "TRAVIS" = "true")
   =?> ("MakeArtifactLighter", environVar "APPVEYOR" = "True")
   ==> "All"
 


### PR DESCRIPTION
Guards against unit tests that are not written for the NUnitTest build activity.