### PR TITLE
[docs] Slightly improve docs navigation

### DIFF
--- a/docs/source/docs.md
+++ b/docs/source/docs.md
@@ -7,11 +7,61 @@ in the Fable repository on GitHub. Is anything unclear or missing?
 Help us make Fable better by contributing!
 
 <div class="fable-docs">
+<div class="row"><div class="col-sm-12">
+
+## Fable version 1 documentation
+
+The following documentation pages contain the most up-to-date information on getting started
+with the latest version of Fable and cover best practices for using Fable in typical projects.
+
+</div></div>
+<div class="row"><div class="col-sm-6">
+
+### [<i class="fa fa-cog" aria-hidden="true"></i> Getting started](pages/getting-started.html)
+
+Start here! The page covers how to create your first Fable project. It explains the
+Fable template and gives a step-by-step guide for creating your first Fable project!
+
+</div><div class="col-sm-6">
+
+### [<i class="fa fa-folder-open" aria-hidden="true"></i> Prerequisites and editors](pages/prerequisites.html)
+
+To get started with Fable, you will need a couple of things installed on your machine
+including Node, Yarn, Dotnet SDK and a suitable editor. This page explains why & how
+to get ready.
+
+</div></div>
+<div class="row"><div class="col-sm-6">
+
+### [<i class="fa fa-cloud" aria-hidden="true"></i> What is Fable server](pages/what-is-fable-server.html)
+
+Fable comes with a daemon that runs in the background and orchestrates the 
+compilation process with Webpack. This page explains how the daemon works.
+
+</div><div class="col-sm-6">
+
+### [<i class="fa fa-pencil-square" aria-hidden="true"></i> Latest blog posts](blog.html)
+
+Check out the latest blog posts on Fable. It contains the most recent information,
+useful links, case studies and sample projects. If you want to keep up-to-date, 
+this is the place to go.
+
+</div></div>
+<div class="row"><div class="col-sm-12">
+
+## Background information
+
+The following pages contain more background on Fable including the .NET and F# library support
+and detailed info about the `fable` command line tool. Some of the information below still
+need to be updated to cover the latest version - you can help by [sending us a pull 
+request](https://github.com/fable-compiler/Fable)!
+
+</div></div>
 <div class="row"><div class="col-sm-6">
 
 ### [<i class="fa fa-cog" aria-hidden="true"></i> Compiling to JavaScript](docs/compiling.html)
 
-Start here! The page covers all you need to get started
+The page covers all you need to get started
 with Fable. This includes the `fable` command parameters, `fableconfig.json` file,
 using Fable through Polyfill, modules, debugging, testing and more.
 

--- a/docs/source/index.html
+++ b/docs/source/index.html
@@ -120,10 +120,10 @@
       <p>Go to the <a href="docs.html">Fable documentation page</a> for more details.  Is anything unclear or missing?
         Help us make Fable docs better by <a href="https://github.com/fable-compiler/Fable/tree/master/docs">contributing</a>!</p>
       <ul>
-        <li><a href="docs/compiling.html">Compiling F# code to JavaScript</a></li>
+        <li><a href="pages/getting-started.html">Getting started with Fable</a></li>
+        <li><a href="pages/prerequisites.html">How to setup your system and editor</a></li>
         <li><a href="docs/compatibility.html">Supported F# language features and libraries</a></li>
         <li><a href="docs/interacting.html">Interacting with JavaScript libraries</a></li>
-        <li><a href="docs/plugins.html">Extending Fable through plugins</a></li>
       </ul>
 
       <h2>Recent news about Fable</h2>


### PR DESCRIPTION
Many of the pages in "Docs" tab are now outdated and there are new pages that are not linked from here. This improves the situation a little by linking to the up-to-date pages and acknowledging that there may be outdated info in the original pages.