### PR TITLE
Corrected path to NUnit when building

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -335,7 +335,7 @@ let buildNUnitPlugin () =
     Util.run nunitDir dotnetExePath "restore"
     Util.run nunitDir dotnetExePath "build -c Release"
     CreateDir "build/nunit"
-    FileUtils.cp (nunitDir + "/bin/Release/netstandard1.6/Fable.Plugins.NUnit.dll") "build/nunit"
+    FileUtils.cp (nunitDir + "/bin/MCD/Release/netstandard1.6/Fable.Plugins.NUnit.dll") "build/nunit"
 
 let buildJsonConverter () =
     "restore src/dotnet/Fable.JsonConverter"

--- a/build.fsx
+++ b/build.fsx
@@ -332,14 +332,16 @@ let buildCore isRelease () =
 
 let buildNUnitPlugin () =
     let nunitDir = "src/plugins/nunit"
+    CreateDir "build/nunit"  // if it does not exist
     Util.run nunitDir dotnetExePath "restore"
-    Util.run nunitDir dotnetExePath "build -c Release"
-    CreateDir "build/nunit"
-    let nunitBinaryPath = 
-        match isWindows with
-        | true -> "/bin/MCD/Release/netstandard1.6/Fable.Plugins.NUnit.dll"
-        | false -> "/bin/Release/netstandard1.6/Fable.Plugins.NUnit.dll"
-    FileUtils.cp (nunitDir + nunitBinaryPath) "build/nunit"
+    // pass output path to build command
+    Util.run nunitDir dotnetExePath ("build -c Release -o ../../../build/nunit")
+    
+    //let nunitBinaryPath = 
+    //    match isWindows with
+    //    | true -> "/bin/MCD/Release/netstandard1.6/Fable.Plugins.NUnit.dll"
+    //    | false -> "/bin/Release/netstandard1.6/Fable.Plugins.NUnit.dll"
+    //FileUtils.cp (nunitDir + nunitBinaryPath) "build/nunit"
 
 let buildJsonConverter () =
     "restore src/dotnet/Fable.JsonConverter"
@@ -353,7 +355,6 @@ let runTestsDotnet () =
     Util.run "src/tests/DllRef" dotnetExePath "restore"
     Util.run "src/tests/Project With Spaces" dotnetExePath "restore"
     Util.run "src/tests/Main" dotnetExePath "restore"
-
     Util.run "src/tests/Main" dotnetExePath "test"
 
 let runFableServer f =

--- a/build.fsx
+++ b/build.fsx
@@ -335,7 +335,11 @@ let buildNUnitPlugin () =
     Util.run nunitDir dotnetExePath "restore"
     Util.run nunitDir dotnetExePath "build -c Release"
     CreateDir "build/nunit"
-    FileUtils.cp (nunitDir + "/bin/MCD/Release/netstandard1.6/Fable.Plugins.NUnit.dll") "build/nunit"
+    let nunitBinaryPath = 
+        match isWindows with
+        | true -> "/bin/MCD/Release/netstandard1.6/Fable.Plugins.NUnit.dll"
+        | false -> "/bin/Release/netstandard1.6/Fable.Plugins.NUnit.dll"
+    FileUtils.cp (nunitDir + nunitBinaryPath) "build/nunit"
 
 let buildJsonConverter () =
     "restore src/dotnet/Fable.JsonConverter"


### PR DESCRIPTION
Addresses #789 
When the path is corrected, building with target "All" seems to work fine (on my windows 10).

@alfonsogarciacaro I am guessing you were also compiling fine on your mac without the "/MCD/" part in the path, so could this be os-specific and that the build script should check what os it is running on to determine the correct path?