### PR TITLE
Make print format keep track of the input format

### DIFF
--- a/src/tests/Main/StringTests.fs
+++ b/src/tests/Main/StringTests.fs
@@ -32,6 +32,14 @@ let ``sprintf without arguments works``() =
       sprintf "hello" |> equal "hello"
 
 [<Test>]
+let ``input of print format can be retrieved``() =
+      let pathScan (pf:PrintfFormat<_,_,_,_,'t>) =
+          let formatStr = pf.Value
+          formatStr
+          
+      equal "/hello/%s" (pathScan "/hello/%s")
+
+[<Test>]
 let ``sprintf with escaped percent symbols works``() = // See #195
       let r, r1, r2 = "Ratio", 0.213849, 0.799898
       sprintf "%s1: %.2f%% %s2: %.2f%%" r (r1*100.) r (r2*100.)


### PR DESCRIPTION
Addresses #536

When using 
```fs
sprintf "something %s"
```
instead of translating to 
```js
String.fsFormat("something  %s")(function(x) { return  x; })
```
It will translate to:
```js
{  
  formatFn: String.fsFormat("something  %s")(function(x) { return  x; }),
  input: "something  %s" 
}
```
Making it possible to retrieve the input string later:
```fs
[<Test>]
let ``input of print format can be retrieved``() =
      let pathScan (pf:PrintfFormat<_,_,_,_,'t>) =
          let formatStr = pf.Value
          formatStr
          
      equal "/hello/%s" (pathScan "/hello/%s")
```

cc @fable-compiler/code-maintenance 