### PR TITLE
Updated FCS-Fable symbols

### DIFF
--- a/src/dotnet/Fable.Client.Browser/demo/webpack.config.js
+++ b/src/dotnet/Fable.Client.Browser/demo/webpack.config.js
@@ -30,6 +30,7 @@ module.exports = {
             fableCore: resolve("../../../../build/fable-core"),
             plugins: [],
             define: [
+              "COMPILER_SERVICE",
               "FX_NO_CORHOST_SIGNER",
               "FX_NO_LINKEDRESOURCES",
               "FX_NO_PDB_READER",

--- a/src/dotnet/Fable.Client.Browser/testapp/app.fs
+++ b/src/dotnet/Fable.Client.Browser/testapp/app.fs
@@ -49,13 +49,18 @@ let main () =
         let createChecker() = references |> createChecker readAllBytes
         let ms, checker = measureTime createChecker
         printfn "InteractiveChecker created in %d ms" ms
-        let f() =
+        let parseFCS() =
+            parseFSharpProject com checker (fileName, source)
+            |> ignore
+        let parseAll() =
             compileAst com checker (fileName, source)
             |> Fable.Core.JsInterop.toJson
             |> ignore
         let bench i =
-            let ms, _ = measureTime f
-            printfn "iteration %d, duration %d ms" i ms
+            let ms, _ = measureTime parseFCS
+            printfn "iteration %d, parse time (FCS) = %d ms" i ms
+            let ms, _ = measureTime parseAll
+            printfn "iteration %d, parse time (ALL) = %d ms" i ms
         [1..10] |> List.iter bench
     with ex ->
         printfn "Error: %A" ex.Message

--- a/src/dotnet/Fable.Client.Browser/testapp/webpack.config.js
+++ b/src/dotnet/Fable.Client.Browser/testapp/webpack.config.js
@@ -30,6 +30,7 @@ module.exports = {
             fableCore: resolve("../../../../build/fable-core"),
             plugins: [],
             define: [
+              "COMPILER_SERVICE",
               "FX_NO_CORHOST_SIGNER",
               "FX_NO_LINKEDRESOURCES",
               "FX_NO_PDB_READER",


### PR DESCRIPTION
- Updated FCS-Fable symbols to match latest FCS (12.0.2) (please get latest)
- REPL seems to be broken again (but FCS works, as you can see from the testapp)
- The testapp now shows the FCS AST parsing time separately, as well as total time)