### PR TITLE
Added Link to a new use case (Google Script)

### DIFF
--- a/docs/source/index.html
+++ b/docs/source/index.html
@@ -150,6 +150,7 @@
         <li><a href="https://github.com/Indy9000/noodle-soup">Cook a tasty noodle soup with Fable!</a> - Indy Garcia</li>
         <li><a href="http://kcieslak.io/Getting-Started-with-Fable-and-Webpack">Getting started with Fable and Webpack</a> - Krzysztof Cieslak</li>
         <li><a href="http://kcieslak.io/Creating-VS-Code-plugins-with-F-and-Fable">Creating VS Code plugins with F# and Fable</a> - Krzysztof Cieslak</li>
+        <li><a href="https://github.com/easysoft2k15/GoogleScriptFableTemplate">Writing Google Script in F#</a> - Alessandro Rizzotto</li>
         <li>Written something about Fable? <a href="https://github.com/fable-compiler/Fable/tree/master/docs">Send a pull request</a>!
       </ul>
     </div>


### PR DESCRIPTION
I don't know if this may be of interest but I created a library in Google Script (recompiling fable-core.ts with some minor changes) and a simple project in Visual Studio 2015 in order to:
1.  being able to write Google Script in F#
2. compile them with Fable
3. copy and past the generated javascript  in Google App script
This is the link to my github project:
https://github.com/easysoft2k15/GoogleScriptFableTemplate
This is the link of the project (VS Code) with the necessary changes to fable-core.ts:
https://github.com/easysoft2k15/Fable-Core-to-ES5
I inserted the link into the index.html file. I don't know if this is the right to do it. If not please advide.
Thank You
Alessandro

PS: Fable is a  very cool project!