### PR TITLE
Optimize assignment blocks as expressions

### DIFF
--- a/src/dotnet/Fable.Compiler/FSharp2Fable.Util.fs
+++ b/src/dotnet/Fable.Compiler/FSharp2Fable.Util.fs
@@ -1339,7 +1339,7 @@ module Util =
                     if refCount > 1 && hasDoubleEvalRisk arg then
                         let tmpVar = com.GetUniqueVar() |> makeIdent
                         let tmpVarExp = Fable.Value(Fable.IdentValue tmpVar)
-                        let assign = Fable.VarDeclaration(tmpVar, arg, false)
+                        let assign = Fable.VarDeclaration(tmpVar, arg, false, None)
                         let ctx = { ctx with scope = (Some argIdent, tmpVarExp)::ctx.scope }
                         let ctx = if idx = 0 then addCallee ctx callee (Some tmpVarExp) else ctx
                         ctx, (assign::assignments), (idx + 1)

--- a/src/dotnet/Fable.Core/AST/AST.Fable.Util.fs
+++ b/src/dotnet/Fable.Core/AST/AST.Fable.Util.fs
@@ -566,12 +566,6 @@ let rec ensureArity com argTypes args =
         | _ -> arg)
 
 and makeApply com range typ callee (args: Expr list) =
-    let callee =
-        match callee with
-        // If we're applying against a F# let binding, wrap it with a lambda
-        | MaybeWrapped(Sequential _) ->
-            Apply(Value(Lambda([],callee,LambdaInfo(true))), [], ApplyMeth, callee.Type, callee.Range)
-        | _ -> callee
     match callee with
     // Dynamic CurriedLambda shouldn't be wrapped, see #996
     | MaybeWrapped(CurriedLambda _) -> Apply(callee, args, ApplyMeth, typ, range)

--- a/tests/Main/MiscTests.fs
+++ b/tests/Main/MiscTests.fs
@@ -6,6 +6,11 @@ open Util.Testing
 open Fable.Tests.Util
 
 [<Test>]
+let ``Assignment block as expression is optimized``() =
+    A.C.Helper.Add5(let mutable x = 2 in let mutable y = 3 in x + y)
+    |> equal 10
+
+[<Test>]
 let ``for .. downto works``() = // See #411
     let mutable x = ""
     for i = 1 to 5 do

--- a/tests/Main/Util/Util.fs
+++ b/tests/Main/Util/Util.fs
@@ -60,6 +60,10 @@ let rec sumFirstList (zs: float list) (n: int): float =
    | _ -> zs.Head + sumFirstList zs.Tail (n-1)
 
 let f2 a b = a + b
+
+// Assignment block as expression outside a function is NOT optimized
+f2(let mutable x = 5 in let mutable y = 6 in x + y) |> ignore
+
 let mutable a = 10
 
 module B =


### PR DESCRIPTION
Optimize assignment blocks (let bindings or value assignments) into JS expressions to avoid generating an extra closure. The sample below looks contrived (I added `mutable` to avoid the bindings being optimized away)  but it happens a lot with the extra bindings automatically generated by the F# compiler. The statements are converted to comma-separated JS sequence expression and the variable declarations are moved to the top of the function.

```fsharp
let foo x = printfn "Foo %i" x

let test() =
    foo(let mutable x = 2 in let mutable y = 3 in x + y)
```

Before:

```js
export function test() {
  foo((() => {
    let x = 2;
    let y = 3;
    return x + y | 0;
  })());
}
```

After:

```js
function test() {
    var y;
    var x;
    foo(x = 2, y = 3, x + y);
}
```