### PR TITLE
Fix searching for paket dependencies from Fable daemon

### DIFF
--- a/src/dotnet/Fable.Tools/Log.fs
+++ b/src/dotnet/Fable.Tools/Log.fs
@@ -1,0 +1,22 @@
+module Log
+
+let rec mkKn (ty: System.Type) =
+    if Reflection.FSharpType.IsFunction(ty) then
+        let _, ran = Reflection.FSharpType.GetFunctionElements(ty)
+        // NOTICE: do not delay `mkKn` invocation until runtime
+        let f = mkKn ran
+        Reflection.FSharpValue.MakeFunction(ty, fun _ -> f)
+    else
+        box ()
+
+[<Sealed>]
+type Format<'T> private () =
+    static let instance : 'T =
+        unbox (mkKn typeof<'T>)
+    static member Instance = instance
+
+let print verbose args =
+    if verbose then
+        printfn args
+    else
+        Format<_>.Instance

--- a/src/dotnet/Fable.Tools/Main.fs
+++ b/src/dotnet/Fable.Tools/Main.fs
@@ -96,7 +96,7 @@ let parseArguments args =
             match Int32.TryParse portArg with
             | true, port -> port
             | false, _ -> 
-                printf "Value for --port is not a valid integer, using default port"
+                printfn "Value for --port is not a valid integer, using default port"
                 Constants.DEFAULT_PORT
         | None -> Constants.DEFAULT_PORT
     let timeout =

--- a/src/dotnet/Fable.Tools/Parser.fs
+++ b/src/dotnet/Fable.Tools/Parser.fs
@@ -91,9 +91,7 @@ let parse (msg: string) =
     let opts =
         { fableCore =
             match parseString "fable-core" "fableCore" json with
-            | "fable-core" ->
-                let paketDir =  ProjectCracker.findPaketDependenciesDir (Path.GetDirectoryName(path)) []
-                IO.Path.Combine(paketDir, "packages", "Fable.Core", "fable-core") |> makePathRelative
+            | "fable-core" -> "fable-core"
             | path -> (makePathRelative path).TrimEnd('/')
         ; declaration = parseBoolean false "declaration" json
         ; typedArrays = parseBoolean true "typedArrays" json

--- a/src/dotnet/Fable.Tools/Parser.fs
+++ b/src/dotnet/Fable.Tools/Parser.fs
@@ -92,7 +92,7 @@ let parse (msg: string) =
         { fableCore =
             match parseString "fable-core" "fableCore" json with
             | "fable-core" ->
-                let paketDir = Path.GetDirectoryName(path) |> ProjectCracker.findPaketDependenciesDir
+                let paketDir =  ProjectCracker.findPaketDependenciesDir (Path.GetDirectoryName(path)) []
                 IO.Path.Combine(paketDir, "packages", "Fable.Core", "fable-core") |> makePathRelative
             | path -> (makePathRelative path).TrimEnd('/')
         ; declaration = parseBoolean false "declaration" json

--- a/src/dotnet/Fable.Tools/ProjectCracker.fs
+++ b/src/dotnet/Fable.Tools/ProjectCracker.fs
@@ -208,11 +208,7 @@ let rec findPaketDependenciesDir dir searchedDirs =
 let tryFindPaketDirFromProject projFile =
     let projDir = Path.GetDirectoryName(projFile)
     if File.Exists(Path.Combine(projDir, "paket.references"))
-    then 
-        try 
-            findPaketDependenciesDir projDir [] |> Some
-        with
-        | _ -> None
+    then findPaketDependenciesDir projDir [] |> Some
     else None
 
 let checkFableCoreVersion paketDir =
@@ -253,7 +249,7 @@ let getPaketProjRefs paketDir projFile =
             []
 
 let getProjectOptionsFromFsproj projFile =
-    let paketDir = tryFindPaketDirFromProject projFile
+    let paketDir = findPaketDependenciesDir projFile [] |> Some
     paketDir |> Option.iter checkFableCoreVersion
     let rec crackProjects (acc: CrackedFsproj list) extraProjRefs projFile =
         acc |> List.tryFind (fun x ->

--- a/src/dotnet/Fable.Tools/dotnet-fable.fsproj
+++ b/src/dotnet/Fable.Tools/dotnet-fable.fsproj
@@ -8,6 +8,7 @@
     <ProjectReference Include="../Fable.Compiler/Fable.Compiler.fsproj" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Log.fs" />
     <Compile Include="Constants.fs" />
     <Compile Include="ProjectCracker.fs" />
     <Compile Include="Printers.fs" />


### PR DESCRIPTION
Addresses #945 
Fable daemon was looking for paket packages folder whenever it compiled a .fs file which caused problems when there were project files in sibling directories.

@alfonsogarciacaro Proposed the following [here, 5th comment](https://github.com/fable-compiler/Fable/issues/945) which is implemented below and tested (locally, with my project that wasn't working and also by running `fsi build.fsx All` that finishes without any errors)
> We could do it like this:
     - Search (and store) paketDir when creating a Project
     - Right before compiling check if com.Options.fableCore = "fable-core" and in that case create a new               compiler with new options calculating the fable-core location as in here

Also I had to set `paketDir = None` within [here](https://github.com/fable-compiler/Fable/compare/master...Zaid-Ajaj:daemon/paket-deps?expand=1#diff-6dfa1eefb46946c0a176783424e4595fR257) when "cracking" project. 

Also I added some logging when trying to find paket.dependencies and that fails, visited directories are logged