### PR TITLE
Node Streams should be generic

### DIFF
--- a/src/dotnet/Fable.Core/Import/Node/ChildProcess.fs
+++ b/src/dotnet/Fable.Core/Import/Node/ChildProcess.fs
@@ -14,11 +14,11 @@ module child_process_types =
 
     type [<AllowNullLiteral>] ChildProcess =
         inherit event_types.EventEmitter
-        abstract stdin: stream_types.Writable with get, set
-        abstract stdout: stream_types.Readable with get, set
-        abstract stderr: stream_types.Readable with get, set
+        abstract stdin: stream_types.Writable<string> with get, set
+        abstract stdout: stream_types.Readable<string> with get, set
+        abstract stderr: stream_types.Readable<string> with get, set
         abstract connected: bool with get, set
-        abstract stdio: U2<stream_types.Readable,stream_types.Writable>[] with get, set
+        abstract stdio: U2<stream_types.Readable<string>,stream_types.Writable<string>>[] with get, set
         abstract pid: float with get, set
         abstract kill: ?signal: string -> unit
         abstract send: message: obj * ?sendHandle: obj -> unit

--- a/src/dotnet/Fable.Core/Import/Node/Net.fs
+++ b/src/dotnet/Fable.Core/Import/Node/Net.fs
@@ -7,8 +7,8 @@ open Fable.Import.Node.Buffer
 
 module net_types =
     type [<AllowNullLiteral>] Socket =
-        inherit stream_types.Readable
-        inherit stream_types.Writable
+        inherit stream_types.Readable<buffer_types.Buffer>
+        inherit stream_types.Writable<buffer_types.Buffer>
         abstract bufferSize: float with get, set
         abstract remoteAddress: string with get, set
         abstract remoteFamily: string with get, set

--- a/src/dotnet/Fable.Core/Import/Node/Process.fs
+++ b/src/dotnet/Fable.Core/Import/Node/Process.fs
@@ -19,9 +19,9 @@ open Fable.Import.JS
       abstract prependListener: ``event``: U2<string, Symbol> * listener: Function -> obj
       abstract prependOnceListener: ``event``: U2<string, Symbol> * listener: Function -> obj
       abstract eventNames: unit -> ResizeArray<U2<string, Symbol>>
-      abstract stdout: stream_types.Writable with get, set
-      abstract stderr: stream_types.Writable with get, set
-      abstract stdin: stream_types.Readable with get, set
+      abstract stdout: stream_types.Writable<string> with get, set
+      abstract stderr: stream_types.Writable<string> with get, set
+      abstract stdin: stream_types.Readable<string> with get, set
       abstract argv: ResizeArray<string> with get, set
       abstract argv0: string with get, set
       abstract execArgv: ResizeArray<string> with get, set


### PR DESCRIPTION
Fixes #864.

Streams in node can carry `string | Buffer | Object` types.

Make streams generic so we can track the contained types.

Signed-off-by: Joe Grund <grundjoseph@gmail.com>