### PR TITLE
Fixes #838 Return empty group values when group is not matched

### DIFF
--- a/src/dotnet/Fable.Compiler/Replacements.fs
+++ b/src/dotnet/Fable.Compiler/Replacements.fs
@@ -1259,7 +1259,11 @@ module AstPass =
                  |> addErrorAndReturnNull com i.fileName i.range |> Some
         | "value" ->
             if isGroup
-            then i.callee.Value |> wrap i.returnType |> Some
+            then 
+                i.callee.Value 
+                |> wrap i.returnType
+                |> fun value -> emit i "($0 || \"\")" [value] 
+                |> Some
             else propInt 0 i.callee.Value |> Some
         | "length" ->
             if isGroup

--- a/tests/Main/RegexTests.fs
+++ b/tests/Main/RegexTests.fs
@@ -261,3 +261,12 @@ let ``Regex.Replace with evaluator, limit and offset works``() =
 let ``Replacing with $0 works``() = // See #1155
     let s = Regex.Replace("1234567890", ".{2}", "$0-")
     equal "12-34-56-78-90-" s
+
+// See #838
+[<Test>]
+let ``Group values are correct and empty when not being matched``() = 
+    Regex.Matches("\n\n\n", @"(?:([^\n\r]+)|\r\n|\n\r|\n|\r)") 
+    |> Seq.cast<Match> 
+    |> Seq.map (fun m -> m.Groups.[1].Value)
+    |> Seq.forall (fun value -> value = "")
+    |> equal true 


### PR DESCRIPTION
According to #838, group values can be undefined which is not correct because they should always be strings. This PR adds a guard for such values and returns `(value || "")` instead of just `value`. 