### PR TITLE
Update cwd for quicktest debugging in vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -36,7 +36,7 @@
             "program": "${workspaceRoot}/src/tools/temp/QuickTest.js",
             // "program": "${workspaceRoot}/temp2/webpack_test/node_modules/webpack/bin/webpack.js",
             "args": ["--help"],
-            "cwd": "${workspaceRoot}/temp2/webpack_test",
+            "cwd": "${workspaceRoot}/src/tools/temp",
             "stopOnEntry": true
         }
     ]


### PR DESCRIPTION
I couldn't launch the node debugger for quicktest without the cwd changed to match the output of the quicktest.js file