### PR TITLE
Fix #1185: Importing functions via importMember

### DIFF
--- a/src/dotnet/Fable.Compiler/FSharp2Fable.fs
+++ b/src/dotnet/Fable.Compiler/FSharp2Fable.fs
@@ -1108,7 +1108,11 @@ let private addMethodToDeclInfo com ctx (declInfo: DeclInfo) range import meth a
                 // When a member returns a function, there are issues with the uncurrying
                 // optimization when calling & applying at once (See #1041, #1154)
                 if isBodyMultiArgFunction then
-                    let body = transformExpr com ctx body
+                    let body =
+                        match transformExpr com ctx body with
+                        | Fable.Value (Fable.ImportRef (Naming.placeholder, path, importKind)) ->
+                            Fable.Value (Fable.ImportRef (meth.DisplayName, path, importKind))
+                        | body -> body
                     let body = makeDynamicCurriedLambda body.Range body.Type body
                     getMemberKind meth, args, extraArgs, body
                 else

--- a/tests/Main/ImportTests.fs
+++ b/tests/Main/ImportTests.fs
@@ -138,6 +138,17 @@ let ``Only omitted optional arguments are removed``() = // See #231, #640
     x.Foo1(5,"3") |> equal 2
     x.Foo2(5,Some "3") |> equal 2
     x.Foo3(5, "3") |> equal 2
+
+let square : int -> int = JsInterop.importMember "./js/foo.js"
+[<Test>]
+let ``Importing curried functions via `importMember` without naming arguments works`` () = // See #1185
+    square 2 |> equal 4
+
+let add : int -> int -> int = JsInterop.importMember "./js/foo.js"
+[<Test>]
+let ``Importing curried functions with multiple arguments via `importMember` without naming arguments works`` () =
+    add 40 2 |> equal 42
+
 #endif
 
 [<Test>]

--- a/tests/Main/js/foo.js
+++ b/tests/Main/js/foo.js
@@ -8,6 +8,14 @@ module.exports = {
         return f(x, y);
     },
 
+    square: function(x) {
+        return x * x;
+    },
+
+    add: function(x, y) {
+        return x + y;
+    },
+
     MyClass: class {
         constructor(v) {
             this.__value = typeof v === "string" ? v : "haha";


### PR DESCRIPTION
References #1185.

It works now, but I'm not sure if `CurriedLambda` should be used in this case.

BTW, @alfonsogarciacaro, how do you debug/step through the .NET side of Fable? I can't set breakpoints with VS Code in the Fable.Compiler project, not on my Mac and not on my Windows workstation at work. I already tried setting the `DebugType` property to `portable` and building with the `Debug` configuration, but that didn't work.