### PR TITLE
Make TransformOptions not inherit

### DIFF
--- a/src/fable/Fable.Core/Import/Fable.Import.Node.fs
+++ b/src/fable/Fable.Core/Import/Fable.Import.Node.fs
@@ -457,9 +457,10 @@ module stream =
         member __.``end``(chunk: obj, ?encoding: string, ?cb: Function): unit = jsNative
 
     and [<AllowNullLiteral>] TransformOptions =
-        inherit ReadableOptions
-        inherit WritableOptions
-
+        abstract highWaterMark: float option with get, set
+        abstract decodeStrings: bool option with get, set
+        abstract objectMode: bool option with get, set
+        abstract encoding: string option with get, set
 
     and [<AllowNullLiteral>] [<Import("Transform","stream")>] Transform(?opts: TransformOptions) =
         inherit events.EventEmitter()


### PR DESCRIPTION
`TransformOptions` currently inherits from `ReadableOptions` and `WritableOptions`. Because the types are exactly the same, it seems like we can't tell F# which slot to use.

Instead, we can just implement the items directly in the interface, which will resolve this issue.