### PR TITLE
[WIP] Output multiple errors

### DIFF
--- a/src/dotnet/Fable.Core/AST/AST.Babel.fs
+++ b/src/dotnet/Fable.Core/AST/AST.Babel.fs
@@ -1,6 +1,7 @@
 namespace Fable.AST.Babel
 open Fable
 open Fable.AST
+open System.Collections.Generic
 
 /// The type field is a string representing the AST variant type.
 /// Each subtype of Node is documented below with the specific string of its type field.
@@ -155,15 +156,15 @@ type Directive(value, ?loc) =
 /// A complete program source tree.
 /// Parsers must specify sourceType as "module" if the source has been parsed as an ES6 module.
 /// Otherwise, sourceType must be "script".
-type Program(fileName, loc, body, ?directives, ?infos, ?warnings) =
+type Program(fileName, loc, body, ?directives, ?logs) =
     inherit Node("Program", loc)
     member x.sourceType = "module" // Don't use "script"
     member x.body: U2<Statement, ModuleDeclaration> list = body
     member x.directives: Directive list = defaultArg directives []
     // Properties below don't belong to babel specs
     member x.fileName: string = fileName
-    member x.infos: string[] = defaultArg infos [||]
-    member x.warnings: string[] = defaultArg warnings [||]
+    member x.logs: IDictionary<string, string[]> =
+        match logs with Some logs -> logs | None -> dict []
 
 (** ##Statements *)
 /// An expression statement, i.e., a statement consisting of a single expression.

--- a/src/dotnet/Fable.Core/AST/AST.Common.fs
+++ b/src/dotnet/Fable.Core/AST/AST.Common.fs
@@ -1,37 +1,5 @@
 namespace Fable.AST
 
-/// Each Position object consists of a line number (1-indexed) and a column number (0-indexed):
-type Position =
-    { line: int; column: int; }
-    static member Empty = { line = 1; column = 0 }
-
-type SourceLocation =
-    { (*source: string option;*) start: Position; ``end``: Position; }
-    member x.Collapse() =
-        { start = x.start; ``end`` = x.start }
-    static member (+) (r1: SourceLocation, r2: SourceLocation) =
-        { start = r1.start; ``end`` = r2.``end`` }
-    static member Empty =
-        { start = Position.Empty; ``end`` = Position.Empty }
-    override x.ToString() =
-        sprintf "(L%i,%i-L%i,%i)"
-            x.start.line x.start.column
-            x.``end``.line x.``end``.column
-
-type FableError(msg: string, ?range: SourceLocation, ?file: string) =
-    inherit System.Exception(msg)
-    member __.Range = range
-    member __.File = file
-    member __.FormattedMessage =
-        match file with
-        | Some file ->
-            let range =
-                match range with
-                | Some r -> sprintf "%i, %i" r.start.line r.start.column
-                | None -> "1"
-            sprintf "%s(%s) : error FABLE: %s" file range msg
-        | None -> msg
-
 type NumberKind =
     | Int8 | UInt8 | Int16 | UInt16 | Int32 | UInt32 | Float32 | Float64
 

--- a/src/dotnet/Fable.Core/AST/AST.Fable.Util.fs
+++ b/src/dotnet/Fable.Core/AST/AST.Fable.Util.fs
@@ -447,10 +447,9 @@ let rec ensureArity com argTypes args =
                 makeApply com f.Range typ f args
                 |> makeLambdaExpr innerArgs
         elif expectedArgsLength > actualArgsLength then
-            if Option.isSome f.Range then
-                sprintf "A function with less arguments than expected has been wrapped at %O. %s"
-                        f.Range.Value "Side effects may be delayed."
-                |> Warning |> com.AddLog
+            // if Option.isSome f.Range then
+            //     com.AddLog("A function with less arguments than expected has been wrapped. " +
+            //                 "Side effects may be delayed.", Warning, f.Range.Value) // filename
             let innerArgs = List.take actualArgsLength outerArgs |> List.map argIdentToExpr
             let outerArgs = List.skip actualArgsLength outerArgs |> List.map argIdentToExpr
             let innerApply = makeApply com f.Range (Function(List.map Expr.getType outerArgs,typ)) f innerArgs
@@ -524,10 +523,12 @@ let compareDeclaredAndAppliedArgs declaredArgs appliedArgs =
         | x, y -> x = y
     listsEqual argEqual declaredArgs appliedArgs
 
-let addWarning (com: ICompiler) (file: string) (range: SourceLocation option) (warning: string) =
-    let range =
-        match range with
-        | Some r -> sprintf "%i, %i" r.start.line r.start.column
-        | None -> "1"
-    sprintf "%s(%s) : warning FABLE: %s" file range warning
-    |> Warning |> com.AddLog
+let addWarning (com: ICompiler) (fileName: string) (range: SourceLocation option) (warning: string) =
+    com.AddLog(warning, Warning, ?range=range, fileName=fileName)
+
+let addError (com: ICompiler) (fileName: string) (range: SourceLocation option) (warning: string) =
+    com.AddLog(warning, Error, ?range=range, fileName=fileName)
+
+let addErrorAndReturnNull (com: ICompiler) (fileName: string) (range: SourceLocation option) (error: string) =
+    com.AddLog(error, Error, ?range=range, fileName=fileName)
+    Value Null

--- a/src/dotnet/Fable.Core/Compiler.fs
+++ b/src/dotnet/Fable.Core/Compiler.fs
@@ -6,17 +6,10 @@ type CompilerOptions =
     ; typedArrays: bool
     ; clampByteArrays: bool }
 
-type Log =
-    | Warning of string
-    | Info of string
-    override x.ToString() =
-        match x with
-        | Warning s -> "[WARNING] " + s
-        | Info s -> "[INFO] " + s
-    static member message x =
-        match x with
-        | Warning s -> s
-        | Info s -> s
+type Severity =
+    | Warning
+    | Error
+    | Info
 
 type IPlugin =
     interface end
@@ -27,5 +20,6 @@ type PluginInfo =
 type ICompiler =
     abstract Options: CompilerOptions
     abstract Plugins: PluginInfo list
-    abstract AddLog: Log->unit
     abstract GetUniqueVar: unit->string
+    abstract AddLog: msg:string * severity: Severity * ?range:SourceLocation
+                        * ?fileName:string * ?tag: string -> unit

--- a/src/dotnet/Fable.Core/Fable.Core.fsproj
+++ b/src/dotnet/Fable.Core/Fable.Core.fsproj
@@ -7,8 +7,8 @@
     <FscToolPath>../../../lib/fsharp.compiler.tools.4.1.0</FscToolPath>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="Compiler.fs" />
     <Compile Include="Util.fs" />
+    <Compile Include="Compiler.fs" />
     <Compile Include="Fable.Core.fs" />
     <Compile Include="AST/AST.Common.fs" />
     <Compile Include="AST/AST.Fable.fs" />

--- a/src/dotnet/Fable.Core/Util.fs
+++ b/src/dotnet/Fable.Core/Util.fs
@@ -1,5 +1,23 @@
 namespace Fable
 
+/// Each Position object consists of a line number (1-indexed) and a column number (0-indexed):
+type Position =
+    { line: int; column: int; }
+    static member Empty = { line = 1; column = 0 }
+
+type SourceLocation =
+    { (*source: string option;*) start: Position; ``end``: Position; }
+    member x.Collapse() =
+        { start = x.start; ``end`` = x.start }
+    static member (+) (r1: SourceLocation, r2: SourceLocation) =
+        { start = r1.start; ``end`` = r2.``end`` }
+    static member Empty =
+        { start = Position.Empty; ``end`` = Position.Empty }
+    override x.ToString() =
+        sprintf "(L%i,%i-L%i,%i)"
+            x.start.line x.start.column
+            x.``end``.line x.``end``.column
+
 module Map =
     let findOrRun<'T> (f: unit->'T) (k: string) (m: Map<string, obj>) =
         match Map.tryFind k m with

--- a/src/dotnet/Fable.Tools/ProjectCracker.fs
+++ b/src/dotnet/Fable.Tools/ProjectCracker.fs
@@ -114,7 +114,7 @@ let tryEvalMsBuildCondition (projDir: string) (condition: string) =
         let contains = projDir.Contains(m.Groups.[2].Value)
         // printfn "ProjDir contains '%s': %b (negate: %b) (%s)" m.Groups.[2].Value contains negate projDir
         if negate then not contains else contains
-    else FableError("Cannot evaluate MSBuild condition " + condition) |> raise
+    else failwith ("Cannot evaluate MSBuild condition " + condition)
 
 /// Ultra-simplistic resolution of .fsproj files
 let crackFsproj (projFile: string) =
@@ -158,9 +158,8 @@ let crackFsproj (projFile: string) =
                 | Some x -> RelativeDllReference x.Value
                 | None -> Another
         | _ -> Another
-    // Use FableError to prevent retryGetProjectOpts keeps trying
     if not(File.Exists(projFile)) then
-        FableError("File does not exist: " + projFile) |> raise
+        failwith ("File does not exist: " + projFile)
     let doc = XDocument.Load(projFile)
     let projDir = Path.GetDirectoryName(projFile) |> Path.normalizePath
     let sourceFiles, projectReferences, relativeDllReferences =
@@ -247,7 +246,7 @@ let getFullProjectOpts (checker: FSharpChecker) (define: string[]) (projFile: st
     let define = Array.append define [|"FABLE_COMPILER"|]
     let projFile = Path.GetFullPath(projFile)
     if not(File.Exists(projFile)) then
-        FableError("File does not exist: " + projFile) |> raise
+        failwith ("File does not exist: " + projFile)
     let projOpts = retryGetProjectOpts checker define projFile
     Array.append (getBasicCompilerArgs define false) projOpts.OtherOptions
     |> makeProjectOptions projOpts.ProjectFileName projOpts.ProjectFileNames

--- a/src/dotnet/Fable.Tools/Server.fs
+++ b/src/dotnet/Fable.Tools/Server.fs
@@ -64,7 +64,7 @@ let rec private loop timeout (server: TcpListener) (buffer: byte[]) (onMessage: 
 let start port timeout onMessage =
     let cts = new CancellationTokenSource()
     let buffer = Array.zeroCreate<byte> 8192
-    let server = new TcpListener(IPAddress.Parse("127.0.0.1"), port)
+    let server = TcpListener(IPAddress.Parse("127.0.0.1"), port)
     // This is needed to prevent errors in Unix when Fable server is restarted quickly
     // See https://github.com/fable-compiler/Fable/issues/809#issuecomment-294073328
     server.Server.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true)
@@ -79,6 +79,4 @@ let stop port = async {
     let data = Encoding.UTF8.GetBytes(SIGTERM)
     use stream = client.GetStream()
     stream.Write(data, 0, data.Length)
-    while client.Connected do
-        do! Async.Sleep 200
 }

--- a/src/dotnet/Fable.Tools/Server.fs
+++ b/src/dotnet/Fable.Tools/Server.fs
@@ -79,4 +79,6 @@ let stop port = async {
     let data = Encoding.UTF8.GetBytes(SIGTERM)
     use stream = client.GetStream()
     stream.Write(data, 0, data.Length)
+    while client.Connected do
+        do! Async.Sleep 200
 }

--- a/src/typescript/fable-loader/index.js
+++ b/src/typescript/fable-loader/index.js
@@ -65,8 +65,18 @@ module.exports = function(buffer) {
             }
             else {
                 console.log("Fable loader received: " + msg.path);
-                ensureArray(data.infos).forEach(x => console.log(x));
-                ensureArray(data.warnings).forEach(x => this.emitWarning(x));
+                if (typeof data.logs === "object") {
+                    Object.keys(data.logs).forEach(key => {
+                        // TODO: Fail if there's one or more error logs?
+                        // That would prevent compilation of other files
+                        if (key === "warning" || key === "error") {
+                            ensureArray(data.logs[key]).forEach(x => this.emitWarning(new Error(x)));
+                        }
+                        else {
+                            ensureArray(data.logs[key]).forEach(x => console.log(x));
+                        }
+                    })
+                }
                 try {
                     var fsCode = null;
                     if (this.sourceMap) {

--- a/src/typescript/rollup-plugin-fable/index.js
+++ b/src/typescript/rollup-plugin-fable/index.js
@@ -71,14 +71,21 @@ module.exports = (
 
           const {
             error = null,
-            infos = [],
-            warnings = []
+            logs = {},
           } = data;
 
           if (error) throw new Error(error);
 
-          infos.forEach(x => console.log(x));
-          warnings.forEach(x => this.warn(x));
+          Object.keys(logs).forEach(key => {
+            // TODO: Fail if there's one or more error logs?
+            // That would prevent compilation of other files
+            if (key === "warning" || key === "error") {
+              ensureArray(logs[key]).forEach(x => this.warn(x));
+            }
+            else {
+              ensureArray(logs[key]).forEach(x => console.log(x));
+            }
+          })
 
           let fsCode = null;
           if (this.sourceMap) {

--- a/src/typescript/rollup-plugin-fable/package.json
+++ b/src/typescript/rollup-plugin-fable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-fable",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Rollup Plugin for fable-compiler",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Atm Fable compilation stops on first error, this PR will continue compilation for the most common Fable-specific errors (like "Replacement not found"), these will make it easier for devs to have an overview of what they need to fix and it will make it possible for editors to display Fable errors alongside F# ones.

cc @Krzysztof-Cieslak 