### PR TITLE
Optionally output FSharp AST and/or Fable AST

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,3 +1,6 @@
 {
-  "projects": [ "../FSharp.Compiler.Service/src/fsharp", "src/netcore", "src/nuget" ]
+  "projects": [ "../FSharp.Compiler.Service/src/fsharp", "src/netcore", "src/nuget" ],
+  "sdk": {
+    "version": "1.0.0-preview2-003131"
+  }
 }

--- a/src/fable/Fable.Client.Node/Main.fs
+++ b/src/fable/Fable.Client.Node/Main.fs
@@ -481,6 +481,94 @@ let compileDll (checker: FSharpChecker) (comOpts: CompilerOptions) (coreVer: Ver
         |> Info |> string |> Log
         |> List.singleton |> printMessages
 
+let attribsOfSymbol (s:FSharpSymbol) = 
+    [ match s with 
+        | :? FSharpField as v -> 
+            yield "field"
+            if v.IsCompilerGenerated then yield "compgen"
+            if v.IsDefaultValue then yield "default"
+            if v.IsMutable then yield "mutable"
+            if v.IsVolatile then yield "volatile"
+            if v.IsStatic then yield "static"
+            if v.IsLiteral then yield sprintf "%A" v.LiteralValue.Value
+
+        | :? FSharpEntity as v -> 
+            v.TryFullName |> ignore // check there is no failure here
+            if v.IsNamespace then yield "namespace"
+            if v.IsFSharpModule then yield "module"
+            if v.IsByRef then yield "byref"
+            if v.IsClass then yield "class"
+            if v.IsDelegate then yield "delegate"
+            if v.IsEnum then yield "enum"
+            if v.IsFSharpAbbreviation then yield "abbrev"
+            if v.IsFSharpExceptionDeclaration then yield "exception"
+            if v.IsFSharpRecord then yield "record"
+            if v.IsFSharpUnion then yield "union"
+            if v.IsInterface then yield "interface"
+            if v.IsMeasure then yield "measure"
+            if v.IsProvided then yield "provided"
+            if v.IsStaticInstantiation then yield "static_inst"
+            if v.IsProvidedAndErased then yield "erased"
+            if v.IsProvidedAndGenerated then yield "generated"
+            if v.IsUnresolved then yield "unresolved"
+            if v.IsValueType then yield "valuetype"
+
+        | :? FSharpMemberOrFunctionOrValue as v -> 
+            if v.IsActivePattern then yield "active_pattern"
+            if v.IsDispatchSlot then yield "dispatch_slot"
+            if v.IsModuleValueOrMember && not v.IsMember then yield "val"
+            if v.IsMember then yield "member"
+            if v.IsProperty then yield "propery"
+            if v.IsExtensionMember then yield "extension_member"
+            if v.IsPropertyGetterMethod then yield "property_getter"
+            if v.IsPropertySetterMethod then yield "property_setter"
+            if v.IsEvent then yield "event"
+            if v.EventForFSharpProperty.IsSome then yield "property_event"
+            if v.IsEventAddMethod then yield "event_add"
+            if v.IsEventRemoveMethod then yield "event_remove"
+            if v.IsTypeFunction then yield "type_func"
+            if v.IsCompilerGenerated then yield "compiler_gen"
+            if v.IsImplicitConstructor then yield "implicit_ctor"
+            if v.IsMutable then yield "mutable" 
+            if v.IsOverrideOrExplicitInterfaceImplementation then yield "override_impl"
+            if not v.IsInstanceMember then yield "static"
+            if v.IsInstanceMember && not v.IsInstanceMemberInCompiledCode && not v.IsExtensionMember then yield "funky"
+            if v.IsExplicitInterfaceImplementation then yield "interface_impl"
+            // if v.IsConstructorThisValue then yield "ctorthis"
+            // if v.IsMemberThisValue then yield "this"
+            // if v.LiteralValue.IsSome then yield "literal"
+        | _ -> () ]
+
+let rec printFSharpDecls prefix decls = seq {
+    let mutable i = 0
+    for decl in decls do
+        i <- i + 1
+        match decl with
+        | FSharpImplementationFileDeclaration.Entity (e, sub) ->
+            yield sprintf "%s%i) ENTITY: %s %A" prefix i e.DisplayName (attribsOfSymbol e)
+            if not (Seq.isEmpty e.Attributes) then
+                yield sprintf "%sattributes: %A" prefix (Seq.toList e.Attributes)
+            if not (Seq.isEmpty e.DeclaredInterfaces) then
+                yield sprintf "%sinterfaces: %A" prefix (Seq.toList e.DeclaredInterfaces)
+            yield ""
+            yield! printFSharpDecls (prefix + "\t") sub
+        | FSharpImplementationFileDeclaration.MemberOrFunctionOrValue (meth, args, body) ->
+            if meth.IsCompilerGenerated |> not then
+                yield sprintf "%s%i) METHOD: %s %A" prefix i meth.DisplayName (attribsOfSymbol meth)
+                yield sprintf "%sargs: %A" prefix args
+                yield sprintf "%sbody: %A" prefix body
+                yield ""
+        | FSharpImplementationFileDeclaration.InitAction (expr) ->
+            yield sprintf "%s%i) ACTION" prefix i
+            yield sprintf "%s%A" prefix expr
+            yield ""
+}
+
+let printFableDecls decls = seq {
+    for decl in decls do
+        yield sprintf "%A" decl
+}
+
 let compile (com: ICompiler) checker (projInfo: FSProjInfo) =
     try
         // Reload project options if necessary
@@ -513,6 +601,24 @@ let compile (com: ICompiler) checker (projInfo: FSProjInfo) =
 
         //let warnings = match timer with Some timer -> (timer.Finish())::warnings | None -> warnings
         warnings |> Seq.map (string >> Log) |> printMessages
+
+        let saveAstFile sourceFile ext decls =
+            let filePath = projInfo.FilePairs.Item(sourceFile)
+            Directory.CreateDirectory(Path.GetDirectoryName(filePath)) |> ignore
+            File.WriteAllLines(Path.ChangeExtension(filePath, ext), decls |> Seq.toArray)
+        
+        // save FSharp AST declarations
+        if com.Options.extra |> Map.containsKey "saveFSharpAst" then
+            parsedProj.AssemblyContents.ImplementationFiles
+            |> Seq.iter (fun file ->
+                printFSharpDecls "" file.Declarations |> saveAstFile file.FileName ".fs.ast" )
+        
+        // save Fable AST declarations
+        let saveFableAst (extra, files) =
+            if com.Options.extra |> Map.containsKey "saveFableAst" then
+                files |> Seq.iter (fun (file: Fable.File) ->
+                    printFableDecls file.Declarations |> saveAstFile file.SourceFile ".fable.ast" )
+            (extra, files)
 
         // Check Fable.Core version on first compilation (whe projInfo.fileMask is None)
         // -----------------------------------------------------------------------------
@@ -550,6 +656,7 @@ let compile (com: ICompiler) checker (projInfo: FSProjInfo) =
         let extraInfo, files =
             FSharp2Fable.Compiler.transformFiles com parsedProj projInfo
             |> applyRewrites
+            |> saveFableAst
             |> Fable2Babel.Compiler.transformFiles com
 
         let files = Array.ofSeq files


### PR DESCRIPTION
Optionally outputs FSharp AST and/or Fable AST to your outDir.
Add either or both of these to your fableconfig.json to enable:
```
    "extra": ["saveFSharpAst", "saveFableAst"],
```