### PR TITLE
Add Arch type to Node.js bindings

### DIFF
--- a/src/dotnet/Fable.Core/Import/Node/Base.fs
+++ b/src/dotnet/Fable.Core/Import/Node/Base.fs
@@ -70,6 +70,9 @@ module NodeJS =
         abstract user: float with get, set
         abstract system: float with get, set
 
+    type [<StringEnum>] Arch =
+        | Arm | Arm64 | Ia32 | Mips | Mipsel | Ppc | Ppc64 | S390 | S390x | X32 | X64 | X86
+
     type [<StringEnum>] Platform =
         | Aix | Android | Darwin | Freebsd | Linux | Openbsd | Sunos | Win32
 

--- a/src/dotnet/Fable.Core/Import/Node/Process.fs
+++ b/src/dotnet/Fable.Core/Import/Node/Process.fs
@@ -33,7 +33,7 @@ open Fable.Import.JS
       abstract config: obj with get, set
       abstract pid: float with get, set
       abstract title: string with get, set
-      abstract arch: string with get, set
+      abstract arch: Arch with get, set
       abstract platform: Platform with get, set
       abstract connected: bool with get, set
       abstract abort: unit -> unit


### PR DESCRIPTION
Values taken from https://nodejs.org/api/os.html#os_os_arch.

/cc @jmmk 