### PR TITLE
Check for missing arguments when using npm-run

### DIFF
--- a/src/dotnet/Fable.Tools/Main.fs
+++ b/src/dotnet/Fable.Tools/Main.fs
@@ -196,6 +196,23 @@ Example: `dotnet fable npm-run build --port free -- -p --config webpack.producti
         let agent = startAgent()
         startServer args.port args.timeout agent.Post (Async.RunSynchronously >> konst 0)
     | Some "npm-run" ->
+        if (argv.Length < 2) then 
+            printfn """
+Missing argument(s) after npm-run, expected at least one more argument corresponding with the name of an npm-script.
+
+Examples: 
+
+  `dotnet fable npm-run start`
+  `dotnet fable npm-run build`
+
+Where 'start' and 'build' are the names of two npm-scripts located at package.json:
+
+"scripts" :{
+    "start": "webpack-dev-server"
+    "build": "webpack" 
+}"""
+            0
+        else
         let args = argv.[2..] |> parseArguments
         let execArgs =
             match args.commandArgs with


### PR DESCRIPTION
Addresses #926 

When running `dotnet fable npm-run` without any more arguments, an exception is thrown which is not very helpful.

With this PR, when you run `dotnet fable npm-run` you would get:
```
Missing argument(s) after npm-run, expected at least one more argument corresponding with the name of an npm-script.

Examples: 

  `dotnet fable npm-run start`
  `dotnet fable npm-run build`

Where 'start' and 'build' are the names of two npm-scripts located at package.json:

"scripts" :{
    "start": "webpack-dev-server"
    "build": "webpack" 
}
```

cc @fable-compiler/code-maintenance 