### PR TITLE
Fixed Babel AST json serialization

### DIFF
--- a/src/dotnet/Fable.Client.Browser/Fable.Client.fs
+++ b/src/dotnet/Fable.Client.Browser/Fable.Client.fs
@@ -108,7 +108,14 @@ let makeCompiler opts plugins =
 
 let printFile =
     fun (file: AST.Babel.Program) ->
-        printfn "%A" file
+#if DOTNETCORE || DOTNET40
+        // technically there should be a conversion to JSON here
+        // but we're trying to avoid adding the Json.NET reference
+        // as this is just to show it compiles properly on dotnet.
+        printfn "Babel AST: %A" file
+#else
+        printfn "%s" (Fable.Core.JsInterop.toJson file)
+#endif
 
 let printMessages (msgs: seq<CompilerMessage>) =
     msgs

--- a/src/dotnet/Fable.Client.Browser/demo/project.fsx
+++ b/src/dotnet/Fable.Client.Browser/demo/project.fsx
@@ -9,4 +9,6 @@ let compileSource readAllBytes references source =
     let com = makeCompiler opts []
     let fileName = "stdin.fsx"
     let files = compileAst com checker (fileName, source)
-    files |> Array.ofSeq
+    files
+    |> Seq.map (fun file -> Fable.Core.JsInterop.toJson file)
+    |> Array.ofSeq

--- a/src/dotnet/Fable.Client.Browser/demo/repl.js
+++ b/src/dotnet/Fable.Client.Browser/demo/repl.js
@@ -324,21 +324,6 @@
       presets.push('babili');
     }
 
-    function fixInvalidAst(ast) {
-      function isObject(x) {
-        return x !== null && typeof x === "object" && !(x instanceof Number) && !(x instanceof String) && !(x instanceof Boolean);
-      }
-      let fixValue = function (k, v) {
-        return v && v[Symbol.iterator] && !Array.isArray(v) && isObject(v) ? Array.from(v)
-          : v && v.Case && v.Fields && Array.isArray(v.Fields) ?
-              v.Fields.length == 1 ? v.Fields[0] : v.Fields.length > 1 ? v.Fields : v.Case
-          : (k.startsWith("directives@") || k.startsWith("specifiers@")) && !v ? [] : v;
-      };
-      let astJson = JSON.stringify(ast, fixValue).replace(/@[0-9]+"/g, '"');
-      let newAst = JSON.parse(astJson);
-      return newAst;
-    }
-
     try {
       const source = this.getSource();
       const references = ["FSharp.Core","mscorlib", "System", "System.Core", "System.Data", "System.IO", "System.Xml", "System.Numerics"];
@@ -352,7 +337,7 @@
         // compile AST from F# source
         const readAllBytes = function (fileName) { return metadata[fileName]; }
         const asts = project.compileSource(readAllBytes, references, source);
-        ast = fixInvalidAst(asts[0]);
+        ast = JSON.parse(asts[0]);
       }
       let options = {
         presets: presets.filter(Boolean),

--- a/src/dotnet/Fable.Compiler/FSharp2Fable.fs
+++ b/src/dotnet/Fable.Compiler/FSharp2Fable.fs
@@ -1129,6 +1129,7 @@ type FableCompiler(com: ICompiler, projectMaps: Dictionary<string,Map<string, Fa
             match ent.TryFullName, ent.Assembly.FileName with
             // TODO: Temporary HACK to fix #577
             | Some fullName, _ when fullName.StartsWith("Fable.Import.Node") -> false
+            | Some fullName, _ when fullName.StartsWith("Fable.Core.JsInterop") -> true
             | _, Some asmPath -> projectMaps.ContainsKey asmPath |> not
             | _ -> false
         member fcom.TryGetInternalFile tdef =

--- a/src/typescript/fable-core/Serialize.ts
+++ b/src/typescript/fable-core/Serialize.ts
@@ -15,6 +15,22 @@ import { parse as dateParse } from "./Date"
 import { fsFormat } from "./String"
 
 function deflate(v: any) {
+
+  // for some reason objects in DU have duplicate props
+  // this copies only the correct unmangled properties
+  function copyProps(o: any) {
+    if (o != null && typeof o === "object") {
+        let tmp: { [key: string]: any; } = {};
+        for (let prop in o) {
+            let i = prop.indexOf('@');
+            if (i >= 0) { prop = prop.substr(0, i); }
+            tmp[prop] = o[prop];
+        }
+        o = tmp;
+    }
+    return o;
+  }
+
   if (ArrayBuffer.isView(v)) {
     return Array.from(v as any);
   }
@@ -49,15 +65,15 @@ function deflate(v: any) {
       else if (fieldsLength === 1) {
         // Prevent undefined assignment from removing case property; see #611:
         const fieldValue = typeof v.a === 'undefined' ? null : v.a;
-        return { [caseName]: fieldValue };
+        return copyProps(fieldValue); //{ [caseName]: fieldValue };
       }
       else {
         let fields = [];
         for (let i = 97 /* 'a' */, j: string; i < 97 + v.size; i++) {
           j = String.fromCharCode(i);
-          fields.push(v[j]);
+          fields.push(copyProps(v[j]));
         }
-        return { [caseName]: fields };
+        return fields; //{ [caseName]: fields };
       }
     }
   }


### PR DESCRIPTION
Recent changes in DU serialization seem to have introduced some inconsistent behavior.
This PR fixes the JS Babel AST json serialization (toJson) to match the one produced by Json.NET.
It does not fix the reverse serialization (ofJson) so a few DU serialization tests are still broken.

- Good news: [Demo page](https://github.com/fable-compiler/Fable/tree/narumi/src/dotnet/Fable.Client.Browser/demo) works again!
- Bad news: ofJson DU has to be fixed so back and forth JSON serialization tests can pass.

@alfonsogarciacaro The change in Serialize.ts is just patching the problem after it already happened.
Somewhere there is a root cause of the problem with the duplicate object properties in the Babel AST.