### PR TITLE
Currying: failing tests

### DIFF
--- a/src/tests/Main/ApplicativeTests.fs
+++ b/src/tests/Main/ApplicativeTests.fs
@@ -442,3 +442,19 @@ let ``Unit expression arguments are not removed``() =
         x <- i
     doNothing <| foo 5
     equal 5 x
+
+[<Test>]
+let ``Basic currying works``() =
+    let curry (fn: 'a -> 'b -> 'c) =
+      let first = fun (a: 'a) ->
+        let second = fun (b: 'b) ->
+          let result = fn a b
+          result
+        second
+      first
+
+    let plus = curry (+)
+    let result = plus 2 3
+    equal 5 result
+    equal 5 (plus 2 3)
+    equal 5 ((curry (+)) 2 3)

--- a/src/tests/Main/ApplicativeTests.fs
+++ b/src/tests/Main/ApplicativeTests.fs
@@ -443,16 +443,17 @@ let ``Unit expression arguments are not removed``() =
     doNothing <| foo 5
     equal 5 x
 
+
+let curry (fn: 'a -> 'b -> 'c) =
+  let first = fun (a: 'a) ->
+    let second = fun (b: 'b) ->
+      let result = fn a b
+      result
+    second
+  first
+
 [<Test>]
 let ``Basic currying works``() =
-    let curry (fn: 'a -> 'b -> 'c) =
-      let first = fun (a: 'a) ->
-        let second = fun (b: 'b) ->
-          let result = fn a b
-          result
-        second
-      first
-
     let plus = curry (+)
     let result = plus 2 3
     equal 5 result


### PR DESCRIPTION
Thanks to @Alxandr and @ed-ilyin  we were able to boil down #976 from a convoluted code base to a managable piece of code. This PR adds a test for basic currying. Again, the bug seems to be the closure-optimization "feature".

### First attempt: the following actually passes (try in the repl)
which surprised me because we checked that it didn't work correctly
```fs
let equal x y = 
 printfn "%A = %A was %A" x y (x = y)
 
let ``Basic currying works``() =
  
 let curry (fn: 'a -> 'b -> 'c) =
   let first = fun (a: 'a) ->
    let second = fun (b: 'b) ->
      let result = fn a b
      result
    second
   first
   
 let plus = curry (+)
 let result = plus 2 3
 equal 5 result            // "5 = 5 was true"
 equal 5 (plus 2 3)        // "5 = 5 was true"
 equal 5 ((curry (+)) 2 3) // "5 = 5 was true"
 
``Basic currying works``()
```
Until you pull `curry` outside of the test method, which then fails. Try it in the repl
```fs
let equal x y = 
    printfn "%A = %A was %A" x y (x = y)

let curry (fn: 'a -> 'b -> 'c) =
  let first = fun (a: 'a) ->
    let second = fun (b: 'b) ->
      let result = fn a b
      result
    second
  first
  
let ``Basic currying works``() =
    let plus = curry (+)
    let result = plus 2 3
    equal 5 result            // "5 = 0 was false"
    equal 5 (plus 2 3)        // "5 = undefined was false"
    equal 5 ((curry (+)) 2 3) // "5 = undefined was false"
    
``Basic currying works``()
```

Makes me wonder what other tests will fail if you just pull the definitions out of the test methods...

cc @fable-compiler/code-maintenance