### PR TITLE
Added rollup config to tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,13 +10,14 @@
     "babel-loader": "^6.4.1",
     "babel-preset-babili": "^0.0.12",
     "babel-preset-es2015": "^6.24.1",
-    "mocha": "^3.2.0",
+    "mocha": "^3.3.0",
     "rollup": "^0.41.6",
     "rollup-pluginutils": "^2.0.1",
+    "rollup-plugin-commonjs": "^8.0.2",
     "rollup-plugin-fable": "file:./src/typescript/rollup-plugin-fable",
     "fable-loader": "file:./src/typescript/fable-loader",
     "fable-utils": "file:./src/typescript/fable-utils",
-    "typescript": "^2.2.2",
+    "typescript": "^2.3.2",
     "webpack": "^2.4.1"
   }
 }

--- a/src/dotnet/Fable.Client.Browser/demo/package.json
+++ b/src/dotnet/Fable.Client.Browser/demo/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "prebuild": "node ../../../../node_modules/webpack/bin/webpack --entry=./babel-standalone.js --output-path=./repl --output-filename=babel-standalone.js --output-library=Babel -p",
     "fable": "dotnet ../../../../build/fable/dotnet-fable.dll start",
-    "build": "node ../../../../node_modules/webpack/bin/webpack -p"
+    "build": "node ../../../../node_modules/webpack/bin/webpack -p",
+    "rollup": "node ../../../../node_modules/rollup/bin/rollup -c"
   }
 }

--- a/src/dotnet/Fable.Client.Browser/demo/rollup.config.js
+++ b/src/dotnet/Fable.Client.Browser/demo/rollup.config.js
@@ -1,0 +1,41 @@
+import fable from 'rollup-plugin-fable';
+var path = require('path');
+
+function resolve(filePath) {
+  return path.resolve(__dirname, filePath)
+}
+
+// var babelOptions = {
+//   "presets": [
+//     ["es2015", {"modules": false}]
+//   ]
+// };
+
+var fableOptions = {
+  //babel: babelOptions,
+  fableCore: resolve("../../../../build/fable-core"),
+  //plugins: [],
+  define: [
+    "COMPILER_SERVICE",
+    "FX_NO_CORHOST_SIGNER",
+    "FX_NO_LINKEDRESOURCES",
+    "FX_NO_PDB_READER",
+    "FX_NO_PDB_WRITER",
+    "FX_NO_WEAKTABLE",
+    "NO_COMPILER_BACKEND",
+    "NO_INLINE_IL_PARSER",
+    "TRACE"
+  ]
+};
+
+export default {
+  entry: resolve('../Fable.Client.Browser.fsproj'),
+  dest: resolve('./repl/bundle.js'),
+  format: 'iife', // 'amd', 'cjs', 'es', 'iife', 'umd'
+  moduleName: 'Fable',
+  //sourceMap: 'inline',
+
+  plugins: [
+    fable(fableOptions),
+  ],
+};

--- a/src/dotnet/Fable.Client.Browser/testapp/package.json
+++ b/src/dotnet/Fable.Client.Browser/testapp/package.json
@@ -1,12 +1,8 @@
 {
   "private": true,
-  "devDependencies": {
-    "rollup": "^0.41.6",
-    "rollup-plugin-fable": "^1.0.3"
-  },
   "scripts": {
     "fable": "dotnet ../../../../build/fable/dotnet-fable.dll start",
     "build": "node ../../../../node_modules/webpack/bin/webpack -p",
-    "rollup": "rollup -c"
+    "rollup": "node ../../../../node_modules/rollup/bin/rollup -c"
   }
 }

--- a/src/dotnet/Fable.Client.Browser/testapp/testapp.fsproj
+++ b/src/dotnet/Fable.Client.Browser/testapp/testapp.fsproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Version>1.0.0-alpha</Version>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
     <DefineConstants>DOTNET40</DefineConstants>
   </PropertyGroup>
 

--- a/src/tests/Main/js/foo.js
+++ b/src/tests/Main/js/foo.js
@@ -1,31 +1,34 @@
 "use strict";
 
-exports.foo = "foo"
+module.exports = {
 
-exports.apply = function(f, x, y) {
-    return f(x, y);
-}
+    foo: "foo",
 
-exports.MyClass = class {
-    constructor(v) {
-        this.__value = typeof v === "string" ? v : "haha";
+    apply: function(f, x, y) {
+        return f(x, y);
+    },
+
+    MyClass: class {
+        constructor(v) {
+            this.__value = typeof v === "string" ? v : "haha";
+        }
+
+        get value() {
+            return this.__value;
+        }
+
+        static foo(i) {
+            return typeof i === "number" ? i * i : "foo";
+        }
+
+        bar(s) {
+            return typeof s === "string" ? s.toUpperCase() : "bar";
+        }
+    },
+
+    fooOptional: {
+        Foo1() { return arguments.length },
+        Foo2() { return arguments.length },
+        Foo3() { return arguments.length }
     }
-
-    get value() {
-        return this.__value;
-    }
-
-    static foo(i) {
-        return typeof i === "number" ? i * i : "foo";
-    }
-
-    bar(s) {
-        return typeof s === "string" ? s.toUpperCase() : "bar";
-    }
-}
-
-exports.fooOptional = {
-    Foo1() { return arguments.length },
-    Foo2() { return arguments.length },
-    Foo3() { return arguments.length }
-}
+};

--- a/src/tests/package.json
+++ b/src/tests/package.json
@@ -1,0 +1,8 @@
+{
+  "private": true,
+  "scripts": {
+    "fable": "dotnet ../../build/fable/dotnet-fable.dll start",
+    "build": "node ../../node_modules/webpack/bin/webpack",
+    "rollup": "node ../../node_modules/rollup/bin/rollup -c"
+  }
+}

--- a/src/tests/package.json
+++ b/src/tests/package.json
@@ -3,6 +3,8 @@
   "scripts": {
     "fable": "dotnet ../../build/fable/dotnet-fable.dll start",
     "build": "node ../../node_modules/webpack/bin/webpack",
-    "rollup": "node ../../node_modules/rollup/bin/rollup -c"
+    "rollup": "node ../../node_modules/rollup/bin/rollup -c",
+    "test": "node ../../node_modules/mocha/bin/mocha ../../build/tests/bundle",
+    "check": "node ../../node_modules/typescript/bin/tsc > check_results.log"
   }
 }

--- a/src/tests/rollup.config.js
+++ b/src/tests/rollup.config.js
@@ -6,14 +6,14 @@ function resolve(filePath) {
   return path.resolve(__dirname, filePath)
 }
 
-var babelOptions = {
-  "presets": [
-    ["es2015", {"modules": false}]
-  ]
-}
+// var babelOptions = {
+//   "presets": [
+//     ["es2015", {"modules": false}]
+//   ]
+// }
 
 var fableOptions = {
-  babel: babelOptions,
+  //babel: babelOptions,
   fableCore: resolve("../../build/fable-core"),
   define: "DOTNETCORE",
   plugins: resolve("../../build/nunit/Fable.Plugins.NUnit.dll")

--- a/src/tests/rollup.config.js
+++ b/src/tests/rollup.config.js
@@ -1,0 +1,33 @@
+import commonjs from 'rollup-plugin-commonjs';
+import fable from 'rollup-plugin-fable';
+var path = require('path');
+
+function resolve(filePath) {
+  return path.resolve(__dirname, filePath)
+}
+
+var babelOptions = {
+  "presets": [
+    ["es2015", {"modules": false}]
+  ]
+}
+
+var fableOptions = {
+  babel: babelOptions,
+  fableCore: resolve("../../build/fable-core"),
+  define: "DOTNETCORE",
+  plugins: resolve("../../build/nunit/Fable.Plugins.NUnit.dll")
+};
+
+export default {
+  entry: resolve('./Main/Fable.Tests.fsproj'),
+  dest: resolve('../../build/tests/bundle.js'),
+  format: 'cjs', // 'amd', 'cjs', 'es', 'iife', 'umd'
+  //sourceMap: 'inline',
+  plugins: [
+    commonjs({
+      namedExports: { './Main/js/foo.js': ['foo','foo2','apply', 'fooOptional', 'MyClass', 'foo_js'] }
+    }),
+    fable(fableOptions)
+  ]
+};

--- a/src/tests/tsconfig.json
+++ b/src/tests/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "files": [
+        "../../build/tests/bundle.js"
+    ],
+    "compilerOptions": {
+        "target": "es2015",
+        "allowJs": true,
+        "checkJs": true,
+        "noEmit": true
+    }
+}


### PR DESCRIPTION
- added Rollup config to Tests, seems to work.
- added Rollup config to REPL, seems to work.
- added a check cmd to try the new --checkJs option in typescript 2.3
   ```cd src/tests / npm run fable / npm run rollup / npm run test / npm run check```