### PR TITLE
allow running redux-webpack sample on an empty computer

### DIFF
--- a/samples/browser/redux-webpack/README.MD
+++ b/samples/browser/redux-webpack/README.MD
@@ -1,0 +1,33 @@
+Fable + React + Redux Sample
+============================
+
+You have to have [Fable](http://fable.io) compiler installed (`npm install -g fable-compiler`)
+
+On Windows do not forget to install 
+
+- either [Microsoft Build Tools 2013](https://www.microsoft.com/en-us/download/details.aspx?id=40760) 
+- or [Microsoft Build Tools 2015](https://www.microsoft.com/en-us/download/confirmation.aspx?id=48159) and redirect versions in `Fable.Client.Node.exe.config`.
+
+Installation
+-----------
+
+`npm i`
+
+`npm install webpack -g`
+
+`npm install -g webpack-dev-server`
+
+
+Compilation
+-----------
+
+`fable index.fsx`
+
+`webpack`
+
+Running local dev server
+------------------------
+
+`webpack-dev-server`
+
+open `http://localhost:8080/webpack-dev-server/` in a browser

--- a/samples/browser/redux-webpack/package.json
+++ b/samples/browser/redux-webpack/package.json
@@ -4,10 +4,16 @@
     "core-js": "^2.1.0",
     "fable-core": "^0.6.1",
     "react": "^15.1.0",
-    "react-dom": "^15.1.0"    
+    "react-dom": "^15.1.0",
+    "todomvc-app-css": "^2.0.6",
+    "todomvc-common": "^1.0.2",
+    "webpack-dev-server": "^1.16.2"
   },
   "devDependencies": {
-    "fable-import-react": "^0.5.2"
+    "fable-import-react": "^0.5.2",
+    "react-hot-loader": "^3.0.0-beta.5",
+    "source-map-loader": "^0.1.5",
+    "webpack": "^1.13.2"
   },
   "engines": {
     "fable": "^0.6.2"

--- a/samples/browser/redux-webpack/webpack.config.js
+++ b/samples/browser/redux-webpack/webpack.config.js
@@ -23,7 +23,7 @@ module.exports = {
         loaders: [{
             test: /\.js$/,
             exclude: /node_modules/,
-            loader: "react-hot-loader"
+            loader: "react-hot-loader/webpack"
         }]
     },
     externals: {


### PR DESCRIPTION
If you do clone the repo and are not familiar with [webpack](https://webpack.github.io/), trying to run `samples/browser/redux-webpack` will be not easy.

Missing (?) packages added. Also updated according to the latest webpack requirements.