### PR TITLE
Always generate source maps for Rollup

### DIFF
--- a/src/js/rollup-plugin-fable/index.js
+++ b/src/js/rollup-plugin-fable/index.js
@@ -96,12 +96,14 @@ module.exports = (
             });
           });
 
-          babelOpts.sourceMaps = true;
-          babelOpts.sourceFileName = path.relative(
-            process.cwd(),
-            data.fileName.replace(/\\/g, '/')
-          );
-          const transformed = babel.transformFromAst(data, code, babelOpts);
+          const babelOptsLocal = Object.assign({}, babelOpts, {
+            sourceMaps: true,
+            sourceFileName: path.relative(
+              process.cwd(),
+              data.fileName.replace(/\\/g, '/')
+            )
+          });
+          const transformed = babel.transformFromAst(data, code, babelOptsLocal);
 
           console.log("fable: Compiled " + path.relative(process.cwd(), msg.path));
           cache.trySaveCache(extra, data.fileName, transformed);

--- a/src/js/rollup-plugin-fable/index.js
+++ b/src/js/rollup-plugin-fable/index.js
@@ -96,16 +96,12 @@ module.exports = (
             });
           });
 
-          let fsCode = null;
-          if (this.sourceMap) {
-            fsCode = code;
-            babelOpts.sourceMaps = true;
-            babelOpts.sourceFileName = path.relative(
-              process.cwd(),
-              data.fileName.replace(/\\/g, '/')
-            );
-          }
-          const transformed = babel.transformFromAst(data, fsCode, babelOpts);
+          babelOpts.sourceMaps = true;
+          babelOpts.sourceFileName = path.relative(
+            process.cwd(),
+            data.fileName.replace(/\\/g, '/')
+          );
+          const transformed = babel.transformFromAst(data, code, babelOpts);
 
           console.log("fable: Compiled " + path.relative(process.cwd(), msg.path));
           cache.trySaveCache(extra, data.fileName, transformed);


### PR DESCRIPTION
References #1141.

What about the `babelOpts` object? Should we define a local copy of it in this `then` call?