### PR TITLE
Fix expecto args order

### DIFF
--- a/tests/Main/Util/Util.fs
+++ b/tests/Main/Util/Util.fs
@@ -18,7 +18,7 @@ module Testing =
     let testCase msg test = testCase msg test
 
     let equal expected actual: unit =
-        Expect.equal expected actual ""
+        Expect.equal actual expected ""
     #endif
 
 (*


### PR DESCRIPTION
Expect.equal signature is:

```fs
val equal: 
   actual  : 'a     ->
   expected: 'a     ->
   message : string 
          -> unit
```