### PR TITLE
Fix tuple array in json converter

### DIFF
--- a/src/nuget/Fable.JsonConverter/Fable.JsonConverter.fs
+++ b/src/nuget/Fable.JsonConverter/Fable.JsonConverter.fs
@@ -33,7 +33,7 @@ type JsonConverter() =
         read 0 List.empty
     override x.CanConvert(t) =
         t.Name = "FSharpOption`1"
-        || t.FullName.StartsWith("System.Tuple")
+        || FSharpType.IsTuple t
         || (FSharpType.IsUnion t && t.Name <> "FSharpList`1")
 
     override x.WriteJson(writer, value, serializer) =


### PR DESCRIPTION
Currently serializing a tuple array doesn't work:

```F#
let json =
    [| "foo", 1. |]
    |> Json.serialize
```

It passes the `CanConvert` because ```System.Tuple`2[System.String,System.Double][]``` starts with `System.Tuple` but is really an array