### PR TITLE
Test deserialization for provided type at run-time

### DIFF
--- a/src/nuget/Fable.JsonConverter.Tests/JsonConverterTests.fs
+++ b/src/nuget/Fable.JsonConverter.Tests/JsonConverterTests.fs
@@ -124,4 +124,19 @@ module JsonConverterTests =
         | Just _ -> Assert.Fail("Should not happed")
         | Nothing -> Assert.Pass()
 
-        
+    [<Test>]
+    let ``Deserialization with provided type at runtime works``() = 
+        let inputType = typeof<Option<int>>
+        let json = "5"
+        let parameterTypes = [| typeof<string>; typeof<System.Type> ; typeof<JsonConverter array> |]
+        let deserialize = typeof<JsonConvert>.GetMethod("DeserializeObject", parameterTypes) 
+        Assert.IsNotNull(deserialize)
+
+        let result = deserialize.Invoke(null, [| json; inputType; [| converter |] |])
+        match result with
+        | :? Option<int> as opt -> 
+              match opt with 
+              | Some n -> Assert.AreEqual(5, n)
+              | None -> Assert.Fail("Should not happen")
+        | _ -> Assert.Fail("Should not happen")
+                


### PR DESCRIPTION
Just to make sure this works, it is critical for [Fable,Remoting](https://github.com/Zaid-Ajaj/Fable.Remoting). I couldn't test it there because VS thinks it will just use it's own prefered version of FSharp.Core from my local machine instead of packages folder and mess my references 😑 will go for paket and vs-code I guess
