### PR TITLE
Fix toJson to serialize { 'Case': undefined } as { 'Case': null } instead of {}

### DIFF
--- a/src/fable/Fable.Core/ts/Serialize.ts
+++ b/src/fable/Fable.Core/ts/Serialize.ts
@@ -39,7 +39,8 @@ export function toJson(o: any): string {
           return v.Case;
         }
         else if (v.Fields.length === 1) {
-          return { [v.Case]: v.Fields[0] };
+          const fieldValue = v.Fields[0];
+          return { [v.Case]: typeof fieldValue === 'undefined' ? null : fieldValue };
         }
         else {
           return { [v.Case]: v.Fields };

--- a/src/fable/Fable.Core/ts/Serialize.ts
+++ b/src/fable/Fable.Core/ts/Serialize.ts
@@ -39,8 +39,9 @@ export function toJson(o: any): string {
           return v.Case;
         }
         else if (v.Fields.length === 1) {
-          const fieldValue = v.Fields[0];
-          return { [v.Case]: typeof fieldValue === 'undefined' ? null : fieldValue };
+          // Prevent undefined assignment from removing case property; see #611:
+          const fieldValue = typeof v.Fields[0] === 'undefined' ? null : v.Fields[0];
+          return { [v.Case]: fieldValue };
         }
         else {
           return { [v.Case]: v.Fields };

--- a/src/tests/Main/JsonTests.fs
+++ b/src/tests/Main/JsonTests.fs
@@ -370,6 +370,18 @@ let ``Optional union of record: for null`` () =
     | _ -> false
     |> equal true
 
+#if FABLE_COMPILER
+type UnionWithCaseOfObj =
+    | CaseOfObj of obj
+    | AnotherCase
+
+[<Test>]
+let ``Union with case of obj with single undefined field value`` () =
+    let x = UnionWithCaseOfObj.CaseOfObj Fable.Import.Node.``global``.undefined
+    let json = toJson x
+    let x2 = ofJson<UnionWithCaseOfObj> json
+    x2 |> equal x
+#endif
 
 #if FABLE_COMPILER
 type IData = interface end


### PR DESCRIPTION
In the wild the issue occurs when a non-Fable js passes an `undefined` for an option of a DU field. `Serializer.toJson` converts this to `{ Case': undefined }` object, which actually means and serializes to `{ }`. 

I've considered null/undefined interchangeable in this concrete case. If it is crucial to preserve `undefined`, I'd propose serializing it as `[undefined]` (needs checks in both `toJson` and `inflate`).