### PR TITLE
Prefix generated lambda expression arguments

### DIFF
--- a/src/dotnet/Fable.Compiler/Replacements.fs
+++ b/src/dotnet/Fable.Compiler/Replacements.fs
@@ -1257,7 +1257,7 @@ module AstPass =
             CoreLibCall("Util", Some  "defaultArg", false, [expr; defValue; f])
             |> makeCall r Fable.Any
         let toArray r arg =
-            let ident = makeIdent "x"
+            let ident = makeIdent (com.GetUniqueVar())
             makeLambdaExpr [ident] (makeArray Fable.Any [Fable.IdentValue ident |> Fable.Value])
             |> runIfSome r arg (makeArray Fable.Any [])
         let getCallee() = match i.callee with Some c -> c | None -> i.args.Head
@@ -1528,7 +1528,7 @@ module AstPass =
                "reduce" => "reduce"; "reduceBack" => "reduceRight";
                "sortInPlace" => "sort"; "sortInPlaceWith" => "sort" ]
 
-    let collectionsSecondPass com (i: Fable.ApplyInfo) kind =
+    let collectionsSecondPass (com: ICompiler) (i: Fable.ApplyInfo) kind =
         let prop (meth: string) callee =
             makeGet i.range i.returnType callee (makeStrConst meth)
         let icall meth (callee, args) =
@@ -1582,7 +1582,7 @@ module AstPass =
                 then Some args.Head, args.Tail
                 else None, args
             let compareFn =
-                let fnArgs = [makeIdent "x"; makeIdent "y"]
+                let fnArgs = [makeIdent (com.GetUniqueVar()); makeIdent (com.GetUniqueVar())]
                 let identValue x =
                     let x = Fable.Value(Fable.IdentValue x)
                     match proyector with
@@ -1662,7 +1662,7 @@ module AstPass =
                 emit i "$0.indexOf($1) > -1" (c::args) |> Some
             | None, [item;xs] ->
                 let f =
-                    wrapInLambda [makeIdent "x"] (fun exprs ->
+                    wrapInLambda [makeIdent (com.GetUniqueVar())] (fun exprs ->
                         CoreLibCall("Util", Some "equals", false, item::exprs)
                         |> makeCall None Fable.Boolean)
                 ccall "Seq" "exists" [f;xs] |> Some
@@ -1712,7 +1712,7 @@ module AstPass =
                 ccall "Seq" meth args |> Some
             | t ->
                 let zero = getZero t
-                let fargs = [makeTypedIdent "x" t; makeTypedIdent "y" t]
+                let fargs = [makeTypedIdent (com.GetUniqueVar()) t; makeTypedIdent (com.GetUniqueVar()) t]
                 let addFn = wrapInLambda fargs (fun args ->
                     applyOp None Fable.Any args "op_Addition")
                 if meth = "sum"

--- a/src/tests/Main/ListTests.fs
+++ b/src/tests/Main/ListTests.fs
@@ -131,6 +131,19 @@ let ``List.contains works``() =
       let xs = [1; 2; 3; 4]
       xs |> List.contains 2 |> equal true
       xs |> List.contains 0 |> equal false
+[<Test>]
+let ``List.contains lambda doesn't clash``() =
+      let modifyList current x =
+          let contains = current |> List.contains x
+          match contains with
+              | true -> current |> (List.filter (fun a -> a <> x))
+              | false -> x::current
+
+
+
+      let l = [1;2;3;4]
+      (modifyList l 1) |> List.contains 1 |> equal false
+      (modifyList l 5) |> List.contains 5 |> equal true
 
 [<Test>]
 let ``List.distinct works``() =
@@ -358,13 +371,13 @@ let ``List.mapFoldBack works`` () =
 let ``List.mapFold works II``() = // See #842
     let f x y = x,y
     let xs,_ = List.mapFold f "a" ["b"]
-    equal "a" xs.Head 
+    equal "a" xs.Head
 
 [<Test>]
 let ``List.mapFoldBack works II``() =
     let f x y = x,y
     let xs,_ = List.mapFoldBack f ["a"] "b"
-    equal "a" xs.Head 
+    equal "a" xs.Head
 
 [<Test>]
 let ``List.max works``() =


### PR DESCRIPTION
In situationes where the user defined variables like x and y it could lead
to naming conflicts with generated lambda expressions because these use the
same names. I deconflicted that by using __ as a prefix. __ is used in many
other languages (e.h C) to indicate a compiled namespace.

See #1028