### PR TITLE
Add support for Option.defaultValue

### DIFF
--- a/src/dotnet/Fable.Compiler/Replacements.fs
+++ b/src/dotnet/Fable.Compiler/Replacements.fs
@@ -1281,6 +1281,12 @@ module AstPass =
             let opt = toArray None i.args.Tail.Head
             let args = i.args.Head::opt::i.args.Tail.Tail
             ccall i "Seq" "foldBack" args |> Some
+        | "defaultValue" ->
+            let defValue = i.args.Head
+            let arg = i.args.Tail.Head
+            CoreLibCall("Util", Some  "defaultArg", false, [arg ;defValue])
+            |> makeCall i.range Fable.Any
+            |> Some
         | meth ->
             let args =
                 let args = List.rev i.args

--- a/src/tests/Main/MiscTests.fs
+++ b/src/tests/Main/MiscTests.fs
@@ -816,3 +816,11 @@ let ``System.Environment.NewLine works``() =
       System.Environment.NewLine
       |> equal "\n"
 #endif
+
+[<Test>]
+let ``Option.defaultValue works``() =
+    let a = Some "MyValue"
+    let b = None
+
+    a |> Option.defaultValue "" |> equal "MyValue"
+    b |> Option.defaultValue "default" |> equal "default"


### PR DESCRIPTION
A propper replacement for `Option.defaultValue` was missing #1005. I added a new replacement for it to issue a call into `Utils.defaultArg`.