### PR TITLE
Display the status of the correct build in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### The compiler that emits JavaScript you can be proud of!
 
-[![Mono Build Status](https://travis-ci.org/fable-compiler/Fable.svg "Mono Build Status")](https://travis-ci.org/fable-compiler/Fable) [![.NET Build Status](https://ci.appveyor.com/api/projects/status/vlmyxg64my74sik5?svg=true ".NET Build Status")](https://ci.appveyor.com/project/alfonsogarciacaro/fable) [![NuGet Status](https://img.shields.io/nuget/v/Fable.Compiler.svg?style=flat)](https://www.nuget.org/packages/Fable.Compiler/) [![Join the chat at https://gitter.im/fable-compiler/Fable](https://badges.gitter.im/fable-compiler/Fable.svg)](https://gitter.im/fable-compiler/Fable?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Mono Build Status](https://travis-ci.org/fable-compiler/Fable.svg?branch=master "Mono Build Status")](https://travis-ci.org/fable-compiler/Fable) [![.NET Build Status](https://ci.appveyor.com/api/projects/status/vlmyxg64my74sik5/branch/master?svg=true ".NET Build Status")](https://ci.appveyor.com/project/alfonsogarciacaro/fable) [![NuGet Status](https://img.shields.io/nuget/v/Fable.Compiler.svg?style=flat)](https://www.nuget.org/packages/Fable.Compiler/) [![Join the chat at https://gitter.im/fable-compiler/Fable](https://badges.gitter.im/fable-compiler/Fable.svg)](https://gitter.im/fable-compiler/Fable?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 [RELEASE NOTES](https://github.com/fable-compiler/Fable/blob/master/src/dotnet/dotnet-fable/RELEASE_NOTES.md) · [Follow us on Twitter!](https://twitter.com/FableCompiler)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### The compiler that emits JavaScript you can be proud of!
 
-[![Mono Build Status](https://travis-ci.org/fable-compiler/Fable.svg?branch=master "Mono Build Status")](https://travis-ci.org/fable-compiler/Fable) [![.NET Build Status](https://ci.appveyor.com/api/projects/status/vlmyxg64my74sik5/branch/master?svg=true ".NET Build Status")](https://ci.appveyor.com/project/alfonsogarciacaro/fable) [![NuGet Status](https://img.shields.io/nuget/v/Fable.Compiler.svg?style=flat)](https://www.nuget.org/packages/Fable.Compiler/) [![Join the chat at https://gitter.im/fable-compiler/Fable](https://badges.gitter.im/fable-compiler/Fable.svg)](https://gitter.im/fable-compiler/Fable?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Mono Build Status](https://travis-ci.org/fable-compiler/Fable.svg?branch=master "Mono Build Status")](https://travis-ci.org/fable-compiler/Fable/branches) [![.NET Build Status](https://ci.appveyor.com/api/projects/status/vlmyxg64my74sik5/branch/master?svg=true ".NET Build Status")](https://ci.appveyor.com/project/alfonsogarciacaro/fable/branch/master) [![NuGet Status](https://img.shields.io/nuget/v/Fable.Compiler.svg?style=flat)](https://www.nuget.org/packages/Fable.Compiler/) [![Join the chat at https://gitter.im/fable-compiler/Fable](https://badges.gitter.im/fable-compiler/Fable.svg)](https://gitter.im/fable-compiler/Fable?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 [RELEASE NOTES](https://github.com/fable-compiler/Fable/blob/master/src/dotnet/dotnet-fable/RELEASE_NOTES.md) · [Follow us on Twitter!](https://twitter.com/FableCompiler)
 


### PR DESCRIPTION
I checked the readme and fable isn't in a good state: All builds are failing, windows linux :-(

Turns out it's false! It's only the configuration of the build badges that was taking the latest branch or PR and displaying that instead of master that was beautifully green...