### PR TITLE
Added UnboxFast intrinsic / List.truncate

### DIFF
--- a/src/fable/Fable.Compiler/Replacements.fs
+++ b/src/fable/Fable.Compiler/Replacements.fs
@@ -762,6 +762,7 @@ module private AstPass =
     let intrinsicFunctions com (i: Fable.ApplyInfo) =
         match i.methodName, (i.callee, i.args) with
         | "checkThis", (None, [arg]) -> Some arg
+        | "unboxFast", OneArg (arg) -> wrap i.returnType arg |> Some
         | "unboxGeneric", OneArg (arg) -> wrap i.returnType arg |> Some
         | "makeDecimal", (_, (Fable.Value (Fable.NumberConst (U2.Case1 low, Int32)))::
                              (Fable.Value (Fable.NumberConst (U2.Case1 medium, Int32)))::

--- a/src/fable/Fable.Compiler/Replacements.fs
+++ b/src/fable/Fable.Compiler/Replacements.fs
@@ -1308,6 +1308,8 @@ module private AstPass =
             match i.methodName with
             | "getSlice" ->
                 listMeth "slice" (i.args@[i.callee.Value])
+            | "truncate" ->
+                listMeth "slice" ([makeConst 0]@i.args)
             | Patterns.SetContains implementedListFunctions meth ->
                 listMeth meth i.args
             | _ -> None

--- a/src/tests/Main/ListTests.fs
+++ b/src/tests/Main/ListTests.fs
@@ -48,6 +48,14 @@ let ``List slice works``() =
       xs.[2..] |> List.sum |> equal 7
       xs.[1..2] |> List.sum |> equal 5
 
+let ``List.truncate works``() =
+      [1..3] = (List.truncate 3 [1..5]) |> equal true
+      [1..5] = (List.truncate 10 [1..5]) |> equal true
+      [] = (List.truncate 0 [1..5]) |> equal true
+      ["str1";"str2"] = (List.truncate 2 ["str1";"str2";"str3"]) |> equal true
+      [] = (List.truncate 0 []) |> equal true
+      [] = (List.truncate 1 []) |> equal true
+
 [<Test>]
 let ``List cons works``() =
       let xs = [1; 2; 3; 4]


### PR DESCRIPTION
Just because they're cheap to add and intrinsic, and so it doesn't make sense to keep 'em in a plugin.