### PR TITLE
Fix sample in Rollup plugin README

### DIFF
--- a/src/js/rollup-plugin-fable/README.md
+++ b/src/js/rollup-plugin-fable/README.md
@@ -35,7 +35,7 @@ export default {
       // Other node-resolve options here
       // See https://github.com/rollup/rollup-plugin-node-resolve
       customResolveOptions: {
-          moduleDirectory: resolve('./node_modules')
+          paths: [resolve('./node_modules')]
       }
     })
   ],


### PR DESCRIPTION
The `moduleDirectory` is not meant to be used as a *path*, it's simply the *name* of the directory, which gets appended to the path of the imported file.

I use the `promise` CE builder from the PowerPack and Rollup (or the [`resolve` module](https://www.npmjs.com/package/resolve)) couldn't find the `babel-runtime/*` modules because it was looking in these directories:

```
[ 'C:\\Users\\nosikil\\.nuget\\packages\\fable.powerpack\\1.3.4\\fable\\src\\G:\\projects\\my-project\\node_modules',
  'C:\\Users\\nosikil\\.nuget\\packages\\fable.powerpack\\1.3.4\\fable\\G:\\projects\\my-project\\node_modules',
  'C:\\Users\\nosikil\\.nuget\\packages\\fable.powerpack\\1.3.4\\G:\\projects\\my-project\\node_modules',
  'C:\\Users\\nosikil\\.nuget\\packages\\fable.powerpack\\G:\\projects\\my-project\\node_modules',
  'C:\\Users\\nosikil\\.nuget\\packages\\G:\\projects\\my-project\\node_modules',
  'C:\\Users\\nosikil\\.nuget\\G:\\projects\\my-project\\node_modules',
  'C:\\Users\\nosikil\\G:\\projects\\my-project\\node_modules',
  'C:\\Users\\G:\\projects\\my-project\\node_modules',
  'C:\\G:\\projects\\my-project\\node_modules' ]
```

With `customResolveOptions.paths`, it looks in these:

```
[ 'C:\\Users\\nosikil\\.nuget\\packages\\fable.powerpack\\1.3.4\\fable\\src\\node_modules',
  'C:\\Users\\nosikil\\.nuget\\packages\\fable.powerpack\\1.3.4\\fable\\node_modules',
  'C:\\Users\\nosikil\\.nuget\\packages\\fable.powerpack\\1.3.4\\node_modules',
  'C:\\Users\\nosikil\\.nuget\\packages\\fable.powerpack\\node_modules',
  'C:\\Users\\nosikil\\.nuget\\packages\\node_modules',
  'C:\\Users\\nosikil\\.nuget\\node_modules',
  'C:\\Users\\nosikil\\node_modules',
  'C:\\Users\\node_modules',
  'C:\\node_modules',
  'G:\\projects\\my-project\\node_modules' ]
```