### PR TITLE
Add List.CompareTo

### DIFF
--- a/src/dotnet/Fable.Compiler/Replacements.fs
+++ b/src/dotnet/Fable.Compiler/Replacements.fs
@@ -1964,6 +1964,7 @@ module AstPass =
                 | Some instance -> 
                     match i.methodName with
                     | "equals" -> icall "Equals" (instance, i.args)
+                    | "compareTo" -> icall "CompareTo" (instance, i.args)
                     | "getHashCode" -> (* TODO *) None
                     | _ -> None
                 | _ -> None


### PR DESCRIPTION
Without tests because the method seems to be hidden by the compiler