### PR TITLE
Speed up the compiler

### DIFF
--- a/src/fable/Fable.Client.Node/Main.fs
+++ b/src/fable/Fable.Client.Node/Main.fs
@@ -671,7 +671,6 @@ let compile (com: ICompiler) checker (projInfo: FSProjInfo) =
             |> saveFableAst
             |> Fable2Babel.Compiler.transformFiles com
 
-        let files = Array.ofSeq files
         files
         |> Seq.iter printFile
 


### PR DESCRIPTION
Same sort of thing as #567 

Before and after:
![image](https://cloud.githubusercontent.com/assets/1804141/20791147/8110058e-b7b3-11e6-889e-0660ec1dbc89.png)

![image](https://cloud.githubusercontent.com/assets/1804141/20791178/9c506596-b7b3-11e6-8464-2b30a0a05959.png)

(I'm not sure `LocationEraser` is being used but I've done it for completeness)
