### PR TITLE
Support String.Join with objects

### DIFF
--- a/src/js/fable-core/String.ts
+++ b/src/js/fable-core/String.ts
@@ -281,8 +281,8 @@ export function isNullOrWhiteSpace(str: string | any) {
 
 export function join(delimiter: string, xs: ArrayLike<string>) {
   let xs2 = xs as any;
-  if (typeof xs === "string") {
-    const len = arguments.length;
+  const len = arguments.length;
+  if (len > 2) {
     xs2 = Array(len - 1);
     for (let key = 1; key < len; key++) {
       xs2[key - 1] = arguments[key];
@@ -290,7 +290,7 @@ export function join(delimiter: string, xs: ArrayLike<string>) {
   } else if (!Array.isArray(xs)) {
     xs2 = Array.from(xs);
   }
-  return xs2.join(delimiter);
+  return xs2.map((x: string) => toString(x)).join(delimiter);
 }
 
 export function newGuid() {

--- a/src/tests/Main/StringTests.fs
+++ b/src/tests/Main/StringTests.fs
@@ -506,6 +506,10 @@ let ``String.Join works``() =
       |> equal "a--b--c"
       String.Join("--", seq { yield "a"; yield "b"; yield "c" })
       |> equal "a--b--c"
+      String.Join("--", [|3I; 5I|])
+      |> equal "3--5"
+      String.Join("--", 3I, 5I)
+      |> equal "3--5"
 
 [<Test>]
 let ``System.String.Concat works``() =


### PR DESCRIPTION
Implementation of "join" function in JS is missing a call to "toString" for every value and doesn't process multiple non-string arguments.

As a result, following tests return ``[object Object]--[object Object]`` and an empty string when compiled to JS:
```
     System.String.Join("--", [|3I; 5I|])
      |> equal "3--5"
      System.String.Join("--", 3I, 5I)
      |> equal "3--5"
```



