### PR TITLE
Add fetch to jsKeywords

### DIFF
--- a/src/fable/Fable.Core/Util.fs
+++ b/src/fable/Fable.Core/Util.fs
@@ -87,7 +87,9 @@ module Naming =
             "DOMString"; "DOMTimeStamp"; "DOMSettableTokenList"; "DOMStringList"; "DOMTokenList"; "Element"; "Event"; "EventTarget"; "HTMLCollection"; "MutationObserver";
             "MutationRecord"; "Node"; "NodeFilter"; "NodeIterator"; "NodeList"; "ProcessingInstruction"; "Range"; "Text"; "TreeWalker"; "URL"; "Window"; "Worker"; "XMLDocument"; 
             // See #258
-            "arguments"
+            "arguments";
+            // See https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
+            "fetch"
         ] 
 
     let sanitizeIdent conflicts name =


### PR DESCRIPTION
The fable-powerpack fetch current complies to:

```
export function fetch(url, init) {
    return fetch(url, init);
}
```

Which creates a stack overflow