### PR TITLE
Update child_process.exec to return Option<Error>

### DIFF
--- a/src/fable/Fable.Core/Import/Fable.Import.Node.fs
+++ b/src/fable/Fable.Core/Import/Fable.Import.Node.fs
@@ -590,8 +590,8 @@ module child_process_types =
 
     type Globals =
         member __.spawn(command: string, ?args: ResizeArray<string>, ?options: obj): ChildProcess = jsNative
-        member __.exec(command: string, options: obj, ?callback: Func<Error, Buffer, Buffer, unit>): ChildProcess = jsNative
-        member __.exec(command: string, ?callback: Func<Error, Buffer, Buffer, unit>): ChildProcess = jsNative
+        member __.exec(command: string, options: obj, ?callback: Func<Error option, Buffer, Buffer, unit>): ChildProcess = jsNative
+        member __.exec(command: string, ?callback: Func<Error option, Buffer, Buffer, unit>): ChildProcess = jsNative
         member __.execFile(file: string, ?callback: Func<Error, Buffer, Buffer, unit>): ChildProcess = jsNative
         member __.execFile(file: string, ?args: ResizeArray<string>, ?callback: Func<Error, Buffer, Buffer, unit>): ChildProcess = jsNative
         member __.execFile(file: string, ?args: ResizeArray<string>, ?options: obj, ?callback: Func<Error, Buffer, Buffer, unit>): ChildProcess = jsNative


### PR DESCRIPTION
The first param to exec is `null | Error` We should represent this as a Option type in the bindings.