### PR TITLE
make appveyor more resilient to npm install failures

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,8 @@ environment:
 install:
   # Get the latest stable version of Node.js
   - ps: Install-Product node $env:nodejs_version
+  # update npm to avoid bug on npm install related to https://github.com/npm/npm/issues/9696
+  - cmd: npm install npm@2.15.12 -g
 
 os: Visual Studio 2015
 # before_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,6 @@ environment:
 install:
   # Get the latest stable version of Node.js
   - ps: Install-Product node $env:nodejs_version
-  # update npm to avoid bug on npm install related to https://github.com/npm/npm/issues/9696
-  - cmd: npm install npm@2.15.12 -g
 
 os: Visual Studio 2015
 # before_build:


### PR DESCRIPTION
the `npm install` on appveyor fails with 

```
cmd /C npm install 
npm WARN optional dep failed, continuing fsevents@1.1.1
npm ERR! Windows_NT 6.3.9600
npm ERR! argv "C:\\Program Files (x86)\\nodejs\\node.exe" "C:\\Program Files (x86)\\nodejs\\node_modules\\npm\\bin\\npm-cli.js" "install"
npm ERR! node v4.8.2
npm ERR! npm  v2.15.11
npm ERR! path C:\Users\appveyor\AppData\Roaming\npm-cache\lodash\4.17.4\package.tgz.2512895503
npm ERR! code EPERM
npm ERR! errno -4048
npm ERR! syscall rename
npm ERR! Error: EPERM: operation not permitted, rename 'C:\Users\appveyor\AppData\Roaming\npm-cache\lodash\4.17.4\package.tgz.2512895503' -> 'C:\Users\appveyor\AppData\Roaming\npm-cache\lodash\4.17.4\package.tgz'
npm ERR!     at Error (native)
npm ERR!  { [Error: EPERM: operation not permitted, rename 'C:\Users\appveyor\AppData\Roaming\npm-cache\lodash\4.17.4\package.tgz.2512895503' -> 'C:\Users\appveyor\AppData\Roaming\npm-cache\lodash\4.17.4\package.tgz']
npm ERR!   errno: -4048,
npm ERR!   code: 'EPERM',
npm ERR!   syscall: 'rename',
npm ERR!   path: 'C:\\Users\\appveyor\\AppData\\Roaming\\npm-cache\\lodash\\4.17.4\\package.tgz.2512895503',
npm ERR!   dest: 'C:\\Users\\appveyor\\AppData\\Roaming\\npm-cache\\lodash\\4.17.4\\package.tgz',
npm ERR!   parent: 'babel-core' }
npm ERR! 
npm ERR! Please try running this command again as root/Administrator
```

ref https://ci.appveyor.com/project/alfonsogarciacaro/fable/build/1.0.2321#L762

this is maybe related to this npm bug https://github.com/npm/npm/issues/9696 (see below https://github.com/npm/npm/issues/9696#issuecomment-208705601 )
