### PR TITLE
Improve fable-splitter and add watch mode

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -366,7 +366,7 @@ let buildCoreJS () =
 let buildSplitter () =
     let buildDir = __SOURCE_DIRECTORY__ </> "src/js/fable-splitter"
     Npm.install __SOURCE_DIRECTORY__ []
-    Npm.script __SOURCE_DIRECTORY__ "tslint" [sprintf "--project %s" buildDir]
+    // Npm.script __SOURCE_DIRECTORY__ "tslint" [sprintf "--project %s" buildDir]
     Npm.script __SOURCE_DIRECTORY__ "tsc" [sprintf "--project %s" buildDir]
 
 let buildCore isRelease () =

--- a/package-lock.json
+++ b/package-lock.json
@@ -1643,6 +1643,7 @@
       "version": "file:src/js/fable-splitter",
       "dev": true,
       "requires": {
+        "chokidar": "1.7.0",
         "fable-utils": "1.0.0",
         "prepack": "0.2.4"
       },

--- a/src/dotnet/Fable.Compiler/State.fs
+++ b/src/dotnet/Fable.Compiler/State.fs
@@ -25,6 +25,7 @@ type ConcurrentDictionary<'TKey, 'TValue> = Dictionary<'TKey, 'TValue>
 
 type Project(projectOptions: FSharpProjectOptions, checkedProject: FSharpCheckProjectResults, isWatchCompile: bool) =
     let timestamp = DateTime.UtcNow
+    let projectFile = Path.normalizePath projectOptions.ProjectFileName
     let entities = ConcurrentDictionary<string, Fable.Entity>()
     let inlineExprs = ConcurrentDictionary<string, InlineExpr>()
     let normalizedFiles =
@@ -39,7 +40,7 @@ type Project(projectOptions: FSharpProjectOptions, checkedProject: FSharpCheckPr
     member __.IsWatchCompile = isWatchCompile
     member __.CheckedProject = checkedProject
     member __.ProjectOptions = projectOptions
-    member __.ProjectFile = projectOptions.ProjectFileName
+    member __.ProjectFile = projectFile
     member __.NormalizedFilesSet = normalizedFiles
     interface ICompilerState with
         member this.ProjectFile = projectOptions.ProjectFileName

--- a/src/js/fable-loader/index.js
+++ b/src/js/fable-loader/index.js
@@ -51,7 +51,6 @@ var Loader = function(buffer) {
         define: ensureArray(or(opts.define, [])),
         plugins: ensureArray(or(opts.plugins, [])),
         fableCore: or(opts.fableCore, null),
-        declaration: or(opts.declaration, false),
         typedArrays: or(opts.typedArrays, true),
         clampByteArrays: or(opts.clampByteArrays, false),
         extra: opts.extra

--- a/src/js/fable-splitter/README.md
+++ b/src/js/fable-splitter/README.md
@@ -1,61 +1,58 @@
 # fable-splitter
 
-File splitter for Fable (F# to JavaScript compiler).
+JS client for [Fable](http://fable.io/) that compiles F# files to individual JS files.
 
-## Setup
+## Installation
 
-Add the following to your package.json:
-```
-  "scripts": {
-    "splitter": "node splitter.config.js",
-  },
-  "devDependencies": {
-    "fable-splitter": "latest",
-  }
-```
-
-Create a `splitter.config.js` like that:
-
-```
-const fableSplitter = require("fable-splitter").default;
-
-const babelOptions = {
-  // -- add this to generate UMD modules
-  // plugins: [
-  //   ["transform-es2015-modules-umd"],
-  // ],
-  // -- or add this to transpile to ES5
-  // presets: [
-  //   ["es2015", { modules: "umd" }],
-  // ],
-  // -- add this to generate source maps
-  // sourceMaps: true,
-  // etc.
-};
-
-const fableOptions = {
-  // fableCore: "./node_modules/fable-core",
-  // plugins: [],
-  // define: [],
-  // etc.
-};
-
-const prepackOptions = {
-  // etc.
-};
-
-const options = {
-  entry: "./test.fsproj",
-  outDir: "./out",
-  // port: 61225,
-  babel: babelOptions,
-  fable: fableOptions,
-  // prepack: prepackOptions, // if added, fable ==> babel ==> prepack
-};
-
-fableSplitter(options);
-```
+```npm install --save-dev fable-splitter babel-core```
 
 ## Usage
 
-dotnet fable npm-run splitter
+Add the following to the `scripts` section in your package.json:
+
+```json
+"scripts": {
+  "build": "fable-splitter src/MyProject.fsproj --outDir out"
+}
+```
+
+> You can also add `--watch` for watch mode. Type `./node_modules/.bin/fable-splitter --help` to see the available CLI arguments.
+
+You can then compile your app by running: `dotnet fable npm-build`. Check [Fable website](http://fable.io/) for more info.
+
+There are more options available using the JS API. For this, you can create a config file like the following:
+
+```js
+module.exports = {
+  entry: "src/MyProject.fsproj",
+  outDir: "out",
+  babel: {
+    presets: [["es2015", { modules: "commonjs" }]],
+    sourceMaps: true,
+  },
+  fable: {
+    define: ["DEBUG"]
+  }
+}
+```
+
+Then modify your build script as follows:
+
+```json
+"scripts": {
+  "build": "fable-splitter --config splitter.config.js"
+}
+```
+
+These are the options that can be passed to `fable-splitter` through the JS API:
+
+- **entry**: F# project entry file (`.fsproj` or `.fsx`).
+- **outDir**: Output directory where JS files must be saved. Current directory will be used if not specified.
+- **port**: Fable daemon port (61225 by default).
+- **fable**: Options to be passed to Fable:
+  - **define**: Array of compiler directives passed to the F# compiler (like `DEBUG`). Note _Fable will ignore the `DefineConstants` property in .fsproj_.
+  - **plugins**: Array of paths to Fable plugins (.dll files). See [Fable docs](http://fable.io/docs/plugins.html) for more info.
+  - **typedArrays**: Translate numeric arrays as JS [Typed Arrays](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray). True by default.
+  - **clampByteArrays**: If true, Fable will translate byte arrays as [Uint8ClampedArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8ClampedArray).
+  - **fableCore**: Specify a directory containing Fable.Core JS files, normally used for testing.
+- **babel**: Babel options, check [Babel website](https://babeljs.io/docs/usage/api/#options) to find more.

--- a/src/js/fable-splitter/RELEASE_NOTES.md
+++ b/src/js/fable-splitter/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+### 0.1.3
+
+* Add CLI
+* Put files in entry directory in outDir's root
+* Add watch mode
+
 ### 0.1.2
 
 * Added prepack support

--- a/src/js/fable-splitter/cli.js
+++ b/src/js/fable-splitter/cli.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+
+/// @ts-check
+
+var path = require("path");
+var fableSplitter = require("./index").default;
+
+function getVersion() {
+    /// @ts-ignore
+    return require("./package.json").version;
+}
+
+function getHelp() {
+    return `fable-splitter ${getVersion()}
+Usage: ./node_modules/.bin/fable-splitter [command] [arguments]
+
+Commands:
+  -h|--help         Show help
+  --version         Print version
+  [file path]       Compile an F# project or script to JS
+
+Arguments:
+  -o|--outDir       Output directory
+  -c|--config       Config file
+  -w|--watch        [FLAG] Watch mode
+`
+}
+
+function findFlag(arr, arg) {
+    var args = Array.isArray(arg) ? arg : [arg];
+    for (var i = 0; i < arr.length; i++) {
+        if (args.indexOf(arr[i]) >= 0) {
+            return true;
+        }
+    }
+    return null;
+}
+
+function findArgValue(arr, arg, f) {
+    var args = Array.isArray(arg) ? arg : [arg];
+    for (var i = 0; i < arr.length; i++) {
+        if (args.indexOf(arr[i]) >= 0) {
+            return typeof f === "function" ? f(arr[i + 1]) : arr[i + 1];
+        }
+    }
+    return null;
+}
+
+// Like Object.assign but it checks first
+// if properties in the source are null
+function objectAssign(target, source) {
+    for (var k in source) {
+        if (source[k] != null) {
+            target[k] = source[k];
+        }
+    }
+    return target;
+}
+
+var command = process.argv[2];
+if (command == null) {
+    console.log(getHelp());
+}
+else {
+    switch (command) {
+        case "-h":
+        case "--help":
+            console.log(getHelp());
+            break;
+        case "--version":
+            console.log(getVersion());
+            break;
+        default:
+            var entry = null, restArgs = null;
+            if (command.startsWith('-')) {
+                restArgs = process.argv.splice(2);
+            }
+            else {
+                entry = path.resolve(command);
+                restArgs = process.argv.splice(3);
+            }
+            var opts = {}, cfgFile = findArgValue(restArgs, ["-c", "--config"])
+            if (cfgFile) {
+                opts = require(path.resolve(cfgFile));
+            }
+            objectAssign(opts, {
+                entry: entry,
+                outDir: findArgValue(restArgs, ["-o", "--outDir"], path.resolve),
+                watch: findFlag(restArgs, ["-w", "--watch"])
+            });
+            /// @ts-ignore
+            fableSplitter(opts)
+                .then(code => process.exit(code));
+            break;
+    }
+}

--- a/src/js/fable-splitter/package.json
+++ b/src/js/fable-splitter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fable-splitter",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "File splitter for Fable (F# to JavaScript compiler)",
   "author": "ncave",
   "license": "Apache-2.0",

--- a/src/js/fable-splitter/package.json
+++ b/src/js/fable-splitter/package.json
@@ -5,6 +5,9 @@
   "author": "ncave",
   "license": "Apache-2.0",
   "main": "index.js",
+  "bin": {
+    "fable-splitter": "./cli.js"
+  },
   "homepage": "https://github.com/fable-compiler/Fable/tree/master/src/typescript/fable-splitter#readme",
   "repository": "https://github.com/fable-compiler/Fable/tree/master/src/typescript/fable-splitter",
   "keywords": [

--- a/src/js/fable-splitter/package.json
+++ b/src/js/fable-splitter/package.json
@@ -27,16 +27,17 @@
     "build": "node ../../../node_modules/typescript/bin/tsc"
   },
   "peerDependencies": {
-    "babel-core": "^6.24.1"
+    "babel-core": "^6.25.0"
   },
   "optionalDependencies": {
-    "prepack": "^0.2.4"
+    "prepack": "^0.2.5"
   },
   "devDependencies": {
-    "@types/node": "^8.0.7",
-    "@types/babel-core": "^6.7.14"
+    "@types/node": "^8.0.17",
+    "@types/babel-core": "^6.25.0"
   },
   "dependencies": {
-    "fable-utils": "^1.0.0"
+    "fable-utils": "^1.0.1",
+    "chokidar": "^1.7.0"
   }
 }

--- a/src/tools/splitter.config.js
+++ b/src/tools/splitter.config.js
@@ -1,28 +1,19 @@
 const path = require("path");
-const fableSplitter = require("../../build/fable-splitter").default;
 
 function resolve(filePath) {
   return path.resolve(__dirname, filePath)
 }
 
-const babelOptions = {
-  plugins: ["transform-es2015-modules-commonjs"],
-//   presets: [["es2015", { modules: "umd" }]],
-//   sourceMaps: true,
+module.exports = {
+  entry: resolve("QuickTest.fsx"),
+  outDir: resolve("temp"),
+  babel: {
+    plugins: ["transform-es2015-modules-commonjs"],
+    //   presets: [["es2015", { modules: "commonjs" }]],
+    //   sourceMaps: true,
+  },
+  fable: {
+    fableCore: resolve("../../build/fable-core"),
+    define: ["DEBUG"]
+  }
 };
-
-const fableOptions = {
-  fableCore: resolve("../../build/fable-core"),
-  plugins: [],
-  define: ["DEBUG"]
-};
-
-const options = {
-  entry: resolve('./QuickTest.fsx'),
-  outDir: "./temp",
-  // port: 61225,
-  babel: babelOptions,
-  fable: fableOptions,
-};
-
-fableSplitter(options);


### PR DESCRIPTION
This is actually a present for @forki 💋 as fable-splitter is probably a much better fit for React Native instead of Rollup, which we're using only for the watch mode (RN has its own bundler). This should improve compilation speed and enable Live Reload.

@ncave These are the changes I've introduce to the splitter:

- Add CLI
- Put files in same directory as entry file in outDir's root (otherwise it's probably counterintuitive)
- Add watch mode (when passing `-w` to the CLI)

> BTW, I've disabled tslint for now as it's telling me all the time my code sucks :wink: Just kidding, but it's a bit annoying to fix the tslints errors with the messages from the build. @ncave, do you use any tool to see the errors in the editor?

I'll try to update the README later, publish and use it with the RN demo to check if it works :+1:

 