### PR TITLE
Replace syste.uri

### DIFF
--- a/src/dotnet/Fable.Compiler/Replacements.fs
+++ b/src/dotnet/Fable.Compiler/Replacements.fs
@@ -1984,6 +1984,20 @@ module AstPass =
             |> Fable.Value |> Some
         | _ -> None
 
+    let uris com (info: Fable.ApplyInfo) =
+        printfn "try to replace uri %s" info.methodName
+        match info.methodName with
+        | "unescapeDataString" ->
+            CoreLibCall("Util", Some "urldecode", false, info.args)
+            |> makeCall info.range info.returnType |> Some
+        | "escapeDataString" ->
+            CoreLibCall("Util", Some "escapeDataString", false, info.args)
+            |> makeCall info.range info.returnType |> Some
+        | "escapeUriString" ->
+            CoreLibCall("Util", Some "escapeUriString", false, info.args)
+            |> makeCall info.range info.returnType |> Some
+        | _ -> None
+
     let laziness com (info: Fable.ApplyInfo) =
         let coreCall meth isCons args =
             CoreLibCall("Lazy", meth, isCons, args)
@@ -2174,6 +2188,7 @@ module AstPass =
         | "Microsoft.FSharp.Control.FSharpAsyncReplyChannel" -> mailbox com info
         | "Microsoft.FSharp.Control.FSharpAsync" -> asyncs com info
         | "System.Guid" -> guids com info
+        | "System.Uri" -> uris com info
         | "System.Lazy" | "Microsoft.FSharp.Control.Lazy"
         | "Microsoft.FSharp.Control.LazyExtensions" -> laziness com info
         | "Microsoft.FSharp.Control.CommonExtensions" -> controlExtensions com info

--- a/src/dotnet/Fable.Compiler/Replacements.fs
+++ b/src/dotnet/Fable.Compiler/Replacements.fs
@@ -1988,7 +1988,7 @@ module AstPass =
         printfn "try to replace uri %s" info.methodName
         match info.methodName with
         | "unescapeDataString" ->
-            CoreLibCall("Util", Some "urldecode", false, info.args)
+            CoreLibCall("Util", Some "unescapeDataString", false, info.args)
             |> makeCall info.range info.returnType |> Some
         | "escapeDataString" ->
             CoreLibCall("Util", Some "escapeDataString", false, info.args)

--- a/src/dotnet/Fable.Tools/ProjectCracker.fs
+++ b/src/dotnet/Fable.Tools/ProjectCracker.fs
@@ -225,6 +225,7 @@ let getBasicCompilerArgs (define: string[]) optimize =
         yield "-r:" + resolve "System.IO"
         yield "-r:" + resolve "System.Reflection"
         yield "-r:" + resolve "System.Runtime"
+        yield "-r:" + resolve "System.Private.Uri" //required for System.Uri types
         yield "-r:" + resolve "System.Runtime.Numerics"
         yield "-r:" + resolve "System.Threading"
         yield "-r:" + resolve "System.Threading.Tasks"

--- a/src/dotnet/Fable.Tools/ProjectCracker.fs
+++ b/src/dotnet/Fable.Tools/ProjectCracker.fs
@@ -181,6 +181,7 @@ let getProjectOptionsFromScript (checker: FSharpChecker) (define: string[]) scri
 let fsCoreLib = typeof<Microsoft.FSharp.Core.MeasureAttribute>.GetTypeInfo().Assembly.Location
 let fableCoreLib = typeof<Fable.Core.EraseAttribute>.GetTypeInfo().Assembly.Location
 let sysCoreLib = typeof<System.Object>.GetTypeInfo().Assembly.Location
+let sysUriLib = typeof<System.Uri>.GetTypeInfo().Assembly.Location
 let sysPath = Path.GetDirectoryName(sysCoreLib)
 let localPath = Path.GetDirectoryName(typeof<TypeInThisAssembly>.GetTypeInfo().Assembly.Location)
 
@@ -225,13 +226,13 @@ let getBasicCompilerArgs (define: string[]) optimize =
         yield "-r:" + resolve "System.IO"
         yield "-r:" + resolve "System.Reflection"
         yield "-r:" + resolve "System.Runtime"
-        yield "-r:" + resolve "System.Private.Uri" //required for System.Uri types
         yield "-r:" + resolve "System.Runtime.Numerics"
         yield "-r:" + resolve "System.Threading"
         yield "-r:" + resolve "System.Threading.Tasks"
         yield "-r:" + resolve "System.Text.RegularExpressions"
         yield "-r:" + fsCoreLib // "FSharp.Core"
         yield "-r:" + fableCoreLib // "FSharp.Core"
+        yield "-r:" + sysUriLib //required for System.Uri types
     |]
 
 let tryGetTargetFramework (xmlDoc: XDocument) =

--- a/src/dotnet/Fable.Tools/ProjectCracker.fs
+++ b/src/dotnet/Fable.Tools/ProjectCracker.fs
@@ -218,6 +218,7 @@ let getBasicCompilerArgs (define: string[]) optimize =
 #else
         yield "--targetprofile:netcore"
         yield "-r:" + sysCoreLib // "CoreLib"
+        yield "-r:" + sysUriLib //required for System.Uri types
 #endif
         yield "-r:" + resolve "mscorlib"
         yield "-r:" + resolve "System.Console"
@@ -232,7 +233,6 @@ let getBasicCompilerArgs (define: string[]) optimize =
         yield "-r:" + resolve "System.Text.RegularExpressions"
         yield "-r:" + fsCoreLib // "FSharp.Core"
         yield "-r:" + fableCoreLib // "FSharp.Core"
-        yield "-r:" + sysUriLib //required for System.Uri types
     |]
 
 let tryGetTargetFramework (xmlDoc: XDocument) =

--- a/src/tests/Main/MiscTests.fs
+++ b/src/tests/Main/MiscTests.fs
@@ -824,3 +824,23 @@ let ``Option.defaultValue works``() =
 
     a |> Option.defaultValue "" |> equal "MyValue"
     b |> Option.defaultValue "default" |> equal "default"
+
+[<Test>]
+let ``System.Uri.UnescapeDataString works``() =
+    System.Uri.UnescapeDataString("Kevin%20van%20Zonneveld%21") |> equal "Kevin van Zonneveld!"
+    System.Uri.UnescapeDataString("http%3A%2F%2Fkvz.io%2F") |> equal "http://kvz.io/"
+    System.Uri.UnescapeDataString("http%3A%2F%2Fwww.google.nl%2Fsearch%3Fq%3DLocutus%26ie%3Dutf-8%26oe%3Dutf-8%26aq%3Dt%26rls%3Dcom.ubuntu%3Aen-US%3Aunofficial%26client%3Dfirefox-a")
+    |> equal "http://www.google.nl/search?q=Locutus&ie=utf-8&oe=utf-8&aq=t&rls=com.ubuntu:en-US:unofficial&client=firefox-a"
+[<Test>]
+let ``System.Uri.EscapeDataString works``() =
+    System.Uri.EscapeDataString("Kevin van Zonneveld!") |> equal "Kevin%20van%20Zonneveld%21"
+    System.Uri.EscapeDataString("http://kvz.io/") |> equal "http%3A%2F%2Fkvz.io%2F"
+    System.Uri.EscapeDataString("http://www.google.nl/search?q=Locutus&ie=utf-8&oe=utf-8&aq=t&rls=com.ubuntu:en-US:unofficial&client=firefox-a")
+    |> equal "http%3A%2F%2Fwww.google.nl%2Fsearch%3Fq%3DLocutus%26ie%3Dutf-8%26oe%3Dutf-8%26aq%3Dt%26rls%3Dcom.ubuntu%3Aen-US%3Aunofficial%26client%3Dfirefox-a"
+[<Test>]
+let ``System.Uri.EscapeUriString works``() =
+    System.Uri.EscapeUriString("Kevin van Zonneveld!") |> equal "Kevin%20van%20Zonneveld!"
+    System.Uri.EscapeUriString("http://kvz.io/") |> equal "http://kvz.io/"
+    System.Uri.EscapeUriString("http://www.google.nl/search?q=Locutus&ie=utf-8&oe=utf-8&aq=t&rls=com.ubuntu:en-US:unofficial&client=firefox-a")
+    |> equal "http://www.google.nl/search?q=Locutus&ie=utf-8&oe=utf-8&aq=t&rls=com.ubuntu:en-US:unofficial&client=firefox-a"
+

--- a/src/typescript/fable-core/Util.ts
+++ b/src/typescript/fable-core/Util.ts
@@ -532,3 +532,18 @@ export function parse<A>(v: string | null, initial: A, parser: RegExp, fn: (s: s
     throw new Error("Input string was not in a correct format.");
   }
 }
+
+export function urldecode(s: string): string {
+  // https://stackoverflow.com/a/4458580/524236
+  return decodeURIComponent((s).replace(/\+/g, "%20"));
+}
+export function escapeDataString(s: string): string {
+  return encodeURIComponent(s).replace(/!/g, "%21")
+    .replace(/'/g, "%27")
+    .replace(/\(/g, "%28")
+    .replace(/\)/g, "%29")
+    .replace(/\*/g, "%2A");
+}
+export function escapeUriString(s: string): string {
+  return encodeURI(s);
+}

--- a/src/typescript/fable-core/Util.ts
+++ b/src/typescript/fable-core/Util.ts
@@ -533,7 +533,7 @@ export function parse<A>(v: string | null, initial: A, parser: RegExp, fn: (s: s
   }
 }
 
-export function urldecode(s: string): string {
+export function unescapeDataString(s: string): string {
   // https://stackoverflow.com/a/4458580/524236
   return decodeURIComponent((s).replace(/\+/g, "%20"));
 }


### PR DESCRIPTION
Added replacements for the static methods of the System.Uri class:

- `UnescapeDataString`: To unescape a URI/Data string
- `EscapeDataString`: Escapes a string to a repesentation safe to put in URI, this includes characters that are safe in URI but should be escaped.
- `EscapeUriString`: Escapes a URI, all characters valid in a URI will remain.

In order to make it work I had to add System.Private.Uri to the compiler path. See #1043 for details.
