### PR TITLE
Add method to construct a Buffer

### DIFF
--- a/src/fable/Fable.Core/Import/Fable.Import.Node.fs
+++ b/src/fable/Fable.Core/Import/Fable.Import.Node.fs
@@ -24,6 +24,7 @@ and [<AllowNullLiteral>] Buffer =
 and [<AllowNullLiteral>] NodeBuffer =
     [<Emit("$0[$1]{{=$2}}")>] abstract Item: index: int -> float with get, set
     abstract length: float with get, set
+    abstract from: string: string * ?encoding: string -> Buffer
     abstract write: string: string * ?offset: float * ?length: float * ?encoding: string -> float
     abstract toString: ?encoding: string * ?start: float * ?``end``: float -> string
     abstract toJSON: unit -> obj


### PR DESCRIPTION
Buffer is currently missing a way to create new buffers.

Add `Buffer.from` which can take a string and construct a Buffer from it.