### PR TITLE
Make Double.Parse and Single.Parse compile with IFormatProvider

### DIFF
--- a/src/dotnet/Fable.Compiler/Replacements.fs
+++ b/src/dotnet/Fable.Compiler/Replacements.fs
@@ -1149,8 +1149,6 @@ module AstPass =
             // just ignore the second args (IFormatProvider) and compile 
             // to System.Double.Parse(string)
             | "parse", [str; _ ] ->
-                "The value of IFormatProvider passed to the Parse function will be ignored"
-                |> addWarning com i.fileName i.range
                 CoreLibCall (numberModule, Some "parse", false,
                     [str; (if isFloat then makeNumConst 10.0 else makeIntConst 10)])
                 |> makeCall i.range i.returnType |> Some
@@ -2261,8 +2259,7 @@ module AstPass =
     let globalization com (i: Fable.ApplyInfo) = 
         match i.methodName with 
         | "invariantCulture" -> 
-            "System.Globalization namespace is not supported by Fable. The value InvariantCulture will be compiled to {} (empty object literal)"
-            |> addWarning com i.fileName i.range 
+            // System.Globalization namespace is not supported by Fable. The value InvariantCulture will be compiled to an empty object literal
             makeJsObject i.range [] |> Some
         | _ -> None
 

--- a/src/dotnet/Fable.Compiler/Replacements.fs
+++ b/src/dotnet/Fable.Compiler/Replacements.fs
@@ -1141,7 +1141,19 @@ module AstPass =
                 CoreLibCall (numberModule, Some "parse", false,
                     [str; (if isFloat then makeNumConst 16.0 else makeIntConst 16)])
                 |> makeCall i.range i.returnType |> Some
-
+            // System.Double.Parse(string, NumberStyle) 
+            | "parse", [inputString; Fable.Wrapped(numberStyleValue, Fable.Enum _)] -> 
+                (* Todo *)
+                None 
+            // System.Double.Parse(string, IFormatProvider)
+            // just ignore the second args (IFormatProvider) and compile 
+            // to System.Double.Parse(string)
+            | "parse", [str; _ ] ->
+                "The value of IFormatProvider passed to the Parse function will be ignored"
+                |> addWarning com i.fileName i.range
+                CoreLibCall (numberModule, Some "parse", false,
+                    [str; (if isFloat then makeNumConst 10.0 else makeIntConst 10)])
+                |> makeCall i.range i.returnType |> Some
             | "tryParse", [str; defValue] ->
                 CoreLibCall (numberModule, Some "tryParse", false,
                     [str; (if isFloat then makeNumConst 10.0 else makeIntConst 10); defValue])
@@ -2243,6 +2255,17 @@ module AstPass =
             |> Some
         | _ -> None
 
+    // Initial support, making at least InvariantCulture compile-able
+    // to be used System.Double.Parse and System.Single.Parse
+    // see https://github.com/fable-compiler/Fable/pull/1197#issuecomment-348034660
+    let globalization com (i: Fable.ApplyInfo) = 
+        match i.methodName with 
+        | "invariantCulture" -> 
+            "System.Globalization namespace is not supported by Fable. The value InvariantCulture will be compiled to {} (empty object literal)"
+            |> addWarning com i.fileName i.range 
+            makeJsObject i.range [] |> Some
+        | _ -> None
+
     let bigint (com: ICompiler) (i: Fable.ApplyInfo) =
         match i.callee, i.methodName with
         | Some callee, meth -> icall i meth |> Some
@@ -2344,6 +2367,7 @@ module AstPass =
         | "System.DateTimeOffset" -> dates com info
         | "System.TimeSpan" -> timeSpans com info
         | "System.Environment" -> systemEnv com info
+        | "System.Globalization.CultureInfo" -> globalization com info
         | "System.Action" | "System.Func"
         | "Microsoft.FSharp.Core.FSharpFunc"
         | "Microsoft.FSharp.Core.OptimizedClosures.FSharpFunc" -> funcs com info

--- a/tests/Main/ArithmeticTests.fs
+++ b/tests/Main/ArithmeticTests.fs
@@ -229,6 +229,21 @@ let ``sqrt matches .net core implementation``() =
 
 
 [<Test>]
+let ``Double.Parse works with IFormatProvider``() = 
+    // culture compiles to { } for now and it is ignore on the call-site
+    let culture = Globalization.CultureInfo.InvariantCulture
+    let result = System.Double.Parse("10.5", culture)
+    equal(10.5, result)
+
+[<Test>]
+let ``Single.Parse works with IFormatProvider``() = 
+    // culture compiles to { } for now and it is ignore on the call-site
+    let culture = Globalization.CultureInfo.InvariantCulture
+    let result = System.Single.Parse("10.5", culture)
+    equal(10.5, float result)
+
+
+[<Test>]
 let ``acos works``() =
     acos 0.25 |> checkTo3dp 1318.
 


### PR DESCRIPTION
Addresses #1266 

According to @ncave's comment [here](https://github.com/fable-compiler/Fable/pull/1197#issuecomment-348034660) it seems that `System.Double.Parse` and `System.Single.Parse` cannot be compiled and because there is no replacement is to be found for `CultureInfo.InvariantCulture` I *assumed* that the underlying problem has to do with the `Parse` functions being called somewhere like this:

```
let result = Double.Parse(input, CultureInfo.InvariantCulture)
// or
let result = Single.Parse(input, CultureInfo.InvariantCulture)
```
Which is rather very common when parsing numbers

@ncave Can you check this to be sure?

This PR makes such code work. Fable does not yet support `CultureInfo` so the value `CultureInfo.InvariantCulture` is compiled to an empty object literal and it is ignored on call-site. 

I know this is kind of a hack so I added warnings where appropriate :smile: