### PR TITLE
More test cases for applicatives, doesn't compile with Fable

### DIFF
--- a/tests/Main/ApplicativeTests.fs
+++ b/tests/Main/ApplicativeTests.fs
@@ -113,15 +113,6 @@ let ``Infix applicative with even more inline functions can be generated``() =
     | Ok addOne -> equal 2 (addOne 1)
     | _ -> failwith "expected Ok(addOne) where addOne(1) = 2"
 
-
-[<Test>]
-let ``Infix applicative with inline functions as operators can be generated``() =
-    let r = Ok (fun x -> x + 1)
-    let a = Ok (|>)
-    match applyInline a r with
-    | Ok addOne -> equal 2 (addOne 1)
-    | _ -> failwith "expected Ok(addOne) where addOne(1) = 2"
-
 type Foo1(i) =
     member x.Foo() = i
     member x.Foo(j) = i + j

--- a/tests/Main/ApplicativeTests.fs
+++ b/tests/Main/ApplicativeTests.fs
@@ -82,10 +82,9 @@ type Result<'s, 'f> =
 let ``Infix applicative can be generated``() =
     let r = Ok 1
     let a = Ok string
-    let r' = match a <*> r with
-             | Ok x -> x
-             | _ -> failwith "expected Ok"
-    equal "1" r'
+    match a <*> r with
+    | Ok x -> equal "1" x
+    | _ -> failwith "expected Ok('1')"
 
 let inline applyInline (a:'a) (b:'b) =
     a <*> b
@@ -94,10 +93,25 @@ let inline applyInline (a:'a) (b:'b) =
 let ``Infix applicative with inline functions can be generated``() =
     let r = Ok 1
     let a = Ok string
-    let r' = match applyInline a r with
-             | Ok x -> x
-             | _ -> failwith "expected Ok"
-    equal "1" r'
+    match applyInline a r with
+    | Ok x -> equal "1" x
+    | _ -> failwith "expected Ok('1')"
+
+[<Test>]
+let ``Infix applicative with inline composed functions can be generated``() =
+    let r = Ok 1
+    let a = Ok (string >> int)
+    match applyInline a r with
+    | Ok x -> equal 1 x
+    | _ -> failwith "expected Ok(1)"
+
+[<Test>]
+let ``Infix applicative with inline even more functions can be generated``() =
+    let r = Ok (fun x -> x + 1)
+    let a = Ok (fun f x -> f x)
+    match applyInline a r with
+    | Ok f -> equal 2 (f 1)
+    | _ -> failwith "expected Ok(f(1)) = 2"
 
 type Foo1(i) =
     member x.Foo() = i

--- a/tests/Main/ApplicativeTests.fs
+++ b/tests/Main/ApplicativeTests.fs
@@ -106,12 +106,21 @@ let ``Infix applicative with inline composed functions can be generated``() =
     | _ -> failwith "expected Ok(1)"
 
 [<Test>]
-let ``Infix applicative with inline even more functions can be generated``() =
+let ``Infix applicative with even more inline functions can be generated``() =
     let r = Ok (fun x -> x + 1)
     let a = Ok (fun f x -> f x)
     match applyInline a r with
-    | Ok f -> equal 2 (f 1)
-    | _ -> failwith "expected Ok(f(1)) = 2"
+    | Ok addOne -> equal 2 (addOne 1)
+    | _ -> failwith "expected Ok(addOne) where addOne(1) = 2"
+
+
+[<Test>]
+let ``Infix applicative with inline functions as operators can be generated``() =
+    let r = Ok (fun x -> x + 1)
+    let a = Ok (|>)
+    match applyInline a r with
+    | Ok addOne -> equal 2 (addOne 1)
+    | _ -> failwith "expected Ok(addOne) where addOne(1) = 2"
 
 type Foo1(i) =
     member x.Foo() = i


### PR DESCRIPTION
Given the provided test cases, Fable cannot compile the test project giving:
```
ERROR in ./tests/Main/ApplicativeTests.fs
/home/zaid-ajaj/github/fable/tests/Main/ApplicativeTests.fs(90,6): (90,9) error FABLE: Cannot resolve trait call op_LessMultiplyGreater
 @ ./tests/Main/Main.fs 2:0-31
 @ ./tests/Main/Fable.Tests.fsproj
```
While it compiled fine in and passed the tests .Net ~~(but didn't run due to some json conversion error)~~ 

Maybe it is just my local machine, let us see what the CI servers have to say about it :smile: