### PR TITLE
add `prefercliruntime` file to `dotnet-fable` package root

### DIFF
--- a/src/dotnet/Fable.Tools/dotnet-fable.fsproj
+++ b/src/dotnet/Fable.Tools/dotnet-fable.fsproj
@@ -17,6 +17,13 @@
     <Compile Include="Main.fs" />
   </ItemGroup>
   <ItemGroup>
+    <!-- Required in the package root to run the cli tool alway with bundled runtime -->
+    <Content Include="prefercliruntime">
+      <PackagePath>prefercliruntime</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
     <DotNetCliToolReference Include="Microsoft.DotNet.Watcher.Tools" Version="1.0.0-msbuild2-final" />
   </ItemGroup>


### PR DESCRIPTION
This make the `dotnet-fable` (running as cli tool) to use always the bundled version of .net core
runtime instead of the one specified in package deps (Microsoft.NETCore.App).

This matter because the Microsoft.NETCore.App is not downloaded as package during restore,
and can be not avaiaible anyway (for example some os support 1.1 but not 1.0)

fix #961

I tried the built package with

- .NET Command Line Tools (1.0.1) **where this bug was found for user**
- .NET Command Line Tools (1.0.4) 
- .NET Command Line Tools (2.0.0-preview1-005899)

on sdk2.0: 

```
e:\temp\f5>dotnet -d fable --help

...
PackagedCommandSpecFactory: Ignoring prefercliruntime file as the tool target framework (1.0.5) has a different major version than the current CLI runtime (2.0.0-preview1-002101-00)
Running C:\dotnetcli\dotnet-dev-win-x64.2.0.0-preview1-005899\dotnet.exe exec --depsfile C:\Users\e.sada\.nuget\packages\.tools\dotnet-fable\1.0.6-f1\netcoreapp2.0\dotnet-fable.deps.json --additionalprobingpath C:\Users\e.sada\.nuget\packages --additionalprobingpath C:\Users\e.sada\.dotnet\NuGetFallbackFolder C:\Users\e.sada\.nuget\packages\dotnet-fable\1.0.6-f1\lib\netcoreapp1.0\dotnet-fable.dll
Process ID: 24144
Fable F# to JS compiler (1.0.6)
Usage: dotnet fable [command] [script] [fable arguments] [-- [script arguments]]

...

```
