### PR TITLE
Node console app sample

### DIFF
--- a/samples/node/ConsoleApp/ConsoleApp.fsproj
+++ b/samples/node/ConsoleApp/ConsoleApp.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard1.6</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="src/App.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
+    <PackageReference Include="FSharp.Core" Version="4.1.*" />
+    <PackageReference Include="Fable.Core" Version="1.0.0-narumi-*" />
+    <DotNetCliToolReference Include="dotnet-fable" Version="1.0.0-narumi-*" />
+  </ItemGroup>
+</Project>

--- a/samples/node/ConsoleApp/README.md
+++ b/samples/node/ConsoleApp/README.md
@@ -1,0 +1,21 @@
+# Node Console App
+This sample demonstrates a simple console app to be run in node. 
+
+Restore dependencies
+--------------------
+```
+npm install
+dotnet restore
+```
+Build the app
+-------------------
+This will start the Fable server and invoke webpack to build and bundle the app.
+```
+dotnet fable npm-run build
+```
+Run with Node
+-------------
+Run the generated file `app.js` in the build directory
+```
+node build/app.js
+``` 

--- a/samples/node/ConsoleApp/package.json
+++ b/samples/node/ConsoleApp/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "console-app",
+  "version": "1.0.0",
+  "description": "Simple Fable Node App",
+  "scripts": {
+    "build": "webpack"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "fable-core": "^1.0.0-narumi-905",
+    "babel-runtime": "^6.23.0"
+  },
+  "devDependencies": {
+    "babel-core": "^6.24.0",
+    "babel-loader": "^6.4.1",
+    "babel-plugin-transform-runtime": "^6.23.0",
+    "babel-preset-es2015": "^6.24.0",
+    "fable-loader": "^1.0.0-narumi-912",
+    "webpack": "^2.2.1"
+  }
+}

--- a/samples/node/ConsoleApp/src/App.fs
+++ b/samples/node/ConsoleApp/src/App.fs
@@ -1,0 +1,9 @@
+module ConsoleApp
+
+open Fable.Core
+open Fable.Core.JsInterop
+
+[<Emit("console.log($0)")>]
+let log (x: 'a) : unit = jsNative
+
+log "Hello from Node"

--- a/samples/node/ConsoleApp/src/App.fs
+++ b/samples/node/ConsoleApp/src/App.fs
@@ -1,9 +1,3 @@
 module ConsoleApp
 
-open Fable.Core
-open Fable.Core.JsInterop
-
-[<Emit("console.log($0)")>]
-let log (x: 'a) : unit = jsNative
-
-log "Hello from Node"
+printfn "Hello from Node"

--- a/samples/node/ConsoleApp/webpack.config.js
+++ b/samples/node/ConsoleApp/webpack.config.js
@@ -1,0 +1,39 @@
+var path = require("path");
+var webpack = require("webpack");
+
+function resolve(filePath) {
+  return path.join(__dirname, filePath)
+}
+
+var babelOptions = {
+  presets: [["es2015", {"modules": false}]],
+  plugins: ["transform-runtime"]
+}
+
+module.exports = {
+  devtool: "source-map",
+  entry: resolve('./ConsoleApp.fsproj'),
+  output: {
+    filename: 'app.js',
+    path: resolve('./build'),
+  },
+  module: {
+    rules: [
+      {
+        test: /\.fs(x|proj)?$/,
+        use: {
+          loader: "fable-loader",
+          options: { babel: babelOptions }
+        }
+      },
+      {
+        test: /\.js$/,
+        exclude: /node_modules[\\\/](?!fable-)/,
+        use: {
+          loader: 'babel-loader',
+          options: babelOptions
+        },
+      }
+    ]
+  }
+};


### PR DESCRIPTION
A simple console app sample for Node. 

I couldn't find `console` in a place other than `Fable.Import.Browser` so I chose to use `[<Emit>] ` for `console.log` @fable-compiler/code-maintenance may know a node-native alternative.

cc @fable-compiler/documentation please review 

#881 