### PR TITLE
Pass more compiler options to FCS

### DIFF
--- a/src/dotnet/Fable.Compiler/CLI/ProjectCracker.fs
+++ b/src/dotnet/Fable.Compiler/CLI/ProjectCracker.fs
@@ -178,6 +178,13 @@ let private getFsprojName (fsprojFullPath: string) =
     let i = fsprojFullPath.LastIndexOf('/')
     fsprojFullPath.[(i + 1) .. (fsprojFullPath.Length - 8)]
 
+let private isUsefulOption (opt : string) =
+    [ "--define"; "-d"
+      "--nowarn"
+      "--warnon"
+      "--warnaserror" ]
+    |> List.exists opt.StartsWith
+
 /// Use Dotnet.ProjInfo (through ProjectCoreCracker) to invoke MSBuild
 /// and get F# compiler args from an .fsproj file. As we'll merge this
 /// later with other projects we'll only take the sources and the references,
@@ -200,8 +207,10 @@ let fullCrack (projFile: string): CrackedFsproj =
                 let dllName = getDllName line
                 dllRefs.Add(dllName, line)
                 src, otherOpts
-            elif line.StartsWith("-") then
+            elif isUsefulOption line then
                 src, line::otherOpts
+            elif line.StartsWith("-") then
+                src, otherOpts
             else
                 (Path.normalizeFullPath line)::src, otherOpts)
     let projRefs =

--- a/src/dotnet/Fable.Compiler/CLI/ProjectCracker.fs
+++ b/src/dotnet/Fable.Compiler/CLI/ProjectCracker.fs
@@ -32,7 +32,8 @@ type CrackedFsproj =
       SourceFiles: string list
       ProjectReferences: string list
       DllReferences: string list
-      PackageReferences: FablePackage list }
+      PackageReferences: FablePackage list
+      OtherCompilerOptions: string list }
 
 let makeProjectOptions project sources otherOptions =
     { ProjectFileName = project
@@ -222,7 +223,8 @@ let fullCrack (projFile: string): CrackedFsproj =
       SourceFiles = sourceFiles
       ProjectReferences = projRefs
       DllReferences = dllRefs.Values |> Seq.toList
-      PackageReferences = fablePkgs }
+      PackageReferences = fablePkgs
+      OtherCompilerOptions = [] }
 
 /// For project references of main project, ignore dll and package references
 let easyCrack (projFile: string): CrackedFsproj =
@@ -237,7 +239,8 @@ let easyCrack (projFile: string): CrackedFsproj =
       SourceFiles = sourceFiles
       ProjectReferences = projRefs |> List.map Path.normalizeFullPath
       DllReferences = []
-      PackageReferences = [] }
+      PackageReferences = []
+      OtherCompilerOptions = [] }
 
 let getCrackedProjectsFromMainFsproj (projFile: string) =
     let rec crackProjects (acc: CrackedFsproj list) (projFile: string) =

--- a/src/dotnet/Fable.Compiler/CLI/ProjectCracker.fs
+++ b/src/dotnet/Fable.Compiler/CLI/ProjectCracker.fs
@@ -342,6 +342,10 @@ let getFullProjectOpts (checker: FSharpChecker) (define: string[]) (rootDir: str
         let otherOptions =
             // We only keep dllRefs for the main project
             let dllRefs = [| for r in mainProj.DllReferences -> "-r:" + r |]
-            Array.append (getBasicCompilerArgs define) dllRefs
+            let otherOpts = mainProj.OtherCompilerOptions |> Array.ofList
+            [ getBasicCompilerArgs define
+              otherOpts
+              dllRefs ]
+            |> Array.concat
         makeProjectOptions projFile sourceFiles otherOptions
     projOpts, fableCorePath

--- a/src/dotnet/Fable.Compiler/CLI/ProjectCracker.fs
+++ b/src/dotnet/Fable.Compiler/CLI/ProjectCracker.fs
@@ -179,8 +179,7 @@ let private getFsprojName (fsprojFullPath: string) =
     fsprojFullPath.[(i + 1) .. (fsprojFullPath.Length - 8)]
 
 let private isUsefulOption (opt : string) =
-    [ "--define"; "-d"
-      "--nowarn"
+    [ "--nowarn"
       "--warnon"
       "--warnaserror" ]
     |> List.exists opt.StartsWith


### PR DESCRIPTION
See #1398.

As it is now, this would pass *all* options we previously ignored to FCS, which means stuff like `--optimize` would be passed too. Here's a list of options which are set by default for `QuickTest.fsproj`:

``` text
"-o:obj/Debug/netcoreapp2.0/QuickTest.dll"; "-g"; "--debug:portable";
  "--noframework"; "--define:TRACE"; "--define:DEBUG"; "--define:NETCOREAPP2_0";
  "--optimize-"; "--target:exe"; "--warn:3"; "--warnaserror:76";
  "--fullpaths"; "--flaterrors"; "--highentropyva-"; "--targetprofile:netcore";
  "--simpleresolution"; "--nocopyfsharpcore"
```

I think we need a filter function, which will filter the options that are useful for us, like `--warnaserror`, or `--nowarn`. What other options should we accept?