### PR TITLE
Version check as a warning

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -429,12 +429,12 @@ let runFableServer args f =
 
 let runTestsJs () =
     Npm.install __SOURCE_DIRECTORY__ []
-    runFableServer ["--no-version-check"; "--verbose"] <| fun () ->
+    runFableServer ["--verbose"] <| fun () ->
         Npm.script __SOURCE_DIRECTORY__ "webpack" ["--config src/tests/webpack.config.js"]
     Npm.script __SOURCE_DIRECTORY__ "mocha" ["./build/tests/bundle.js"]
 
 let quickTest() =
-    Util.run "src/tools" dotnetExePath "../../build/fable/dotnet-fable.dll npm-run rollup --no-version-check"
+    Util.run "src/tools" dotnetExePath "../../build/fable/dotnet-fable.dll npm-run rollup"
     Node.run "." "src/tools/temp/QuickTest.js" []
 
 Target "QuickTest" quickTest

--- a/src/dotnet/Fable.Tools/ProjectCracker.fs
+++ b/src/dotnet/Fable.Tools/ProjectCracker.fs
@@ -132,7 +132,7 @@ let checkFableCoreVersion paketDir projFile =
                         if fableCoreVersion <> Constants.VERSION then
                             failwith ("Version mismatch! " + versions)
                     | None -> failwithf "Cannot find version in %s" nuspec
-            else failwithf "Missing %s" nuspec
+            else Log.logAllways(sprintf "Fable.Core: Missing %s, cannot verify version" nuspec)
         | None -> failwith "Cannot find Fable.Core package location"
 
 type CrackedFsproj = {


### PR DESCRIPTION
@alfonsogarciacaro Converted missing .nuspec build error to a warning.
Instead of adding --no-version-check flag everywhere, this avoids build crashing when referencing Fable.Core that does not have a .nuspec. Again, this is IMO a slightly better behavior than flags, but if you don't like it let me know and I'll close it.