### PR TITLE
Fix old links: 'typescript' -> 'js'

### DIFF
--- a/src/js/fable-splitter/package.json
+++ b/src/js/fable-splitter/package.json
@@ -8,8 +8,8 @@
   "bin": {
     "fable-splitter": "./cli.js"
   },
-  "homepage": "https://github.com/fable-compiler/Fable/tree/master/src/typescript/fable-splitter#readme",
-  "repository": "https://github.com/fable-compiler/Fable/tree/master/src/typescript/fable-splitter",
+  "homepage": "https://github.com/fable-compiler/Fable/tree/master/src/js/fable-splitter#readme",
+  "repository": "https://github.com/fable-compiler/Fable/tree/master/src/js/fable-splitter",
   "keywords": [
     "fable",
     "fsharp",

--- a/src/js/rollup-plugin-fable/package.json
+++ b/src/js/rollup-plugin-fable/package.json
@@ -22,7 +22,7 @@
   "bugs": {
     "url": "https://github.com/fable-compiler/Fable/issues"
   },
-  "homepage": "https://github.com/fable-compiler/Fable/tree/master/src/typescript/rollup-plugin-fable#readme",
+  "homepage": "https://github.com/fable-compiler/Fable/tree/master/src/js/rollup-plugin-fable#readme",
   "devDependencies": {
     "eslint": "3.19.0",
     "eslint-config-prettier": "1.7.0",


### PR DESCRIPTION
Was browsing the fable-splitter page on npm and noticed the homepage link went to a 404. Fixes the rollup-fable-plugin page too.