### PR TITLE
add debugger() to Fable.Import.JS

### DIFF
--- a/src/dotnet/Fable.Core/Import/Fable.Import.JS.fs
+++ b/src/dotnet/Fable.Core/Import/Fable.Import.JS.fs
@@ -1202,3 +1202,5 @@ module JS =
     let [<Global>] decodeURIComponent: string -> string = jsNative
     let [<Global>] encodeURI: string -> string = jsNative
     let [<Global>] encodeURIComponent: string -> string = jsNative
+
+    let [<Emit("debugger;")>] debugger () : unit = jsNative


### PR DESCRIPTION
calling the Fable.Import.JS.debugger() function will emit the js `debugger` keyword

closes #814