### PR TITLE
Fixed failing tests

### DIFF
--- a/src/fable/Fable.Compiler/Replacements.fs
+++ b/src/fable/Fable.Compiler/Replacements.fs
@@ -211,7 +211,7 @@ module Util =
                 CoreLibCall ("Long", Some "fromString", false, args)
                 |> makeCall i.range i.returnType
             | _ ->
-                GlobalCall ("Number", Some "parseInt", false, [args.Head; makeConst 10])
+                GlobalCall ("Number", Some "parseInt", false, args)
                 |> makeCall i.range i.returnType
         | Fable.Number kindFrom ->
             match i.returnType with


### PR DESCRIPTION
No need to fix the radix to 10, it already defaults to 10 if not passed, and if fixed at 10 will prevent the ability to pass other bases, like 2 or 16.

e.g. see Convert.ToIntXX tests in StringTests.fs that were failing.