### PR TITLE
[WIP] Fix REPL build

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
         "typescript": "^2.2.1",
         "webpack": "^2.2.1",
         "mocha": "^3.2.0",
-        "babel-core": "^6.23.1",
-        "babel-loader": "^6.4.0",
-        "babel-preset-es2015": "^6.22.0"
+        "babel-core": "^6.24.0",
+        "babel-loader": "^6.4.1",
+        "babel-preset-es2015": "^6.24.0",
+        "babel-preset-babili": "^0.0.12"
     }
 }

--- a/src/dotnet/Fable.Client.Browser/Fable.Client.Browser.fsproj
+++ b/src/dotnet/Fable.Client.Browser/Fable.Client.Browser.fsproj
@@ -1,23 +1,36 @@
 ﻿<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
     <Version>1.0.0-alpha</Version>
-    <DefineConstants>$(DefineConstants);DOTNET40</DefineConstants>
-    <DefineConstants>$(DefineConstants);FABLE_COMPILER</DefineConstants>
-    <DefineConstants>$(DefineConstants);FX_NO_CORHOST_SIGNER</DefineConstants>
-    <DefineConstants>$(DefineConstants);FX_NO_LINKEDRESOURCES</DefineConstants>
-    <DefineConstants>$(DefineConstants);FX_NO_PDB_READER</DefineConstants>
-    <DefineConstants>$(DefineConstants);FX_NO_PDB_WRITER</DefineConstants>
-    <DefineConstants>$(DefineConstants);FX_NO_WEAKTABLE</DefineConstants>
-    <DefineConstants>$(DefineConstants);NO_COMPILER_BACKEND</DefineConstants>
-    <DefineConstants>$(DefineConstants);NO_INLINE_IL_PARSER</DefineConstants>
-    <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
+    <TargetFramework>netstandard1.6</TargetFramework>
+    <DefineConstants>FABLE_COMPILER</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="Fable.Compiler.fsx"/>
+    <ProjectReference Include="../../../../FSharp.Compiler.Service_fable/src/fsharp/fcs-fable/fcs-fable.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="../Fable.Core/Compiler.fs"/>
+    <Compile Include="../Fable.Core/Util.fs"/>
+    <Compile Include="../Fable.Core/Fable.Core.fs"/>
+    <Compile Include="../Fable.Core/AST/AST.Common.fs"/>
+    <Compile Include="../Fable.Core/AST/AST.Fable.fs"/>
+    <Compile Include="../Fable.Core/AST/AST.Fable.Util.fs"/>
+    <Compile Include="../Fable.Core/AST/AST.Babel.fs"/>
+    <Compile Include="../Fable.Core/Plugins.fs"/>
+    <!--<Compile Include="../Fable.Core/Import/Fable.Import.JS.fs"/>-->
+    <!--<Compile Include="../Fable.Core/Import/Fable.Import.Browser.fs"/>-->
+    <!--<Compile Include="../Fable.Core/Import/Fable.Import.Node.fs"/>-->
+    <!--<Compile Include="../Fable.Core/Fable.Core.Extensions.fs"/>-->
+
+    <Compile Include="../Fable.Compiler/Utils.fs"/>
+    <Compile Include="../Fable.Compiler/Replacements.fs"/>
+    <Compile Include="../Fable.Compiler/FSharp2Fable.Util.fs"/>
+    <Compile Include="../Fable.Compiler/FSharp2Fable.fs"/>
+    <Compile Include="../Fable.Compiler/Fable2Babel.fs"/>
+
+    <Compile Include="Fable.Client.fs"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnet/Fable.Client.Browser/Fable.Client.fs
+++ b/src/dotnet/Fable.Client.Browser/Fable.Client.fs
@@ -7,65 +7,52 @@ open Fable
 open Fable.AST
 open Fable.Core
 
-type FSProjInfo = FSharp2Fable.Compiler.FSProjectInfo
 
-type CompilerMessage =
-    | Error of message: string * stack: string option
-    | Log of message: string
-    static member toDic = function
-        | Error (msg, Some stack) ->
-            dict [ ("type", "ERROR"); ("message", msg); ("stack", stack) ]
-        | Error (msg, None) ->
-            dict [ ("type", "ERROR"); ("message", msg) ]
-        | Log msg ->
-            dict [ ("type", "LOG"); ("message", msg) ]
+type State(projectOptions: FSharpProjectOptions, checkedProject: FSharpCheckProjectResults) =
+    // let entities = ConcurrentDictionary<string, Fable.Entity>()
+    // let inlineExprs = ConcurrentDictionary<string, InlineExpr>()
+    let compiledFiles =
+        let dic = System.Collections.Generic.Dictionary()
+        for file in projectOptions.ProjectFileNames do
+            dic.Add(Path.normalizeFullPath file, false)
+        dic
+    let rootModules =
+        checkedProject.AssemblyContents.ImplementationFiles
+        |> Seq.map (fun file -> file.FileName, FSharp2Fable.Compiler.getRootModuleFullName file)
+        |> Map
+    member __.CheckedProject = checkedProject
+    member __.ProjectOptions = projectOptions
+    member __.ProjectFile = projectOptions.ProjectFileName
+    member __.CompiledFiles = compiledFiles
+    interface ICompilerState with
+        member __.GetRootModule(fileName) =
+            match Map.tryFind fileName rootModules with
+            | Some rootModule -> rootModule
+            | None -> FableError("Cannot find root module for " + fileName) |> raise
+        member __.GetOrAddEntity(fullName, generate) =
+            generate() //entities.GetOrAdd(fullName, fun _ -> generate())
+        member __.GetOrAddInlineExpr(fullName, generate) =
+            generate() //inlineExprs.GetOrAdd(fullName, fun _ -> generate())
 
-// Make the type non-erasable
-type U2<'a, 'b> = Case1 of 'a | Case2 of 'b
+type Compiler(options, plugins) =
+    let mutable id = 0
+    let logs = ResizeArray()
+    member __.Logs = logs
+    interface ICompiler with
+        member __.Options = options
+        member __.Plugins = plugins
+        member __.AddLog msg = logs.Add msg
+        member __.GetUniqueVar() =
+            id <- id + 1
+            "$var" + (string id)
 
-let readOptions argv =
-    let splitKeyValue (x: string) =
-        let xs = x.Split('=')
-        if xs.Length > 1
-        then xs.[0], xs.[1]
-        else xs.[0], (string true)
-    let def opts key defArg f =
-        defaultArg (Map.tryFind key opts |> Option.map f) defArg
-    let rec readOpts opts = function
-        | [] -> opts
-        | (opt: string)::rest ->
-            let k = opt.Substring(2)
-            match Map.tryFind k opts with
-            | None -> Map.add k (U2.Case1 rest.Head) opts
-            | Some (U2.Case1 v) -> Map.add k (U2.Case2 [rest.Head;v]) opts
-            | Some (U2.Case2 v) -> Map.add k (U2.Case2 (rest.Head::v)) opts
-            |> readOpts <| rest.Tail
-    let boolParse (s:string) = (s.ToLower() = "true")
-    let un f = function U2.Case1 v -> f v | U2.Case2 _ -> failwith "Unexpected multiple argument"
-    let li f = function U2.Case1 v -> [f v] | U2.Case2 v -> List.map f v
-    let opts = readOpts Map.empty<_,_> (List.ofArray argv)
-    let opts = {
-        projFile = def opts "projFile" "" (un Path.GetFullPath)
-        outDir = def opts "outDir" "." (un Path.GetFullPath)
-        coreLib = "fable-core"
-        moduleSystem = def opts "module" "es2015" (un id)
-        symbols = def opts "symbols" [] (li id) |> List.append ["FABLE_COMPILER"] |> List.distinct
-        plugins = def opts "plugins" [] (li id)
-        rollup = def opts "rollup" false (un boolParse)
-        watch = def opts "watch" false (un boolParse)
-        dll = def opts "dll" false (un boolParse)
-        includeJs = def opts "includeJs" false (un boolParse)
-        noTypedArrays = def opts "noTypedArrays" false (un boolParse)
-        clamp = def opts "clamp" false (un boolParse)
-        declaration = def opts "declaration" false (un boolParse)
-        refs = Map(def opts "refs" [] (li splitKeyValue))
-        extra = Map(def opts "extra" [] (li splitKeyValue))
-    }
-    match Map.tryFind "Fable.Core" opts.refs with
-    | Some coreLib -> { opts with coreLib = coreLib }
-    | None when not opts.rollup && Naming.umdModules.Contains opts.moduleSystem ->
-        { opts with coreLib = "fable-core/umd" }
-    | None -> opts
+let makeCompiler options plugins = Compiler(options, plugins)
+
+let readOptions _argv : CompilerOptions =
+    { fableCore = "fable-core"
+    ; declaration = false
+    ; typedArrays = true
+    ; clampByteArrays = false }
 
 /// Returns an (errors, warnings) tuple
 let parseErrors errors =
@@ -94,50 +81,9 @@ let parseFSharpProject (com: ICompiler) (checker: InteractiveChecker) (fileName,
         |> String.concat "\n"
         |> FableError |> raise
 
-let makeCompiler opts plugins =
-    let id = ref 0
-    let logs = ResizeArray()
-    let projDir = "." //Fable.Path.getCommonBaseDir opts.projFile
-    { new ICompiler with
-        member __.Options = opts
-        member __.ProjDir = projDir
-        member __.Plugins = plugins
-        member __.AddLog msg = logs.Add msg
-        member __.GetLogs() =
-            let copy = logs.ToArray()
-            logs.Clear()
-            upcast copy
-        member __.GetUniqueVar() =
-            id := !id + 1
-            "$var" + string !id }
-
-let printFile =
-    fun (file: AST.Babel.Program) ->
-#if DOTNETCORE || DOTNET40
-        // technically there should be a conversion to JSON here
-        // but we're trying to avoid adding the Json.NET reference
-        // as this is just to show it compiles properly on dotnet.
-        printfn "Babel AST: %A" file
-#else
-        printfn "%s" (Fable.Core.JsInterop.toJson file)
-#endif
-
-let printMessages (msgs: seq<CompilerMessage>) =
-    msgs
-    |> Seq.map CompilerMessage.toDic
-    |> Seq.iter (printfn "%A")
-
-let printException (ex: Exception) =
-    let msg, stackTrace =
-        match ex with
-        // Don't print stack trace for known Fable errors
-        | :? FableError as err -> err.FormattedMessage, None
-        | ex -> ex.Message, Some(ex.StackTrace)
-    printMessages [Error(msg, stackTrace)]
-
-let makeProjInfo (com: ICompiler) fileName =
+let makeProjOptions (com: ICompiler) projFile =
     let projOptions: FSharpProjectOptions =
-      { ProjectFileName = "test.fsx"
+      { ProjectFileName = projFile
         ProjectFileNames = [| |]
         OtherOptions = [| |]
         ReferencedProjects = [| |]
@@ -147,52 +93,15 @@ let makeProjInfo (com: ICompiler) fileName =
         UnresolvedReferences = None
         OriginalLoadReferences = []
         ExtraProjectInfo = None }
-    let filePairs =
-        [fileName]
-        |> Seq.map (fun fileName ->
-            fileName, Fable.Path.Combine(com.Options.outDir, Fable.Path.ChangeExtension(fileName, ".js")))
-        |> Map
-    let projInfo = FSProjInfo(projOptions, filePairs)
-    projInfo
+    projOptions
 
 let compileAst (com: ICompiler) checker (fileName, source) =
-    let warnings, parsedProj = parseFSharpProject com checker (fileName, source)
-    let projInfo = makeProjInfo com fileName
-    let extraInfo, files =
-        FSharp2Fable.Compiler.transformFiles com parsedProj projInfo
-        |> Fable2Babel.Compiler.transformFiles com
-    files
-
-let compile (com: ICompiler) checker (fileName, source) =
-    try
-        // Parse project (F# Compiler Services) and print diagnostic info
-        // --------------------------------------------------------------
-        let warnings, parsedProj =
-            parseFSharpProject com checker (fileName, source)
-
-        warnings |> Seq.map (string >> Log) |> printMessages
-
-        [Log "F# compilation complete. Starting Fable..."] |> printMessages
-
-        // make projInfo
-        let projInfo = makeProjInfo com fileName
-
-        // Compile project files, print them and get extra info
-        // ----------------------------------------------------
-        let extraInfo, files =
-            FSharp2Fable.Compiler.transformFiles com parsedProj projInfo
-            |> Fable2Babel.Compiler.transformFiles com
-
-        files
-        |> Seq.iter printFile
-
-        // Print logs
-        // ----------
-        com.GetLogs() |> Seq.map (string >> Log) |> printMessages
-
-        printfn "[SIGSUCCESS]"
-        true
-    with ex ->
-        printException ex
-        printfn "[SIGFAIL]"
-        false
+    let projectOptions = makeProjOptions com fileName
+    let warnings, checkedProject = parseFSharpProject com checker (fileName, source)
+    for warning in warnings do
+        com.AddLog(warning)
+    let state = State(projectOptions, checkedProject)
+    let file: Babel.Program =
+        FSharp2Fable.Compiler.transformFile com state state.CheckedProject fileName
+        |> Fable2Babel.Compiler.transformFile com state
+    file

--- a/src/dotnet/Fable.Client.Browser/Fable.Compiler.fsx
+++ b/src/dotnet/Fable.Client.Browser/Fable.Compiler.fsx
@@ -1,4 +1,4 @@
-#if FABLE_COMPILER && !DOTNETCORE && !DOTNET40
+#if FABLE_COMPILER && !(DOTNETCORE || DOTNET40)
 #r "System.Text.RegularExpressions.dll"
 #endif
 
@@ -37,28 +37,9 @@ let compileSource checker source =
     let opts = readOptions [||]
     let com = makeCompiler opts []
     let fileName = "stdin.fsx"
-    let files = compileAst com checker (fileName, source)
-    files
+    let file = compileAst com checker (fileName, source)
+    file
 
 let compileToJson checker source =
     compileSource checker source
-    |> Seq.map (fun file -> Fable.Core.JsInterop.toJson file)
-    |> Seq.head
-
-#if !FABLE_COMPILER
-let readAllBytes = fun (fileName:string) -> System.IO.File.ReadAllBytes ("/temp/metadata/" + fileName)
-let readAllText = fun (filePath:string) -> System.IO.File.ReadAllText (filePath, System.Text.Encoding.UTF8)
-
-[<EntryPoint>]
-let main argv =
-    try
-        let references = ["mscorlib";"System";"System.Core";"System.Data";"System.IO";"System.Xml";"System.Numerics";"FSharp.Core";"Fable.Core"]
-        let checker = InteractiveChecker(references, readAllBytes)
-        let ast =
-            System.IO.File.ReadAllText("/temp/test.fsx")
-            |> compileSource checker
-        printfn "%A" ast
-    with ex ->
-        printException ex
-    0
-#endif
+    |> Fable.Core.JsInterop.toJson

--- a/src/dotnet/Fable.Client.Browser/demo/fableconfig.json
+++ b/src/dotnet/Fable.Client.Browser/demo/fableconfig.json
@@ -1,28 +1,28 @@
-{
-    "projFile": "../Fable.Compiler.fsx",
-    "verbose": true,
-    "ecma": "es2015",
-    "coreLib": "../../../../build/fable-core",
-    "babelrc": false,
-    "babelPlugins": [
-        "transform-es2015-block-scoping"
-    ],
-    "rollup": {
-        "dest": "./repl/bundle.js"
-    },
-    "outDir": "out",
-    "symbols": [
-      "FX_NO_CORHOST_SIGNER",
-      "FX_NO_LINKEDRESOURCES",
-      "FX_NO_PDB_READER",
-      "FX_NO_PDB_WRITER",
-      "FX_NO_WEAKTABLE",
-      "NO_COMPILER_BACKEND",
-      "NO_INLINE_IL_PARSER",
-      "TRACE"
-    ],
-    "scripts": {
-        "prebuild": "node node_modules/webpack/bin/webpack babel-standalone.js repl/babel-standalone.js --output-library Babel -p",
-        // "postbuild": "node server"
-    }
-}
+// {
+//     "projFile": "../Fable.Compiler.fsx",
+//     "verbose": true,
+//     "ecma": "es2015",
+//     "coreLib": "../../../../build/fable-core",
+//     "babelrc": false,
+//     "babelPlugins": [
+//         "transform-es2015-block-scoping"
+//     ],
+//     "rollup": {
+//         "dest": "./repl/bundle.js"
+//     },
+//     "outDir": "out",
+//     "symbols": [
+//       "FX_NO_CORHOST_SIGNER",
+//       "FX_NO_LINKEDRESOURCES",
+//       "FX_NO_PDB_READER",
+//       "FX_NO_PDB_WRITER",
+//       "FX_NO_WEAKTABLE",
+//       "NO_COMPILER_BACKEND",
+//       "NO_INLINE_IL_PARSER",
+//       "TRACE"
+//     ],
+//     "scripts": {
+//         "prebuild": "node node_modules/webpack/bin/webpack babel-standalone.js repl/babel-standalone.js --output-library Babel -p",
+//         // "postbuild": "node server"
+//     }
+// }

--- a/src/dotnet/Fable.Client.Browser/demo/package.json
+++ b/src/dotnet/Fable.Client.Browser/demo/package.json
@@ -1,13 +1,15 @@
 {
   "private": true,
   "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "dependencies": {
     "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
     "babel-standalone": "^6.23.1",
     "babel-template": "^6.23.0",
     "webpack": "^2.2.1"
+  },
+  "scripts": {
+    "fable": "dotnet ../../../../build/fable/dotnet-fable.dll start",
+    "build": "node ../../../../node_modules/webpack/bin/webpack.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
   }
 }

--- a/src/dotnet/Fable.Client.Browser/demo/repl.js
+++ b/src/dotnet/Fable.Client.Browser/demo/repl.js
@@ -159,7 +159,7 @@
     this.session = this.editor.getSession();
     this.document = this.session.getDocument();
 
-    this.editor.setTheme('ace/theme/tomorrow');
+    this.editor.setTheme('ace/theme/tomorrow_night_bright');
     this.editor.setShowPrintMargin(false);
     this.editor.commands.removeCommands(['gotoline', 'find']);
     this.$el.css({
@@ -167,7 +167,11 @@
       lineHeight: 'inherit'
     });
 
-    this.session.setMode('ace/mode/javascript');
+    if (selector.indexOf('-repl-input') >= 0) {
+      this.session.setMode('ace/mode/ocaml'); //todo: mode/fsharp
+    } else {
+      this.session.setMode('ace/mode/javascript');
+    }
     this.session.setUseSoftTabs(true);
     this.session.setTabSize(2);
     this.session.setUseWorker(false);

--- a/src/dotnet/Fable.Client.Browser/demo/server.js
+++ b/src/dotnet/Fable.Client.Browser/demo/server.js
@@ -9,6 +9,7 @@ const port = 8080
 
 http.createServer(function (request, response) {
   try {
+    console.log(`${request.method} ${request.url}`);
     let requestUrl = url.parse(request.url);
     let fsPath = baseDirectory + path.normalize(requestUrl.pathname);
     var fileStream = fs.createReadStream(fsPath)

--- a/src/dotnet/Fable.Client.Browser/demo/webpack.config.js
+++ b/src/dotnet/Fable.Client.Browser/demo/webpack.config.js
@@ -1,0 +1,54 @@
+var path = require('path');
+
+function resolve(filePath) {
+  return path.resolve(__dirname, filePath)
+}
+
+var babelOptions = {
+  "presets": [
+    [resolve("../../../../node_modules/babel-preset-es2015"), {"modules": false}],
+    //[resolve("../../../../node_modules/babel-preset-babili"), {}]
+  ]
+}
+
+module.exports = {
+  entry: resolve('../Fable.Client.Browser.fsproj'),
+  output: {
+    filename: 'bundle.min.js',
+    path: resolve('./repl'),
+  },
+  //devtool: "source-map",
+  module: {
+    rules: [
+      {
+        test: /\.fs(x|proj)?$/,
+        use: {
+          loader: resolve("../../../typescript/fable-loader"),
+          options: {
+            babel: babelOptions,
+            fableCore: resolve("../../../../build/fable-core"),
+            plugins: [],
+            define: [
+              "FX_NO_CORHOST_SIGNER",
+              "FX_NO_LINKEDRESOURCES",
+              "FX_NO_PDB_READER",
+              "FX_NO_PDB_WRITER",
+              "FX_NO_WEAKTABLE",
+              "NO_COMPILER_BACKEND",
+              "NO_INLINE_IL_PARSER",
+              "TRACE"
+            ]
+          }
+        }
+      },
+      {
+        test: /\.js$/,
+        exclude: /node_modules\/(?!fable)/,
+        use: {
+          loader: '../../../../node_modules/babel-loader',
+          options: babelOptions
+        },
+      }
+    ]
+  },
+};

--- a/src/dotnet/Fable.Client.Browser/demo/worker.js
+++ b/src/dotnet/Fable.Client.Browser/demo/worker.js
@@ -5,16 +5,16 @@ var metadata = {}
 
 // Files have .txt extension to allow gzipping in Github Pages
 var references = [
-    "mscorlib.txt",
-    "System.txt",
-    "System.Core.txt",
-    "System.Data.txt",
-    "System.IO.txt",
-    "System.Xml.txt",
-    "System.Numerics.txt",
-    "FSharp.Core.sigdata.txt",
-    "FSharp.Core.txt",
-    "Fable.Core.txt"
+    "mscorlib.dll",
+    "System.dll",
+    "System.Core.dll",
+    "System.Data.dll",
+    "System.IO.dll",
+    "System.Xml.dll",
+    "System.Numerics.dll",
+    "FSharp.Core.sigdata",
+    "FSharp.Core.dll",
+    "Fable.Core.dll"
 ];
 
 function isSigdata(ref) {
@@ -22,9 +22,8 @@ function isSigdata(ref) {
 }
 
 function getFileBlob(key, url) {
-    key = key.replace(".txt", isSigdata(key) ? "" : ".dll")
     var xhr = new XMLHttpRequest();
-    xhr.open("GET", url);
+    xhr.open("GET", url + ".txt");
     xhr.responseType = "arraybuffer";
     xhr.onload = function (oEvent) {
       var arrayBuffer = xhr.response;
@@ -50,7 +49,7 @@ function compile(source) {
                 return;
             }
             var readAllBytes = function (fileName) { return metadata[fileName]; }
-            var references2 = references.filter(x => !isSigdata(x)).map(x => x.replace(".txt", ""));
+            var references2 = references.filter(x => !isSigdata(x)).map(x => x.replace(".dll", ""));
             checker = Fable.createChecker(readAllBytes, references2);
         }
         var startTime = performance.now();

--- a/src/dotnet/Fable.Client.Browser/testapp/fableconfig.json
+++ b/src/dotnet/Fable.Client.Browser/testapp/fableconfig.json
@@ -1,22 +1,22 @@
-{
-    "projFile": "project.fsx",
-    "module": "commonjs",
-    "sourceMaps": false,
-    "ecma": "es2015",
-    "outDir": "out",
-    "coreLib": "../../../../build/fable-core/umd",
-    "symbols": [
-      "FX_NO_CORHOST_SIGNER",
-      "FX_NO_LINKEDRESOURCES",
-      "FX_NO_PDB_READER",
-      "FX_NO_PDB_WRITER",
-      "FX_NO_WEAKTABLE",
-      "NO_COMPILER_BACKEND",
-      "NO_INLINE_IL_PARSER",
-      "TRACE"
-    ],
-    "scripts": {
-        "prebuild": "REM npm install",
-        "postbuild": "node out/testapp/project"
-    }
-}
+// {
+//     "projFile": "project.fsx",
+//     "module": "commonjs",
+//     "sourceMaps": false,
+//     "ecma": "es2015",
+//     "outDir": "out",
+//     "coreLib": "../../../../build/fable-core/umd",
+//     "symbols": [
+//       "FX_NO_CORHOST_SIGNER",
+//       "FX_NO_LINKEDRESOURCES",
+//       "FX_NO_PDB_READER",
+//       "FX_NO_PDB_WRITER",
+//       "FX_NO_WEAKTABLE",
+//       "NO_COMPILER_BACKEND",
+//       "NO_INLINE_IL_PARSER",
+//       "TRACE"
+//     ],
+//     "scripts": {
+//         "prebuild": "REM npm install",
+//         "postbuild": "node out/testapp/project"
+//     }
+// }

--- a/src/dotnet/Fable.Client.Browser/testapp/package.json
+++ b/src/dotnet/Fable.Client.Browser/testapp/package.json
@@ -1,10 +1,8 @@
 {
   "private": true,
-  "engines": {
-    "fable": "^0.7.42"
-  },
-  "dependencies": {
-    "babel-preset-babili": "^0.0.10",
-    "fable-core": "^0.7.26"
+  "scripts": {
+    "fable": "dotnet ../../../../build/fable/dotnet-fable.dll start",
+    "build": "node ../../../../node_modules/webpack/bin/webpack.js",
+    "start": "node ./out/bundle.js"
   }
 }

--- a/src/dotnet/Fable.Client.Browser/testapp/project.fsproj
+++ b/src/dotnet/Fable.Client.Browser/testapp/project.fsproj
@@ -1,23 +1,17 @@
 ﻿<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Version>1.0.0-alpha</Version>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.0</TargetFramework>
-    <Version>1.0.0-alpha</Version>
-    <DefineConstants>$(DefineConstants);DOTNET40</DefineConstants>
-    <DefineConstants>$(DefineConstants);FABLE_COMPILER</DefineConstants>
-    <DefineConstants>$(DefineConstants);FX_NO_CORHOST_SIGNER</DefineConstants>
-    <DefineConstants>$(DefineConstants);FX_NO_LINKEDRESOURCES</DefineConstants>
-    <DefineConstants>$(DefineConstants);FX_NO_PDB_READER</DefineConstants>
-    <DefineConstants>$(DefineConstants);FX_NO_PDB_WRITER</DefineConstants>
-    <DefineConstants>$(DefineConstants);FX_NO_WEAKTABLE</DefineConstants>
-    <DefineConstants>$(DefineConstants);NO_COMPILER_BACKEND</DefineConstants>
-    <DefineConstants>$(DefineConstants);NO_INLINE_IL_PARSER</DefineConstants>
-    <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
+    <DefineConstants>DOTNETCORE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="../Fable.Compiler.fsx"/>
+    <ProjectReference Include="../Fable.Client.Browser.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="app.fs"/>
   </ItemGroup>
 

--- a/src/dotnet/Fable.Client.Browser/testapp/webpack.config.js
+++ b/src/dotnet/Fable.Client.Browser/testapp/webpack.config.js
@@ -1,0 +1,53 @@
+var path = require('path');
+
+function resolve(filePath) {
+  return path.resolve(__dirname, filePath)
+}
+
+var babelOptions = {
+  "presets": [
+    [resolve("../../../../node_modules/babel-preset-es2015"), {"modules": false}]
+  ]
+}
+
+module.exports = {
+  entry: resolve('./project.fsproj'),
+  output: {
+    filename: 'bundle.js',
+    path: resolve('./out'),
+  },
+  devtool: "source-map",
+  module: {
+    rules: [
+      {
+        test: /\.fs(x|proj)?$/,
+        use: {
+          loader: resolve("../../../typescript/fable-loader"),
+          options: {
+            babel: babelOptions,
+            fableCore: resolve("../../../../build/fable-core"),
+            plugins: [],
+            define: [
+              "FX_NO_CORHOST_SIGNER",
+              "FX_NO_LINKEDRESOURCES",
+              "FX_NO_PDB_READER",
+              "FX_NO_PDB_WRITER",
+              "FX_NO_WEAKTABLE",
+              "NO_COMPILER_BACKEND",
+              "NO_INLINE_IL_PARSER",
+              "TRACE"
+            ]
+          }
+        }
+      },
+      {
+        test: /\.js$/,
+        exclude: /node_modules\/(?!fable)/,
+        use: {
+          loader: '../../../../node_modules/babel-loader',
+          options: babelOptions
+        },
+      }
+    ]
+  },
+};


### PR DESCRIPTION
Outstanding issues:
- Blocked on #754.
- babel standalone is not being generated, needs fixing or replace with cdn version.
- for some reason in testapp cannot import nodejs "fs"
- not an issue, just an observation: using webpack results in 50% bigger bundle size than before.
- not an issue per se, but for some reason with webpack we can no longer use nested .fsx script files as project files, if they use relative paths. The work-around is to use .fsproj and project references.