### PR TITLE
Inspecting function range and domain by Reflection

### DIFF
--- a/src/tests/Main/ReflectionTests.fs
+++ b/src/tests/Main/ReflectionTests.fs
@@ -227,6 +227,18 @@ let ``FSharp.Reflection: Record`` () =
     let all = isRecord && matchRecordFields && matchIndividualRecordFields && canMakeSameRecord
     all |> equal true
 
+type RecordF = { F : int -> string }
+[<Test>]
+let ``FSharp.Reflection Functions``() = 
+    let recordType = typeof<RecordF>
+    let fields = FSharpType.GetRecordFields recordType
+    let funcProperty = Array.head fields
+    let funcType = funcProperty.PropertyType
+    let range, domain = FSharpType.GetFunctionElements funcType
+    equal range typeof<int>
+    equal domain typeof<string>
+    equal true (FSharpType.IsFunction funcType)
+
 [<Test>]
 let ``FSharp.Reflection: Tuple`` () =
     let typ = typeof<string * int>

--- a/src/tests/Main/ReflectionTests.fs
+++ b/src/tests/Main/ReflectionTests.fs
@@ -234,9 +234,9 @@ let ``FSharp.Reflection Functions``() =
     let fields = FSharpType.GetRecordFields recordType
     let funcProperty = Array.head fields
     let funcType = funcProperty.PropertyType
-    let range, domain = FSharpType.GetFunctionElements funcType
-    equal range typeof<int>
-    equal domain typeof<string>
+    let domain, range = FSharpType.GetFunctionElements funcType
+    equal domain typeof<int>
+    equal range typeof<string>
     equal true (FSharpType.IsFunction funcType)
 
 [<Test>]


### PR DESCRIPTION
Addresses #772 

Adds failing tests to inspect input (domain) and output (range) types of functions extracted from record fields. 

Missing Replacements:
 - FSharpType.IsFunction
 - FSharpType.GetFunctionElements 

