### PR TITLE
Fixed REPL build

### DIFF
--- a/src/dotnet/Fable.Client.Browser/Fable.Client.Browser.fsproj
+++ b/src/dotnet/Fable.Client.Browser/Fable.Client.Browser.fsproj
@@ -11,8 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="../Fable.Core/Compiler.fs"/>
     <Compile Include="../Fable.Core/Util.fs"/>
+    <Compile Include="../Fable.Core/Compiler.fs"/>
     <Compile Include="../Fable.Core/Fable.Core.fs"/>
     <Compile Include="../Fable.Core/AST/AST.Common.fs"/>
     <Compile Include="../Fable.Core/AST/AST.Fable.fs"/>
@@ -29,6 +29,8 @@
     <Compile Include="../Fable.Compiler/FSharp2Fable.Util.fs"/>
     <Compile Include="../Fable.Compiler/FSharp2Fable.fs"/>
     <Compile Include="../Fable.Compiler/Fable2Babel.fs"/>
+
+    <Compile Include="../Fable.Tools/State.fs"/>
 
     <Compile Include="Fable.Client.fs"/>
   </ItemGroup>

--- a/src/dotnet/Fable.Client.Browser/testapp/app.fs
+++ b/src/dotnet/Fable.Client.Browser/testapp/app.fs
@@ -36,14 +36,11 @@ let measureTime (f: unit -> 'a) =
 
 #endif
 
-// #if (DOTNETCORE || DOTNET40)
-// [<EntryPoint>]
-// #endif
-let main () =
+[<EntryPoint>]
+let main argv =
     try
         let references = [|"FSharp.Core";"mscorlib";"System";"System.Core";"System.Data";"System.IO";"System.Xml";"System.Numerics";"Fable.Core"|]
-        let opts = getDefaultOptions ()
-        let com = makeCompiler opts []
+        let com = makeCompiler ()
         let fileName = "test_script.fsx"
         let source = readAllText fileName
         let createChecker() = references |> createChecker readAllBytes
@@ -64,5 +61,3 @@ let main () =
     with ex ->
         printfn "Error: %A" ex.Message
     0
-
-main () |> ignore

--- a/src/dotnet/Fable.Client.Browser/testapp/rollup.config.js
+++ b/src/dotnet/Fable.Client.Browser/testapp/rollup.config.js
@@ -7,8 +7,7 @@ function resolve(filePath) {
 
 // var babelOptions = {
 //   "presets": [
-//     [resolve("../../../../node_modules/babel-preset-es2015"), {"modules": false}],
-//     //[resolve("../../../../node_modules/babel-preset-babili"), {}]
+//     ["es2015", {"modules": false}]
 //   ]
 // };
 

--- a/src/dotnet/Fable.Client.Browser/testapp/webpack.config.js
+++ b/src/dotnet/Fable.Client.Browser/testapp/webpack.config.js
@@ -6,8 +6,7 @@ function resolve(filePath) {
 
 var babelOptions = {
   "presets": [
-    [resolve("../../../../node_modules/babel-preset-es2015"), {"modules": false}],
-    //[resolve("../../../../node_modules/babel-preset-babili"), {}]
+    ["es2015", {"modules": false}]
   ]
 };
 
@@ -30,12 +29,12 @@ var fableOptions = {
 
 module.exports = {
   target: 'node',
+  //devtool: "source-map",
   entry: resolve('./testapp.fsproj'),
   output: {
     filename: 'bundle.min.js',
     path: resolve('./out')
   },
-  //devtool: "source-map",
   module: {
     rules: [
       {
@@ -47,9 +46,9 @@ module.exports = {
       },
       {
         test: /\.js$/,
-        exclude: /node_modules\/(?!fable)/,
+        exclude: /node_modules/,
         use: {
-          loader: '../../../../node_modules/babel-loader',
+          loader: 'babel-loader',
           options: babelOptions
         },
       }

--- a/src/dotnet/Fable.Tools/Parser.fs
+++ b/src/dotnet/Fable.Tools/Parser.fs
@@ -106,9 +106,3 @@ let parse (msg: string) =
         ; clampByteArrays = parseBoolean false "clampByteArrays" json }
     // printfn "Parsed options: path=%s; define=%A; plugins=%A; options=%A" path define plugins opts
     { path=path; define=define; plugins=plugins; options=opts; extra=parseDic "extra" json }
-
-let getDefaultOptions() =
-    { fableCore = "fable-core"
-    ; declaration = false
-    ; typedArrays = true
-    ; clampByteArrays = false }


### PR DESCRIPTION
@alfonsogarciacaro
- All samples work again, finally :)
- Suggestion for future improvement may be to move `Compiler `and `State `up the chain from Fable.Tools to Fable.Compiler as they don't seem to have many dependencies.