### PR TITLE
Implement replacements for eprintf and friends

### DIFF
--- a/src/dotnet/Fable.Compiler/Replacements.fs
+++ b/src/dotnet/Fable.Compiler/Replacements.fs
@@ -779,6 +779,9 @@ module AstPass =
         | "printFormatLineToTextWriter" ->
             // addWarning com i.fileName i.range "fprintfn will behave as printfn"
             ccall i "String" "toConsole" i.args.Tail |> Some
+        | "printFormatToError"
+        | "printFormatLineToError" ->
+            ccall i "String" "toStdErr" i.args |> Some
         | "printFormat" ->
             // addWarning com i.fileName i.range "printf will behave as printfn"
             ccall i "String" "toConsole" i.args |> Some
@@ -931,6 +934,9 @@ module AstPass =
         | "printFormatThen"                 // Printf.kprintf
         | "printFormatToStringThenFail" ->  // Printf.failwithf
             fsFormat com info
+        | "printFormatToError"              // eprintf
+        | "printFormatLineToError" ->       // eprintfn
+            ccall info "String" "toStdErr" info.args |> Some
         // Exceptions
         | "raise" ->
             Fable.Throw (args.Head, typ, r) |> Some

--- a/src/dotnet/Fable.Compiler/Replacements.fs
+++ b/src/dotnet/Fable.Compiler/Replacements.fs
@@ -781,7 +781,7 @@ module AstPass =
             ccall i "String" "toConsole" i.args.Tail |> Some
         | "printFormatToError"
         | "printFormatLineToError" ->
-            ccall i "String" "toStdErr" i.args |> Some
+            ccall i "String" "toConsoleError" i.args |> Some
         | "printFormat" ->
             // addWarning com i.fileName i.range "printf will behave as printfn"
             ccall i "String" "toConsole" i.args |> Some
@@ -936,7 +936,7 @@ module AstPass =
             fsFormat com info
         | "printFormatToError"              // eprintf
         | "printFormatLineToError" ->       // eprintfn
-            ccall info "String" "toStdErr" info.args |> Some
+            ccall info "String" "toConsoleError" info.args |> Some
         // Exceptions
         | "raise" ->
             Fable.Throw (args.Head, typ, r) |> Some

--- a/src/js/fable-core/String.ts
+++ b/src/js/fable-core/String.ts
@@ -112,6 +112,10 @@ export function toConsole(arg: IPrintfFormat) {
   return arg.cont((x) => { console.log(x); });
 }
 
+export function toStdErr(arg: IPrintfFormat) {
+  return arg.cont((x) => { console.error(x); });
+}
+
 export function toText(arg: IPrintfFormat) {
   return arg.cont((x) => x);
 }

--- a/src/js/fable-core/String.ts
+++ b/src/js/fable-core/String.ts
@@ -112,7 +112,7 @@ export function toConsole(arg: IPrintfFormat) {
   return arg.cont(console.log);
 }
 
-export function toStdErr(arg: IPrintfFormat) {
+export function toConsoleError(arg: IPrintfFormat) {
   return arg.cont(console.error);
 }
 

--- a/src/js/fable-core/String.ts
+++ b/src/js/fable-core/String.ts
@@ -109,11 +109,11 @@ export function printf(input: string): IPrintfFormat {
 }
 
 export function toConsole(arg: IPrintfFormat) {
-  return arg.cont((x) => { console.log(x); });
+  return arg.cont(console.log);
 }
 
 export function toStdErr(arg: IPrintfFormat) {
-  return arg.cont((x) => { console.error(x); });
+  return arg.cont(console.error);
 }
 
 export function toText(arg: IPrintfFormat) {


### PR DESCRIPTION
Closes #1328.

I had to do this twice, because we have `eprintf` and `Printf.eprintf`.

Some questions:

1. How to test this?

    I tested it with `FableCompilerQuickTest` and it worked, but I guess actually printing to stderr would make the CI build fail. Maybe add a method which uses `eprintf` but omit the `Test` attribute?

2. Should we omit the lambda expression in the printing functions? In other words, do this change:

    ``` patch
     export function toConsole(arg: IPrintfFormat) {
    -   return arg.cont((x) => { console.log(x); });
    +   return arg.cont(console.log);
     }
    ```