### PR TITLE
Update dotnet-fable.fsproj

### DIFF
--- a/src/dotnet/Fable.Tools/dotnet-fable.fsproj
+++ b/src/dotnet/Fable.Tools/dotnet-fable.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Version>1.0.0-narumi-905</Version>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
     <!-- See https://github.com/dotnet/netcorecli-fsc/issues/98 -->
     <FscToolPath>../../../lib/fsharp.compiler.tools.4.1.0</FscToolPath>
   </PropertyGroup>

--- a/src/tests/Main/TypeTests.fs
+++ b/src/tests/Main/TypeTests.fs
@@ -291,7 +291,7 @@ let ``lazy.IsValueCreated works``() =
 
 [<Test>]
 let ``Lazy constructor works``() =
-    let items = Lazy<_>(fun () -> ["a";"b";"c"])
+    let items = Lazy<string list>(fun () -> ["a";"b";"c"])
     let search e = items.Value |> List.tryFind (fun m -> m = e)
     search "b" |> equal (Some "b")
     search "d" |> equal None


### PR DESCRIPTION
Update TargetFramework to point at `netcoreapp1.1`.

I'm trying to use dotnet-fable on a Fedora 24 box and it only supports dotnet core 1.1.

Do you see any issue with bumping the `TargetFramework` here?