### PR TITLE
[ON HOLD] Attempt to create a façade for interfaces

### DIFF
--- a/src/fable/Fable.Client.Node/Main.fs
+++ b/src/fable/Fable.Client.Node/Main.fs
@@ -59,8 +59,6 @@ let readOptions argv =
         declaration = def opts "declaration" false (un bool.Parse)
         symbols = def opts "symbols" [] (li id) |> List.append ["FABLE_COMPILER"] |> List.distinct
         plugins = def opts "plugins" [] (li id)
-        refs = Map(def opts "refs" [] (li (fun (x: string) ->
-            let xs = x.Split('=') in xs.[0], xs.[1])))
         extra = Map(def opts "extra" [] (li (fun (x: string) ->
             if x.Contains("=")
             then let xs = x.Split('=') in xs.[0], xs.[1]

--- a/src/fable/Fable.Client.Node/js/constants.js
+++ b/src/fable/Fable.Client.Node/js/constants.js
@@ -16,7 +16,7 @@ exports.FSHARP_PROJECT_EXTENSIONS = [".fsproj", ".fsx"];
 /** Set of options compatible with Fable's .NET process */
 exports.FABLE_BIN_OPTIONS = new Set([
     "projFile", "outDir", "coreLib", "symbols", "plugins",
-    "refs", "watch", "dll", "clamp", "extra", "declaration", "noTypedArrays"
+    "watch", "dll", "clamp", "extra", "declaration", "noTypedArrays"
 ]);
 
 /** Accepted JS modules an the alias for Rollup */

--- a/src/fable/Fable.Client.Node/js/fable.js
+++ b/src/fable/Fable.Client.Node/js/fable.js
@@ -20,7 +20,6 @@ var optionDefinitions = [
   { name: 'babelPlugins', multiple: true, description: "Additional Babel plugins (without `babel-plugin-` prefix). Must be installed in the project directory." },
   { name: 'loose', type: Boolean, description: "Enable “loose” transformations for babel-preset-es2015 plugins (true by default)." },
   { name: 'babelrc', type: Boolean, description: "Use a `.babelrc` file for Babel configuration (invalidates other Babel related options)." },
-  { name: 'refs', multiple: true, description: "Specify dll or project references in `Reference=js/import/path` format (e.g. `MyLib=../lib`)." },
   { name: 'dll', type: Boolean, description: "Generate a `dll` assembly." },
   { name: 'noTypedArrays', type: Boolean, description: "Don't compile numeric arrays as JS typed arrays." },
   { name: 'clamp', type: Boolean, description: "Compile unsigned byte arrays as Uint8ClampedArray." },
@@ -354,8 +353,6 @@ function resolvePath(optName, value, workingDir) {
             case "plugins":
             case "babelPlugins":
                 return resolveArray(value, resolve);
-            case "refs":
-                return resolveKeyValuePairs(value);
         }
     }
     return value;
@@ -559,14 +556,6 @@ function readOptions(opts) {
         opts.module = opts.rollup
             ? "iife"
             : (opts.ecma != "es2015" && opts.ecma != "es6" ? "commonjs" : "es2015");
-    }
-
-    // If refs is set in fableconfig.json, convert them to an array
-    if (typeof opts.refs == "object" && !Array.isArray(opts.refs)) {
-        var refs = [];
-        for (var k in opts.refs)
-            refs.push(k + "=" + opts.refs[k]);
-        opts.refs = refs;
     }
 
     // Check version

--- a/src/fable/Fable.Core/AST/AST.Fable.Util.fs
+++ b/src/fable/Fable.Core/AST/AST.Fable.Util.fs
@@ -110,7 +110,7 @@ let tryImported com name srcFile curFile (decs: #seq<Decorator>) =
 
 let makeJsObject range (props: (string * Expr) list) =
     let decls = props |> List.map (fun (name, body) ->
-        MemberDeclaration(Member(name, Field, [], body.Type), None, [], body, range))
+        MemberDeclaration(Member(name, Field, InstanceLoc, [], body.Type), None, [], body, range))
     ObjExpr(decls, [], None, Some range)
 
 let makeNonDeclaredTypeRef (kind: TypeKind) arg =
@@ -229,17 +229,30 @@ let rec makeTypeTest com range curFile (typ: Type) expr =
             CoreLibCall ("Util", Some "hasInterface", false, [expr; makeConst typEnt.FullName])
             |> makeCall com range Boolean
         | _ ->
+            let expr =
+                match expr.Type with
+                | DeclaredType(ent, _) as t when ent.Kind = Interface && not typEnt.IsErased ->
+                    getSymbol com "this" |> makeGet range t expr
+                | _ -> expr
             makeBinOp range Boolean [expr; makeNonGenTypeRef com range curFile typ] BinaryInstanceOf
     | GenericParam name ->
         "Cannot type test generic parameter " + name
         |> attachRange range |> failwith
+
+let makeUpcast com range typ expr =
+    match typ with
+    | Fable.DeclaredType(ent, _)
+        when ent.Kind = Interface && not(Naming.replacedInterfaces.Contains ent.FullName) ->
+        CoreLibCall ("Util", Some "upcast", false, [expr; Value(StringConst ent.FullName)])
+        |> makeCall com range typ
+    | _ -> Fable.Wrapped(expr, typ)
 
 let makeUnionCons () =
     let args = [Ident("caseName", String); Ident("fields", Array Any)]
     let argTypes = List.map Ident.getType args
     let emit = Emit "this.Case=caseName; this.Fields = fields;" |> Value
     let body = Apply (emit, [], ApplyMeth, Unit, None)
-    MemberDeclaration(Member(".ctor", Constructor, argTypes, Any), None, args, body, SourceLocation.Empty)
+    MemberDeclaration(Member(".ctor", Constructor, InstanceLoc, argTypes, Any), None, args, body, SourceLocation.Empty)
 
 let makeRecordCons (props: (string*Type) list) =
     let args =
@@ -259,14 +272,15 @@ let makeRecordCons (props: (string*Type) list) =
             "this" + propName + "=" + arg.Name)
         |> String.concat ";"
         |> fun body -> makeEmit None Unit [] body
-    MemberDeclaration(Member(".ctor", Constructor, List.map Ident.getType args, Any), None, args, body, SourceLocation.Empty)
+    MemberDeclaration(Member(".ctor", Constructor, InstanceLoc, List.map Ident.getType args, Any), None, args, body, SourceLocation.Empty)
 
 let private makeMeth com argType returnType name coreMeth =
     let arg = Ident("other", argType)
     let body =
-        CoreLibCall("Util", Some coreMeth, false, [Value This; Value(IdentValue arg)])
+        let thisExpr = makeIdentExpr Naming.capturedThisIdent
+        CoreLibCall("Util", Some coreMeth, false, [thisExpr; Value(IdentValue arg)])
         |> makeCall com None returnType
-    MemberDeclaration(Member(name, Method, [arg.Type], returnType), None, [arg], body, SourceLocation.Empty)
+    MemberDeclaration(Member(name, Method, InstanceLoc,[arg.Type], returnType), None, [arg], body, SourceLocation.Empty)
 
 let makeUnionEqualMethod com argType = makeMeth com argType Boolean "Equals" "equalsUnions"
 let makeRecordEqualMethod com argType = makeMeth com argType Boolean "Equals" "equalsRecords"
@@ -275,19 +289,29 @@ let makeRecordCompareMethod com argType = makeMeth com argType (Number Int32) "C
 
 let makeTypeNameMeth com typeFullName =
     let typeFullName = Value(StringConst typeFullName)
-    MemberDeclaration(Member("typeName", Method, [], String, isSymbol=true),
+    MemberDeclaration(Member("typeName", Method, InstanceLoc, [], String, isSymbol=true),
                         None, [], typeFullName, SourceLocation.Empty)
 
-let makeInterfacesMethod com curFile (ent: Fable.Entity) extend interfaces =
+let makeInterfacesMethod com curFile (ent: Fable.Entity) extend (interfaces: Map<string, Declaration list>) =
     let interfaces: Expr =
-        let interfaces = List.map (StringConst >> Value) interfaces
-        ArrayConst(ArrayValues interfaces, String) |> Value
+        interfaces |> Seq.map (fun kv ->
+            match kv.Value with
+            | [] -> MemberDeclaration(Member(kv.Key, Field, InstanceLoc, [], Any),
+                                      None, [], Value(BoolConst true), SourceLocation.Empty)
+            | impls ->
+                let thisArg = makeIdent "_this"
+                let thisCapture = MemberDeclaration(Member("this", Field, InstanceLoc, [], Any, isSymbol=true),
+                                                    None, [], Value(IdentValue thisArg), SourceLocation.Empty)
+                let r = (List.head impls).Range + (List.last impls).Range
+                let body: Expr = ObjExpr(thisCapture::impls, [], None, Some r)
+                MemberDeclaration(Member(kv.Key, Method, InstanceLoc, [Any], Any), None, [thisArg], body, r))
+        |> fun decls -> ObjExpr(Seq.toList decls, [], None, None)
     let interfaces =
         if not extend then interfaces else
         CoreLibCall("Util", Some "extendInfo", false,
             [makeTypeRefFrom com curFile ent; makeConst "interfaces"; interfaces])
         |> makeCall com None Any
-    MemberDeclaration(Member("interfaces", Method, [], Array String, isSymbol=true),
+    MemberDeclaration(Member("interfaces", Method, InstanceLoc, [], Array String, isSymbol=true),
                         None, [], interfaces, SourceLocation.Empty)
 
 let makePropertiesMethod com curFile ent extend properties =
@@ -295,14 +319,14 @@ let makePropertiesMethod com curFile ent extend properties =
         let genInfo = { makeGeneric=true; genericAvailability=false }
         properties |> List.map (fun (name, typ) ->
             let body = makeTypeRef com None curFile genInfo typ
-            MemberDeclaration(Member(name, Field, [], Any), None, [], body, SourceLocation.Empty))
+            MemberDeclaration(Member(name, Field, InstanceLoc, [], Any), None, [], body, SourceLocation.Empty))
         |> fun decls -> ObjExpr(decls, [], None, None)
     let body =
         if not extend then body else
         CoreLibCall("Util", Some "extendInfo", false,
             [makeTypeRefFrom com curFile ent; makeConst "properties"; body])
         |> makeCall com None Any
-    MemberDeclaration(Member("properties", Method, [], Any, isSymbol=true),
+    MemberDeclaration(Member("properties", Method, InstanceLoc, [], Any, isSymbol=true),
                         None, [], body, SourceLocation.Empty)
 
 let makeCasesMethod com curFile (cases: Map<string, Type list>) =
@@ -311,9 +335,9 @@ let makeCasesMethod com curFile (cases: Map<string, Type list>) =
         cases |> Seq.map (fun kv ->
             let typs = kv.Value |> List.map (makeTypeRef com None curFile genInfo)
             let typs = Fable.ArrayConst(Fable.ArrayValues typs, Any) |> Fable.Value
-            MemberDeclaration(Member(kv.Key, Field, [], Any), None, [], typs, SourceLocation.Empty))
+            MemberDeclaration(Member(kv.Key, Field, InstanceLoc, [], Any), None, [], typs, SourceLocation.Empty))
         |> fun decls -> ObjExpr(Seq.toList decls, [], None, None)
-    MemberDeclaration(Member("cases", Method, [], Any, isSymbol=true), None, [], body, SourceLocation.Empty)
+    MemberDeclaration(Member("cases", Method, InstanceLoc, [], Any, isSymbol=true), None, [], body, SourceLocation.Empty)
 
 let makeDelegate (com: ICompiler) arity (expr: Expr) =
     let rec flattenLambda (arity: int option) isArrow accArgs = function

--- a/src/fable/Fable.Core/AST/AST.Fable.fs
+++ b/src/fable/Fable.Core/AST/AST.Fable.fs
@@ -94,10 +94,10 @@ and Entity(kind: Lazy<_>, file, fullName, members: Lazy<Member list>,
         List.exists ((=) fullName) interfaces
     member x.TryGetDecorator decorator =
         decorators |> List.tryFind (fun x -> x.Name = decorator)
-    member x.TryGetMember(name, kind, isStatic, argTypes, ?argsEqual) =
+    member x.TryGetMember(name, kind, loc, argTypes, ?argsEqual) =
         let argsEqual = defaultArg argsEqual (=)
         members.Value |> List.tryFind (fun m ->
-            if m.IsStatic <> isStatic
+            if m.Location <> loc
                 || m.Name <> name
                 || m.Kind <> kind
             then false
@@ -131,10 +131,16 @@ and MemberKind =
     | Setter
     | Field
 
-and Member(name, kind, argTypes, returnType, ?originalType, ?genParams, ?decorators,
-           ?isPublic, ?isMutable, ?isStatic, ?isSymbol, ?hasRestParams, ?overloadIndex) =
+and MemberLoc =
+    | InstanceLoc
+    | StaticLoc
+    | InterfaceLoc of string
+
+and Member(name, kind, loc, argTypes, returnType, ?originalType, ?genParams, ?decorators,
+           ?isPublic, ?isMutable, ?isSymbol, ?hasRestParams, ?overloadIndex) =
     member x.Name: string = name
     member x.Kind: MemberKind = kind
+    member x.Location: MemberLoc = loc
     member x.ArgumentTypes: Type list = argTypes
     member x.ReturnType: Type = returnType
     member x.OriginalCurriedType: Type = defaultArg originalType (Function(argTypes, returnType))
@@ -142,7 +148,6 @@ and Member(name, kind, argTypes, returnType, ?originalType, ?genParams, ?decorat
     member x.Decorators: Decorator list = defaultArg decorators []
     member x.IsPublic: bool = defaultArg isPublic true
     member x.IsMutable: bool = defaultArg isMutable false
-    member x.IsStatic: bool = defaultArg isStatic false
     member x.IsSymbol: bool = defaultArg isSymbol false
     member x.HasRestParams: bool = defaultArg hasRestParams false
     member x.OverloadIndex: int option = overloadIndex

--- a/src/fable/Fable.Core/Compiler.fs
+++ b/src/fable/Fable.Core/Compiler.fs
@@ -6,7 +6,6 @@ type CompilerOptions = {
         coreLib: string
         symbols: string list
         plugins: string list
-        refs: Map<string, string>
         watch: bool
         dll: bool
         noTypedArrays: bool

--- a/src/fable/Fable.Core/Util.fs
+++ b/src/fable/Fable.Core/Util.fs
@@ -24,8 +24,10 @@ module Naming =
 
     let [<Literal>] placeholder = "__PLACE-HOLDER__"
     let [<Literal>] dummyFile = "__DUMMY-FILE__.txt"
-    let [<Literal>] exportsIdent = "__exports"
+    let [<Literal>] exportsIdent = "_exports"
     let [<Literal>] genArgsIdent = "_genArgs"
+    let [<Literal>] capturedThisIdent = "_this"
+
     let [<Literal>] fablemapExt = ".fablemap"
 
     /// Calls to methods of these interfaces will be replaced
@@ -75,7 +77,7 @@ module Naming =
     let jsKeywords =
         set [
             // Fable reserved keywords
-            exportsIdent; genArgsIdent
+            exportsIdent; genArgsIdent; capturedThisIdent
             // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Keywords
             "abstract"; "await"; "boolean"; "break"; "byte"; "case"; "catch"; "char"; "class"; "const"; "continue"; "debugger"; "default"; "delete"; "do"; "double";
             "else"; "enum"; "export"; "extends"; "false"; "final"; "finally"; "float"; "for"; "function"; "goto"; "if"; "implements"; "import"; "in"; "instanceof"; "int"; "interface";

--- a/src/fable/Fable.Core/ts/AsyncBuilder.ts
+++ b/src/fable/Fable.Core/ts/AsyncBuilder.ts
@@ -1,4 +1,5 @@
 import { IDisposable } from "./Util"
+import { upcast } from "./Util"
 
 export type Continuation<T> = (x: T) => void;
 
@@ -143,7 +144,8 @@ export class AsyncBuilder {
   }
 
   Using<T extends IDisposable, U>(resource: T, binder: (x: T) => IAsync<U>) {
-    return this.TryFinally(binder(resource), () => resource.Dispose());
+    return this.TryFinally(binder(resource),
+      () => upcast(resource, "System.IDisposable").Dispose());
   }
 
   While(guard: () => boolean, computation: IAsync<void>): IAsync<void> {

--- a/src/fable/Fable.Core/ts/Seq.ts
+++ b/src/fable/Fable.Core/ts/Seq.ts
@@ -1,6 +1,7 @@
 import { IDisposable } from "./Util"
 import { equals } from "./Util"
 import { compare } from "./Util"
+import { upcast } from "./Util"
 import { permute as arrayPermute } from "./Array"
 import List from "./List"
 import FSet from "./Set"
@@ -182,7 +183,7 @@ export function enumerateUsing<T extends IDisposable, U>(disp: T, work: (x: T) =
   const disposeOnce = () => {
     if (!isDisposed) {
       isDisposed = true;
-      disp.Dispose();
+      upcast(disp, "System.IDisposable").Dispose();
     }
   };
   try {

--- a/src/fable/Fable.Core/ts/Serialize.ts
+++ b/src/fable/Fable.Core/ts/Serialize.ts
@@ -186,7 +186,7 @@ export function toJsonWithTypeInfo(o: any): string {
           { $type: (v as any)[FSymbol.typeName] ? (v as any)[FSymbol.typeName]() : "System.Collections.Generic.Dictionary" }, v);
       }
       else if (v[FSymbol.typeName]) {
-        if (hasInterface(v, "FSharpUnion", "FSharpRecord")) {
+        if (hasInterface(v, "FSharpUnion") || hasInterface(v, "FSharpRecord")) {
           return Object.assign({ $type: v[FSymbol.typeName]() }, v);
         }
         else {

--- a/src/fable/Fable.Core/ts/Symbol.ts
+++ b/src/fable/Fable.Core/ts/Symbol.ts
@@ -7,7 +7,8 @@ export const fableGlobal: {
     typeName: symbol,
     properties: symbol,
     generics: symbol,
-    cases: symbol
+    cases: symbol,
+    this: symbol
   }
 } = function () {
   const globalObj =
@@ -22,7 +23,8 @@ export const fableGlobal: {
         typeName: Symbol("typeName"),
         properties: Symbol("properties"),
         generics: Symbol("generics"),
-        cases: Symbol("cases")
+        cases: Symbol("cases"),
+        this: Symbol("this")
       }
     };
   }

--- a/src/fable/Fable.sln
+++ b/src/fable/Fable.sln
@@ -9,7 +9,7 @@ Project("{f2a71f9b-5d33-465a-a702-920d77279786}") = "Fable.Compiler", "Fable.Com
 EndProject
 Project("{f2a71f9b-5d33-465a-a702-920d77279786}") = "Fable.Client.Node", "Fable.Client.Node\Fable.Client.Node.fsproj", "{6C87964E-0B32-48D4-BAA3-BDDBD7264C97}"
 EndProject
-Project("{f2a71f9b-5d33-465a-a702-920d77279786}") = "Fable.Tests", "..\tests\Fable.Tests.fsproj", "{6EF06954-FBDF-42C7-815C-B13BA2926C93}"
+Project("{f2a71f9b-5d33-465a-a702-920d77279786}") = "Fable.Tests", "..\tests\Main\Fable.Tests.fsproj", "{6EF06954-FBDF-42C7-815C-B13BA2926C93}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/tests/Main/Fable.Tests.fsproj
+++ b/src/tests/Main/Fable.Tests.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Name>Fable.Tests</Name>
@@ -66,6 +66,7 @@
     <Compile Include="EnumTests.fs" />
     <Compile Include="EventTests.fs" />
     <Compile Include="HashSetTests.fs" />
+    <Compile Include="InterfaceTests.fs" />
     <Compile Include="JsonTests.fs" />
     <Compile Include="ListTests.fs" />
     <Compile Include="MapTests.fs" />

--- a/src/tests/Main/InterfaceTests.fs
+++ b/src/tests/Main/InterfaceTests.fs
@@ -1,0 +1,38 @@
+[<Util.Testing.TestFixture>]
+module Fable.Tests.Interfaces
+
+open System
+open FSharp.Core.LanguagePrimitives
+open Util.Testing
+open Fable.Tests.Util
+
+// TODO: Moar tests
+// Test object expression for interface
+// Upcast class to interface
+// Downcast class to interface
+// Type test class for interface
+// Type test interface for interface
+// Type test interface for class
+// Inherited interfaces
+// IEnumerable implementations
+
+type IFoo =
+    abstract Foo: int -> string
+
+[<AbstractClass>]
+type Abstract() =
+    abstract member Foo : float -> string
+    interface IFoo with
+        member this.Foo i =
+            float i * 2. |> this.Foo
+
+type Impl() =
+    inherit Abstract()
+    override this.Foo(f) =
+        f + 5. |> string
+
+[<Test>]
+let ``Interfaces in abstract classes work``() =
+    let x = Impl()
+    x.Foo 3. |> equal "8"
+    (x :> IFoo).Foo 3 |> equal "11"

--- a/src/tests/Main/JsonTests.fs
+++ b/src/tests/Main/JsonTests.fs
@@ -238,10 +238,7 @@ let ``Properties`` () =
 [<Test>]
 let ``Union of list``() =
     let u = CaseB [{Name="Sarah";Child={a="John";b=14}}]
-    // Providing type parameters when treating method as a first class value
-    // isn't supported in AppVeyor, see http://stackoverflow.com/a/2743479
-    let json = toJson u
-    let u2: U = ofJson json
+    let u2: U = toJson u |> ofJson
     u = u2 |> equal true
     let u3: U = ofJson """{"CaseB":[{"Name":"Sarah","Child":{"a":"John","b":14}}]}"""
     u = u3 |> equal true

--- a/src/tools/ASTViewer.fsx
+++ b/src/tools/ASTViewer.fsx
@@ -1,5 +1,4 @@
 #r "../../packages/FSharp.Compiler.Service/lib/net45/FSharp.Compiler.Service.dll"
-#r "../../packages/FSharp.Compiler.Service.ProjectCracker/lib/net45/FSharp.Compiler.Service.ProjectCracker.dll"
 
 open System
 open System.IO
@@ -12,7 +11,7 @@ let (|NonAbbreviatedType|) (t: FSharpType) =
     let rec abbr (t: FSharpType) =
         if t.IsAbbreviation then abbr t.AbbreviatedType else t
     abbr t
-    
+
 let (|Typ|) (e: FSharpMemberOrFunctionOrValue) = e.FullType
 
 let checker = FSharpChecker.Create(keepAssemblyContents=true)
@@ -24,13 +23,13 @@ let parse projFile =
             let projCode = File.ReadAllText projFile
             checker.GetProjectOptionsFromScript(projFile, projCode)
             |> Async.RunSynchronously
-        | ".fsproj" ->
-            ProjectCracker.GetProjectOptionsFromProjectFile(Path.GetFullPath projFile)
+        // | ".fsproj" ->
+        //     ProjectCracker.GetProjectOptionsFromProjectFile(Path.GetFullPath projFile)
         | ext -> failwithf "Unexpected extension: %s" ext
     options
     |> checker.ParseAndCheckProject
     |> Async.RunSynchronously
-    
+
 let rec printDecls prefix decls =
     decls |> Seq.iteri (fun i decl ->
         match decl with
@@ -38,19 +37,21 @@ let rec printDecls prefix decls =
             printfn "%s%i) ENTITY: %s" prefix i e.DisplayName
             printDecls (prefix + "\t") sub
         | FSharpImplementationFileDeclaration.MemberOrFunctionOrValue (meth, args, body) ->
+          try
             if meth.IsCompilerGenerated |> not then
                 printfn "%s%i) METHOD: %s" prefix i meth.DisplayName
                 printfn "%A" body
+          with _ -> ()
         | FSharpImplementationFileDeclaration.InitAction (expr) ->
             printfn "%s%i) ACTION" prefix i
             printfn "%A" expr
         )
-        
+
 and lookup f (expr: FSharpExpr) =
     f expr
     List.iter (lookup f) expr.ImmediateSubExpressions
 
-let proj = parse "temp2/Test2.fsx"
+let proj = parse "temp2/Test.fsx"
 proj.AssemblyContents.ImplementationFiles
 |> Seq.iteri (fun i file -> printfn "%i) %s" i file.FileName)
 proj.AssemblyContents.ImplementationFiles.[0].Declarations


### PR DESCRIPTION
This will probably be another frustrated PR. I've been thinking how to fix #502 which is about name conflicts of implemented interface methods and methods of the type. At the moment, Fable does name mangling with overloaded class methods, but it's very complicated to modify the name of interface methods for a number of reasons.
- In TypeScript declarations, _fake_ interface overloads are allowed.
- Even if we added a `NoMangling` attribute for imported interfaces, interfaces cannot foresee which types are going to implement them so they know nothing about potential name conflicts.
- Even if we modify the name the names of the class methods to avoid the conflict, a type can implement two interfaces with the same method so these types would still be conflicting with each other.
- A type cannot know which interfaces an inhering type is going to implement.

> Also note overloading class methods is not easy either as there're cases, like statically resolved type parameters (lenses in Aether rely on this, for example), where the F# AST doesn't give much information about the method calls and it's difficult to resolve overloads.

The only solution would be to implement some kind of virtual table as other runtimes have. But this will mean all interface calls much be checked at runtime and it'll probably have a noticeable performance hit.

The proposed solution in this PR takes advantage on the fact that F# forces coertion when you want to use an interface method. The idea is that interface methods are in a separate object (which captures a reference to the implementing object) as a façade that gets activated when the object is coerced. If we need the full class back we recover the captured reference. Example:

``` fsharp
type IFoo =
    abstract Foo: unit->unit

type MyType() =
    member __.Foo() = printfn "Hello"
    interface IFoo with
        member this.Foo() =
            this.Foo()
            printfn "world!"

let test() =
    let x = MyType()
    x.Foo()
    let ifc = x :> IFoo
    ifc.Foo()
    match ifc with
    | :? MyType as y -> y.Foo()
    | _ -> ()
```

becomes:

``` js
export class MyType {
  constructor() {}

  Foo() {
    fsFormat("Hello")(x => {
      console.log(x);
    });
  }

  [_Symbol.interfaces]() {
    return {
      ["Test.IFoo"](_this) {
        return {
          [_Symbol.this]: _this,
          Foo() {
            _this.Foo();
            fsFormat("world!")(x => {
              console.log(x);
            });
          }
        };
      }
    };
  }
}
export function test() {
  const x = new MyType();
  x.Foo();
  // This is the same as x[_Symbol.interfaces]()["Test.IFoo"](x)
  const ifc = upcast(x, "Test.IFoo");
  ifc.Foo();

  if (ifc[_Symbol.this] instanceof MyType) {
    // Same as ifc[_Symbol.this]
    const y = downcast(ifc);
    y.Foo();
  }
}
```

The problem is that interfaces can also be used to interact with JS objects so it's necessary to check also whether the interface method is located directly in the object. Because Fable is designed to make interaction with JS easy, many times the compiler doesn't know where the types are coming from and you end needing a lot of casting and checks at runtime.

When I run the tests many of them were failing. I've managed to reduce the fails to less than 10, but I don't like that I have to deal with each case individually (as this means there may be other corner cases not covered by the tests) and that I'm introducing too much complexity for too little gain 😕 

I'll left this here so it can be reviewed by others. But for now, I'll just implement a compile time check that will throw an error if the user tries to implement an interface conflicting with a method of the class.
