### PR TITLE
expose deflate function in Fable.Core

### DIFF
--- a/src/dotnet/Fable.Compiler/Replacements.fs
+++ b/src/dotnet/Fable.Compiler/Replacements.fs
@@ -624,7 +624,7 @@ module AstPass =
                 then "awaitPromise" else "startAsPromise"
             CoreLibCall("Async", Some meth, false, i.args)
             |> makeCall i.range i.returnType |> Some
-        | "toJson" | "ofJson" | "inflate" | "toPlainJsObj"
+        | "toJson" | "ofJson" | "deflate" | "inflate" | "toPlainJsObj"
         | "toJsonWithTypeInfo" | "ofJsonWithTypeInfo" ->
             let modName = if i.methodName = "toPlainJsObj" then "Util" else "Serialize"
             CoreLibCall(modName, Some i.methodName, false, i.args)

--- a/src/dotnet/Fable.Core/Fable.Core.fs
+++ b/src/dotnet/Fable.Core/Fable.Core.fs
@@ -183,6 +183,11 @@ module JsInterop =
     /// DEPRECATED: Use a Pojo record or union
     let [<Obsolete>] toPlainJsObj (o: 'T): obj = jsNative
 
+    /// Converts an F# object into a plain JS object (POJO)
+    /// This is only intended if you're using a custom serialization method
+    /// and will produce the same object structure that `toJson` encodes
+    let deflate(o: 'T): obj = jsNative
+
     /// Serialize F# objects to JSON
     let toJson(o: 'T): string = jsNative
 

--- a/src/typescript/fable-core/Serialize.ts
+++ b/src/typescript/fable-core/Serialize.ts
@@ -12,7 +12,7 @@ import { resolveGeneric, getTypeFullName } from "./Reflection"
 import { parse as dateParse } from "./Date"
 import { fsFormat } from "./String"
 
-function deflate(v: any) {
+export function deflate(v: any) {
   if (ArrayBuffer.isView(v)) {
     return Array.from(v as any);
   }


### PR DESCRIPTION
Exposes the deflate function to handle a devtool use case needing both deflate / inflate to handle custom serialization.

Should there be additional tests added or would any existing serializations cover this implicitly?