### PR TITLE
Json conversion case insensitive union cases

### DIFF
--- a/src/fable/Fable.Core/ts/Serialize.ts
+++ b/src/fable/Fable.Core/ts/Serialize.ts
@@ -74,6 +74,9 @@ export function inflate(val: any, typ: any): any {
             ? arr.map((x: any) => inflate(x, enclosing))
             : arr;
   }
+  function firstCharUpper(str: string) {
+    return str.charAt(0).toUpperCase() + str.slice(1);
+  }
   function inflateMap(obj: any, keyEnclosing: List<any>, valEnclosing: List<any>): [any, any][] {
     const inflateKey = keyEnclosing.head !== "string";
     const inflateVal = needsInflate(valEnclosing);
@@ -135,7 +138,7 @@ export function inflate(val: any, typ: any): any {
     if (typ.prototype[FSymbol.cases]) {
       let u: any = { Fields: [] };
       if (typeof val === "string") {
-        u.Case = val;
+        u.Case = firstCharUpper(val);
       }
       else {
         const caseName = Object.getOwnPropertyNames(val)[0];

--- a/src/nuget/Fable.JsonConverter/Fable.JsonConverter.fs
+++ b/src/nuget/Fable.JsonConverter/Fable.JsonConverter.fs
@@ -31,6 +31,9 @@ type JsonConverter() =
                 read (index + 1) (acc @ [value])
         advance reader
         read 0 List.empty
+
+    let firstCharToUpper (str: string) = str.[0].ToString().ToUpper() + str.Substring(1)
+
     override x.CanConvert(t) =
         t.Name = "FSharpOption`1"
         || t.FullName.StartsWith("System.Tuple")
@@ -79,8 +82,9 @@ type JsonConverter() =
             | _ -> failwith "invalid token"
         | t -> // Unions
             let getUci name =
+                let normalizedCaseName = firstCharToUpper name
                 FSharpType.GetUnionCases(t)
-                |> Array.find (fun uci -> uci.Name = name)
+                |> Array.find (fun uci -> uci.Name = normalizedCaseName)
             match reader.TokenType with
             | JsonToken.String ->
                 let name = serializer.Deserialize(reader, typeof<string>) |> unbox<string>

--- a/src/tests/JsonTests.fs
+++ b/src/tests/JsonTests.fs
@@ -298,7 +298,7 @@ let ``Union case name case sensitivity: camel case (string enum)``() =
 [<Test>]
 let ``Union case name case sensitivity: mixed case``() =
     let tryParse (): MultiUnion = S.ofJson """ "EMptyCasE" """
-    (try tryParse () |> ignore; false with | _ -> true) |> equal true
+    (try not (tryParse () = EmptyCase) with | _ -> true) |> equal true // fail or return null
 
 
 #if FABLE_COMPILER

--- a/src/tests/JsonTests.fs
+++ b/src/tests/JsonTests.fs
@@ -285,6 +285,22 @@ let ``Union case with multiple fields``() =
     let u2 = MultiCase("foo", {a="John"; b=14})
     u = u2 |> equal true
 
+[<Test>]
+let ``Union case name case sensitivity: pascal case (normal)``() =
+    let u: MultiUnion = S.ofJson """ "EmptyCase" """
+    u = EmptyCase |> equal true
+
+[<Test>]
+let ``Union case name case sensitivity: camel case (string enum)``() =
+    let u: MultiUnion = S.ofJson """ "emptyCase" """
+    u = EmptyCase |> equal true
+
+[<Test>]
+let ``Union case name case sensitivity: mixed case``() =
+    let tryParse (): MultiUnion = S.ofJson """ "EMptyCasE" """
+    (try tryParse () |> ignore; false with | _ -> true) |> equal true
+
+
 #if FABLE_COMPILER
 type IData = interface end
 


### PR DESCRIPTION
In some places union case names appear in lowercase, e.g. cases of unions marked as StringEnum and initialized js-side. This patch makes first letter of union case names case insensitive in Fable.JsonConverter (it fails with an exception otherwise) and in Serialize.inflate/ofJson (mostly for uniformity with server-side). Not quite sure if it's the right way to go, but considering DU's case names must always be uppercase in F#, this should not introduce any ambiguities at least.
