### PR TITLE
Problem with deserialized int64

### DIFF
--- a/src/tests/Main/JsonTests.fs
+++ b/src/tests/Main/JsonTests.fs
@@ -428,3 +428,10 @@ let ``Generics with interface`` () =
     let result : Things list = Fable.Core.JsInterop.ofJsonWithTypeInfo json
     result.[1].data = ({ kind = "number"; number = 3 } :> IData) |> equal true
 #endif
+
+type RrdWithLong = { long: int64 }
+[<Test>]
+let ``Roundtripped int64 is convertible to float``() =
+    let r = {long = 0L} |> Fable.Core.JsInterop.toJson  |> Fable.Core.JsInterop.ofJson<RrdWithLong>
+    r.long |> float
+    |> equal 0.

--- a/src/tests/Main/TypeTests.fs
+++ b/src/tests/Main/TypeTests.fs
@@ -518,3 +518,4 @@ let ``Custom exceptions work``() =
     | :? MyEx2 as ex -> ex.Message, ex.Code
     | ex -> "unknown", 0.
     |> equal ("Code: 5", 5.5)
+


### PR DESCRIPTION
The unit test demonstrates the problem: deserialized int64 is not convertible to float, this used to work a couple of releases ago.