### PR TITLE
Save the daylight!

### DIFF
--- a/src/tests/Main/DateTimeTests.fs
+++ b/src/tests/Main/DateTimeTests.fs
@@ -130,6 +130,14 @@ let ``DateTime.IsLeapYear works``() =
     DateTime.IsLeapYear(2016) |> equal true
 
 [<Test>]
+let ``DateTime.IsDaylightSavingTime works``() =
+    let d1 = DateTime(2017, 7, 18, 2, 0, 0, DateTimeKind.Utc)
+    let d2 = DateTime(2017, 12, 18, 2, 0, 0, DateTimeKind.Utc)
+    d1.IsDaylightSavingTime() |> equal true
+    d2.IsDaylightSavingTime() |> equal false
+    
+
+[<Test>]
 let ``DateTime.DaysInMonth works``() =
     DateTime.DaysInMonth(2014, 1) |> equal 31
     DateTime.DaysInMonth(2014, 2) |> equal 28

--- a/src/tests/Main/DateTimeTests.fs
+++ b/src/tests/Main/DateTimeTests.fs
@@ -131,8 +131,8 @@ let ``DateTime.IsLeapYear works``() =
 
 [<Test>]
 let ``DateTime.IsDaylightSavingTime works``() =
-    let d1 = DateTime(2017, 7, 18, 2, 0, 0, DateTimeKind.Utc)
-    let d2 = DateTime(2017, 12, 18, 2, 0, 0, DateTimeKind.Utc)
+    let d1 = DateTime(2017, 7, 18, 2, 0, 0)
+    let d2 = DateTime(2017, 12, 18, 2, 0, 0)
     d1.IsDaylightSavingTime() |> equal true
     d2.IsDaylightSavingTime() |> equal false
     


### PR DESCRIPTION
    'isDaylightSavingTime' is not exported by packages\Fable.Core\fable-core\Date.js