### PR TITLE
Fix option Some wrapper in toJson

### DIFF
--- a/src/js/fable-core/Serialize.ts
+++ b/src/js/fable-core/Serialize.ts
@@ -5,6 +5,7 @@ import List from "./List";
 import { ofArray as listOfArray } from "./List";
 import { create as mapCreate } from "./Map";
 import FableMap from "./Map";
+import { getValue, Some } from "./Option";
 import { getTypeFullName, resolveGeneric } from "./Reflection";
 import { fold } from "./Seq";
 import FableSet from "./Set";
@@ -38,6 +39,8 @@ export function deflate(v: any): any {
         o[stringKeys ? kv[0] : toJson(kv[0])] = deflateValue(kv[1]);
         return o;
       }, {}, v);
+    } else if (v instanceof Some) {
+      return deflateValue(getValue(v, true));
     }
     const reflectionInfo = typeof v[FableSymbol.reflection] === "function" ? v[FableSymbol.reflection]() : {};
     if (reflectionInfo.properties) {

--- a/tests/Main/JsonTests.fs
+++ b/tests/Main/JsonTests.fs
@@ -251,8 +251,8 @@ let ``Option Wrapped Some`` () =
     let a = createSome 1
     let json1 = toJson <| { a=a }
     equal (json1.Replace(" ", "")) """{"a":1}"""
-    let result1 : int option = ofJson json1
-    match result1 with
+    let result1 : OptionJson = ofJson json1
+    match result1.a with
     | Some v -> v
     | _ -> -1
     |> equal 1

--- a/tests/Main/JsonTests.fs
+++ b/tests/Main/JsonTests.fs
@@ -245,6 +245,18 @@ let ``Option Some`` () =
     | _ -> -1
     |> equal 1
 
+[<Test>]
+let ``Option Wrapped Some`` () =
+    let createSome (a: 'T) = Some a
+    let a = createSome 1
+    let json1 = toJson <| { a=a }
+    equal (json1.Replace(" ", "")) """{"a":1}"""
+    let result1 : int option = ofJson json1
+    match result1 with
+    | Some v -> v
+    | _ -> -1
+    |> equal 1
+
 type ComplexOptionJson =
     { a: Child option }
 


### PR DESCRIPTION
`Some` wrapper would break json deserialization in Fable/JsonConverter, see: [repl](http://fable.io/repl/#?code=%0A%0Aopen%20Fable.Core%0Aopen%20Fable.Core.JsInterop%0A%0Alet%20toOpt%20(a%3A%20'T)%20%3D%20%0A%20%20%20Some%20a%0A%0A%0Alet%20json%20%3D%20toJson%20(toOpt%201)%0Aprintfn%20%22json%3A%20%25A%22%20json%0A%0Alet%20a%3A%20int%20option%20%3D%20ofJson%20json%0A%0Aprintfn%20%22a%3A%20%25A%22%20a%0A)

