### PR TITLE
Replacement for Double.IsNaN and Math.Log(x, b) with tests

### DIFF
--- a/src/fable/Fable.Compiler/Replacements.fs
+++ b/src/fable/Fable.Compiler/Replacements.fs
@@ -862,6 +862,13 @@ module private AstPass =
             GlobalCall("Number", Some meth, false, args)
             |> makeCall i.range (Fable.Number kind)
         match i.methodName with
+        | "isNaN" when isFloat -> 
+            match i.args with
+            | [someNumber] ->
+                GlobalCall("Number", Some "isNaN", false, i.args)
+                |> makeCall i.range (Fable.Number Float64)
+                |> Some
+            | _ -> None
         | "parse" | "tryParse" ->
             match i.methodName, i.args with
             | "parse", [str] ->
@@ -1798,7 +1805,8 @@ module private AstPass =
         | "Microsoft.FSharp.Core.PrintfFormat" -> fsFormat com info
         | "System.BitConverter" -> bitConvert com info
         | "System.Int32" -> parse com info false
-        | "System.Single" | "System.Double" -> parse com info true
+        | "System.Single" 
+        | "System.Double" -> parse com info true
         | "System.Convert" -> convert com info
         | "System.Console" -> console com info
         | "System.Decimal" -> decimals com info

--- a/src/fable/Fable.Compiler/Replacements.fs
+++ b/src/fable/Fable.Compiler/Replacements.fs
@@ -645,6 +645,11 @@ module private AstPass =
          | "op_BitwiseAnd" | "op_BitwiseOr" | "op_ExclusiveOr"
          | "op_LogicalNot" | "op_UnaryNegation" | "op_BooleanAnd" | "op_BooleanOr" ->
             applyOp com info args info.methodName |> Some
+        | "log" -> // log with base value i.e. log(8.0, 2.0) -> 3.0
+            match info.args with 
+            | [x] -> math r typ args info.methodName
+            | [x; baseValue] ->  emit info "Math.log($0) / Math.log($1)" info.args |> Some
+            | _ -> None
         // Math functions
         // TODO: optimize square pow: x * x
         | "pow" | "powInteger" | "op_Exponentiation" -> math r typ args "pow"

--- a/src/tests/Main/ArithmeticTests.fs
+++ b/src/tests/Main/ArithmeticTests.fs
@@ -195,6 +195,23 @@ let ``pown works``() =
 let ``sqrt works``() =
     sqrt 4.5 |> checkTo3dp 2121.
 
+// As per 
+// https://github.com/dotnet/corefx/blob/master/src/System.Runtime.Extensions/tests/System/Math.cs#L217
+[<Test>]
+let ``sqrt matches .net core implementation``() = 
+    let positiveInfinity = System.Double.PositiveInfinity
+    let negativeInfinity = System.Double.NegativeInfinity
+    let NaN = System.Double.NaN
+    let isNaN = fun x -> System.Double.IsNaN(x)
+
+    checkTo3dp 1732. (sqrt 3.0)
+    Assert.AreEqual(sqrt 0.0 , 0.0) 
+    Assert.AreEqual(isNaN (sqrt -3.0), true)
+    Assert.AreEqual(isNaN (sqrt NaN), true)
+    Assert.AreEqual(isNaN (sqrt negativeInfinity), true)
+    Assert.AreEqual(sqrt positiveInfinity, positiveInfinity)
+
+
 [<Test>]
 let ``acos works``() =
     acos 0.25 |> checkTo3dp 1318.

--- a/src/tests/Main/ArithmeticTests.fs
+++ b/src/tests/Main/ArithmeticTests.fs
@@ -244,6 +244,7 @@ let ``tan works``() =
 let ``exp works``() =
     exp 8.0 |> checkTo3dp 2980957.
 
+// https://github.com/dotnet/corefx/blob/master/src/System.Runtime.Extensions/tests/System/Math.cs#L228
 [<Test>]
 let ``log works``() =
     log 232.12 |> checkTo3dp 5447.
@@ -254,6 +255,7 @@ let ``log works``() =
     Assert.AreEqual(isNaN (log negativeInfinity), true)
     Assert.AreEqual(log positiveInfinity, positiveInfinity)
 
+// https://github.com/dotnet/corefx/blob/master/src/System.Runtime.Extensions/tests/System/Math.cs#L239
 let ``Math.Log(double, double) works``() = 
     Assert.AreEqual(3.0, Math.Log(8.0, 2.0))
     Assert.AreEqual(1.0, Math.Log(3.0, 3.0))

--- a/src/tests/Main/ArithmeticTests.fs
+++ b/src/tests/Main/ArithmeticTests.fs
@@ -195,15 +195,15 @@ let ``pown works``() =
 let ``sqrt works``() =
     sqrt 4.5 |> checkTo3dp 2121.
 
+let positiveInfinity = System.Double.PositiveInfinity
+let negativeInfinity = System.Double.NegativeInfinity
+let NaN = System.Double.NaN
+let isNaN = fun x -> System.Double.IsNaN(x)
+
 // As per 
 // https://github.com/dotnet/corefx/blob/master/src/System.Runtime.Extensions/tests/System/Math.cs#L217
 [<Test>]
 let ``sqrt matches .net core implementation``() = 
-    let positiveInfinity = System.Double.PositiveInfinity
-    let negativeInfinity = System.Double.NegativeInfinity
-    let NaN = System.Double.NaN
-    let isNaN = fun x -> System.Double.IsNaN(x)
-
     checkTo3dp 1732. (sqrt 3.0)
     Assert.AreEqual(sqrt 0.0 , 0.0) 
     Assert.AreEqual(isNaN (sqrt -3.0), true)
@@ -247,6 +247,26 @@ let ``exp works``() =
 [<Test>]
 let ``log works``() =
     log 232.12 |> checkTo3dp 5447.
+    checkTo3dp 1098. (log 3.0)
+    Assert.AreEqual(log 0.0, negativeInfinity)
+    Assert.AreEqual(isNaN (log -2.0), true)
+    Assert.AreEqual(isNaN (log NaN), true)
+    Assert.AreEqual(isNaN (log negativeInfinity), true)
+    Assert.AreEqual(log positiveInfinity, positiveInfinity)
+
+let ``Math.Log(double, double) works``() = 
+    Assert.AreEqual(3.0, Math.Log(8.0, 2.0))
+    Assert.AreEqual(1.0, Math.Log(3.0, 3.0))
+    Math.Log(14., 3.0) |> checkTo3dp 2402.
+    Assert.AreEqual(negativeInfinity, Math.Log(0.0, 3.0)) 
+    Assert.AreEqual(positiveInfinity, Math.Log(positiveInfinity, 3.0))
+    Assert.AreEqual(true, isNaN (Math.Log(-3.0, 3.0)))
+    Assert.AreEqual(true, isNaN (Math.Log(NaN, 3.0)))
+    Assert.AreEqual(true, isNaN (Math.Log(negativeInfinity, 3.0)))
+    
+    
+
+
 
 [<Test>]
 let ``log10 works``() =


### PR DESCRIPTION
This PR adds a replacement for the method `System.Double.IsNaN` and for `Math.Log(x, baseValue)` with their tests and some more tests to make sure the output matches the output in .Net, for example in [these tests](https://github.com/dotnet/corefx/blob/master/src/System.Runtime.Extensions/tests/System/Math.cs#L217)