### PR TITLE
Add failing test for Array.concat with strings

### DIFF
--- a/tests/Main/ArrayTests.fs
+++ b/tests/Main/ArrayTests.fs
@@ -277,6 +277,12 @@ let tests =
         ys.[0] + ys.[1]
         |> equal 3.
 
+    testCase "Array.concat works with strings" <| fun test -> 
+        [| [| "One" |]; [| "Two" |] |]
+        |> Array.concat 
+        |> List.ofArray
+        |> equal [ "One"; "Two" ]
+        
     testCase "Array.exists works" <| fun () ->
         let xs = [|1u; 2u; 3u; 4u|]
         xs |> Array.exists (fun x -> x = 2u)


### PR DESCRIPTION
the following test fails at [simple-json-repro](https://github.com/Zaid-Ajaj/simple-json-repro) with error `TypeError: a.set is not a function`:
```fs
testCase "Array.concat works" <| fun test -> 
    [| [| "One" |]; [| "Two" |] |]
    |> Array.concat 
    |> List.ofArray
    |> test.areEqual [ "One"; "Two" ]
```
