### PR TITLE
Fix `dotnet new fable` documentation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,7 +26,7 @@ dotnet new -i Fable.Template
 After that, if you type `dotnet new -h` you should see "fable" among the list of available templates. Let's call it to scaffold a Fable app:
 
 ```shell
-dotnet new fable -n FableApp
+dotnet new fable -n FableApp -lang F#
 cd FableApp
 ```
 


### PR DESCRIPTION
Apparently, 
```
dotnet new fable -n FableApp
```
command does not do anything when using dotnet 2.1.2 cli tools. I tried my best to figure out why it can't create a new project and finally succeed. It needs -lang parameter. So the command should be:
```
dotnet new fable -n FableApp -lang F#
```
Now it works and I finally managed to create a Fable sample app.