### PR TITLE
Fable 1.3 beta: Speed up watch compilations

### DIFF
--- a/src/dotnet/Fable.Compiler/FSharp2Fable.Util.fs
+++ b/src/dotnet/Fable.Compiler/FSharp2Fable.Util.fs
@@ -1242,7 +1242,7 @@ module Util =
                 when emitFsType.HasTypeDefinition ->
                 try
                     let emitInstance = getEmitter emitFsType.TypeDefinition
-                    let emitMeth = emitInstance.GetType().GetMethod(emitMethName)
+                    let emitMeth = emitInstance.GetType().GetTypeInfo().GetMethod(emitMethName)
                     let args: obj[] =
                         match extraArg with
                         | [extraArg] -> [|com; i; extraArg|]

--- a/src/dotnet/Fable.Compiler/Fable.Compiler.fsproj
+++ b/src/dotnet/Fable.Compiler/Fable.Compiler.fsproj
@@ -14,9 +14,10 @@
     <Compile Include="Fable2Babel.fs" />
     <Compile Include="State.fs" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup>    
+    <Reference Include="..\..\..\..\FSharp.Compiler.Service\fcs\FSharp.Compiler.Service.netstandard\bin\Release\netstandard1.6\FSharp.Compiler.Service.dll" />
+    <!-- <PackageReference Include="FSharp.Compiler.Service" Version="14.0.2" /> -->
     <PackageReference Include="FSharp.Core" Version="4.2.3" />
-    <PackageReference Include="FSharp.Compiler.Service" Version="14.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />

--- a/src/dotnet/Fable.Compiler/Fable.Compiler.fsproj
+++ b/src/dotnet/Fable.Compiler/Fable.Compiler.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.4</Version>
+    <Version>1.3.0-beta-001</Version>
     <TargetFramework>netstandard1.6</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
@@ -14,9 +14,12 @@
     <Compile Include="Fable2Babel.fs" />
     <Compile Include="State.fs" />
   </ItemGroup>
-  <ItemGroup>    
-    <Reference Include="..\..\..\..\FSharp.Compiler.Service\fcs\FSharp.Compiler.Service.netstandard\bin\Release\netstandard1.6\FSharp.Compiler.Service.dll" />
+  <ItemGroup>
     <!-- <PackageReference Include="FSharp.Compiler.Service" Version="14.0.2" /> -->
+    <!-- Reference FCS custom build and add it to package -->
+    <Reference Include="..\..\..\..\FSharp.Compiler.Service\fcs\FSharp.Compiler.Service.netstandard\bin\Release\netstandard1.6\FSharp.Compiler.Service.dll" />
+    <Content Include="..\..\..\..\FSharp.Compiler.Service\fcs\FSharp.Compiler.Service.netstandard\bin\Release\netstandard1.6\FSharp.Compiler.Service.dll"
+             PackagePath="lib\netstandard1.6\" />
     <PackageReference Include="FSharp.Core" Version="4.2.3" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />

--- a/src/dotnet/Fable.Compiler/Fable.Compiler.fsproj
+++ b/src/dotnet/Fable.Compiler/Fable.Compiler.fsproj
@@ -15,11 +15,7 @@
     <Compile Include="State.fs" />
   </ItemGroup>
   <ItemGroup>
-    <!-- <PackageReference Include="FSharp.Compiler.Service" Version="14.0.2" /> -->
-    <!-- Reference FCS custom build and add it to package -->
-    <Reference Include="..\..\..\..\FSharp.Compiler.Service\fcs\FSharp.Compiler.Service.netstandard\bin\Release\netstandard1.6\FSharp.Compiler.Service.dll" />
-    <Content Include="..\..\..\..\FSharp.Compiler.Service\fcs\FSharp.Compiler.Service.netstandard\bin\Release\netstandard1.6\FSharp.Compiler.Service.dll"
-             PackagePath="lib\netstandard1.6\" />
+    <PackageReference Include="FSharp.Compiler.Service" Version="16.0.3" />
     <PackageReference Include="FSharp.Core" Version="4.2.3" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />

--- a/src/dotnet/Fable.Compiler/Fable2Babel.fs
+++ b/src/dotnet/Fable.Compiler/Fable2Babel.fs
@@ -1182,6 +1182,12 @@ module Compiler =
                             member __.DeclareMember(a,b,c,d,e,f,g) =
                                 declareRootModMember a b c d e f g }
                     transformModDecls com ctx helper None file.Declarations
+            let dependencies =
+                com.GetAllImports()
+                |> Seq.choose (fun i -> i.internalFile)
+                |> Seq.distinct
+                |> Seq.append (file.Dependencies)
+                |> Seq.toArray
             // Add imports
             com.GetAllImports()
             |> Seq.mapi (fun ident import ->
@@ -1217,6 +1223,6 @@ module Compiler =
                         :> ModuleDeclaration |> U2.Case2 |> Some))
             // Return the Babel file
             |> fun importDecls ->
-                 Program(file.SourcePath, file.Range, (Seq.toList importDecls)@rootDecls)
+                 Program(file.SourcePath, file.Range, (Seq.toList importDecls)@rootDecls, dependencies=dependencies)
         with
         | ex -> exn (sprintf "%s (%s)" ex.Message file.SourcePath, ex) |> raise

--- a/src/dotnet/Fable.Compiler/RELEASE_NOTES.md
+++ b/src/dotnet/Fable.Compiler/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### 1.3.0-beta-001
+
+* See dotnet-fable 1.3.0-beta-001 release notes
+
 ### 1.2.4
 
 * See dotnet-fable 1.2.4 release notes

--- a/src/dotnet/Fable.Compiler/State.fs
+++ b/src/dotnet/Fable.Compiler/State.fs
@@ -27,7 +27,8 @@ type PathRef =
     | FilePath of string
     | NonFilePath of string
 
-type Project(projectOptions: FSharpProjectOptions, checkedProject: FSharpCheckProjectResults, fableCore: PathRef, isWatchCompile: bool) =
+type Project(projectOptions: FSharpProjectOptions, implFiles: Map<string, FSharpImplementationFileContents>,
+             errors: FSharpErrorInfo array,  fableCore: PathRef, isWatchCompile: bool) =
     let timestamp = DateTime.Now
     let projectFile = Path.normalizePath projectOptions.ProjectFileName
     let entities = ConcurrentDictionary<string, Fable.Entity>()
@@ -37,13 +38,12 @@ type Project(projectOptions: FSharpProjectOptions, checkedProject: FSharpCheckPr
         |> Seq.map Path.normalizeFullPath
         |> Set
     let rootModules =
-        checkedProject.AssemblyContents.ImplementationFiles
-        |> Seq.map (fun file -> file.FileName, FSharp2Fable.Compiler.getRootModuleFullName file)
-        |> Map
+        implFiles |> Map.map (fun _ file -> FSharp2Fable.Compiler.getRootModuleFullName file)
     member __.TimeStamp = timestamp
     member __.FableCore = fableCore
     member __.IsWatchCompile = isWatchCompile
-    member __.CheckedProject = checkedProject
+    member __.ImplementationFiles = implFiles
+    member __.Errors = errors
     member __.ProjectOptions = projectOptions
     member __.ProjectFile = projectFile
     member __.NormalizedFilesSet = normalizedFiles

--- a/src/dotnet/Fable.Compiler/State.fs
+++ b/src/dotnet/Fable.Compiler/State.fs
@@ -34,11 +34,14 @@ type Project(projectOptions: FSharpProjectOptions, implFiles: Map<string, FSharp
     let entities = ConcurrentDictionary<string, Fable.Entity>()
     let inlineExprs = ConcurrentDictionary<string, InlineExpr>()
     let normalizedFiles =
-        projectOptions.SourceFiles
-        |> Seq.map Path.normalizeFullPath
-        |> Set
+        let dic = Dictionary()
+        for f in projectOptions.SourceFiles do
+            dic.Add(Path.normalizeFullPath f, false)
+        dic
     let rootModules =
-        implFiles |> Map.map (fun _ file -> FSharp2Fable.Compiler.getRootModuleFullName file)
+        implFiles
+        |> Map.filter (fun file _ -> not <| file.EndsWith("fsi"))
+        |> Map.map (fun _ file -> FSharp2Fable.Compiler.getRootModuleFullName file)
     member __.TimeStamp = timestamp
     member __.FableCore = fableCore
     member __.IsWatchCompile = isWatchCompile
@@ -46,7 +49,12 @@ type Project(projectOptions: FSharpProjectOptions, implFiles: Map<string, FSharp
     member __.Errors = errors
     member __.ProjectOptions = projectOptions
     member __.ProjectFile = projectFile
-    member __.NormalizedFilesSet = normalizedFiles
+    member __.ContainsFile(sourceFile) =
+        normalizedFiles.ContainsKey(sourceFile)
+    member __.IsCompiled(sourceFile) =
+        normalizedFiles.[sourceFile]
+    member __.MarkCompiled(sourceFile) =
+        normalizedFiles.[sourceFile] <- true
     interface ICompilerState with
         member this.ProjectFile = projectOptions.ProjectFileName
         member this.GetRootModule(fileName) =

--- a/src/dotnet/Fable.Compiler/Utils.fs
+++ b/src/dotnet/Fable.Compiler/Utils.fs
@@ -104,12 +104,12 @@ module Json =
         inherit JsonConverter()
         let typeCache = ConcurrentDictionary<Type,bool>()
         override x.CanConvert t =
-            typeCache.GetOrAdd(t, typeof<AST.Babel.Node>.IsAssignableFrom)
+            typeCache.GetOrAdd(t, fun t -> typeof<AST.Babel.Node>.GetTypeInfo().IsAssignableFrom(t))
         override x.ReadJson(reader, t, v, serializer) =
             failwith "Not implemented"
         override x.WriteJson(writer, v, serializer) =
             writer.WriteStartObject()
-            v.GetType().GetProperties()
+            v.GetType().GetTypeInfo().GetProperties()
             |> Seq.filter (fun p -> p.Name <> "loc")
             |> Seq.iter (fun p ->
                 writer.WritePropertyName(p.Name)

--- a/src/dotnet/Fable.Core/AST/AST.Fable.fs
+++ b/src/dotnet/Fable.Core/AST/AST.Fable.fs
@@ -162,11 +162,12 @@ type ExternalEntity =
         match x with ImportModule (fullName, _, _)
                    | GlobalModule fullName -> fullName
 
-type File(sourcePath, root, decls, ?usedVarNames) =
+type File(sourcePath, root, decls, ?usedVarNames, ?dependencies) =
     member x.SourcePath: string = sourcePath
     member x.Root: Entity = root
     member x.Declarations: Declaration list = decls
     member x.UsedVarNames: Set<string> = defaultArg usedVarNames Set.empty
+    member x.Dependencies: Set<string> = defaultArg dependencies Set.empty
     member x.Range =
         match decls with
         | [] -> SourceLocation.Empty

--- a/src/dotnet/Fable.Core/Fable.Core.fsproj
+++ b/src/dotnet/Fable.Core/Fable.Core.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.4</Version>
+    <Version>1.3.0-beta-001</Version>
     <TargetFramework>netstandard1.6</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/dotnet/Fable.Core/RELEASE_NOTES.md
+++ b/src/dotnet/Fable.Core/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### 1.3.0-beta-001
+
+* See dotnet-fable 1.3.0-beta-001 release notes
+
 ### 1.2.4
 
 * See dotnet-fable 1.2.4 release notes

--- a/src/dotnet/dotnet-fable/RELEASE_NOTES.md
+++ b/src/dotnet/dotnet-fable/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### 1.3.0-beta-001
+
+* Optimize watch compilations with `extra.optimizeWatch` option (see FSharp.Compiler.Service/issues/796)
+
 ### 1.2.4
 
 * Add `jsOptions` helper

--- a/src/dotnet/dotnet-fable/ToolsUtil.fs
+++ b/src/dotnet/dotnet-fable/ToolsUtil.fs
@@ -2,7 +2,7 @@ namespace Fable.CLI
 
 module Constants =
 
-  let [<Literal>] VERSION = "1.2.4"
+  let [<Literal>] VERSION = "1.3.0-beta-001"
   let [<Literal>] DEFAULT_PORT = 61225
 
 /// These values must be only set by the Main method

--- a/src/dotnet/dotnet-fable/dotnet-fable.fsproj
+++ b/src/dotnet/dotnet-fable/dotnet-fable.fsproj
@@ -24,6 +24,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="..\..\..\..\FSharp.Compiler.Service\fcs\FSharp.Compiler.Service.netstandard\bin\Release\netstandard1.6\FSharp.Compiler.Service.dll" />  
     <PackageReference Include="FSharp.Core" Version="4.2.3" />
     <PackageReference Include="Dotnet.ProjInfo" Version="0.7.4" />
   </ItemGroup>

--- a/src/dotnet/dotnet-fable/dotnet-fable.fsproj
+++ b/src/dotnet/dotnet-fable/dotnet-fable.fsproj
@@ -24,7 +24,6 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="..\..\..\..\FSharp.Compiler.Service\fcs\FSharp.Compiler.Service.netstandard\bin\Release\netstandard1.6\FSharp.Compiler.Service.dll" />  
     <PackageReference Include="FSharp.Core" Version="4.2.3" />
     <PackageReference Include="Dotnet.ProjInfo" Version="0.7.4" />
   </ItemGroup>

--- a/src/dotnet/dotnet-fable/dotnet-fable.fsproj
+++ b/src/dotnet/dotnet-fable/dotnet-fable.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.4</Version>
+    <Version>1.3.0-beta-001</Version>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.0</RuntimeFrameworkVersion>

--- a/src/js/fable-loader/RELEASE_NOTES.md
+++ b/src/js/fable-loader/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### 1.1.4
+
+* Add dependencies for files other than .fsproj
+
 ### 1.1.3
 
 * Don't add dependencies to Webpack by default

--- a/src/js/fable-loader/index.js
+++ b/src/js/fable-loader/index.js
@@ -70,9 +70,11 @@ var Loader = function(buffer) {
             try {
                 // Fable now returns all file projects as `.dependencies` for .fsproj
                 // If we add them to Webpack, .fsproj will be recompiled every time
-                // ensureArray(data.dependencies).forEach(path => {
-                //     this.addDependency(path)
-                // });
+                if (!msg.path.endsWith(".fsproj")) {
+                    ensureArray(data.dependencies).forEach(path => {
+                        this.addDependency(path)
+                    });
+                }
                 if (typeof data.logs === "object") {
                     var isErrored = false;
                     Object.keys(data.logs).forEach(key => {


### PR DESCRIPTION
This PR uses the new capabilities of FCS `ParseAndCheckFileInProject` to get the AST of single files and speed up watch compilations. [More info here](https://github.com/fsharp/FSharp.Compiler.Service/issues/796). It also detects the dependencies of each file (both for inlined expressions and JS imports) to make sure all necessary files are recompiled in a watch compilation.

The PR also updates fable-loader to detect file dependencies. Other JS clients (Rollup, splitter) will need similar modifications.