### PR TITLE
[EXPERIMENTAL] Compile records and unions as JS arrays

### DIFF
--- a/src/dotnet/Fable.Compiler/FSharp2Fable.Util.fs
+++ b/src/dotnet/Fable.Compiler/FSharp2Fable.Util.fs
@@ -112,7 +112,7 @@ module Helpers =
         atts |> Seq.tryPick (fun att ->
             match (nonAbbreviatedEntity att.AttributeType).TryFullName with
             | Some fullName ->
-                if f fullName then Some att else None
+                if f fullName then Some(att, fullName) else None
             | None -> None)
 
     let hasAtt name atts =
@@ -215,7 +215,7 @@ module Helpers =
         unionCase.Attributes
         |> tryFindAtt ((=) Atts.compiledName)
         |> function
-            | Some name -> name.ConstructorArguments.[0] |> snd |> string
+            | Some(name,_) -> name.ConstructorArguments.[0] |> snd |> string
             | None -> Naming.lowerFirst unionCase.DisplayName
         |> makeStrConst
 
@@ -703,7 +703,7 @@ module Patterns =
         | _ -> None
 
     let (|ContainsAtt|_|) (name: string) (atts: #seq<FSharpAttribute>) =
-        atts |> tryFindAtt ((=) name) |> Option.map (fun att ->
+        atts |> tryFindAtt ((=) name) |> Option.map (fun (att,_) ->
             att.ConstructorArguments |> Seq.map snd |> Seq.toList)
 
 module Types =
@@ -956,7 +956,7 @@ module Types =
                     uci.Attributes
                     |> tryFindAtt ((=) Atts.compiledName)
                     |> function
-                        | Some name -> name.ConstructorArguments.[0] |> snd |> string
+                        | Some(name,_) -> name.ConstructorArguments.[0] |> snd |> string
                         | None -> uci.Name
                 name, [for fi in uci.UnionCaseFields do yield makeType com [] fi.FieldType])
             |> Seq.toList

--- a/src/dotnet/Fable.Compiler/FSharp2Fable.Util.fs
+++ b/src/dotnet/Fable.Compiler/FSharp2Fable.Util.fs
@@ -74,6 +74,7 @@ module Atts =
     let global_ = typeof<Fable.Core.GlobalAttribute>.FullName
     let erase = typeof<Fable.Core.EraseAttribute>.FullName
     let pojo = typeof<Fable.Core.PojoAttribute>.FullName
+    let asArray = typeof<Fable.Core.CompileAsArrayAttribute>.FullName
     let stringEnum = typeof<Fable.Core.StringEnumAttribute>.FullName
     let passGenerics = typeof<Fable.Core.PassGenericsAttribute>.FullName
     let paramList = typeof<Fable.Core.ParamListAttribute>.FullName
@@ -109,7 +110,7 @@ module Helpers =
 
     let tryFindAtt f (atts: #seq<FSharpAttribute>) =
         atts |> Seq.tryPick (fun att ->
-            match att.AttributeType.TryFullName with
+            match (nonAbbreviatedEntity att.AttributeType).TryFullName with
             | Some fullName ->
                 if f fullName then Some att else None
             | None -> None)
@@ -621,7 +622,7 @@ module Patterns =
         | Naming.StartsWith "Microsoft.FSharp.Core.decimal" _ -> Some Decimal
         | _ -> None
 
-    let (|OptionUnion|ListUnion|ErasedUnion|StringEnum|PojoUnion|OtherType|) (NonAbbreviatedType typ: FSharpType) =
+    let (|OptionUnion|ListUnion|ErasedUnion|StringEnum|PojoUnion|ArrayUnion|OtherType|) (NonAbbreviatedType typ: FSharpType) =
         match tryDefinition typ with
         | None -> OtherType
         | Some tdef ->
@@ -630,11 +631,17 @@ module Patterns =
             | "Microsoft.FSharp.Collections.FSharpList`1" -> ListUnion
             | _ ->
                 tdef.Attributes
-                |> Seq.choose (fun att -> att.AttributeType.TryFullName)
+                |> Seq.choose (fun att -> (nonAbbreviatedEntity att.AttributeType).TryFullName)
                 |> Seq.tryPick (fun name ->
                     if name = Atts.erase then Some ErasedUnion
                     elif name = Atts.stringEnum then Some StringEnum
                     elif name = Atts.pojo then Some PojoUnion
+                    elif name = Atts.asArray then
+                        // Checks if any of the union cases has a data field
+                        let anyCaseWithData =
+                            tdef.UnionCases |> Seq.exists (fun uci ->
+                                uci.UnionCaseFields.Count > 0)
+                        Some (ArrayUnion anyCaseWithData)
                     else None)
                 |> defaultArg <| OtherType
 
@@ -668,7 +675,7 @@ module Patterns =
                     Some(matchValue,true,idx,bindings,case,elseExpr)
                 | None when not var.IsMemberThisValue && not(isInline var) ->
                     match typ with
-                    | OptionUnion | ListUnion | ErasedUnion | StringEnum | PojoUnion -> None
+                    | OptionUnion | ListUnion | ErasedUnion | StringEnum | PojoUnion | ArrayUnion _ -> None
                     | OtherType -> Some(var,true,idx,bindings,case,elseExpr)
                 | _ -> None
             | _ -> None
@@ -797,11 +804,11 @@ module Types =
         | _ ->
             // Check erased types
             tdef.Attributes
-            |> Seq.choose (fun att -> att.AttributeType.TryFullName)
+            |> Seq.choose (fun att -> (nonAbbreviatedEntity att.AttributeType).TryFullName)
             |> Seq.tryPick (fun name ->
                 if name = Atts.stringEnum
                 then Some Fable.String
-                elif name = Atts.erase || name = Atts.pojo
+                elif name = Atts.erase || name = Atts.pojo || name = Atts.asArray
                 then Some Fable.Any
                 else None)
             |> defaultArg <|

--- a/src/dotnet/Fable.Core/Fable.Core.fs
+++ b/src/dotnet/Fable.Core/Fable.Core.fs
@@ -48,6 +48,13 @@ type PassGenericsAttribute() =
 type PojoAttribute() =
     inherit Attribute()
 
+type CompileAsPojoAttribute = PojoAttribute
+
+/// EXPERIMENTAL: Compile records and unions as JS arrays
+[<AttributeUsage(AttributeTargets.Class)>]
+type CompileAsArrayAttribute() =
+    inherit Attribute()
+
 /// Compile union types as string literals.
 /// More info: http://fable.io/docs/interacting.html#StringEnum-attribute
 [<AttributeUsage(AttributeTargets.Class)>]

--- a/tests/Main/CompileAsArrayTests.fs
+++ b/tests/Main/CompileAsArrayTests.fs
@@ -87,3 +87,57 @@ let ``Union cases called Tag still work (bug due to Tag field)``() =
     | Tag x -> x
     | _ -> failwith "unexpected"
     |> equal "abc"
+
+[<CompileAsArray>]
+type RecursiveRecord =
+    { things : RecursiveRecord list }
+
+[<CompileAsArray>]
+type Person =
+    { name: string; mutable luckyNumber: int }
+
+[<Test>]
+let ``Recursive record does not cause issues``() =
+    let r = { things = [ { things = [] } ] }
+    equal r.things.Length 1
+
+[<Test>]
+let ``Record property access can be generated``() =
+    let x = { name = "Alfonso"; luckyNumber = 7 }
+    equal "Alfonso" x.name
+    equal 7 x.luckyNumber
+    x.luckyNumber <- 14
+    equal 14 x.luckyNumber
+    // Order of members in constructor shouldn't alter result
+    let x = { luckyNumber = 9; name = "Maxime" }
+    equal "Maxime" x.name
+    equal 9 x.luckyNumber
+    x.luckyNumber <- 12
+    equal 12 x.luckyNumber
+
+
+[<Test>]
+let ``Record expression constructors can be generated``() =
+    let x = { name = "Alfonso"; luckyNumber = 7 }
+    let y = { x with luckyNumber = 14 }
+    equal "Alfonso" y.name
+    equal 14 y.luckyNumber
+
+[<CompileAsArray>]
+type JSKiller =
+   { ``for`` : float; ``class`` : float }
+
+[<CompileAsArray>]
+type JSKiller2 =
+   { ``s p a c e`` : float; ``s*y*m*b*o*l`` : float }
+
+[<Test>]
+let ``Records with key/reserved words are mapped correctly``() =
+    let x = { ``for`` = 1.0; ``class`` = 2.0 }
+    equal 2. x.``class``
+
+[<Test>]
+let ``Records with special characters are mapped correctly``() =
+    let x = { ``s p a c e`` = 1.0; ``s*y*m*b*o*l`` = 2.0 }
+    equal 1. x.``s p a c e``
+    equal 2. x.``s*y*m*b*o*l``

--- a/tests/Main/CompileAsArrayTests.fs
+++ b/tests/Main/CompileAsArrayTests.fs
@@ -1,0 +1,89 @@
+[<Util.Testing.TestFixture>]
+module Fable.Tests.CompileAsArray
+
+open Fable.Core
+open Util.Testing
+open Fable.Tests.Util
+
+[<CompileAsArray>]
+type Gender = Male | Female
+
+[<Test>]
+let ``Union cases matches with no arguments can be generated``() =
+    let x = Male
+    match x with
+    | Female -> true
+    | Male -> false
+    |> equal false
+
+[<CompileAsArray>]
+type Either<'TL,'TR> =
+    | Left of 'TL
+    | Right of 'TR
+    // override x.ToString() =
+    //   match x with
+    //   | Left y -> y.ToString()
+    //   | Right y -> y.ToString()
+
+[<Test>]
+let ``Union cases matches with one argument can be generated``() =
+    let x = Left "abc"
+    match x with
+    | Left data -> data
+    | Right _ -> failwith "unexpected"
+    |> equal "abc"
+
+// [<Test>]
+// let ``Union methods can be generated``() =
+//     let x = Left 5
+//     x.ToString()
+//     |> equal "5"
+
+[<Test>]
+let ``Nested pattern matching works``() =
+    let x = Right(Left 5)
+    match x with
+    | Left _ -> failwith "unexpected"
+    | Right x ->
+        match x with
+        | Left x -> x
+        | Right _ -> failwith "unexpected"
+    |> equal 5
+
+[<CompileAsArray>]
+type TestUnion =
+   | Case0
+   | Case1 of string
+   | Case2 of string * string
+   | Case3 of string * string * string
+
+[<Test>]
+let ``Union cases matches with many arguments can be generated``() =
+    let x = Case3("a", "b", "c")
+    match x with
+    | Case3(a, b, c) -> a + b + c
+    | _ -> failwith "unexpected"
+    |> equal "abc"
+
+[<Test>]
+let ``Pattern matching with common targets works``() =
+    let x = Case2("a", "b")
+    match x with
+    | Case0 -> failwith "unexpected"
+    | Case1 _
+    | Case2 _ -> "a"
+    | Case3(a, b, c) -> a + b + c
+    |> equal "a"
+
+[<CompileAsArray>]
+type TestUnion2 =
+    | Tag of string
+    | NewTag of string
+
+[<Test>]
+let ``Union cases called Tag still work (bug due to Tag field)``() =
+    let x = Tag "abc"
+    match x with
+    | Tag x -> x
+    | _ -> failwith "unexpected"
+    |> equal "abc"

--- a/tests/Main/Fable.Tests.fsproj
+++ b/tests/Main/Fable.Tests.fsproj
@@ -48,6 +48,7 @@
     <Compile Include="TypeTests.fs" />
     <Compile Include="UnionTypeTests.fs" />
     <Compile Include="ElmishParserTests.fs" />
+    <Compile Include="CompileAsArrayTests.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This is an attempt to implement #1308 but with a `CompileAsArray` attribute. It can be used both for records and unions. Same as `Pojo`, the types are erased so no reflection, members, etc can be used. Things like JSON serialization haven't been implemented yet. Also note, single case unions have no special handling.