### PR TITLE
Avoid html elements being blocked by AdBlock in Fable website

### DIFF
--- a/docs/docs.fsx
+++ b/docs/docs.fsx
@@ -314,17 +314,21 @@ let refreshEvent = new Event<unit>()
 
 let socketHandler (webSocket : WebSocket) cx = socket {
     while true do
+      let byteResponse = 
+        "refreshed"
+        |> System.Text.Encoding.ASCII.GetBytes
+        |> ByteSegment
       let! refreshed =
         Control.Async.AwaitEvent(refreshEvent.Publish)
         |> Suave.Sockets.SocketOp.ofAsync
-      do! webSocket.send Text (Suave.Utils.ASCII.bytes "refreshed") true }
+      do! webSocket.send Text byteResponse true }
 
 let startWebServer () =
     let port = 8911
     let serverConfig =
         { defaultConfig with
            homeFolder = Some (FullName output)
-           bindings = [ HttpBinding.mkSimple HTTP "127.0.0.1" port ] }
+           bindings = [ HttpBinding.createSimple HTTP "127.0.0.1" port ] }
     let app =
       choose [
         Filters.path "/websocket" >=> handShake socketHandler
@@ -334,8 +338,8 @@ let startWebServer () =
         >=> choose [ Files.browseHome; Filters.path "/" >=> Files.browseFileHome "index.html" ] ]
 
     let addMime f = function
-      | ".wav" -> Writers.mkMimeType "audio/wav" false
-      | ".tsv" -> Writers.mkMimeType "text/tsv" false | ext -> f ext
+      | ".wav" -> Writers.createMimeType "audio/wav" false
+      | ".tsv" -> Writers.createMimeType "text/tsv" false | ext -> f ext
     let app ctx = app { ctx with runtime = { ctx.runtime with mimeTypesMap = addMime ctx.runtime.mimeTypesMap } }
 
     startWebServerAsync serverConfig app |> snd |> Async.Start

--- a/docs/docs.fsx
+++ b/docs/docs.fsx
@@ -29,7 +29,7 @@ open Fake.Git
 // --------------------------------------------------------------------------------------
 
 // Where to push generated documentation
-let publishSite = "//fable.io"
+let publishSite = "//fable.io" //Use something like "//127.0.0.1:8080" to test locally
 let githubLink = "http://github.com/fable-compiler/fable-compiler.github.io"
 let publishBranch = "master"
 

--- a/docs/source/content/custom.css
+++ b/docs/source/content/custom.css
@@ -3,7 +3,7 @@ body {
 }
 
 /* Navigation bar - links at the top */
-.fb-navbar {
+.fable-navbar {
   background:#202020;
   padding:0px;
 }
@@ -39,123 +39,123 @@ body {
 
 
 /* Heading - purple box */
-.fb-heading {
+.fable-heading {
   background:#7A325D;
   color:#f0f0f0;
   padding:15px 0px 20px 0px;
   text-align:center;
 }
-.fb-heading h1 {
+.fable-heading h1 {
   font-weight:400;
   font-size:35pt;
 }
-.fb-heading p {
+.fable-heading p {
   font-size:20pt;
 }
-.fb-heading .links {
+.fable-heading .links {
   margin:20px 0px 10px 0px;
 }
-.fb-heading .links a {
+.fable-heading .links a {
   margin:0px 10px 0px 10px;
   color:#CC86B0;
   font-size:14pt;
 }
-.fb-heading .links a:hover, .fb-heading .links a:active {
+.fable-heading .links a:hover, .fable-heading .links a:active {
   text-decoration:none;
   color:#FFC6E8;
 }
-.fb-heading .links a i {
+.fable-heading .links a i {
   margin-right:5px;
 }
 
 
 /* Standard page formatting */
-.fb-content {
+.fable-content {
   padding:30px 20px 80px 20px;
 }
-.fb-content-wrapper p, .fb-content-wrapper li {
+.fable-content-wrapper p, .fable-content-wrapper li {
   font-size:14pt;
 }
-.fb-content-wrapper code {
+.fable-content-wrapper code {
   font:11pt 'Roboto Mono',consolas,monospace;
 }
-.fb-content-wrapper h1 {
+.fable-content-wrapper h1 {
   font-size:30pt;
   font-weight:500;
 }
-.fb-content-wrapper h2 {
+.fable-content-wrapper h2 {
   font-size:24pt;
   font-weight:500;
 }
-.fb-content-wrapper h3 {
+.fable-content-wrapper h3 {
   font-size:16pt;
   font-weight:700;
 }
-.fb-content-wrapper h3 .anchor, .fb-content-wrapper h2 .anchor, .fb-content-wrapper h1 .anchor {
+.fable-content-wrapper h3 .anchor, .fable-content-wrapper h2 .anchor, .fable-content-wrapper h1 .anchor {
   color:#7A325D;
 }
-.fb-content-wrapper h3 a.anchor:hover, .fb-content-wrapper h2 a.anchor:hover, .fb-content-wrapper h1 a.anchor:hover {
+.fable-content-wrapper h3 a.anchor:hover, .fable-content-wrapper h2 a.anchor:hover, .fable-content-wrapper h1 a.anchor:hover {
   text-decoration:none;
 }
-.fb-content-wrapper table code {
+.fable-content-wrapper table code {
   background:transparent;
 }
-.fb-content-wrapper table p {
+.fable-content-wrapper table p {
   margin:0px;
 }
-.fb-content-wrapper th {
+.fable-content-wrapper th {
   background:#f0f0f0;
 }
-.fb-content-wrapper tr:nth-child(even) {
+.fable-content-wrapper tr:nth-child(even) {
   background:#f8f8f8;
 }
-.fb-content-wrapper td, .fb-content-wrapper th {
+.fable-content-wrapper td, .fable-content-wrapper th {
   padding:2px 10px 2px 10px;
 }
-.fb-content-wrapper table {
+.fable-content-wrapper table {
   margin:0px 20px 0px 20px;
   border-left:1px solid #e0e0e0;
   border-top:1px solid #e0e0e0;
 }
-.fb-content-wrapper td, .fb-content-wrapper th {
+.fable-content-wrapper td, .fable-content-wrapper th {
   border-right:1px solid #e0e0e0;
   border-bottom:1px solid #e0e0e0;
 }
-.fb-content-wrapper .pre, .fb-content-wrapper .pre td {
+.fable-content-wrapper .pre, .fable-content-wrapper .pre td {
   border-style:none;
 }
 
 /* Styles for some of the special pages */
-.fb-docs .fa {
+.fable-docs .fa {
   margin:0px 10px 5px 10px;
   float:right;
   font-size:40px;
 }
-.fb-gettingstarted {
+.fable-gettingstarted {
   background:#f4f4f4;
   margin:30px 0px 30px 0px;
 }
-.fb-buzzwords {
+.fable-buzzwords {
   padding:30px 0px 30px 0px;
 }
-.fb-buzzwords p {
+.fable-buzzwords p {
   font-size:14pt;
 }
-.fb-buzzwords .fa {
+.fable-buzzwords .fa {
   margin:25px 20px 20px 0px;
   float:left;
   font-size:40px;
 }
-.fb-homepage pre {
+.fable-homepage pre {
   font-size:11pt;
   line-height:18pt;
   padding:12px;
 }
 @media(max-width:768px) {
-  .fb-gettingstarted {
+  .fable-gettingstarted {
     padding:0px 20px 0px 20px;
   }
-  .fb-buzzwords {
+  .fable-buzzwords {
     padding:20px 30px 20px 30px;
   }
 }

--- a/docs/source/docs.md
+++ b/docs/source/docs.md
@@ -6,7 +6,7 @@ The following documentation pages are generated from the `docs` pages
 in the Fable repository on GitHub. Is anything unclear or missing?
 Help us make Fable better by contributing!
 
-<div class="fb-docs">
+<div class="fable-docs">
 <div class="row"><div class="col-sm-6">
 
 ### [<i class="fa fa-cog" aria-hidden="true"></i> Compiling to JavaScript](docs/compiling.html)

--- a/docs/source/index.html
+++ b/docs/source/index.html
@@ -4,7 +4,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="fb-heading fb-hp-heading">
+<div class="fable-heading fable-hp-heading">
 <div class="container">
   <div class="row">
     <div class="col-sm-12">
@@ -20,8 +20,8 @@
 </div>
 </div>
 
-<div class="fb-homepage">
-<div class="container fb-buzzwords">
+<div class="fable-homepage">
+<div class="container fable-buzzwords">
   <div class="row">
     <div class="col-sm-6">
       <h2>Functional-first programming</h2>
@@ -58,7 +58,7 @@
   </div>
 </div>
 
-<div class="fb-gettingstarted">
+<div class="fable-gettingstarted">
 <div class="container" style="padding:20px 0px 30px 0px">
   <div class="row">
     <div class="col-md-1 col-lg-2"></div>

--- a/docs/templates/content.html
+++ b/docs/templates/content.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="fb-heading">
+<div class="fable-heading">
 <div class="container">
   <div class="row">
     <div class="col-sm-12">
@@ -21,7 +21,7 @@
 </div>
 </div>
 
-<div class="container fb-content">
+<div class="container fable-content">
   <div class="row">
     <div class="col-md-1 col-lg-2"></div>
     <div class="col-sm-12 col-md-10 col-lg-8">

--- a/docs/templates/page.html
+++ b/docs/templates/page.html
@@ -34,7 +34,7 @@
 </head>
 <body>
 
-  <div class="fb-navbar">
+  <div class="fable-navbar">
   <div class="container">
   <nav class="navbar navbar-default">
     <div class="navbar-wrapper">
@@ -60,7 +60,7 @@
   </div>
   </div>
 
-  <div class="fb-content-wrapper">
+  <div class="fable-content-wrapper">
   {% block content %} {% endblock %}
   </div>
 

--- a/docs/templates/sample.html
+++ b/docs/templates/sample.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="fb-heading">
+<div class="fable-heading">
 <div class="container">
   <div class="row">
     <div class="col-sm-12">
@@ -19,7 +19,7 @@
 </div>
 </div>
 
-<div class="container fb-content">
+<div class="container fable-content">
   <div class="row">
     <div class="col-md-1 col-lg-2"></div>
     <div class="col-sm-12 col-md-10 col-lg-8">


### PR DESCRIPTION
Just changed the class name from `fb-*`to `fable-*` and it does the job. Update the docs.fsx so it still works with the new Suave API