### PR TITLE
Fix 2 digits years datetime

### DIFF
--- a/src/js/fable-core/Date.ts
+++ b/src/js/fable-core/Date.ts
@@ -60,6 +60,11 @@ export function create(
   } else {
     date = new Date(Date.UTC(year, month - 1, day, h, m, s, ms));
   }
+
+  if (year <= 99) {
+    date.setFullYear(year);
+  }
+
   if (isNaN(date.getTime())) {
     throw new Error("The parameters describe an unrepresentable Date.");
   }

--- a/src/tests/Main/DateTimeTests.fs
+++ b/src/tests/Main/DateTimeTests.fs
@@ -49,6 +49,20 @@ let ``DateTime can be JSON serialized forth and back``() =
     utc.Kind = DateTimeKind.Utc |> equal true
     utc.ToString("HH:mm") |> equal "17:30"
 
+[<Test>]
+let ``DateTime from Year 1 to 99 works``() =
+    let date = DateTime(1, 1, 1)
+    date.Year |> equal 1
+    let date = DateTime(99, 1, 1)
+    date.Year |> equal 99
+
+[<Test>]
+let ``DateTime UTC from Year 1 to 99 works``() =
+    let date = DateTime(1, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+    date.Year |> equal 1
+    let date = DateTime(99, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+    date.Year |> equal 99
+
 // TODO: These two tests give different values for .NET and JS because DateTime
 // becomes as a plain JS Date object, so I'm just checking the fields get translated
 [<Test>]


### PR DESCRIPTION
In JavaScript date have this behavior:

> If a year between 0 and 99 is specified, the method converts the year to a year in the 20th century (1900 + year); for example, if you specify 95, the year 1995 is used.

In F#, if you set a datetime via `Datetime(1, 1, 1)` you want the year 1 and not 1901.