### PR TITLE
Mangle property names clashing with interfaces

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -91,8 +91,8 @@ let nugetRestore baseDir () =
     run (baseDir </> "dotnet-fable") dotnetExePath "restore"
 
 let buildCLI baseDir isRelease () =
-    sprintf "publish -o %s -c %s -v n" cliBuildDir
-        (if isRelease then "Release" else "Debug")
+    sprintf "publish -o %s -c %s" cliBuildDir
+        (if isRelease then "Release -v n" else "Debug")
     |> run (baseDir </> "dotnet-fable") dotnetExePath
 
 let buildCoreJS () =
@@ -138,7 +138,7 @@ let quickTest() =
 
 Target "QuickTest" quickTest
 Target "QuickFableCompilerTest" (fun () ->
-    buildCLI "src/dotnet" true ()
+    buildCLI "src/dotnet" false ()
     quickTest ())
 Target "QuickFableCoreTest" (fun () ->
     buildCoreJS ()

--- a/src/dotnet/Fable.Compiler/Fable2Babel.fs
+++ b/src/dotnet/Fable.Compiler/Fable2Babel.fs
@@ -899,8 +899,8 @@ module Util =
                     match m.Kind with
                     | Fable.Constructor -> ClassConstructor, "constructor", Fable.InstanceLoc, None, body
                     | Fable.Method -> ClassFunction, m.OverloadName, m.Location, m.Computed, body
-                    | Fable.Getter | Fable.Field -> ClassGetter, m.Name, m.Location, m.Computed, body
-                    | Fable.Setter -> ClassSetter, m.Name, m.Location, m.Computed, body
+                    | Fable.Getter | Fable.Field -> ClassGetter, m.OverloadName, m.Location, m.Computed, body
+                    | Fable.Setter -> ClassSetter, m.OverloadName, m.Location, m.Computed, body
                 let isStatic = loc = Fable.StaticLoc
                 declareMethod range kind name args body m.GenericParameters m.HasRestParams isStatic computed
             | Fable.ActionDeclaration _


### PR DESCRIPTION
Related #546. Apparently the previous fix didn't cover properties