### PR TITLE
Fixed REPL decimals and build

### DIFF
--- a/src/dotnet/Fable.Client.Browser/Fable.Client.Browser.fsproj
+++ b/src/dotnet/Fable.Client.Browser/Fable.Client.Browser.fsproj
@@ -38,7 +38,7 @@
 
   <ItemGroup>
     <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
-    <PackageReference Include="FSharp.Core" Version="4.1.*" />
+    <PackageReference Include="FSharp.Core" Version="4.2.*" />
   </ItemGroup>
 
 </Project>

--- a/src/dotnet/Fable.Client.Browser/Fable.Client.fs
+++ b/src/dotnet/Fable.Client.Browser/Fable.Client.fs
@@ -48,7 +48,7 @@ let compileAst (com: Compiler) checkedProject fileName =
     Babel.Program(file.fileName, loc, file.body, file.directives, com.Logs)
 
 let createChecker readAllBytes references =
-    InteractiveChecker(List.ofArray references, readAllBytes)
+    InteractiveChecker.Create(List.ofArray references, readAllBytes)
 
 let makeCompiler () = Compiler()
 

--- a/src/dotnet/Fable.Client.Browser/demo/repl.html
+++ b/src/dotnet/Fable.Client.Browser/demo/repl.html
@@ -36,7 +36,7 @@ body { padding-top: 0; }
       </div>
     </div>
     <div class="pull-right">
-      <div class="form-group"> <strong>Fable v1.0.0-narumi, FCS v12.0.8, Babel v<span id="babel-repl-version"></span></strong></div>
+      <div class="form-group"> <strong>Fable v1.1.0, FCS v12.0.8, Babel v<span id="babel-repl-version"></span></strong></div>
     </div>
   </form>
   <div class="babel-repl-left-panel">

--- a/src/dotnet/Fable.Client.Browser/demo/repl_samples/fibonacci_memoize.fs
+++ b/src/dotnet/Fable.Client.Browser/demo/repl_samples/fibonacci_memoize.fs
@@ -1,12 +1,12 @@
 open System.Collections.Generic
 
 let fastFib (n: int) : int =
-  let a = (1.0 + sqrt 5.0) / 2.0
-  let b = (1.0 - sqrt 5.0) / 2.0
+  let sqrt5 = sqrt 5.0
+  let a = (1.0 + sqrt5) / 2.0
+  let b = (1.0 - sqrt5) / 2.0
   let power = float n
-  let result = ((a ** power) - (b ** power)) / sqrt 5.0
-  int result
-
+  let result = ((a ** power) - (b ** power)) / sqrt5
+  int (round result)
 
 let rec slowFib n =
     match n with

--- a/src/dotnet/Fable.Client.Browser/testapp/splitter.config.js
+++ b/src/dotnet/Fable.Client.Browser/testapp/splitter.config.js
@@ -1,12 +1,12 @@
 const fableSplitter = require("fable-splitter").default;
 
 const babelOptions = {
-  // plugins: [
-  //   ["transform-es2015-modules-umd"],
-  // ],
-  presets: [
-    ["es2015", { modules: "umd" }],
+  plugins: [
+    ["transform-es2015-modules-commonjs"],
   ],
+  // presets: [
+  //   ["es2015", { modules: "umd" }],
+  // ],
   // sourceMaps: true,
 };
 

--- a/src/dotnet/Fable.Client.Browser/testapp/testapp.fsproj
+++ b/src/dotnet/Fable.Client.Browser/testapp/testapp.fsproj
@@ -17,8 +17,8 @@
 
   <ItemGroup>
     <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
-    <PackageReference Include="FSharp.Core" Version="4.1.*" />
-    <!--<PackageReference Include="Fable.Core" Version="1.0.*" />-->
+    <PackageReference Include="FSharp.Core" Version="4.2.*" />
+    <!--<PackageReference Include="Fable.Core" Version="1.1.*" />-->
     <!--<DotNetCliToolReference Include="dotnet-fable" Version="1.0.*" />-->
   </ItemGroup>
 

--- a/src/dotnet/Fable.Compiler/FSharp2Fable.Util.fs
+++ b/src/dotnet/Fable.Compiler/FSharp2Fable.Util.fs
@@ -583,10 +583,9 @@ module Patterns =
         | "System.UInt32" -> Some UInt32
         | "System.Single" -> Some Float32
         | "System.Double" -> Some Float64
-        // TODO: Proper decimal implementation (move to ExtendedNumberKind)
-        | "System.Decimal"
-        | Naming.StartsWith "Microsoft.FSharp.Core.decimal" _ -> Some Float64
         // Units of measure
+        | Naming.StartsWith "Microsoft.FSharp.Core.sbyte" _ -> Some Int8
+        | Naming.StartsWith "Microsoft.FSharp.Core.int16" _ -> Some Int16
         | Naming.StartsWith "Microsoft.FSharp.Core.int" _ -> Some Int32
         | Naming.StartsWith "Microsoft.FSharp.Core.float32" _ -> Some Float32
         | Naming.StartsWith "Microsoft.FSharp.Core.float" _ -> Some Float64
@@ -595,7 +594,11 @@ module Patterns =
     let (|ExtendedNumberKind|_|) = function
         | "System.Int64" -> Some Int64
         | "System.UInt64" -> Some UInt64
+        | "System.Decimal" -> Some Decimal
         | "System.Numerics.BigInteger" -> Some BigInt
+        // Units of measure
+        | Naming.StartsWith "Microsoft.FSharp.Core.int64" _ -> Some Int64
+        | Naming.StartsWith "Microsoft.FSharp.Core.decimal" _ -> Some Decimal
         | _ -> None
 
     let (|Switch|_|) fsExpr =

--- a/src/dotnet/Fable.Compiler/FSharp2Fable.fs
+++ b/src/dotnet/Fable.Compiler/FSharp2Fable.fs
@@ -115,38 +115,40 @@ let private transformNonListNewUnionCase com ctx (fsExpr: FSharpExpr) fsType uni
     let unionType, range = makeType com ctx.typeArgs fsType, makeRange fsExpr.Range
     let genericArg = fsType.GenericArguments |> List.ofSeq |> List.tryHead
 
-    match (fsType, genericArg) with
-    | (OptionUnion, Some OptionUnion) ->
-        "Nested option in option won't work at runtime"
-        |> addErrorAndReturnNull com ctx.fileName (Some range)
-    | (OptionUnion, _) ->
+    match fsType with
+    | OptionUnion ->
+        match genericArg with
+        | Some OptionUnion ->
+            "Nested option in option won't work at runtime"
+            |> addWarning com ctx.fileName (Some range)
+        | _ -> ()
         match argExprs: Fable.Expr list with
         // Represent `Some ()` with an empty object, see #478
         | expr::_ when expr.Type = Fable.Unit ->
             Fable.Wrapped(Fable.ObjExpr([], [], None, Some range), unionType)
         | expr::_ -> Fable.Wrapped(expr, unionType)
         | _ -> Fable.Wrapped(Fable.Value Fable.Null, unionType)
-    | (ErasedUnion, _) ->
+    | ErasedUnion ->
         match argExprs with
         | [] -> Fable.Wrapped(Fable.Value Fable.Null, unionType)
         | [expr] -> Fable.Wrapped(expr, unionType)
         | _ ->
             "Erased Union Cases must have one single field: " + unionType.FullName
             |> addErrorAndReturnNull com ctx.fileName (Some range)
-    | (StringEnum, _) ->
+    | StringEnum ->
         if not(List.isEmpty argExprs)
         then
             "StringEnum types cannot have fields"
             |> addErrorAndReturnNull com ctx.fileName (Some range)
         else lowerCaseName unionCase
-    | (PojoUnion, _) ->
+    | PojoUnion ->
         List.zip (Seq.toList unionCase.UnionCaseFields) argExprs
         |> List.map (fun (fi, e) -> fi.Name, e)
         |> List.append ["type", makeStrConst unionCase.Name]
         |> makeJsObject (Some range)
-    | (ListUnion, _) ->
+    | ListUnion ->
         failwithf "transformNonListNewUnionCase must not be used with List %O" range
-    | (OtherType, _) ->
+    | OtherType ->
         let argExprs =
             let tag = getUnionCaseIndex fsType unionCase.Name |> makeIntConst
             let argTypes =

--- a/src/dotnet/Fable.Core/AST/AST.Common.fs
+++ b/src/dotnet/Fable.Core/AST/AST.Common.fs
@@ -5,7 +5,7 @@ type NumberKind =
 
 /// Numbers that are not represented with JS native number type
 type ExtendedNumberKind =
-    | Int64 | UInt64 | BigInt
+    | Int64 | UInt64 | Decimal | BigInt
 
 type RegexFlag =
     | RegexGlobal | RegexIgnoreCase | RegexMultiline | RegexSticky

--- a/src/dotnet/Fable.Core/AST/AST.Fable.Util.fs
+++ b/src/dotnet/Fable.Core/AST/AST.Fable.Util.fs
@@ -74,6 +74,8 @@ let makeTypeConst (typ: Type) (value: obj) =
     // Long Integer types
     | ExtendedNumber Int64, (:? int64 as x) -> makeLongInt (uint64 x) false
     | ExtendedNumber UInt64, (:? uint64 as x) -> makeLongInt x true
+    // Decimal type
+    | ExtendedNumber Decimal, (:? decimal as x) -> makeDecConst x
     // Enum 64-bit types (TODO: proper JS support, as Enum has no type)
     | Enum _, (:? int64 as x) -> makeLongInt (uint64 x) false
     | Enum _, (:? uint64 as x) -> makeLongInt x true
@@ -93,7 +95,6 @@ let makeTypeConst (typ: Type) (value: obj) =
         | Number UInt32, (:? uint32 as x) -> NumberConst (float x, UInt32)
         // Float types
         | Number Float64, (:? float as x) -> NumberConst (float x, Float64)
-        | Number Float64, (:? decimal as x) -> NumberConst (float x, Float64)
         // Enums (TODO: proper JS support, as Enum has no type)
         | Enum _, (:? byte as x) -> NumberConst (float x, UInt8)
         | Enum _, (:? sbyte as x) -> NumberConst (float x, Int8)
@@ -188,6 +189,7 @@ let rec makeTypeRef (com: ICompiler) (genInfo: GenericInfo) typ =
     | ExtendedNumber kind ->
         match kind with
         | Int64|UInt64 -> makeCoreRef "Long" (Some "Long")
+        | Decimal -> str "number"
         | BigInt -> makeCoreRef "BigInt" None
     | Function(argTypes, returnType) ->
         argTypes@[returnType]
@@ -279,6 +281,7 @@ let rec makeTypeTest com range (typ: Type) expr =
     | Number _ | Enum _ -> jsTypeof "number" expr
     | ExtendedNumber (Int64|UInt64) ->
         makeBinOp range Boolean [expr; makeCoreRef "Long" (Some "Long")] BinaryInstanceOf
+    | ExtendedNumber Decimal -> jsTypeof "number" expr
     | ExtendedNumber BigInt ->
         makeBinOp range Boolean [expr; makeCoreRef "BigInt" None] BinaryInstanceOf
     | Boolean -> jsTypeof "boolean" expr


### PR DESCRIPTION
- Fixed REPL decimal constants (needs FCS_fable latest).
- Moved Decimal to ExtendedNumber so it can be easier to migrate to a different implementation.
- Unfortunately the nested option error was breaking the REPL build, so changed the error to a warning.
