### PR TITLE
print relative path of compiled files

### DIFF
--- a/src/typescript/fable-loader/index.js
+++ b/src/typescript/fable-loader/index.js
@@ -153,7 +153,7 @@ module.exports = function(buffer) {
                     })
                 }
                 var babelParsed = transformBabelAst(data, babelOptions, data.fileName, buffer);
-                console.log("fable: Compiled " + path.basename(msg.path));
+                console.log("fable: Compiled " + path.relative(process.cwd(), msg.path));
                 trySaveCache(opts, data.fileName, babelParsed);
                 callback(null, babelParsed.code, babelParsed.map);
             }


### PR DESCRIPTION
In project with several files that have the same name but different paths
it's not clear form the message which file was compiled. #988

I changed the log outout to print the relative path of file.

Previously the output looked like:

```
fable: Compiled ConvertTests.fs
fable: Compiled ResizeArrayTests.fs
fable: Compiled ResultTests.fs
fable: Compiled RegexTests.fs
```

not it looks like this:

```
fable: Compiled src/tests/Main/ConvertTests.fs
fable: Compiled src/tests/Main/ResizeArrayTests.fs
fable: Compiled src/tests/Main/ResultTests.fs
fable: Compiled src/tests/Main/RegexTests.fs
```