### PR TITLE
Mutating Update records

### DIFF
--- a/src/fable/Fable.Compiler/FSharp2Fable.Util.fs
+++ b/src/fable/Fable.Compiler/FSharp2Fable.Util.fs
@@ -33,9 +33,19 @@ type Context =
     thisAvailability: ThisAvailability
     }
     static member Empty =
+<<<<<<< HEAD
         { fileName="unknown"; scope=[]; typeArgs=[]; baseClass=None;
           decisionTargets=Map.empty<_,_>; thisAvailability=ThisUnavailable }
     
+=======
+        { fileName="unknown"; scope=[]; typeArgs=[]; decisionTargets=Map.empty<_,_>; baseClass=None }
+
+type Role =
+    | AppliedArgument
+    // For now we're only interested in applied arguments
+    | UnknownRole
+
+>>>>>>> Prepare types
 type IFableCompiler =
     inherit ICompiler
     abstract Transform: Context -> FSharpExpr -> Fable.Expr
@@ -671,10 +681,10 @@ module Identifiers =
         let sanitizedName = tentativeName |> Naming.sanitizeIdent (fun x ->
             List.exists (fun (_,x') ->
                 match x' with
-                | Fable.Value (Fable.IdentValue {name=name}) -> x = name
+                | Fable.Value (Fable.IdentValue i) -> x = i.Name
                 | _ -> false) ctx.scope)
         com.AddUsedVarName sanitizedName
-        let ident: Fable.Ident = { name=sanitizedName; typ=typ}
+        let ident = Fable.Ident(sanitizedName, typ)
         let identValue = Fable.Value (Fable.IdentValue ident)
         { ctx with scope = (fsRef, identValue)::ctx.scope}, ident
 
@@ -687,7 +697,13 @@ module Identifiers =
     let tryGetBoundExpr (ctx: Context) (fsRef: FSharpMemberOrFunctionOrValue) =
         ctx.scope
         |> List.tryFind (fst >> function Some fsRef' -> obj.Equals(fsRef, fsRef') | None -> false)
-        |> function Some (_,boundExpr) -> Some boundExpr | None -> None
+        |> function
+            | Some(_, (Fable.Value(Fable.IdentValue i) as boundExpr)) ->
+                // TODO: Check if value is uniqueness type
+                // if i.IsConsumed then failwithf "Value %s has already been consumed" i.Name
+                Some boundExpr
+            | Some(_, boundExpr) -> Some boundExpr
+            | None -> None
 
     /// Get corresponding identifier to F# value in current scope
     let getBoundExpr (ctx: Context) (fsRef: FSharpMemberOrFunctionOrValue) =
@@ -695,6 +711,13 @@ module Identifiers =
         | Some boundExpr -> boundExpr
         | None -> failwithf "Detected non-bound identifier: %s in %O"
                     fsRef.CompiledName (getRefLocation fsRef |> makeRange)
+
+    let tryConsumeBoundExpr (ctx: Context) (fsRef: FSharpMemberOrFunctionOrValue) =
+        tryGetBoundExpr ctx fsRef
+        |> Option.map (function
+            | Fable.Value(Fable.IdentValue i) as e ->
+                i.Consume(); e
+            | e -> e)
 
 module Util =
     open Helpers
@@ -1012,7 +1035,7 @@ module Util =
          // TODO: This shouldn't happen, throw exception?
         | ThisUnavailable -> Fable.Value Fable.This
 
-    let makeValueFrom com ctx r typ (v: FSharpMemberOrFunctionOrValue) =
+    let makeValueFrom com ctx r typ role (v: FSharpMemberOrFunctionOrValue) =
         if not v.IsModuleValueOrMember
         then
             if typ = Fable.Unit
@@ -1023,10 +1046,11 @@ module Util =
         elif isReplaceCandidate com v.EnclosingEntity
         then wrapInLambda com ctx r typ v
         else
-            match v with
-            | Emitted com ctx r typ ([], []) (None, []) emitted -> emitted
-            | Imported com ctx r typ [] imported -> imported
-            | Try (tryGetBoundExpr ctx) e -> e 
+            match role, v with
+            | _, Emitted com ctx r typ ([], []) (None, []) emitted -> emitted
+            | _, Imported com ctx r typ [] imported -> imported
+            | AppliedArgument, Try (tryConsumeBoundExpr ctx) e -> e 
+            | _, Try (tryGetBoundExpr ctx) e -> e 
             | _ ->
                 let typeRef =
                     makeTypeFromDef com ctx v.EnclosingEntity []

--- a/src/fable/Fable.Compiler/FSharp2Fable.fs
+++ b/src/fable/Fable.Compiler/FSharp2Fable.fs
@@ -217,7 +217,7 @@ and private transformExprWithRole (role: Role) (com: IFableCompiler) ctx fsExpr 
             Fable.DeclaredType(ent, [Fable.Any; Fable.Any])
         Fable.Wrapped(expr, appType)
 
-    | RecordUpdate(NonAbbreviatedType fsType, record, updatedFields) ->
+    | RecordMutatingUpdate(NonAbbreviatedType fsType, record, updatedFields) ->
         let r, typ = makeRangeFrom fsExpr, makeType com ctx fsType
         // TODO: Use a different role type?
         let record = makeValueFrom com ctx r typ AppliedArgument record
@@ -352,7 +352,7 @@ and private transformExprWithRole (role: Role) (com: IFableCompiler) ctx fsExpr 
             if flags.IsInstance
             then transformExpr com ctx argExprs.Head,
                  List.map (transformExprWithRole AppliedArgument com ctx) argExprs.Tail
-            else makeTypeRef com range sourceType,
+            else makeTypeRef com range false sourceType,
                  List.map (transformExprWithRole AppliedArgument com ctx) argExprs
         let argTypes = List.map (makeType com ctx) argTypes
         let methName =

--- a/src/fable/Fable.Compiler/FSharp2Fable.fs
+++ b/src/fable/Fable.Compiler/FSharp2Fable.fs
@@ -218,8 +218,8 @@ and private transformExprWithRole (role: Role) (com: IFableCompiler) ctx fsExpr 
         Fable.Wrapped(expr, appType)
 
     | RecordUpdate(NonAbbreviatedType fsType, record, updatedFields) ->
-        // TODO: Use a different role type?
         let r, typ = makeRangeFrom fsExpr, makeType com ctx fsType
+        // TODO: Use a different role type?
         let record = makeValueFrom com ctx r typ AppliedArgument record
         let assignments =
             ([record], updatedFields)

--- a/src/fable/Fable.Compiler/FSharp2Fable.fs
+++ b/src/fable/Fable.Compiler/FSharp2Fable.fs
@@ -154,6 +154,9 @@ and private transformComposableExpr com ctx fsExpr argExprs =
     | _ -> failwith "ComposableExpr expected"
 
 and private transformExpr (com: IFableCompiler) ctx fsExpr =
+    transformExprWithRole UnknownRole com ctx fsExpr
+
+and private transformExprWithRole (role: Role) (com: IFableCompiler) ctx fsExpr =
     match fsExpr with
     (** ## Custom patterns *)
     | SpecialValue com ctx replacement ->
@@ -165,27 +168,28 @@ and private transformExpr (com: IFableCompiler) ctx fsExpr =
         |> makeLoop (makeRangeFrom fsExpr)
         
     | ErasableLambda (expr, argExprs) ->
-        List.map (com.Transform ctx) argExprs
+        List.map (transformExprWithRole AppliedArgument com ctx) argExprs
         |> transformComposableExpr com ctx expr
 
     // Pipe must come after ErasableLambda
     | Pipe (Transform com ctx callee, args) ->
         let typ, range = makeType com ctx fsExpr.Type, makeRangeFrom fsExpr
-        makeApply range typ callee (List.map (transformExpr com ctx) args)
+        makeApply range typ callee (List.map (transformExprWithRole AppliedArgument com ctx) args)
         
     | Composition (expr1, args1, expr2, args2) ->
         let lambdaArg = com.GetUniqueVar() |> makeIdent
         let r, typ = makeRangeFrom fsExpr, makeType com ctx fsExpr.Type
         let expr1 =
-            (List.map (com.Transform ctx) args1)@[Fable.Value (Fable.IdentValue lambdaArg)]
+            (List.map (transformExprWithRole AppliedArgument com ctx) args1)
+                @ [Fable.Value (Fable.IdentValue lambdaArg)]
             |> transformComposableExpr com ctx expr1
         let expr2 =
-            (List.map (com.Transform ctx) args2)@[expr1]
+            (List.map (transformExprWithRole AppliedArgument com ctx) args2)@[expr1]
             |> transformComposableExpr com ctx expr2
         makeLambdaExpr [lambdaArg] expr2             
 
     | BaseCons com ctx (meth, args) ->
-        let args = List.map (com.Transform ctx) args
+        let args = List.map (transformExprWithRole AppliedArgument com ctx) args
         let typ, range = makeType com ctx fsExpr.Type, makeRangeFrom fsExpr
         Fable.Apply(Fable.Value Fable.Super, args, Fable.ApplyMeth, typ, range)
 
@@ -263,7 +267,7 @@ and private transformExpr (com: IFableCompiler) ctx fsExpr =
 
     | BasicPatterns.Value v ->
         let r, typ = makeRangeFrom fsExpr, makeType com ctx fsExpr.Type
-        makeValueFrom com ctx r typ v
+        makeValueFrom com ctx r typ role v
 
     | BasicPatterns.DefaultValue (FableType com ctx typ) ->
         let valueKind =
@@ -334,8 +338,10 @@ and private transformExpr (com: IFableCompiler) ctx fsExpr =
         let range, typ = makeRangeFrom fsExpr, makeType com ctx fsExpr.Type
         let callee, args =
             if flags.IsInstance
-            then transformExpr com ctx argExprs.Head, List.map (transformExpr com ctx) argExprs.Tail
-            else makeTypeRef com range false sourceType, List.map (transformExpr com ctx) argExprs
+            then transformExpr com ctx argExprs.Head,
+                 List.map (transformExprWithRole AppliedArgument com ctx) argExprs.Tail
+            else makeTypeRef com range sourceType,
+                 List.map (transformExprWithRole AppliedArgument com ctx) argExprs
         let argTypes = List.map (makeType com ctx) argTypes
         let methName =
             match sourceType with
@@ -347,12 +353,13 @@ and private transformExpr (com: IFableCompiler) ctx fsExpr =
         |> fun m -> Fable.Apply (m, args, Fable.ApplyMeth, typ, range)
 
     | BasicPatterns.Call(callee, meth, typArgs, methTypArgs, args) ->
-        let callee, args = Option.map (com.Transform ctx) callee, List.map (com.Transform ctx) args
+        let callee = Option.map (com.Transform ctx) callee
+        let args = List.map (transformExprWithRole AppliedArgument com ctx) args
         let r, typ = makeRangeFrom fsExpr, makeType com ctx fsExpr.Type
         makeCallFrom com ctx r typ meth (typArgs, methTypArgs) callee args
 
     | BasicPatterns.Application(Transform com ctx callee, _typeArgs, args) ->
-        let args = List.map (transformExpr com ctx) args
+        let args = List.map (transformExprWithRole AppliedArgument com ctx) args
         let typ, range = makeType com ctx fsExpr.Type, makeRangeFrom fsExpr
         match callee.Type.FullName, args with
         | "Fable.Core.Applicable", args ->
@@ -433,7 +440,7 @@ and private transformExpr (com: IFableCompiler) ctx fsExpr =
 
     | BasicPatterns.ValueSet (valToSet, Transform com ctx valueExpr) ->
         let r, typ = makeRangeFrom fsExpr, makeType com ctx valToSet.FullType
-        let valToSet = makeValueFrom com ctx r typ valToSet
+        let valToSet = makeValueFrom com ctx r typ UnknownRole valToSet
         Fable.Set (valToSet, None, valueExpr, r)
 
     (** Instantiation *)
@@ -598,8 +605,8 @@ and private transformExpr (com: IFableCompiler) ctx fsExpr =
             let defaultCase = transformBody defaultCase
             cases, defaultCase
         let matchValue =
-            makeType com ctx matchValue.FullType
-            |> makeValueFrom com ctx None <| matchValue
+            let t = makeType com ctx matchValue.FullType
+            makeValueFrom com ctx None t UnknownRole matchValue
         let r, typ = makeRangeFrom fsExpr, makeType com ctx fsExpr.Type
         match typ with
         | Fable.Unit ->
@@ -780,7 +787,7 @@ let private transformMemberDecl (com: IFableCompiler) ctx (declInfo: DeclInfo)
             if meth.EnclosingEntity.IsFSharpModule then
                 let typ = makeType com ctx meth.FullType
                 let ctx, privateName = bindIdent com ctx typ (Some meth) memberName
-                ctx, Some (privateName.name)
+                ctx, Some (privateName.Name)
             else ctx, None
         let args, body =
             bindMemberArgs com ctx meth.IsInstanceMember args
@@ -868,7 +875,7 @@ let rec private transformEntityDecl
             // Bind entity name to context to prevent name
             // clashes (it will become a variable in JS)
             let ctx, ident = sanitizeEntityName ent |> bindIdent com ctx Fable.Any None
-            declInfo.AddChild(com, ent, ident.name, childDecls)
+            declInfo.AddChild(com, ent, ident.Name, childDecls)
             declInfo, ctx
 
 and private transformDeclarations (com: IFableCompiler) ctx init decls =

--- a/src/fable/Fable.Compiler/Fable2Babel.fs
+++ b/src/fable/Fable.Compiler/Fable2Babel.fs
@@ -64,7 +64,7 @@ module Util =
             | expr -> com.TransformExpr ctx expr |> U2.Case1)
         
     let ident (id: Fable.Ident) =
-        Babel.Identifier id.name
+        Babel.Identifier id.Name
 
     let identFromName name =
         let name = Naming.sanitizeIdent (fun _ -> false) name
@@ -292,7 +292,7 @@ module Util =
                     match arg with
                     | :? Babel.Identifier as id ->
                         Babel.Identifier(id.name,
-                            Babel.TypeAnnotation(typeAnnotation com ctx args.[i].typ))
+                            Babel.TypeAnnotation(typeAnnotation com ctx args.[i].Type))
                         :> Babel.Pattern
                     | arg -> arg),
                 Babel.TypeAnnotation(typeAnnotation com ctx body.Type) |> Some,
@@ -320,7 +320,7 @@ module Util =
         | Fable.This -> upcast Babel.ThisExpression ()
         | Fable.Super -> upcast Babel.Super ()
         | Fable.Null -> upcast Babel.NullLiteral ()
-        | Fable.IdentValue {name=name} -> upcast Babel.Identifier (name)
+        | Fable.IdentValue i -> upcast Babel.Identifier (i.Name)
         | Fable.NumberConst (x,_) -> upcast Babel.NumericLiteral x
         | Fable.StringConst x -> upcast Babel.StringLiteral (x)
         | Fable.BoolConst x -> upcast Babel.BooleanLiteral (x)
@@ -496,7 +496,7 @@ module Util =
             com.TransformExprAndResolve ctx ret value
 
         | Fable.VarDeclaration (var, Fable.Value(Fable.ImportRef(Naming.placeholder, path)), isMutable) ->
-            let value = com.GetImportExpr ctx None var.name path
+            let value = com.GetImportExpr ctx None var.Name path
             varDeclaration expr.Range (ident var) isMutable value :> Babel.Statement
 
         | Fable.VarDeclaration (var, TransformExpr com ctx value, isMutable) ->

--- a/src/fable/Fable.Core/AST/AST.Fable.Util.fs
+++ b/src/fable/Fable.Core/AST/AST.Fable.Util.fs
@@ -23,8 +23,8 @@ let getSymbol (com: ICompiler) name =
     Apply (import, [Value(StringConst name)], ApplyGet, Any, None)
 
 let makeLoop range loopKind = Loop (loopKind, range)
-let makeIdent name: Ident = {name=name; typ=Any}
-let makeTypedIdent name typ: Ident = {name=name; typ=typ}
+let makeIdent name = Ident(name)
+let makeTypedIdent name typ = Ident(name, typ)
 let makeIdentExpr name = makeIdent name |> IdentValue |> Value
 let makeLambdaExpr args body = Value(Lambda(args, body))
 
@@ -210,7 +210,7 @@ let rec makeTypeTest com range (typ: Type) expr =
         |> attachRange range |> failwith
 
 let makeUnionCons () =
-    let args = [{name="caseName"; typ=String}; {name="fields"; typ=Array Any}]
+    let args = [Ident("caseName", String); Ident("fields", Array Any)]
     let argTypes = List.map Ident.getType args
     let emit = Emit "this.Case=caseName; this.Fields = fields;" |> Value
     let body = Apply (emit, [], ApplyMeth, Unit, None)
@@ -221,8 +221,8 @@ let makeRecordCons (props: (string*Type) list) =
         ([], props) ||> List.fold (fun args (name, typ) ->
             let name =
                 Naming.lowerFirst name |> Naming.sanitizeIdent (fun x ->
-                    List.exists (fun (y: Ident) -> y.name = x) args)
-            {name=name; typ=typ}::args)
+                    List.exists (fun (y: Ident) -> y.Name = x) args)
+            (Ident(name, typ))::args)
         |> List.rev
     let body =
         Seq.zip args props
@@ -231,17 +231,17 @@ let makeRecordCons (props: (string*Type) list) =
                 if Naming.identForbiddenCharsRegex.IsMatch propName
                 then "['" + (propName.Replace("'", "\\'")) + "']"
                 else "." + propName
-            "this" + propName + "=" + arg.name)
+            "this" + propName + "=" + arg.Name)
         |> String.concat ";"
         |> fun body -> makeEmit None Unit [] body
     MemberDeclaration(Member(".ctor", Constructor, List.map Ident.getType args, Any), None, args, body, SourceLocation.Empty)
 
 let private makeMeth com argType returnType name coreMeth =
-    let arg = {name="other"; typ=argType}
+    let arg = Ident("other", argType)
     let body =
         CoreLibCall("Util", Some coreMeth, false, [Value This; Value(IdentValue arg)])
         |> makeCall com None returnType
-    MemberDeclaration(Member(name, Method, [arg.typ], returnType), None, [arg], body, SourceLocation.Empty)
+    MemberDeclaration(Member(name, Method, [arg.Type], returnType), None, [arg], body, SourceLocation.Empty)
 
 let makeUnionEqualMethod com argType = makeMeth com argType Boolean "Equals" "equalsUnions"
 let makeRecordEqualMethod com argType = makeMeth com argType Boolean "Equals" "equalsRecords"
@@ -297,8 +297,7 @@ let makeDelegate (com: ICompiler) arity (expr: Expr) =
         match arity with
         | Some arity when arity > 1 ->
             let lambdaArgs =
-                [for i=1 to arity do
-                    yield {name=com.GetUniqueVar(); typ=Any}]
+                [for i=1 to arity do yield Ident(com.GetUniqueVar(), Any)]
             let lambdaBody =
                 (expr, lambdaArgs)
                 ||> List.fold (fun callee arg ->

--- a/src/fable/Fable.Core/AST/AST.Fable.fs
+++ b/src/fable/Fable.Core/AST/AST.Fable.fs
@@ -192,9 +192,13 @@ and ArrayConsKind =
     | ArrayValues of Expr list
     | ArrayAlloc of Expr
 
-and Ident =
-    { name: string; typ: Type }
-    static member getType (i: Ident) = i.typ
+and Ident(name: string, ?typ: Type) =
+    let mutable consumed = false
+    member x.Name = name
+    member x.Type = defaultArg typ Any
+    member x.IsConsumed = consumed
+    member x.Consume() = consumed <- true
+    static member getType (i: Ident) = i.Type
 
 and ValueKind =
     | Null
@@ -219,7 +223,7 @@ and ValueKind =
         match x with
         | Null -> Any
         | Spread x -> x.Type
-        | IdentValue {typ=typ} -> typ
+        | IdentValue i -> i.Type
         | This | Super | ImportRef _ | TypeRef _ | Emit _ -> Any
         | NumberConst (_,kind) -> Number kind
         | StringConst _ -> String

--- a/src/fable/Fable.Core/Fable.Core.fs
+++ b/src/fable/Fable.Core/Fable.Core.fs
@@ -46,6 +46,12 @@ type StringEnumAttribute() =
 type GenericParamAttribute(name: string) =
     inherit Attribute()
 
+/// [EXPERIMENTAL] Record updates will be compiled as mutations: { x with a = 5 }
+/// Fable will fail if the original value is used after being updated or passed to a function.
+/// More info: http://fable-compiler.github.io/docs/interacting.html#Uniqueness-attribute
+type UniquenessAttribute() =
+    inherit Attribute()      
+
 /// Erased union type to represent one of two possible values.
 /// More info: http://fable-compiler.github.io/docs/interacting.html#Erase-attribute
 type [<Erase>] U2<'a, 'b> = Case1 of 'a | Case2 of 'b

--- a/src/fable/Fable.Core/Fable.Core.fs
+++ b/src/fable/Fable.Core/Fable.Core.fs
@@ -7,35 +7,35 @@ module Exceptions =
     let jsNative<'T> : 'T = failwith "JS only"
 
 /// Used for erased union types and to ignore modules in JS compilation.
-/// More info: http://fable-compiler.github.io/docs/interacting.html#Erase-attribute
+/// More info: http://fable.io/docs/interacting.html#Erase-attribute
 type EraseAttribute() =
     inherit Attribute()
 
 /// The module, type, function... is globally accessible in JS.
-/// More info: http://fable-compiler.github.io/docs/interacting.html#Import-attribute
+/// More info: http://fable.io/docs/interacting.html#Import-attribute
 type GlobalAttribute() =
     inherit Attribute()
 
 /// References to the module, type, function... will be replaced by import statements.
-/// More info: http://fable-compiler.github.io/docs/interacting.html#Import-attribute
+/// More info: http://fable.io/docs/interacting.html#Import-attribute
 type ImportAttribute(get: string, from: string) =
     inherit Attribute()
 
 /// Function calls will be replaced by inlined JS code.
-/// More info: http://fable-compiler.github.io/docs/interacting.html#Import-attribute
+/// More info: http://fable.io/docs/interacting.html#Import-attribute
 type EmitAttribute private () =
     inherit Attribute()
     new (macro: string) = EmitAttribute()
     new (emitterType: Type, methodName: string) = EmitAttribute()
 
 /// Compile union case lists as JS object literals.
-/// More info: http://fable-compiler.github.io/docs/interacting.html#KeyValueList-attribute
+/// More info: http://fable.io/docs/interacting.html#KeyValueList-attribute
 [<AttributeUsage(AttributeTargets.Class)>]
 type KeyValueListAttribute() =
     inherit Attribute()
 
 /// Compile union types as string literals.
-/// More info: http://fable-compiler.github.io/docs/interacting.html#StringEnum-attribute
+/// More info: http://fable.io/docs/interacting.html#StringEnum-attribute
 [<AttributeUsage(AttributeTargets.Class)>]
 type StringEnumAttribute() =
     inherit Attribute()
@@ -48,28 +48,29 @@ type GenericParamAttribute(name: string) =
 
 /// [EXPERIMENTAL] Record updates will be compiled as mutations: { x with a = 5 }
 /// Fable will fail if the original value is used after being updated or passed to a function.
-/// More info: http://fable-compiler.github.io/docs/interacting.html#Uniqueness-attribute
-type UniquenessAttribute() =
+/// More info: http://fable.io/docs/interacting.html#MutatingUpdate-attribute
+[<AttributeUsage(AttributeTargets.Class)>]
+type MutatingUpdateAttribute() =
     inherit Attribute()      
 
 /// Erased union type to represent one of two possible values.
-/// More info: http://fable-compiler.github.io/docs/interacting.html#Erase-attribute
+/// More info: http://fable.io/docs/interacting.html#Erase-attribute
 type [<Erase>] U2<'a, 'b> = Case1 of 'a | Case2 of 'b
 
 /// Erased union type to represent one of three possible values.
-/// More info: http://fable-compiler.github.io/docs/interacting.html#Erase-attribute
+/// More info: http://fable.io/docs/interacting.html#Erase-attribute
 type [<Erase>] U3<'a, 'b, 'c> = Case1 of 'a | Case2 of 'b | Case3 of 'c    
 
 /// Erased union type to represent one of four possible values.
-/// More info: http://fable-compiler.github.io/docs/interacting.html#Erase-attribute
+/// More info: http://fable.io/docs/interacting.html#Erase-attribute
 type [<Erase>] U4<'a, 'b, 'c, 'd> = Case1 of 'a | Case2 of 'b | Case3 of 'c | Case4 of 'd    
 
 /// Erased union type to represent one of five possible values.
-/// More info: http://fable-compiler.github.io/docs/interacting.html#Erase-attribute
+/// More info: http://fable.io/docs/interacting.html#Erase-attribute
 type [<Erase>] U5<'a, 'b, 'c, 'd, 'e> = Case1 of 'a | Case2 of 'b | Case3 of 'c | Case4 of 'd | Case5 of 'e    
 
 /// Erased union type to represent one of six possible values.
-/// More info: http://fable-compiler.github.io/docs/interacting.html#Erase-attribute
+/// More info: http://fable.io/docs/interacting.html#Erase-attribute
 type [<Erase>] U6<'a, 'b, 'c, 'd, 'e, 'f> = Case1 of 'a | Case2 of 'b | Case3 of 'c | Case4 of 'd | Case5 of 'e | Case6 of 'f    
 
 /// DO NOT USE: Internal type for Fable dynamic operations

--- a/src/tests/RecordTypeTests.fs
+++ b/src/tests/RecordTypeTests.fs
@@ -104,3 +104,19 @@ let ``Records can be JSON serialized forth and back``() =
 //         | _ -> false
 //     equal false success
 // #endif
+
+#if FABLE_COMPILER
+[<Fable.Core.Uniqueness>]
+#endif
+type UniquenessRecord =
+    { uniqueA: int; uniqueB: int }
+
+[<Test>]
+let ``Uniqueness records work``() =
+    let x = { uniqueA = 10; uniqueB = 20 }
+    equal 10 x.uniqueA
+    equal 20 x.uniqueB
+    let x' = { x with uniqueB = -20 }
+    // equal 10 x.uniqueA // This would make Fable compilation fail
+    equal 10 x'.uniqueA
+    equal -20 x'.uniqueB

--- a/src/tests/RecordTypeTests.fs
+++ b/src/tests/RecordTypeTests.fs
@@ -116,7 +116,11 @@ let ``Uniqueness records work``() =
     let x = { uniqueA = 10; uniqueB = 20 }
     equal 10 x.uniqueA
     equal 20 x.uniqueB
-    let x' = { x with uniqueB = -20 }
+    let uniqueB' = -x.uniqueB
+    let x' = { x with uniqueB = uniqueB' }
     // equal 10 x.uniqueA // This would make Fable compilation fail
     equal 10 x'.uniqueA
     equal -20 x'.uniqueB
+    let x'' = { x with uniqueA = -10 }
+    equal -10 x''.uniqueA
+    equal 20 x''.uniqueB

--- a/src/tests/RecordTypeTests.fs
+++ b/src/tests/RecordTypeTests.fs
@@ -106,13 +106,13 @@ let ``Records can be JSON serialized forth and back``() =
 // #endif
 
 #if FABLE_COMPILER
-[<Fable.Core.Uniqueness>]
+[<Fable.Core.MutatingUpdate>]
 #endif
-type UniquenessRecord =
+type MutatingRecord =
     { uniqueA: int; uniqueB: int }
 
 [<Test>]
-let ``Uniqueness records work``() =
+let ``Mutating records work``() =
     let x = { uniqueA = 10; uniqueB = 20 }
     equal 10 x.uniqueA
     equal 20 x.uniqueB

--- a/src/tests/RecordTypeTests.fs
+++ b/src/tests/RecordTypeTests.fs
@@ -121,6 +121,6 @@ let ``Uniqueness records work``() =
     // equal 10 x.uniqueA // This would make Fable compilation fail
     equal 10 x'.uniqueA
     equal -20 x'.uniqueB
-    let x'' = { x with uniqueA = -10 }
+    let x'' = { x' with uniqueA = -10 }
     equal -10 x''.uniqueA
-    equal 20 x''.uniqueB
+    equal -20 x''.uniqueB


### PR DESCRIPTION
Supersedes #425 

I changed the name of the attribute to `MutatingUpdate`. It's uglier but the intention should be clearer. Also these are not properly `Uniqueness` types because the compiler only checks direct references, not if the values is coming from an array, etc (actually, as the purpose of this is to prevent allocations we'll usually want to update the values within an array).