### PR TITLE
Fix Enum.HasFlag

### DIFF
--- a/src/dotnet/Fable.Compiler/Replacements.fs
+++ b/src/dotnet/Fable.Compiler/Replacements.fs
@@ -2225,15 +2225,15 @@ module AstPass =
             asyncMeth "catchAsync" info.args
         | _ -> None
 
-    let enums (com: ICompiler) (appInfo: Fable.ApplyInfo) = 
+    let enums (com: ICompiler) (appInfo: Fable.ApplyInfo) =
         match appInfo.callee, appInfo.methodName, appInfo.args with
-        | Some callee, "hasFlag", [arg] -> 
-            // x.HasFlags(y) => (int x) ||| (int y) <> 0 
-            makeBinOp appInfo.range (Fable.Number Int32) [callee; arg] BinaryOrBitwise
+        | Some callee, "hasFlag", [arg] ->
+            // x.HasFlags(y) => (int x) &&& (int y) <> 0
+            makeBinOp appInfo.range (Fable.Number Int32) [callee; arg] BinaryAndBitwise
             |> fun bitwise -> makeEqOp appInfo.range [bitwise; makeIntConst 0] BinaryUnequal
             |> Some
         | _ -> None
-    
+
     let bigint (com: ICompiler) (i: Fable.ApplyInfo) =
         match i.callee, i.methodName with
         | Some callee, meth -> icall i meth |> Some
@@ -2317,7 +2317,7 @@ module AstPass =
         | "System.Object" -> objects com info
         | "System.Timers.ElapsedEventArgs" -> info.callee // only signalTime is available here
         | "System.Char" -> chars com info
-        | "System.Enum" -> enums com info 
+        | "System.Enum" -> enums com info
         | "System.String"
         | "Microsoft.FSharp.Core.StringModule" -> strings com info
         | "Microsoft.FSharp.Core.PrintfModule"

--- a/tests/Main/EnumTests.fs
+++ b/tests/Main/EnumTests.fs
@@ -9,13 +9,15 @@ open Fable.Tests.Util
 type Fruits =
 | Apple = 1
 | Banana = 2
-| Coconut = 3
+| Coconut = 4
 
 
 [<Test>]
-let ``Enum.HasFlag works``() = 
-    let value = Fruits.Apple
+let ``Enum.HasFlag works``() =
+    let value = Fruits.Apple ||| Fruits.Banana
     equal true (value.HasFlag Fruits.Apple)
+    equal true (value.HasFlag Fruits.Banana)
+    equal false (value.HasFlag Fruits.Coconut)
 
 [<Test>]
 let ``Enum operator = works``() =
@@ -111,13 +113,13 @@ let ``Enum operator >= works``() =
 let ``EnumOfValue works``() =
     EnumOfValue 1 |> equal Fruits.Apple
     EnumOfValue 2 |> equal Fruits.Banana
-    EnumOfValue 3 |> equal Fruits.Coconut
+    EnumOfValue 4 |> equal Fruits.Coconut
 
 [<Test>]
 let ``Enum operator enum works``() =
     enum 1 |> equal Fruits.Apple
     enum 2 |> equal Fruits.Banana
-    enum 3 |> equal Fruits.Coconut
+    enum 4 |> equal Fruits.Coconut
 
 open LanguagePrimitives
 


### PR DESCRIPTION
see: [repl](http://fable.io/repl/#?code=%0A%0Aopen%20Fable.Core%0Aopen%20Fable.Import%0Aopen%20Fable.Core.JsInterop%0A%0Atype%20Enum%20%3D%0A%7C%20None%20%3D%200%0A%7C%20A%20%3D%201%0A%7C%20B%20%3D%202%0A%7C%20C%20%3D%204%0A%7C%20D%20%3D%208%0A%0Alet%20hasFlag%20(x%3A%20Enum)%20(y%3A%20Enum)%20%3D%0A%20%20%20%20(x%20%7C%7C%7C%20y)%20%3C%3E%20Enum.None%0A%0A%0Alet%20hasFlag2%20x%20y%20%3D%0A%20%20%20%20(x%20%26%26%26%20y)%20%3C%3E%20Enum.None%0A%0A%0AhasFlag%20(Enum.A%20%7C%7C%7C%20Enum.B)%20Enum.C%20%7C%3E%20printfn%20%22hasFlag%3A%20%25A%22%0AhasFlag%20(Enum.A%20%7C%7C%7C%20Enum.B)%20Enum.A%20%7C%3E%20printfn%20%22hasFlag%3A%20%25A%22%0AhasFlag2%20(Enum.A%20%7C%7C%7C%20Enum.B)%20Enum.C%20%7C%3E%20printfn%20%22hasFlag%3A%20%25A%22%0AhasFlag2%20(Enum.A%20%7C%7C%7C%20Enum.B)%20Enum.A%20%7C%3E%20printfn%20%22hasFlag%3A%20%25A%22)