### PR TITLE
Add compiler version to defined directives

### DIFF
--- a/src/dotnet/dotnet-fable/Parser.fs
+++ b/src/dotnet/dotnet-fable/Parser.fs
@@ -93,7 +93,7 @@ let parse (msg: string) =
     { path = path
       define =
         parseStringArray [||] "define" json
-        |> Array.append [|"FABLE_COMPILER"|]
+        |> Array.append [|"FABLE_COMPILER"; "FABLE1X"|]
         |> Array.distinct
       plugins = parseStringArray [||] "plugins" json
       fableCore = tryParseString "fableCore" json


### PR DESCRIPTION
This will make it possible to have libraries be backwards-compatible, especially ones that rely on specific features or compilation results from Fable 1.x and need custom implementations for Fable 2+