### PR TITLE
Fix optional tuple in record raise errors for jsonConverter

### DIFF
--- a/src/dotnet/Fable.JsonConverter/Fable.JsonConverter.fs
+++ b/src/dotnet/Fable.JsonConverter/Fable.JsonConverter.fs
@@ -237,6 +237,7 @@ type JsonConverter() =
             | JsonToken.StartArray ->
                 let values = readElements(reader, FSharpType.GetTupleElements(t), serializer)
                 FSharpValue.MakeTuple(values |> List.toArray, t)
+            | JsonToken.Null -> null // {"tuple": null}
             | _ -> failwith "invalid token"
         | true, Kind.PojoDU ->
             let dic = serializer.Deserialize(reader, typeof<Dictionary<string,obj>>) :?> Dictionary<string,obj>

--- a/tests/Main/JsonTests.fs
+++ b/tests/Main/JsonTests.fs
@@ -266,6 +266,23 @@ let ``Tuple`` () =
     let result : TupleJson = ofJson json
     result.a = (1, 2) |> equal true
 
+
+type OptionalTuple =
+    { tuple: (string * string) option }
+
+[<Test>]
+let ``Optional Tuple in records`` () =
+
+    let json1 = """ { "tuple": ["a", "b"] } """
+    let result1 : OptionalTuple = ofJson json1
+    let json2 = """ { "tuple": null } """
+    let result2 : OptionalTuple = ofJson json2
+    match result1.tuple, result2.tuple with
+    | Some v, None -> v
+    | _ -> ("", "")
+    |> equal ("a", "b")
+
+
 type TupleComplexJson =
     { a: int * Child }
 


### PR DESCRIPTION
I got `invalid token` error when trying to deserialize optional tuple in records.

e.g.
```json
{"name":null,"id":null,"range":null}
``` 
to 
```F#
type LocationQuery = {
    name: string option
    id: int64 option
    // (minLongitude, minLatitude), (maxLongitude, maxLatitude)
    range: ((double * double) * (double * double)) option
}
```
Then I found this related PR: https://github.com/fable-compiler/Fable/pull/506 , looks it didn't fix optional tuple case.

