### PR TITLE
Fix Fable.JsonConverter failing on reading 'null' JSON token for erased option of union

### DIFF
--- a/src/nuget/Fable.JsonConverter/Fable.JsonConverter.fs
+++ b/src/nuget/Fable.JsonConverter/Fable.JsonConverter.fs
@@ -100,4 +100,5 @@ type JsonConverter() =
                     let value = serializer.Deserialize(reader, itemTypes.[0])
                     advance reader
                     FSharpValue.MakeUnion(uci, [|value|])
+            | JsonToken.Null -> null // for { "union": null }
             | _ -> failwith "invalid token"

--- a/src/tests/JsonTests.fs
+++ b/src/tests/JsonTests.fs
@@ -285,6 +285,38 @@ let ``Union case with multiple fields``() =
     let u2 = MultiCase("foo", {a="John"; b=14})
     u = u2 |> equal true
 
+
+type OptionalUnionHolder =
+    { a : UnionJson option }
+
+[<Test>]
+let ``Optional union of record: with a value`` () =
+    let json = """ {"a":{"Type2": {"a":"a","b":1} }} """
+    let result : OptionalUnionHolder = S.ofJson json
+    match result.a with
+    | Some (Type2 t) -> t = { a= "a"; b=1 }
+    | _ -> false
+    |> equal true
+
+[<Test>]
+let ``Optional union of record: for undefined`` () =
+    let json = """ {} """
+    let result : OptionalUnionHolder = S.ofJson json
+    match result.a with
+    | None -> true
+    | _ -> false
+    |> equal true
+
+[<Test>]
+let ``Optional union of record: for null`` () =
+    let json = """ {"a":null} """
+    let result : OptionalUnionHolder = S.ofJson json
+    match result.a with
+    | None -> true
+    | _ -> false
+    |> equal true
+
+
 #if FABLE_COMPILER
 type IData = interface end
 


### PR DESCRIPTION
Currently Fable.JsonConverter fails with "invalid token" for { "a": null }, when "a" is an erased option of a union. The fix propagates Null JSON token further as a null reference.