### PR TITLE
Implement isDaylightSavingTime

### DIFF
--- a/src/js/fable-core/Date.ts
+++ b/src/js/fable-core/Date.ts
@@ -265,3 +265,13 @@ export function op_Addition(x: Date, y: number) {
 export function op_Subtraction(x: Date, y: number | Date) {
   return subtract(x, y);
 }
+
+export function isDaylightSavingTime(x : Date) {
+  var jan = new Date(x.getFullYear(), 0, 1);
+  var jun = new Date(x.getFullYear(), 6, 1);
+  return isDST(jan.getTimezoneOffset(), jun.getTimezoneOffset(), x.getTimezoneOffset());
+}
+
+function isDST(janOffset : number, junOffset : number, tOffset : number) {
+  return Math.min(janOffset, junOffset) == tOffset;
+}


### PR DESCRIPTION
References #1082.

Because JS doesn't have a native function for this, we need to check if the `Date`s UTC offset is equal to either the offset in January or in June.

If a users time zone doesn't have DST, this function should always return `false`.

@alfonsogarciacaro where can I add tests for the `isDST` function?