### PR TITLE
add rollup-pluginutils as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "fable-utils": "^1.0.0",
     "mocha": "^3.2.0",
     "rollup": "^0.41.6",
+    "rollup-pluginutils": "^2.0.1",
     "typescript": "^2.2.2",
     "webpack": "^2.4.1"
   }


### PR DESCRIPTION
When I sync'd latest and ran `build Quicktest` I got the message:

> @ rollup D:\Development\GitHub\Fable\src\tools
> node ../../node_modules/rollup/bin/rollup -c

**�   Cannot find module 'rollup-pluginutils'**

After installing `rollup-pluginutils` I don't see this message anymore. 