### PR TITLE
Fable.JsonConverter DateTime fixes

### DIFF
--- a/src/nuget/Fable.JsonConverter/Fable.JsonConverter.fs
+++ b/src/nuget/Fable.JsonConverter/Fable.JsonConverter.fs
@@ -93,7 +93,8 @@ type JsonConverter() =
             | true, Kind.DateTime ->
                 let dt = value :?> DateTime
                 // Make sure the DateTime is saved in UTC and ISO format (see #604)
-                serializer.Serialize(writer, dt.ToUniversalTime().ToString("O"))
+                let universalTime = if dt.Kind = DateTimeKind.Local then dt.ToUniversalTime() else dt
+                serializer.Serialize(writer, universalTime.ToString("O"))
             | true, Kind.Option ->
                 let _,fields = FSharpValue.GetUnionFields(value, t)
                 serializer.Serialize(writer, fields.[0])

--- a/src/nuget/Fable.JsonConverter/Fable.JsonConverter.fs
+++ b/src/nuget/Fable.JsonConverter/Fable.JsonConverter.fs
@@ -136,8 +136,11 @@ type JsonConverter() =
         | false, _ ->
             serializer.Deserialize(reader, t)
         | true, Kind.DateTime ->
-            let json = serializer.Deserialize(reader, typeof<string>) :?> string
-            upcast DateTime.Parse(json)
+            match reader.Value with
+            | :? DateTime -> reader.Value // Avoid culture-sensitive string roundtrip for already parsed dates
+            | _ ->
+                let json = serializer.Deserialize(reader, typeof<string>) :?> string
+                upcast DateTime.Parse(json)
         | true, Kind.Option ->
             let innerType = t.GetGenericArguments().[0]
             let innerType =

--- a/src/tests/Main/JsonTests.fs
+++ b/src/tests/Main/JsonTests.fs
@@ -111,21 +111,25 @@ let ``Validation works``() =
 
 [<Test>]
 let ``Date``() =
-    let d = System.DateTime(2016, 1, 30, 0, 0, 0, System.DateTimeKind.Utc)
+    let d = System.DateTime(2016, 1, 30, 11, 25, 0, System.DateTimeKind.Utc)
     let json = d |> toJson
     let result : System.DateTime = ofJson json
     result.Year |> equal 2016
     result.Month |> equal 1
     result.Day |> equal 30
+    result.Hour |> equal 11
+    result.Minute |> equal 25
 
 [<Test>]
-let ``Date Unspecified Kind``() =
-    let d = System.DateTime(2016, 1, 30, 0, 0, 0, System.DateTimeKind.Unspecified)
+let ``Date Kind Unspecified roundtrip``() =
+    let d = System.DateTime(2016, 1, 30, 11, 25, 0, System.DateTimeKind.Unspecified)
     let json = d |> toJson
     let result : System.DateTime = ofJson json
     result.Year |> equal 2016
     result.Month |> equal 1
     result.Day |> equal 30
+    result.Hour |> equal 11
+    result.Minute |> equal 25
 
 type JsonDate = {
     Date : System.DateTime

--- a/src/tests/Main/JsonTests.fs
+++ b/src/tests/Main/JsonTests.fs
@@ -118,6 +118,15 @@ let ``Date``() =
     result.Month |> equal 1
     result.Day |> equal 30
 
+[<Test>]
+let ``Date Unspecified Kind``() =
+    let d = System.DateTime(2016, 1, 30, 0, 0, 0, System.DateTimeKind.Unspecified)
+    let json = d |> toJson
+    let result : System.DateTime = ofJson json
+    result.Year |> equal 2016
+    result.Month |> equal 1
+    result.Day |> equal 30
+
 type JsonDate = {
     Date : System.DateTime
 }

--- a/src/tests/Main/JsonTests.fs
+++ b/src/tests/Main/JsonTests.fs
@@ -111,10 +111,12 @@ let ``Validation works``() =
 
 [<Test>]
 let ``Date``() =
-    let d = System.DateTime(2016, 1, 1, 0, 0, 0, System.DateTimeKind.Utc)
+    let d = System.DateTime(2016, 1, 30, 0, 0, 0, System.DateTimeKind.Utc)
     let json = d |> toJson
     let result : System.DateTime = ofJson json
     result.Year |> equal 2016
+    result.Month |> equal 1
+    result.Day |> equal 30
 
 type JsonDate = {
     Date : System.DateTime


### PR DESCRIPTION
### Fix `DateTime` parsing failing on some cultures
Deserialization was failing on my local machine due to en-US culture. `serializer.Deserialize(reader, typeof<string>)` is culture specific with no easy API to override on per-call basis and could deserialize to something like `"12/20/2016 13:56:00"`. Therefore, I made a short circuit for already parsed dates to `reader.Value`, and preserved the current parsing for manual parsing fallback for non-recognized dates.

### Do not convert `DateTime.Kind = Unspecified` to UTC on serialization
[.ToUniversalTime()](https://msdn.microsoft.com/en-us/library/system.datetime.touniversaltime(v=vs.110).aspx) assumes `Kind = Unspecified` values as `Local` ones and converts them to UTC. But it breaks roundtrip - serialized and then deserialized value will have UTC offset applied twice. Thus I've overridden this behavior to match JsonConverter  pre-0.1.0. If you think it's better to stick with default BCL behavior, I'd be happy to revert this change.