### PR TITLE
Simpler test case for #483.

### DIFF
--- a/src/tests/EnumTests.fs
+++ b/src/tests/EnumTests.fs
@@ -107,62 +107,20 @@ let ``EnumOfValue works``() =
     EnumOfValue 2 |> equal Fruits.Banana
     EnumOfValue 3 |> equal Fruits.Coconut
 
-open LanguagePrimitives
-
-type Instruction =
-| Jmp = 0x40uy // 0100 0000
-| Jsr = 0x60uy // 0110 0000
-
-type Register =
-| R0 = 0x00uy // 0000 0000
-
-let InstructionMask    = 0b11110000uy
-let RegisterMask       = 0b00000111uy
-
-type Operand =
-| NoOp
-| Reg of Register
-| Addr of uint16
-
-type InstructionRegister = {
-    mutable Data: byte array
-    mutable SourceOperand: Operand
-    mutable TargetOperand: Operand
-}
-
-type Registers = {
-    R: uint16 array
-    InstructionRegister: InstructionRegister
-}
-
-type Cpu = {
-    Registers: Registers
-}
-
 [<Test>]
 let ``Pattern matching can be nested within a switch statement``() = // See #483
-    let Execute cpu =
-        let _r = cpu.Registers.R
-        let _ir = cpu.Registers.InstructionRegister
+    let rand = new System.Random();
 
-        let firstOpCode = _ir.Data.[0]
-        let instruction = firstOpCode &&& InstructionMask |> EnumOfValue
-        let register = firstOpCode &&& RegisterMask
-
-        match instruction with
-        | Instruction.Jmp ->
-            match _ir.TargetOperand with
-            | Addr address -> _r.[7] <- address
-            | _ -> ()
-
-        | Instruction.Jsr ->
-            match _ir.TargetOperand with
-            | Addr address ->
-                _r.[6] <- _r.[6] - 2us
-                _r.[int register] <- _r.[7]
-                _r.[7] <- address
-            | _ -> ()
-
+    match rand.Next(1, 3) with
+    | 1 ->
+        match rand.Next(1, 2) with
+        | 1 -> ()
         | _ -> ()
-    // Not sure how to test this, just check it compiles
-    ()
+    | 2 ->
+        match rand.Next(1, 2) with
+        | 1 -> ()
+        | _ -> ()
+    | _ -> 
+        match rand.Next(1, 2) with
+        | 1 -> ()
+        | _ -> ()


### PR DESCRIPTION
Smaller test case for #483.

Like the original, it fails to compile when using the old version of `Fable2Babel.transformBranch`. But passes when using the new one.