### PR TITLE
Fix solution file and UseScriptResolutionRules=false

### DIFF
--- a/src/fable/Fable.Client.Node/Main.fs
+++ b/src/fable/Fable.Client.Node/Main.fs
@@ -188,7 +188,7 @@ let forgeGetProjectOptions (opts: CompilerOptions) projFile =
         OtherOptions = allFlags
         ReferencedProjects = [| |] // TODO: read from projParsed.ProjectReferences
         IsIncompleteTypeCheckEnvironment = false
-        UseScriptResolutionRules = true
+        UseScriptResolutionRules = false
         LoadTime = DateTime.Now
         UnresolvedReferences = None
     }
@@ -267,7 +267,7 @@ let mergeProjectOpts (opts1: FSharpProjectOptions option, resolver: FileResolver
             OtherOptions = Array.append opts1.OtherOptions opts2.OtherOptions |> Array.distinct
             ReferencedProjects = [| |]
             IsIncompleteTypeCheckEnvironment = false
-            UseScriptResolutionRules = true
+            UseScriptResolutionRules = false
             LoadTime = DateTime.Now
             UnresolvedReferences = None }
         | None -> opts2

--- a/src/fable/Fable.sln
+++ b/src/fable/Fable.sln
@@ -3,13 +3,13 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{f2a71f9b-5d33-465a-a702-920d77279786}") = "Fable.Core", "Fable.Core\Fable.Core.fsproj", "{6BAB7FDB-C31E-4EF2-9C6E-CA2603A8E1A7}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fable.Core", "Fable.Core\Fable.Core.fsproj", "{6BAB7FDB-C31E-4EF2-9C6E-CA2603A8E1A7}"
 EndProject
-Project("{f2a71f9b-5d33-465a-a702-920d77279786}") = "Fable.Compiler", "Fable.Compiler\Fable.Compiler.fsproj", "{D341FF6B-F526-4370-8318-0F5A654BA70C}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fable.Compiler", "Fable.Compiler\Fable.Compiler.fsproj", "{D341FF6B-F526-4370-8318-0F5A654BA70C}"
 EndProject
-Project("{f2a71f9b-5d33-465a-a702-920d77279786}") = "Fable.Client.Node", "Fable.Client.Node\Fable.Client.Node.fsproj", "{6C87964E-0B32-48D4-BAA3-BDDBD7264C97}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fable.Client.Node", "Fable.Client.Node\Fable.Client.Node.fsproj", "{6C87964E-0B32-48D4-BAA3-BDDBD7264C97}"
 EndProject
-Project("{f2a71f9b-5d33-465a-a702-920d77279786}") = "Fable.Tests", "..\tests\Fable.Tests.fsproj", "{6EF06954-FBDF-42C7-815C-B13BA2926C93}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Forge.ProjectSystem", "..\..\paket-files\fable-compiler\Forge\src\Forge.ProjectSystem\Forge.ProjectSystem.fsproj", "{9029BE0F-A72C-4281-9FD1-AA15F5722306}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -29,10 +29,10 @@ Global
 		{6C87964E-0B32-48D4-BAA3-BDDBD7264C97}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6C87964E-0B32-48D4-BAA3-BDDBD7264C97}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6C87964E-0B32-48D4-BAA3-BDDBD7264C97}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6EF06954-FBDF-42C7-815C-B13BA2926C93}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6EF06954-FBDF-42C7-815C-B13BA2926C93}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6EF06954-FBDF-42C7-815C-B13BA2926C93}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6EF06954-FBDF-42C7-815C-B13BA2926C93}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9029BE0F-A72C-4281-9FD1-AA15F5722306}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9029BE0F-A72C-4281-9FD1-AA15F5722306}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9029BE0F-A72C-4281-9FD1-AA15F5722306}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9029BE0F-A72C-4281-9FD1-AA15F5722306}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This fixes the Visual Studio solution file and sets `UseScriptResolutionRules` to `false`.

With `UseScriptResolutionRules=true`, you cannot use one of my favorite tricks: https://github.com/the-gamma/thegamma-script/blob/master/tests/thegamma-tests/tokenizer.fs#L1. I have `fsproj` file with `fs` files that compile normally as part of the project, but have `#if INTERACTIVE` that also lets me run them interactively:

```
#if INTERACTIVE
#r "../../src/thegamma/bin/Debug/thegamma.dll"
#r "../../packages/NUnit/lib/net45/nunit.framework.dll"
#endif
```

Setting `UseScriptResolutionRules=true` also sets the `INTERACTIVE` symbol (see [source](https://github.com/fsharp/FSharp.Compiler.Service/blob/53d10d6e280301124dc2a3421ac270e3adf20ae2/src/fsharp/vs/IncrementalBuild.fs#L1785)). Aside from this, it also changes search paths order for MSBUILD (see [source](https://github.com/fsharp/FSharp.Compiler.Service/blob/9aed86819e50af08b455ae6902c0fe57ba30ae6a/src/fsharp/MSBuildReferenceResolver.fs#L283)) (according to comment, nobody knows why) and I think that's all - so I think we should be able to safely set this to `false`.
