### PR TITLE
Support TimeSpan correctly in Fable.JsonConverter

### DIFF
--- a/src/dotnet/Fable.JsonConverter/Fable.JsonConverter.fs
+++ b/src/dotnet/Fable.JsonConverter/Fable.JsonConverter.fs
@@ -245,7 +245,7 @@ type JsonConverter() =
                 upcast DateTime.Parse(json)
         | true, Kind.TimeSpan ->
             match reader.Value with
-            | :? TimeSpan -> reader.Value // Avoid culture-sensitive string roundtrip for already parsed dates (see #613).
+            | :? TimeSpan -> reader.Value
             | _ ->
                 let json = serializer.Deserialize(reader, typeof<int>) :?> int
                 let ts = TimeSpan.FromMilliseconds (float json)


### PR DESCRIPTION
Not sure I could put tests for this since by itself, Fable handles TimeSpan correctly. The problem was using Fable.JsonConverter is not enough for TimeSpan. 