### PR TITLE
Add String.Remove method

### DIFF
--- a/src/fable/Fable.Core/npm/fable-core.ts
+++ b/src/fable/Fable.Core/npm/fable-core.ts
@@ -943,6 +943,18 @@ class FString {
     return FString.padLeft(str, len, ch, true);
   }
 
+  static remove(str: string, args1: number, args2?: number) {
+    var start = 0;
+    var len = 0;
+    if (args2 === undefined) {
+      len = args1;
+    } else {
+      start = args1;
+      len = args2;
+    }
+    return str.slice(start, -len);
+  }
+
   static replace(str: string, search: string, replace: string) {
     return str.replace(new RegExp(FRegExp.escape(search), "g"), replace);
   }

--- a/src/fable/Fable.Core/npm/fable-core.ts
+++ b/src/fable/Fable.Core/npm/fable-core.ts
@@ -944,23 +944,15 @@ class FString {
   }
 
   static remove(str: string, startIndex: number, count?: number) {
-    if (count === undefined) {
-      if (startIndex >= str.length) {
-        throw "startIndex must be less than length of string";
-      }
-    } else {
-      if (startIndex >= str.length || count > str.length) {
-        throw "Index and count must refer to a location within the string."
-      }
+    if (startIndex >= str.length) {
+      throw "startIndex must be less than length of string";
     }
-
-    if (count === undefined) {
-      return str.slice(0, startIndex);
-    } else {
-      return str.slice(0, startIndex) + str.substring(startIndex + count);
+    if (typeof count === "number" && (startIndex + count) > str.length) {
+      throw "Index and count must refer to a location within the string."
     }
+    return str.slice(0, startIndex) + (typeof count === "number" ? str.substr(startIndex + count) : "");
   }
-
+  
   static replace(str: string, search: string, replace: string) {
     return str.replace(new RegExp(FRegExp.escape(search), "g"), replace);
   }

--- a/src/fable/Fable.Core/npm/fable-core.ts
+++ b/src/fable/Fable.Core/npm/fable-core.ts
@@ -943,16 +943,22 @@ class FString {
     return FString.padLeft(str, len, ch, true);
   }
 
-  static remove(str: string, args1: number, args2?: number) {
-    var start = 0;
-    var len = 0;
-    if (args2 === undefined) {
-      len = args1;
+  static remove(str: string, startIndex: number, count?: number) {
+    if (count === undefined) {
+      if (startIndex >= str.length) {
+        throw "startIndex must be less than length of string";
+      }
     } else {
-      start = args1;
-      len = args2;
+      if (startIndex >= str.length || count > str.length) {
+        throw "Index and count must refer to a location within the string."
+      }
     }
-    return str.slice(start, -len);
+
+    if (count === undefined) {
+      return str.slice(0, startIndex);
+    } else {
+      return str.slice(0, startIndex) + str.substring(startIndex + count);
+    }
   }
 
   static replace(str: string, search: string, replace: string) {

--- a/src/tests/StringTests.fs
+++ b/src/tests/StringTests.fs
@@ -364,6 +364,21 @@ let ``System.String.Concat works``() =
       String.Concat(seq { yield "a"; yield "b"; yield "c" })
       |> equal "abc"
 
+[<Test>]
+let ``String.Remove works``() =
+      let str = "abcd"
+      str.Remove(1)
+      |> equal "abc"
+      str.Remove(1, 1)
+      |> equal "bc"
+      str.Remove(3,1)
+      |> equal ""
+      // Even offset values should works
+      // Not need to handle exception here
+      str.Remove(5,5)
+      |> equal ""
+
+
 // String - F# module functions
 
 [<Test>]

--- a/src/tests/StringTests.fs
+++ b/src/tests/StringTests.fs
@@ -366,18 +366,16 @@ let ``System.String.Concat works``() =
 
 [<Test>]
 let ``String.Remove works``() =
-      let str = "abcd"
-      str.Remove(1)
-      |> equal "abc"
-      str.Remove(1, 1)
-      |> equal "bc"
-      str.Remove(3,1)
+      "abcd".Remove(2)
+      |> equal "ab"
+      "abcd".Remove(1,2)
+      |> equal "ad"
+      "abcd".Remove(0,2)
+      |> equal "cd"
+      "abcd".Remove(0,4)
       |> equal ""
-      // Even offset values should works
-      // Not need to handle exception here
-      str.Remove(5,5)
-      |> equal ""
-
+      "abcd".Remove(0,0)
+      |> equal "abcd"
 
 // String - F# module functions
 


### PR DESCRIPTION
@alfonsogarciacaro I am not sure of the arguments handling in `fable-core.ts`.

I did this way because if there is only one argument then the index is 0, and remove X characters.

I used `slice` method because it's more elegant than `substring` and performance are the sames.