### PR TITLE
update documentation about JSON serialisation

### DIFF
--- a/docs/source/docs/interacting.md
+++ b/docs/source/docs/interacting.md
@@ -507,46 +507,51 @@ Caveats:
   the server side.
 - `DateTime` will always be serialized in UTC format and any string matching the [DateTime ISO Format](https://www.w3.org/TR/NOTE-datetime)
   will be deserialized as a string.
+- Be aware when using type attrbitues like `[<PoJo>]` that they are applied at both sides serialising and deserialising. Otherwise you will see unexpected runtime behaviour.
 - Json.NET doesn't serialize type info for F# unions even when using the `TypeNameHandling.All` setting,
-  but you can use the following converter:
+  but `Fable.JsonConverter` overcomes this limitation.
+
+Fable.JsonConverter:
+
+You can install directly via [nuget](https://www.nuget.org/packages/Fable.JsonConverter/1.0.0-narumi-908) if your project is a dotnet core project by simply adding it as a dependency to you `paket.dependencies` file:
+
+```
+nuget Fable.JsonConverter prerelease
+```
+
+If you are not using dotnet core you can add it as file dependency to your `paket.dependencies`:
+
+```
+github fable-compiler/Fable src/dotnet/Fable.JsonConverter/Fable.JsonConverter.fs
+nuget Newtonsoft.Json prerelease
+```
+
+Make sure you also include `Newtonsoft.Json`.
+
+And in your projects `paket.references` file add:
+
+```
+Newtonsoft.Json
+File: Fable.JsonConverter.fs
+```
+
+Now you can use the converter directly in your code by passing it to the `JsonConvert.SerializeObject` method.
 
 ```fsharp
-open FSharp.Reflection
 open Newtonsoft.Json
-open Newtonsoft.Json.Linq
 
-type UnionTypeInfoConverter() =
-    inherit JsonConverter()
-    override x.CanConvert t = FSharpType.IsUnion t
-    override x.ReadJson(reader, t, _, serializer) =
-        let token = JObject()
-        for prop in JToken.ReadFrom(reader).Children<JProperty>() do
-            if prop.Name <> "$type" then
-                token.Add(prop)
-        token.ToObject(t)
-    override x.WriteJson(writer, v, serializer) =
-        let t = v.GetType()
-        let typeFulName = t.FullName.Substring(0, t.FullName.LastIndexOf("+"))
-        let uci, fields = FSharpValue.GetUnionFields(v, t)
-        writer.WriteStartObject()
-        writer.WritePropertyName("$type")
-        writer.WriteValue(typeFulName)
-        writer.WritePropertyName("Case")
-        writer.WriteValue(uci.Name)
-        writer.WritePropertyName("Fields")
-        writer.WriteStartArray()
-        for field in fields do writer.WriteValue(field)
-        writer.WriteEndArray()
-        writer.WriteEndObject()
+let jsonConverter = Fable.JsonConverter() :> JsonConverter
 
-let settings =
-    JsonSerializerSettings(
-        Converters = [|UnionTypeInfoConverter()|],
-        TypeNameHandling = TypeNameHandling.All)
+let toJson value =
+    JsonConvert.SerializeObject(value, [|jsonConverter|])
 
 type U = A of int | B of string * float
-JsonConvert.SerializeObject(A 4, settings)
-JsonConvert.SerializeObject(B("hi",5.6), settings)
+
+let a = A 4
+toJson a
+
+let b = B("hi",5.6)
+toJson b
 ```
 
 ## Publishing a Fable package


### PR DESCRIPTION
updated the docs section to use Fable.JsonConverter and document how to use it in
in projects other than dotnet core. To prevent confusions that I reported in #991 

http://fable.io/blog/Introducing-0-7.html#JSON-Serialization