### PR TITLE
Socket should inherit from NodeJS.ReadableStream

### DIFF
--- a/src/fable/Fable.Core/Import/Fable.Import.Node.fs
+++ b/src/fable/Fable.Core/Import/Fable.Import.Node.fs
@@ -224,7 +224,7 @@ open NodeJS
 
 module net_types =
     type [<AllowNullLiteral>] Socket =
-        inherit EventEmitter
+        inherit Duplex
         abstract writable: bool with get, set
         abstract _write: chunk: obj * encoding: string * callback: Function -> unit
         abstract write: chunk: obj * ?cb: Function -> bool

--- a/src/fable/Fable.Core/Import/Fable.Import.Node.fs
+++ b/src/fable/Fable.Core/Import/Fable.Import.Node.fs
@@ -224,7 +224,7 @@ open NodeJS
 
 module net_types =
     type [<AllowNullLiteral>] Socket =
-        inherit Duplex
+        inherit NodeJS.ReadableStream
         abstract writable: bool with get, set
         abstract _write: chunk: obj * encoding: string * callback: Function -> unit
         abstract write: chunk: obj * ?cb: Function -> bool

--- a/src/fable/Fable.Core/Import/Fable.Import.Node.fs
+++ b/src/fable/Fable.Core/Import/Fable.Import.Node.fs
@@ -224,6 +224,7 @@ open NodeJS
 
 module net_types =
     type [<AllowNullLiteral>] Socket =
+        inherit EventEmitter
         abstract writable: bool with get, set
         abstract _write: chunk: obj * encoding: string * callback: Function -> unit
         abstract write: chunk: obj * ?cb: Function -> bool


### PR DESCRIPTION
Socket is an extension of a Duplex stream. We should inherit from NodeJS.ReadableStream. The write methods appear to be implemented on socket already.