### PR TITLE
Use hashes as overload suffix (but indices for Replacements)

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -112,10 +112,13 @@ let buildCoreJsTypescriptFiles () =
 
 let buildCoreJsFsharpFiles () =
     nugetRestore coreJsSrcDir
-    sprintf "%s/dotnet-fable.dll node-run %s --fable-core %s -- -c splitter.config.js"
+    sprintf "%s/dotnet-fable.dll %s %s %s"
         cliBuildDir
-        "../fable-splitter/dist/cli"
-        "force:${outDir}" // fable-splitter will adjust the path
+        "node-run ../fable-splitter/dist/cli"
+        "--fable-core force:${outDir}"  // fable-splitter will adjust the path
+        // Use overload indices instead of hashes
+        // See https://github.com/fable-compiler/Fable/issues/1472#issuecomment-403976332
+        "--experimental overload-index"
     |> run coreJsSrcDir dotnetExePath
 
 let buildCoreJs () =

--- a/src/dotnet/Fable.Compiler/AST/AST.Fable.fs
+++ b/src/dotnet/Fable.Compiler/AST/AST.Fable.fs
@@ -202,6 +202,7 @@ type ArgInfo =
 
 type ReplaceCallInfo =
   { CompiledName: string
+    OverloadSuffix: Lazy<string>
     /// See ArgIngo.SignatureArgTypes
     SignatureArgTypes: Type list
     Spread: SpreadKind

--- a/src/dotnet/Fable.Compiler/CLI/Parser.fs
+++ b/src/dotnet/Fable.Compiler/CLI/Parser.fs
@@ -90,6 +90,7 @@ let toCompilerOptions (msg: Message): CompilerOptions =
     { typedArrays = msg.typedArrays
       clampByteArrays = msg.clampByteArrays
       verbose = GlobalParams.Singleton.Verbose
+      overloadIndex = GlobalParams.Singleton.Experimental.Contains("overload-index")
     }
 
 let parse (msg: string) =

--- a/src/dotnet/Fable.Compiler/Fable.Compiler.fsproj
+++ b/src/dotnet/Fable.Compiler/Fable.Compiler.fsproj
@@ -20,6 +20,7 @@
     <Compile Include="AST/AST.Fable.fs" />
     <Compile Include="AST/AST.Babel.fs" />
     <Compile Include="Transforms/Transforms.Util.fs" />
+    <Compile Include="Transforms/OverloadSuffix.fs" />
     <Compile Include="Transforms/FSharp2Fable.Util.fs" />
     <Compile Include="Transforms/Inject.fs" />
     <Compile Include="Transforms/ReplacementsInject.fs" />

--- a/src/dotnet/Fable.Compiler/Global/Compiler.fs
+++ b/src/dotnet/Fable.Compiler/Global/Compiler.fs
@@ -4,6 +4,8 @@ type CompilerOptions =
     { typedArrays: bool
       clampByteArrays: bool
       verbose: bool
+      /// Use overload index instead of hash, intended for fable-core F# types
+      overloadIndex: bool
     }
 
 [<RequireQualifiedAccess>]

--- a/src/dotnet/Fable.Compiler/Global/Prelude.fs
+++ b/src/dotnet/Fable.Compiler/Global/Prelude.fs
@@ -198,13 +198,17 @@ module Naming =
     let getUniqueName baseName (index: int) =
         "$" + baseName + "$$" + string index
 
+    let private printOverloadIndex (index: int option) =
+        match index with
+        | None | Some 0 -> ""
+        | Some i when i < 0 -> "$$_" + string (abs i)
+        | Some i -> "$$" + string i
+
     let private buildName sanitize name part =
         (sanitize name) +
             (match part with
-                | InstanceMemberPart(s, Some i) -> "$$" + (sanitize s) + "$$" + string i
-                | StaticMemberPart(s, Some i) -> "$$$" + (sanitize s) + "$$" + string i
-                | InstanceMemberPart(s, None) -> "$$" + (sanitize s)
-                | StaticMemberPart(s, None) -> "$$$" + (sanitize s)
+                | InstanceMemberPart(s, i) -> "$$" + (sanitize s) + printOverloadIndex i
+                | StaticMemberPart(s, i) -> "$$$" + (sanitize s) + printOverloadIndex i
                 | NoMemberPart -> "")
 
     let buildNameWithoutSanitation name part =

--- a/src/dotnet/Fable.Compiler/Transforms/FSharp2Fable.Util.fs
+++ b/src/dotnet/Fable.Compiler/Transforms/FSharp2Fable.Util.fs
@@ -112,7 +112,7 @@ module Helpers =
             let overloadSuffix =
                 if com.Options.overloadIndex
                 then OverloadSuffix.getIndex ent memb
-                else OverloadSuffix.getHash memb
+                else OverloadSuffix.getHash ent memb
             let entName = getEntityMangledName com trimRootModule ent
             if memb.IsInstanceMember
             then entName, Naming.InstanceMemberPart(memb.CompiledName, overloadSuffix)

--- a/src/dotnet/Fable.Compiler/Transforms/FSharp2Fable.fs
+++ b/src/dotnet/Fable.Compiler/Transforms/FSharp2Fable.fs
@@ -56,6 +56,7 @@ let private transformTraitCall com (ctx: Context) r typ (sourceTypes: FSharpType
           DeclaringEntityFullName = entityFullName
           Spread = Fable.NoSpread
           CompiledName = traitName
+          OverloadSuffix = lazy ""
           GenericArgs =
             // TODO: Check the source F# entity to get the actual gen param names?
             match genArgs with
@@ -923,7 +924,9 @@ type FableCompiler(com: ICompiler, implFiles: Map<string, FSharpImplementationFi
         member this.InjectArgument(enclosingEntity, r, genArgs, parameter) =
             Inject.injectArg this enclosingEntity r genArgs parameter
         member this.GetInlineExpr(memb) =
-            let fileName = (getMemberLocation memb).FileName |> Path.normalizePath
+            let fileName =
+                (getMemberLocation memb).FileName
+                |> Path.normalizePathAndEnsureFsExtension
             if fileName <> com.CurrentFile then
                 this.Dependencies.Add(fileName) |> ignore
             let fullName = getMemberUniqueName com memb

--- a/src/dotnet/Fable.Compiler/Transforms/OverloadSuffix.fs
+++ b/src/dotnet/Fable.Compiler/Transforms/OverloadSuffix.fs
@@ -97,9 +97,10 @@ let getIndex (entity: FSharpEntity) (m: FSharpMemberOrFunctionOrValue) =
         else false
     // Check that m.CurriedParameterGroups.Count <= 1 before using this
     let getOverloadableParams (m: FSharpMemberOrFunctionOrValue): IList<_> =
-        if m.CurriedParameterGroups.Count = 0
+        let curriedParams = m.CurriedParameterGroups
+        if curriedParams.Count = 0 || (curriedParams.[0].Count = 1 && isUnit curriedParams.[0].[0].Type)
         then upcast [||]
-        else m.CurriedParameterGroups.[0]
+        else curriedParams.[0]
     // Overrides and interface implementations don't have override suffix in Fable
     // Members with curried params cannot be overloaded in F#
     if m.IsOverrideOrExplicitInterfaceImplementation || m.CurriedParameterGroups.Count > 1

--- a/src/dotnet/Fable.Compiler/Transforms/OverloadSuffix.fs
+++ b/src/dotnet/Fable.Compiler/Transforms/OverloadSuffix.fs
@@ -1,0 +1,105 @@
+[<RequireQualifiedAccess>]
+module Fable.Transforms.OverloadSuffix
+
+open System.Collections.Generic
+open Microsoft.FSharp.Compiler.SourceCodeServices
+
+// TODO: These two first functions are duplicateds from FSharp2Fable.Util
+let rec private nonAbbreviatedType (t: FSharpType) =
+    if t.IsAbbreviation then nonAbbreviatedType t.AbbreviatedType else t
+
+let private isUnit (typ: FSharpType) =
+    let typ = nonAbbreviatedType typ
+    if typ.HasTypeDefinition
+    then typ.TypeDefinition.TryFullName = Some "Microsoft.FSharp.Core.Unit"
+    else false
+
+// Attention: we need to keep this similar to FSharp2Fable.TypeHelpers.makeType
+let rec private getTypeFastFullName (t: FSharpType) =
+    let t = nonAbbreviatedType t
+    if t.IsGenericParameter
+    then t.GenericParameter.Name
+    elif t.IsTupleType
+    then t.GenericArguments |> Seq.map getTypeFastFullName |> String.concat " * "
+    elif t.IsFunctionType
+    then t.GenericArguments |> Seq.map getTypeFastFullName |> String.concat " -> "
+    elif t.HasTypeDefinition
+    then
+        let tdef = t.TypeDefinition
+        let genArgs = t.GenericArguments |> Seq.map getTypeFastFullName |> String.concat ","
+        match tdef.IsArrayType, genArgs with
+        | true, _ -> genArgs + "[]"
+        | false, "" -> t.TypeDefinition.FullName
+        | false, genArgs -> t.TypeDefinition.FullName + "[" + genArgs + "]"
+    else "System.Object"
+
+// From https://stackoverflow.com/a/37449594
+let private combineHashCodes (hashes: int seq) =
+    let hashes = Seq.toArray hashes
+    if hashes.Length = 0
+    then 0
+    else hashes |> Array.reduce (fun h1 h2 -> ((h1 <<< 5) + h1) ^^^ h2)
+
+// F# hash function gives different results in different runs
+// Taken from fable-core/Util.ts. Possible variant in https://stackoverflow.com/a/1660613
+let stringHash (s: string) =
+    let mutable h = 5381
+    for i = 0 to s.Length - 1 do
+        h <- (h * 33) ^^^ (int s.[i])
+    h
+
+let private hashToString (i: int) =
+    if i < 0
+    then "Z" + (abs i).ToString("X")
+    else i.ToString("X")
+
+let getHash (m: FSharpMemberOrFunctionOrValue) =
+    let curriedParams = m.CurriedParameterGroups
+        // Overrides and interface implementations don't have override suffix in Fable
+    if m.IsOverrideOrExplicitInterfaceImplementation
+        // Members with curried params cannot be overloaded in F#
+        || curriedParams.Count <> 1
+        // Don't use overload suffix for members without arguments
+        || curriedParams.[0].Count = 0
+        || (curriedParams.[0].Count = 1 && isUnit curriedParams.[0].[0].Type)
+    then ""
+    else
+        curriedParams.[0]
+        |> Seq.map (fun p -> getTypeFastFullName p.Type |> stringHash)
+        |> combineHashCodes
+        |> hashToString
+
+/// Simple overload resolution enumerating overloads within an entity (used for fable-core F# types)
+let getIndex (entity: FSharpEntity) (m: FSharpMemberOrFunctionOrValue) =
+    let argsEqual (args1: IList<FSharpParameter>) (args2: IList<FSharpParameter>) =
+        if args1.Count = args2.Count
+        // We're using the overload index mainly for types in fable-core to replace BCL classes,
+        // just checking the param name should be enough to disambiguate interfaces
+        then (args1, args2) ||> Seq.forall2 (fun a1 a2 -> a1.Name = a2.Name)
+        else false
+    // Check that m.CurriedParameterGroups.Count <= 1 before using this
+    let getOverloadableParams (m: FSharpMemberOrFunctionOrValue): IList<_> =
+        if m.CurriedParameterGroups.Count = 0
+        then upcast [||]
+        else m.CurriedParameterGroups.[0]
+    // Overrides and interface implementations don't have override suffix in Fable
+    // Members with curried params cannot be overloaded in F#
+    if m.IsOverrideOrExplicitInterfaceImplementation || m.CurriedParameterGroups.Count > 1
+    then ""
+    else
+        // m.Overloads(false) doesn't work
+        let name = m.CompiledName
+        let isInstance = m.IsInstanceMember
+        let params1 = getOverloadableParams m
+        let index, _found =
+            ((0, false), entity.MembersFunctionsAndValues)
+            ||> Seq.fold (fun (i, found) m2 ->
+                if not found && m2.IsInstanceMember = isInstance && m2.CompiledName = name && m2.CurriedParameterGroups.Count <= 1 then
+                    // .Equals() doesn't work.
+                    // .IsEffectivelySameAs() doesn't work for constructors
+                    if argsEqual params1 (getOverloadableParams m2)
+                    then i, true
+                    else i + 1, false
+                else i, found)
+        // TODO: Log error if not found?
+        if index = 0 then "" else string index

--- a/src/dotnet/Fable.Compiler/Transforms/Replacements.fs
+++ b/src/dotnet/Fable.Compiler/Transforms/Replacements.fs
@@ -531,10 +531,11 @@ let applyOp (com: ICompiler) (ctx: Context) r t opName (args: Expr list) argType
     | Builtin(BclInt64|BclUInt64|BclBigInt|BclDateTime|BclDateTimeOffset as bt)::_ ->
         Helper.CoreCall(coreModFor bt, opName, t, args, argTypes, ?loc=r)
     | Builtin(FSharpSet _)::_ ->
-        // F# Set and Map operators shouldn't have an overload index
+        // FSharpSet operators don't have an overload index
         let mangledName = Naming.buildNameWithoutSanitationFrom "FSharpSet" true opName ""
         Helper.CoreCall("Set", mangledName, t, args, argTypes, ?loc=r)
     | Builtin (FSharpMap _)::_ ->
+        // FSharpMap operators don't have an overload index
         let mangledName = Naming.buildNameWithoutSanitationFrom "FSharpMap" true opName ""
         Helper.CoreCall("Map", mangledName, t, args, argTypes, ?loc=r)
     | Builtin BclTimeSpan::_ ->
@@ -1441,7 +1442,8 @@ let sets (com: ICompiler) (_: Context) r (t: Type) (i: CallInfo) (thisArg: Expr 
     | ".ctor" -> (genArg com r 0 i.GenericArgs) |> makeSet com r t "OfSeq" args |> Some
     | _ ->
         let isStatic = Option.isNone thisArg
-        let mangledName = Naming.buildNameWithoutSanitationFrom "FSharpSet" isStatic i.CompiledName i.OverloadSuffix.Value
+        // FSharpSet doesn't have overloads, we don't need to calculate the suffix
+        let mangledName = Naming.buildNameWithoutSanitationFrom "FSharpSet" isStatic i.CompiledName ""
         let args = injectArg com r "Set" mangledName i.GenericArgs args
         Helper.CoreCall("Set", mangledName, t, args, i.SignatureArgTypes, ?thisArg=thisArg, ?loc=r) |> Some
 
@@ -1455,7 +1457,8 @@ let maps (com: ICompiler) (_: Context) r (t: Type) (i: CallInfo) (thisArg: Expr 
     | ".ctor" -> (genArg com r 0 i.GenericArgs) |> makeMap com r t "OfSeq" args |> Some
     | _ ->
         let isStatic = Option.isNone thisArg
-        let mangledName = Naming.buildNameWithoutSanitationFrom "FSharpMap" isStatic i.CompiledName i.OverloadSuffix.Value
+        // FSharpMap doesn't have overloads, we don't need to calculate the suffix
+        let mangledName = Naming.buildNameWithoutSanitationFrom "FSharpMap" isStatic i.CompiledName ""
         let args = injectArg com r "Map" mangledName i.GenericArgs args
         Helper.CoreCall("Map", mangledName, t, args, i.SignatureArgTypes, ?thisArg=thisArg, ?loc=r) |> Some
 

--- a/src/js/fable-core/System.Text.fs
+++ b/src/js/fable-core/System.Text.fs
@@ -1,8 +1,10 @@
 namespace System.Text
 
-type StringBuilder(?s: string) =
-    let buf = ResizeArray<string>()
-    do if Option.isSome s then buf.Add(s.Value)
+type StringBuilder(?capacity: int, ?value: string) =
+    let buf = ResizeArray<string>(defaultArg capacity 16)
+    do if Option.isSome value then buf.Add(value.Value)
+    new (capacity: int) = StringBuilder(capacity=capacity, ?value=None)
+    new (value: string) = StringBuilder(?capacity=None, value=value)
     member x.Append(s: string) = buf.Add(s); x
     member x.AppendFormat(fmt: string, o: obj) = buf.Add(System.String.Format(fmt, o)); x
-    override x.ToString() = System.String.Concat(buf)
+    override __.ToString() = System.String.Concat(buf)

--- a/src/js/fable-core/quickfsbuild.sh
+++ b/src/js/fable-core/quickfsbuild.sh
@@ -1,7 +1,7 @@
 pushd ../../dotnet/Fable.Compiler
 dotnet run $1 node-run ../fable-splitter/dist/cli \
     --cwd ../../js/fable-core --fable-core force:\${outDir} \
-    --args "-c splitter.config.js"
+    --experimental overload-index
 popd
 
 # Check argument injections

--- a/src/tools/InjectProcessor/InjectProcessor.fs
+++ b/src/tools/InjectProcessor/InjectProcessor.fs
@@ -73,8 +73,9 @@ let rec getInjects initialized decls =
                     let membName =
                         match memb.DeclaringEntity with
                         | Some ent when not ent.IsFSharpModule ->
+                            let suffix = Fable.Transforms.OverloadSuffix.getIndex ent memb
                             Naming.buildNameWithoutSanitationFrom
-                                ent.CompiledName (not memb.IsInstanceMember) memb.CompiledName
+                                ent.CompiledName (not memb.IsInstanceMember) memb.CompiledName suffix
                         | _ -> memb.CompiledName
                     yield membName, injections
         }

--- a/src/tools/InjectProcessor/InjectProcessor.fsproj
+++ b/src/tools/InjectProcessor/InjectProcessor.fsproj
@@ -6,6 +6,7 @@
   <ItemGroup>
     <Compile Include="../../dotnet/Fable.Compiler/CLI/ProjectCoreCracker.fs" />
     <Compile Include="../../dotnet/Fable.Compiler/Global/Prelude.fs" />
+    <Compile Include="../../dotnet/Fable.Compiler/Transforms/OverloadSuffix.fs" />
     <Compile Include="InjectProcessor.fs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Discussion here: https://github.com/fable-compiler/Fable/issues/1472

I've made it so types in fable-core still use enumeration. So, as long as the overloads keep the same order as the original types in the BCL, it should work. I tried it with the StringBuilder constructors (check System.Text.fs) and it seems to work.

@ncave If possible, please have a look and tell me what you think. As commented in the issue, I like the hash approach (if chances of collision are low) because it's predictable, but we still need to keep the enumeration approach for Replacements. So this may be introducing too much complication in the code base.