### PR TITLE
Prevent dotnet template engine to parse Paket.Restore.targets

### DIFF
--- a/src/templates/simple/Content/.paket/Paket.Restore.targets
+++ b/src/templates/simple/Content/.paket/Paket.Restore.targets
@@ -1,4 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--/-:cnd:noEmit-->
   <PropertyGroup>
     <!-- Mark that this target file has been loaded.  -->
     <IsPaketRestoreTargetsFileLoaded>true</IsPaketRestoreTargetsFileLoaded>
@@ -127,5 +128,5 @@
               NuspecBasePath="$(NuspecBasePath)"
               NuspecProperties="$(NuspecProperties)"/>
   </Target>
-
+  <!--/+:cnd:noEmit-->
 </Project>

--- a/src/templates/simple/Fable.Template.proj
+++ b/src/templates/simple/Fable.Template.proj
@@ -8,7 +8,7 @@
     <PackageTags>fable;template;fsharp</PackageTags>
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageType>Template</PackageType>
-    <Version>1.1.8</Version>
+    <Version>1.1.9</Version>
     <PackProjectInputFile>$(MSBuildProjectFullPath)</PackProjectInputFile>
     <NoBuild>true</NoBuild>
     <IncludeBuildOutput>false</IncludeBuildOutput>


### PR DESCRIPTION
@alfonsogarciacaro Careful when you run `paket.exe update/install` perhaps this will override this changes.

@forki could probably confirm/infirm the behaviour of paket on this file. :)