### PR TITLE
Add EntryModule attribute

### DIFF
--- a/RELEASE_NOTES_COMPILER.md
+++ b/RELEASE_NOTES_COMPILER.md
@@ -3,6 +3,7 @@
 * Add type info to JS constructors: cases (unions) and properties (records and classes)
 * Extend type references with generic info when calling `typeof`
 * Add `GenericParamAttribute` to implicitly pass type info of generic parameters
+* Add `EntryModuleAttribute` to mark assemblies as Fable libraries
 
 ### 0.6.12
 

--- a/docs/source/docs/compiling.md
+++ b/docs/source/docs/compiling.md
@@ -88,6 +88,8 @@ fable src/main/MyProject.fsproj --refs MyLib=my-lib/js
 
 > See [fable-helpers-sample](https://www.npmjs.com/package/fable-helpers-sample) to know how to publish a Fable package.
 
+TODO: Explain how to use the EntryModule attribute
+
 ## fableconfig.json
 
 Rather than passing all the options to the CLI, it may be more convenient to put them

--- a/docs/source/docs/interacting.md
+++ b/docs/source/docs/interacting.md
@@ -120,10 +120,6 @@ npm install -g ts2fable
 You can find common definitions already parsed [here](https://github.com/fable-compiler/Fable/blob/master/import).
 Some of them are available in npm, just search for `fable-import` packages.
 
-> **Attention**: Files starting with `Fable.Import` are ignored by Fable compiler as they're supposed
-to contain only empty bindings. If you're writing you're own bindings, please be aware of this fact
-and don't include any compilable code in a file with this prefix.
-
 ## Special attributes
 
 There are some attributes available in the `Fable.Core` namespace to ease the interaction with JS.

--- a/samples/other/fable-helpers-sample/README.md
+++ b/samples/other/fable-helpers-sample/README.md
@@ -49,11 +49,13 @@ the `dll` reference with references to the JS files. This is the purpose
 of the [`--refs` compiler parameter](http://fable-compiler.github.io/docs/compiling.html#Project-references).
 This parameter correlates the name of the referenced project (usually the name
 of the `dll` without the extension) and the path where the compiled JS files are.
-This way, we could compile our consumer script file like this: 
+This way, we could compile our consumer script file like this:
 
 ```bash
 fable MyScript.fsx --refs Fable.Helpers.Sample=fable-helpers-sample/js
 ```
+
+TODO: Explain how to use the EntryModule attribute
 
 When using [fableconfig.json](http://fable-compiler.github.io/docs/compiling.html#fableconfig-json), add this to the JSON config instead:
 

--- a/src/fable/Fable.Core/Fable.Core.fs
+++ b/src/fable/Fable.Core/Fable.Core.fs
@@ -51,7 +51,15 @@ type GenericParamAttribute(name: string) =
 /// More info: http://fable.io/docs/interacting.html#MutatingUpdate-attribute
 [<AttributeUsage(AttributeTargets.Class)>]
 type MutatingUpdateAttribute() =
-    inherit Attribute()      
+    inherit Attribute()
+
+/// Replace references to types in this assembly with JS imports.
+/// The attribute must decorate a non-nested module (or type) in a file
+/// located in the root directory for all other files in the project.
+/// More info: http://fable-compiler.github.io/docs/compiling.html#Project-references
+[<AttributeUsage(AttributeTargets.Class)>]
+type EntryModuleAttribute(jsImportPath: string) =
+    inherit Attribute()
 
 /// Erased union type to represent one of two possible values.
 /// More info: http://fable.io/docs/interacting.html#Erase-attribute

--- a/src/fable/Fable.Core/Util.fs
+++ b/src/fable/Fable.Core/Util.fs
@@ -48,9 +48,6 @@ module Naming =
     let ignoredAtts =
         set ["Import"; "Global"; "Emit"]
 
-    let ignoredFilesRegex =
-        Regex(@"Fable\.Import\.[\w.]*\.fs$")
-
     let identForbiddenCharsRegex =
         Regex @"^[^a-zA-Z_$]|[^0-9a-zA-Z_$]"
 

--- a/src/tests/DllRef/Fable.Tests.DllRef.fsproj
+++ b/src/tests/DllRef/Fable.Tests.DllRef.fsproj
@@ -41,6 +41,9 @@
     <OtherFlags />
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Fable.Core">
+      <HintPath>../../fable/Fable.Core/npm/Fable.Core.dll</HintPath>
+    </Reference>  
     <Reference Include="mscorlib" />
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>True</Private>

--- a/src/tests/DllRef/Lib.fs
+++ b/src/tests/DllRef/Lib.fs
@@ -1,3 +1,4 @@
+[<Fable.Core.EntryModule("./DllRef")>]
 module Fable.Tests.DllRef.Lib
 
 let 足す x y = x + y

--- a/src/tests/fableconfig.json
+++ b/src/tests/fableconfig.json
@@ -4,8 +4,7 @@
     "module": "commonjs",
     "plugins": ["../plugins/nunit/Fable.Plugins.NUnit.dll"],
     "refs": {
-        "Fable.Tests.Clamp": "./Another Project",
-        "Fable.Tests.DllRef": "./DllRef"
+        "Fable.Tests.Clamp": "./Another Project"
     },
     "targets": {
         "netcore": {

--- a/src/ts2fable/README.md
+++ b/src/ts2fable/README.md
@@ -21,10 +21,6 @@ You can find more information about how to interact with JavaScript
 from F# [here](https://github.com/fable-compiler/Fable/blob/master/docs/source/docs/interacting.md).
 Please note the parser is not perfect and some tweaking by hand may be needed.
 
-> **Attention**: Files starting with `Fable.Import` are ignored by Fable compiler as they're supposed
-to contain only empty bindings. If you're writing you're own bindings, please be aware of this fact
-and don't include any compilable code in a file with this prefix.
-
 ## Conventions
 
 Some JavaScript/TypeScript features have no direct translation to F#. Here is


### PR DESCRIPTION
This attribute allows library authors to mark directly their assembly as a Fable package, so consumers don't need to use the [--refs argument](http://fable.io/docs/compiling.html#Project-references).

Please note:

- The argument of the attribute is the base path (usually, the npm package name) that'll be used when importing types and functions from the lib.
- The attribute must decorate a non-nested module (or type) in a file located in the root directory for all other files in the project.