### PR TITLE
Array inside keyValueList is lost forever

### DIFF
--- a/src/tests/Main/ArrayTests.fs
+++ b/src/tests/Main/ArrayTests.fs
@@ -865,3 +865,17 @@ let ``Array.chunkBySize works`` () =
     |> equal [| [|1..4|]; [|5..8|] |]
     Array.chunkBySize 4 [|1..10|]
     |> equal [| [|1..4|]; [|5..8|]; [|9..10|] |]
+
+
+
+open Fable.Core
+open Fable.Core.JsInterop
+type ActionProp = { Name: string }
+type DialogProps =
+    | Actions of ActionProp array
+[<Test>]
+let ``Array as keyValueList is preserved`` () =
+    let actions = [ Actions [| { Name = "name" } |] ]
+    let prop = [ Actions [| { Name = "name" } |] ] |> keyValueList CaseRules.LowerFirst
+    let expected = actions |> keyValueList CaseRules.LowerFirst
+    prop |> equal expected

--- a/src/tests/Main/ArrayTests.fs
+++ b/src/tests/Main/ArrayTests.fs
@@ -870,12 +870,12 @@ let ``Array.chunkBySize works`` () =
 
 open Fable.Core
 open Fable.Core.JsInterop
-type ActionProp = { Name: string }
-type DialogProps =
-    | Actions of ActionProp array
+type NameProp = { Name: string }
+type Props =
+    | Names of NameProp array
 [<Test>]
-let ``Array as keyValueList is preserved`` () =
-    let actions = [ Actions [| { Name = "name" } |] ]
-    let prop = [ Actions [| { Name = "name" } |] ] |> keyValueList CaseRules.LowerFirst
-    let expected = actions |> keyValueList CaseRules.LowerFirst
-    prop |> equal expected
+let ``Array inside keyValueList is preserved`` () =
+    let props = [ Names [| { Name = "name" } |] ]
+    let actual = [ Names [| { Name = "name" } |] ] |> keyValueList CaseRules.LowerFirst
+    let expected = props |> keyValueList CaseRules.LowerFirst
+    actual |> equal expected


### PR DESCRIPTION
Not sure if this is expected behaviour, but an Array inside a list of DU's being passed into `keyValueList` is being transpiled as a plain object.

```
  1233 passing (5s)
  1 failing

  1) Arrays Array inside keyValueList is preserved:

      Error: Expected: [object Object] - Actual: [object Object]
      + expected - actual

       {
      -  "names": {
      -    "Name": "name"
      -  }
      +  "names": [
      +    {
      +      "Name": "name"
      +    }
      +  ]
       }
```