### PR TITLE
Replacement fixes

### DIFF
--- a/src/dotnet/Fable.JS/Metadata.fs
+++ b/src/dotnet/Fable.JS/Metadata.fs
@@ -20,7 +20,7 @@ let references use_net45_meta =
         "System.Collections.NonGeneric"
         "System.Collections.Specialized"
         "System.ComponentModel.Annotations"
-        "System.ComponentModel.Composition"
+        //"System.ComponentModel.Composition" // removed in 2.1.300
         "System.ComponentModel.DataAnnotations"
         "System.ComponentModel"
         "System.ComponentModel.EventBasedAsync"
@@ -48,6 +48,7 @@ let references use_net45_meta =
         "System.Globalization.Calendars"
         "System.Globalization"
         "System.Globalization.Extensions"
+        //"System.IO.Compression.Brotli" // added in 2.1.300
         "System.IO.Compression"
         "System.IO.Compression.FileSystem"
         "System.IO.Compression.ZipFile"
@@ -64,6 +65,7 @@ let references use_net45_meta =
         "System.Linq.Expressions"
         "System.Linq.Parallel"
         "System.Linq.Queryable"
+        //"System.Memory" // added in 2.1.300
         "System.Net"
         "System.Net.Http"
         "System.Net.HttpListener"

--- a/src/js/fable-splitter/src/index.ts
+++ b/src/js/fable-splitter/src/index.ts
@@ -183,7 +183,12 @@ async function getFileAstAsync(path: string, options: FableSplitterOptions, info
             info.projectFiles = babelAst.sourceFiles;
         }
         addLogs(babelAst.logs, info);
-        ast = Babel.transformFromAst(babelAst, undefined, { code: false });
+        try {
+            ast = Babel.transformFromAst(babelAst, undefined, { code: false });
+        } catch (err) {
+            console.log(`fable: Error transforming ${Path.relative(process.cwd(), path)}`);
+            console.error(err);
+        }
     } else {
         // return Babel AST from JS file
         path = JAVASCRIPT_EXT.test(path) ? path : path + ".js";

--- a/tests/Main/ComparisonTests.fs
+++ b/tests/Main/ComparisonTests.fs
@@ -421,38 +421,36 @@ let tests =
     //     Status.CreateNewMeterReadingPicture >= Status.SelectingNewDevice
     //     |> equal true
 
-    // TODO!!!
-    // testCase "LanguagePrimitives.GenericHash works" <| fun () ->
-    //     (LanguagePrimitives.GenericHash 111) = (LanguagePrimitives.GenericHash 111) |> equal true
-    //     (LanguagePrimitives.GenericHash 222) = (LanguagePrimitives.GenericHash 333) |> equal false
-    //     (LanguagePrimitives.GenericHash "1") = (LanguagePrimitives.GenericHash "1") |> equal true
-    //     (LanguagePrimitives.GenericHash "2") = (LanguagePrimitives.GenericHash "3") |> equal false
-    //     (LanguagePrimitives.GenericHash [1]) = (LanguagePrimitives.GenericHash [1]) |> equal true
-    //     (LanguagePrimitives.GenericHash [2]) = (LanguagePrimitives.GenericHash [3]) |> equal false
+    testCase "LanguagePrimitives.GenericHash works" <| fun () ->
+        (LanguagePrimitives.GenericHash 111) = (LanguagePrimitives.GenericHash 111) |> equal true
+        (LanguagePrimitives.GenericHash 222) = (LanguagePrimitives.GenericHash 333) |> equal false
+        (LanguagePrimitives.GenericHash "1") = (LanguagePrimitives.GenericHash "1") |> equal true
+        (LanguagePrimitives.GenericHash "2") = (LanguagePrimitives.GenericHash "3") |> equal false
+        (LanguagePrimitives.GenericHash [1]) = (LanguagePrimitives.GenericHash [1]) |> equal true
+        (LanguagePrimitives.GenericHash [2]) = (LanguagePrimitives.GenericHash [3]) |> equal false
 
-    // testCase "LanguagePrimitives.GenericComparison works" <| fun () ->
-    //     LanguagePrimitives.GenericComparison 111 111 |> equal 0
-    //     LanguagePrimitives.GenericComparison 222 333 |> equal -1
-    //     LanguagePrimitives.GenericComparison 333 222 |> equal 1
-    //     LanguagePrimitives.GenericComparison "1" "1" |> equal 0
-    //     LanguagePrimitives.GenericComparison "2" "3" |> equal -1
-    //     LanguagePrimitives.GenericComparison "3" "2" |> equal 1
-    //     LanguagePrimitives.GenericComparison [1] [1] |> equal 0
-    //     LanguagePrimitives.GenericComparison [2] [3] |> equal -1
-    //     LanguagePrimitives.GenericComparison [3] [2] |> equal 1
+    testCase "LanguagePrimitives.GenericComparison works" <| fun () ->
+        LanguagePrimitives.GenericComparison 111 111 |> equal 0
+        LanguagePrimitives.GenericComparison 222 333 |> equal -1
+        LanguagePrimitives.GenericComparison 333 222 |> equal 1
+        LanguagePrimitives.GenericComparison "1" "1" |> equal 0
+        LanguagePrimitives.GenericComparison "2" "3" |> equal -1
+        LanguagePrimitives.GenericComparison "3" "2" |> equal 1
+        LanguagePrimitives.GenericComparison [1] [1] |> equal 0
+        LanguagePrimitives.GenericComparison [2] [3] |> equal -1
+        LanguagePrimitives.GenericComparison [3] [2] |> equal 1
 
-    // testCase "LanguagePrimitives.GenericEquality works" <| fun () ->
-    //     LanguagePrimitives.GenericEquality 111 111 |> equal true
-    //     LanguagePrimitives.GenericEquality 222 333 |> equal false
-    //     LanguagePrimitives.GenericEquality "1" "1" |> equal true
-    //     LanguagePrimitives.GenericEquality "2" "3" |> equal false
-    //     LanguagePrimitives.GenericEquality [1] [1] |> equal true
-    //     LanguagePrimitives.GenericEquality [2] [3] |> equal false
+    testCase "LanguagePrimitives.GenericEquality works" <| fun () ->
+        LanguagePrimitives.GenericEquality 111 111 |> equal true
+        LanguagePrimitives.GenericEquality 222 333 |> equal false
+        LanguagePrimitives.GenericEquality "1" "1" |> equal true
+        LanguagePrimitives.GenericEquality "2" "3" |> equal false
+        LanguagePrimitives.GenericEquality [1] [1] |> equal true
+        LanguagePrimitives.GenericEquality [2] [3] |> equal false
 
-    // testCase "LanguagePrimitives.PhysicalEquality works" <| fun () ->
-    //     LanguagePrimitives.PhysicalEquality "1" "1" |> equal true
-    //     LanguagePrimitives.PhysicalEquality "2" "3" |> equal false
-    //     LanguagePrimitives.PhysicalEquality [1] [1] |> equal false
-    //     LanguagePrimitives.PhysicalEquality [2] [3] |> equal false
-
+    testCase "LanguagePrimitives.PhysicalEquality works" <| fun () ->
+        LanguagePrimitives.PhysicalEquality "1" "1" |> equal true
+        LanguagePrimitives.PhysicalEquality "2" "3" |> equal false
+        LanguagePrimitives.PhysicalEquality [1] [1] |> equal false
+        LanguagePrimitives.PhysicalEquality [2] [3] |> equal false
   ]


### PR DESCRIPTION
- fixed incorrect replacement logic (to match what it was before).
- fixed language intrinsic replacements and tests.
- splitter now not stopping on babel errors, so we can see all errors (we might need to track build status and output at the end if build has failed).