### PR TITLE
Issue #897: Use Platform enum for process.platform

### DIFF
--- a/src/dotnet/Fable.Core/Import/Node/Process.fs
+++ b/src/dotnet/Fable.Core/Import/Node/Process.fs
@@ -3,6 +3,7 @@ module rec Fable.Import.Node.Process
 open System
 open Fable.Core
 open Fable.Import.Node.Stream
+open Fable.Import.Node.Base.NodeJS
 open Fable.Import.JS
 
   type [<AllowNullLiteral>] Process =
@@ -33,7 +34,7 @@ open Fable.Import.JS
       abstract pid: float with get, set
       abstract title: string with get, set
       abstract arch: string with get, set
-      abstract platform: string with get, set
+      abstract platform: Platform with get, set
       abstract connected: bool with get, set
       abstract abort: unit -> unit
       abstract chdir: directory: string -> unit


### PR DESCRIPTION
Instead of using a string, use the `Platform` `StringEnum` from `Fable.Import.Node.Base`