### PR TITLE
Fix list comprehensions returning None

### DIFF
--- a/src/js/fable-core/Seq.ts
+++ b/src/js/fable-core/Seq.ts
@@ -605,7 +605,7 @@ export function scanBack<T, ST>(f: (x: T, st: ST) => ST, xs: Iterable<T>, seed: 
 }
 
 export function singleton<T>(y: T) {
-  return unfold((x) => x != null ? [x, null] : null, y);
+  return [y];
 }
 
 export function skip<T>(n: number, xs: Iterable<T>) {

--- a/tests/Main/ListTests.fs
+++ b/tests/Main/ListTests.fs
@@ -670,4 +670,11 @@ let tests =
           let xs = [1..5] |> List.toSeq
           xs |> Seq.map string |> String.concat "," |> equal "1,2,3,4,5"
           xs |> Seq.map string |> String.concat "," |> equal "1,2,3,4,5"
+
+      testCase "List comprehensions returning None work" <| fun () ->
+          let spam : string option list = [for _ in 0..5 -> None]
+
+          spam
+          |> List.length
+          |> equal 6
   ]

--- a/tests/Main/SeqTests.fs
+++ b/tests/Main/SeqTests.fs
@@ -648,6 +648,12 @@ let tests =
         Seq.head xs |> equal 1.
         Seq.head xs |> equal 1.
 
+    testCase "Seq.singleton works with None" <| fun () ->
+        let xs : int option seq = Seq.singleton None
+        xs
+        |> Seq.length
+        |> equal 1
+
     testCase "Seq.skipWhile works" <| fun () ->
         let xs = [1.; 2.; 3.; 4.; 5.]
         xs |> Seq.skipWhile (fun i -> i <= 3.)


### PR DESCRIPTION
On a side note: It got a little bit harder to just recompile and run tests. You have to remember to remove the `.fable/fable-core` directory if you changed something in `fable-core`.

Should I create the same PR for `master` or can you just cherry pick the change to `Seq.ts`, @alfonsogarciacaro?