### PR TITLE
Fix cramped code in pong game and use different keys to start and move

### DIFF
--- a/samples/browser/pong/index.html
+++ b/samples/browser/pong/index.html
@@ -5,10 +5,11 @@
   <meta http-equiv='Content-Type' content='text/html; charset=utf-8'>
 </head>
 <body>
-  <!-- [body] -->
-    <h3>Fable Pong</h3>
-    <p>Left Paddle: w => up; s => down | Right Paddle: Arrow up => up; Arrow down => down<p>
-    <canvas id="canvas" width="800" height="600"></canvas>
+<!-- [body] -->
+    <div>
+        <p style="position: absolute">Left Paddle: w => up; s => down | Right Paddle: o => up; l => down<p>
+        <canvas id="canvas" width="800" height="600" style="position: absolute"></canvas>
+    </div>
     <script src="out/bundle.js"></script>
   <!-- [/body] -->
 </body>

--- a/samples/browser/pong/index.html
+++ b/samples/browser/pong/index.html
@@ -7,7 +7,7 @@
 <body>
 <!-- [body] -->
     <div>
-        <p style="position: absolute">Left Paddle: w => up; s => down | Right Paddle: o => up; l => down<p>
+        <p>Left Paddle: w => up; s => down | Right Paddle: o => up; l => down<p>
         <canvas id="canvas" width="800" height="600" style="position: absolute"></canvas>
     </div>
     <script src="out/bundle.js"></script>

--- a/samples/browser/pong/keyboard.fsx
+++ b/samples/browser/pong/keyboard.fsx
@@ -18,10 +18,10 @@ module Keyboard =
     /// code 87 = w, code 83 = s
     let leftControlsPressed() = (code 87, code 83)
 
-    /// code 38 = up, code 40 = down
-    let rightControlsPressed() = (code 38, code 40)
+    /// code 79 = o, code 76 = l
+    let rightControlsPressed() = (code 79, code 76)
 
-    let spacePressed() = code 32
+    let rKeyPressed() = code 82
 
     let init () =
       document.addEventListener_keydown(fun e -> update(e, true))

--- a/samples/browser/pong/pong.fsx
+++ b/samples/browser/pong/pong.fsx
@@ -96,10 +96,24 @@ With this function, implementing a final collision-function to determine the new
 let checkCollision leftPaddle rightPaddle ball =
     let hitTop = ball.element.y <= 0.
     let hitBottom = ball.element.y + ball.element.height >= h
-    let hitLeft = ball.element.x <= leftPaddle.x && ((ball.element.y >= leftPaddle.y && ball.element.y <= leftPaddle.y + leftPaddle.height) |> not)
-    let hitRight = ball.element.x + ball.element.width >= rightPaddle.x + rightPaddle.width && ((ball.element.y >= rightPaddle.y && ball.element.y <= rightPaddle.y + rightPaddle.height) |> not)
-    let hitLeftPaddle = ball.element.x <= leftPaddle.x + leftPaddle.width && ball.element.y >= leftPaddle.y && ball.element.y <= leftPaddle.y + leftPaddle.height
-    let hitRightPaddle = ball.element.x + ball.element.width >= rightPaddle.x && ball.element.y >= rightPaddle.y && ball.element.y <= rightPaddle.y + rightPaddle.height
+    let hitLeft =
+        ball.element.x <= leftPaddle.x 
+        && ((ball.element.y >= leftPaddle.y 
+            && ball.element.y <= leftPaddle.y + leftPaddle.height) 
+            |> not)
+    let hitRight =
+        ball.element.x + ball.element.width >= rightPaddle.x + rightPaddle.width 
+        && ((ball.element.y >= rightPaddle.y 
+            && ball.element.y <= rightPaddle.y + rightPaddle.height) 
+            |> not)
+    let hitLeftPaddle =
+        ball.element.x <= leftPaddle.x + leftPaddle.width 
+        && ball.element.y >= leftPaddle.y 
+        && ball.element.y <= leftPaddle.y + leftPaddle.height
+    let hitRightPaddle =
+        ball.element.x + ball.element.width >= rightPaddle.x 
+        && ball.element.y >= rightPaddle.y 
+        && ball.element.y <= rightPaddle.y + rightPaddle.height
     match (hitTop, hitBottom, hitLeft, hitRight, hitLeftPaddle, hitRightPaddle) with
     | (true, _, _, _, _, _) -> Top
     | (_, true, _, _, _, _) -> Bottom
@@ -130,8 +144,14 @@ let collision leftPaddle rightPaddle ball =
     | None -> ball.angle
     | Top | Bottom -> -ball.angle
     | Left | Right -> ball.angle
-    | LeftPaddle -> ball |> calculateAngle leftPaddle false (fun intersection -> intersection * (5. * Math.PI / 12.)) // Max. bounce = 75°
-    | RightPaddle -> ball |> calculateAngle rightPaddle true (fun intersection -> Math.PI - intersection * (5. * Math.PI / 12.))
+    | LeftPaddle -> ball 
+                    |> calculateAngle leftPaddle false 
+                        (fun intersection -> 
+                                intersection * (5. * Math.PI / 12.))
+    | RightPaddle -> ball 
+                    |> calculateAngle rightPaddle true 
+                        (fun intersection -> 
+                                Math.PI - intersection * (5. * Math.PI / 12.))
 
 let moveBall angle ball = {
     element = { x = ball.element.x + ball.speed * cos angle;
@@ -144,24 +164,38 @@ let moveBall angle ball = {
 
 let checkGameStatus leftPaddle rightPaddle ball gameStatus =
     match ball |> checkCollision leftPaddle rightPaddle with
-    | Left -> { gameStatus with scoreRight = gameStatus.scoreRight + 1; active = false }
-    | Right -> { gameStatus with scoreLeft = gameStatus.scoreLeft + 1; active = false }
+    | Left -> { gameStatus with scoreRight
+                                    = gameStatus.scoreRight + 1; active = false }
+    | Right -> { gameStatus with scoreLeft 
+                                    = gameStatus.scoreLeft + 1; active = false }
     | _ -> gameStatus
 
-// ------------------------------------------------------------------------------------------------------------------------
+
+(**
+## Game loop and rendering
+
+*)
 
 let render (w, h) leftPaddle rightPaddle ball gameStatus  =
     (0., 0., w, h) |> Win.drawRect("black")
-    (leftPaddle.x, leftPaddle.y, leftPaddle.width, leftPaddle.height) |> Win.drawRect("white")
-    (rightPaddle.x, rightPaddle.y, rightPaddle.width, rightPaddle.height) |> Win.drawRect("white")
-    (w / 4., 40.) |> Win.drawText (string(gameStatus.scoreLeft)) "white" "30px Arial"
-    (w / 1.25 - 30., 40.) |> Win.drawText (string(gameStatus.scoreRight)) "white" "30px Arial"
-    (ball.element.x, ball.element.y, ball.element.width, 0., 2. * Math.PI) |> Win.drawCircle("yellow")
+    (leftPaddle.x, leftPaddle.y, leftPaddle.width, leftPaddle.height)
+    |> Win.drawRect("white")
+    (rightPaddle.x, rightPaddle.y, rightPaddle.width, rightPaddle.height) 
+    |> Win.drawRect("white")
+    (w / 4., 40.) |> Win.drawText (string(gameStatus.scoreLeft)) 
+        "white" "30px Arial"
+    (w / 1.25 - 30., 40.) |> Win.drawText (string(gameStatus.scoreRight)) 
+        "white" "30px Arial"
+    (ball.element.x, ball.element.y, ball.element.width, 0., 2. * Math.PI) 
+    |> Win.drawCircle("yellow")
     if gameStatus.active |> not then
-        (w / 2. - 230., h / 2. + 40.) |> Win.drawText "Press space to start" "green" "40px Lucida Console"
+        (w / 2. - 230., h / 2. + 40.) 
+        |> Win.drawText "Press 'r' to start" "green" "40px Lucida Console"
 
-let initialLeftPaddle = { x = 10.; y = h / 2. - 70. / 2.; width = 15.; height = 70. }
-let initialRightPaddle = { x = w - 15. - 10.; y = h / 2. - 70. / 2.; width = 15.; height = 70. }
+let initialLeftPaddle =
+    { x = 10.; y = h / 2. - 70. / 2.; width = 15.; height = 70. }
+let initialRightPaddle =
+    { x = w - 15. - 10.; y = h / 2. - 70. / 2.; width = 15.; height = 70. }
 let initialBall =
     { element = { x = w / 2.; y = h / 2.; width = 5.; height = 5. };
     speed = 3.;
@@ -172,12 +206,27 @@ let initialGameStatus = { scoreLeft = 0; scoreRight = 0; active = false; }
 Keyboard.init()
 
 let rec update leftPaddle rightPaddle ball gameStatus () =
-    let leftPaddle = if gameStatus.active then leftPaddle |> move (Keyboard.leftControlsPressed()) else initialLeftPaddle
-    let rightPaddle = if gameStatus.active then rightPaddle |> move (Keyboard.rightControlsPressed()) else initialRightPaddle
-    let angle = if gameStatus.active then collision leftPaddle rightPaddle ball else ball.angle
-    let ball = if gameStatus.active then ball |> moveBall angle else { initialBall with angle = if angle = 0. then Math.PI else 0. }
-    let gameStatus = if Keyboard.spacePressed() = 1 then { gameStatus with active = true } else gameStatus |> checkGameStatus leftPaddle rightPaddle ball
+    let leftPaddle = if gameStatus.active then 
+                        leftPaddle 
+                        |> move (Keyboard.leftControlsPressed()) 
+                     else initialLeftPaddle
+    let rightPaddle = if gameStatus.active then
+                        rightPaddle
+                        |> move (Keyboard.rightControlsPressed()) 
+                      else initialRightPaddle
+    let angle = if gameStatus.active then
+                    collision leftPaddle rightPaddle ball 
+                else ball.angle
+    let ball = if gameStatus.active then
+                    ball |> moveBall angle 
+               else 
+                   { initialBall with angle = if angle = 0. then Math.PI else 0. }
+    let gameStatus = if Keyboard.rKeyPressed() = 1 then 
+                        { gameStatus with active = true } 
+                     else
+                        gameStatus |> checkGameStatus leftPaddle rightPaddle ball
     render (w, h) leftPaddle rightPaddle ball gameStatus
-    window.setTimeout(update leftPaddle rightPaddle ball gameStatus, 1000. / 60.) |> ignore
+    window.setTimeout(update leftPaddle rightPaddle ball gameStatus, 1000. / 60.)
+    |> ignore
 
 update initialLeftPaddle initialRightPaddle initialBall initialGameStatus ()


### PR DESCRIPTION
As described in the previous PR:

- Fix controls for the right paddle and use 'r'-key to start the game instead of space
- Fix cramped code

Even though I wasn't able to test the changes, everything should be fine now.