### PR TITLE
Enable nested options

### DIFF
--- a/src/dotnet/Fable.Compiler/Replacements.fs
+++ b/src/dotnet/Fable.Compiler/Replacements.fs
@@ -1279,7 +1279,7 @@ module AstPass =
             CoreLibCall("Array", Some "setSlice", false, args)
             |> makeCall i.range i.returnType |> Some
         | "typeTestGeneric", (None, [expr]) ->
-            makeTypeTest com i.range i.methodTypeArgs.Head expr |> Some
+            makeTypeTest com i.fileName i.range expr i.methodTypeArgs.Head |> Some
         | "createInstance", (None, _) ->
             let typRef, args = resolveTypeRef com i false i.methodTypeArgs.Head, []
             Fable.Apply (typRef, args, Fable.ApplyCons, i.returnType, i.range) |> Some

--- a/src/tools/QuickTest.fs
+++ b/src/tools/QuickTest.fs
@@ -28,3 +28,106 @@ let equal expected actual =
 
 // You'll have to run your test manually, sorry!
 // ``My Test``()
+
+let makeSome (x: 'a): 'a option =
+    Some x
+
+let ``Generic options work``() =
+    let x1 = makeSome ()
+    let x2 = makeSome None
+    let x3 = makeSome null |> makeSome
+    Option.isSome x1 |> equal true
+    Option.isNone x1 |> equal false
+    x1.IsSome |> equal true
+    x1.IsNone |> equal false
+    match x1 with Some _ -> true | None -> false
+    |> equal true
+    Option.isSome x2 |> equal true
+    Option.isNone x2 |> equal false
+    x2.IsSome |> equal true
+    x2.IsNone |> equal false
+    match x2 with
+    | Some(Some _) -> 0
+    | Some(None) -> 1
+    | None -> 2
+    |> equal 1
+    Option.isSome x3 |> equal true
+    Option.isNone x3 |> equal false
+    x3.IsSome |> equal true
+    x3.IsNone |> equal false
+    match x3 with
+    | None -> 0
+    | Some(None) -> 1
+    | Some(Some _) -> 2
+    |> equal 2
+
+let ``Nested options work``() =
+    let x1 = Some(Some 5)
+    let x2 = Some(Some ())
+    let x3 = Some(None)
+    Option.isSome x1 |> equal true
+    Option.isNone x1 |> equal false
+    x1.IsSome |> equal true
+    x1.IsNone |> equal false
+    match x1 with
+    | Some(Some 5) -> 0
+    | Some(Some _) -> 1
+    | Some(None) -> 2
+    | None -> 3
+    |> equal 0
+    Option.isSome x2 |> equal true
+    Option.isNone x2 |> equal false
+    x2.IsSome |> equal true
+    x2.IsNone |> equal false
+    match x2 with
+    | Some(None) -> 0
+    | Some(Some _) -> 1
+    | None -> 2
+    |> equal 1
+    Option.isSome x3 |> equal true
+    Option.isNone x3 |> equal false
+    x3.IsSome |> equal true
+    x3.IsNone |> equal false
+    match x3 with
+    | None -> 0
+    | Some(Some _) -> 1
+    | Some(None) -> 2
+    |> equal 2
+
+``Generic options work``()
+``Nested options work``()
+
+type Option2<'T> =
+    | Some2 of 'T
+    | None2
+
+module Option =
+    let apply x f =
+        match (x, f) with
+        | Some x, Some f -> Some (f x)
+        | _ -> None
+
+    let apply2 x f =
+        match (x, f) with
+        | Some2 x, Some2 f -> Some2 (f x)
+        | _ -> None2
+
+    module Operators =
+        let inline (<*>) m x = apply x m
+        let inline (<**>) m x = apply2 x m
+
+open Option.Operators
+
+[<Test>]
+let ``Option.apply (<*>) auto curried`` () =
+    let f x y = x + y
+    let r = Some f <*> Some 2 <*> Some 3
+    r |> equal (Some 5)
+
+let ``Option.apply (<**>) auto curried`` () =
+    let f x y = x + y
+    let r = Some2 f <**> Some2 2 <**> Some2 3
+    r |> equal (Some2 5)
+
+``Option.apply (<*>) auto curried`` ()
+``Option.apply (<**>) auto curried`` ()

--- a/tests/Main/ApplicativeTests.fs
+++ b/tests/Main/ApplicativeTests.fs
@@ -525,6 +525,9 @@ let ``Point-free style with multiple arguments works``() = // See #1041
 
 
 module CurriedApplicativeTests =
+    type Option2<'T> =
+        | Some2 of 'T
+        | None2
 
     module Option =
         let apply x f =
@@ -532,8 +535,14 @@ module CurriedApplicativeTests =
             | Some x, Some f -> Some (f x)
             | _ -> None
 
+        let apply2 x f =
+            match (x, f) with
+            | Some2 x, Some2 f -> Some2 (f x)
+            | _ -> None2
+
         module Operators =
             let inline (<*>) m x = apply x m
+            let inline (<**>) m x = apply2 x m
 
     open Option.Operators
 
@@ -548,6 +557,12 @@ module CurriedApplicativeTests =
         let f x y = x + y
         let r = Some f <*> Some 2 <*> Some 3
         r |> equal (Some 5)
+
+    [<Test>]
+    let ``Option.apply (<**>) auto curried`` () =
+        let f x y = x + y
+        let r = Some2 f <**> Some2 2 <**> Some2 3
+        r |> equal (Some2 5)
 
     [<Test>]
     let ``Option.apply (<*>) manually curried workaround`` () =

--- a/tests/Main/UnionTypeTests.fs
+++ b/tests/Main/UnionTypeTests.fs
@@ -397,7 +397,7 @@ let ``Calling Some with side-effects works``() =
     let mutable state = 0
     let f x = state <- x
     let fo = f 3 |> Some
-    
+
     state |> equal 3
 
 type OptTest = OptTest of int option
@@ -435,6 +435,73 @@ let ``Mixing refs and options works``() = // See #238
     setter (fun i -> res := i + 2)
     getter 5
     equal 7 !res
+
+let makeSome (x: 'a): 'a option =
+    Some x
+
+[<Test>]
+let ``Generic options work``() =
+    let x1 = makeSome ()
+    let x2 = makeSome None
+    let x3 = makeSome null |> makeSome
+    Option.isSome x1 |> equal true
+    Option.isNone x1 |> equal false
+    x1.IsSome |> equal true
+    x1.IsNone |> equal false
+    match x1 with Some _ -> true | None -> false
+    |> equal true
+    Option.isSome x2 |> equal true
+    Option.isNone x2 |> equal false
+    x2.IsSome |> equal true
+    x2.IsNone |> equal false
+    match x2 with
+    | Some(Some _) -> 0
+    | Some(None) -> 1
+    | None -> 2
+    |> equal 1
+    Option.isSome x3 |> equal true
+    Option.isNone x3 |> equal false
+    x3.IsSome |> equal true
+    x3.IsNone |> equal false
+    match x3 with
+    | None -> 0
+    | Some(None) -> 1
+    | Some(Some _) -> 2
+    |> equal 2
+
+[<Test>]
+let ``Nested options work``() =
+    let x1 = Some(Some 5)
+    let x2 = Some(Some ())
+    let x3 = Some(None)
+    Option.isSome x1 |> equal true
+    Option.isNone x1 |> equal false
+    x1.IsSome |> equal true
+    x1.IsNone |> equal false
+    match x1 with
+    | Some(Some 5) -> 0
+    | Some(Some _) -> 1
+    | Some(None) -> 2
+    | None -> 3
+    |> equal 0
+    Option.isSome x2 |> equal true
+    Option.isNone x2 |> equal false
+    x2.IsSome |> equal true
+    x2.IsNone |> equal false
+    match x2 with
+    | Some(None) -> 0
+    | Some(Some _) -> 1
+    | None -> 2
+    |> equal 1
+    Option.isSome x3 |> equal true
+    Option.isNone x3 |> equal false
+    x3.IsSome |> equal true
+    x3.IsNone |> equal false
+    match x3 with
+    | None -> 0
+    | Some(Some _) -> 1
+    | Some(None) -> 2
+    |> equal 2
 
 type MyExUnion = MyExUnionCase of exn
 


### PR DESCRIPTION
This PR adds a new JS runtime type `Some`, to represent `Some` options that are sometimes interpreted as `None` by Fable, mainly nested options but also unit options or options from unknown types.

With this we have now a mixed of erased options and cases where options have a runtime representation (only for the `Some` case), let's see how it works :wink: