### PR TITLE
Use {} when Window, Global and Self are undefined

### DIFF
--- a/src/fable/Fable.Core/ts/Symbol.ts
+++ b/src/fable/Fable.Core/ts/Symbol.ts
@@ -10,7 +10,7 @@ const fableGlobal: {
   const globalObj =
     typeof window !== "undefined" ? window
     : (typeof global !== "undefined" ? global
-    : (typeof self !== "undefined" ? self : null));
+    : (typeof self !== "undefined" ? self : {}));
   if (typeof globalObj.__FABLE_CORE__ === "undefined") {
     globalObj.__FABLE_CORE__ = {
       types: new Map<string, FunctionConstructor>(),


### PR DESCRIPTION
If there is not a specific reason to use null in place of {}, I'd would suggest to use the latter (as in Babel-Polyfill).