### PR TITLE
Fixed list tests and REPL

### DIFF
--- a/src/dotnet/Fable.Compiler/Transforms/Replacements.fs
+++ b/src/dotnet/Fable.Compiler/Transforms/Replacements.fs
@@ -1374,9 +1374,6 @@ let arrayModule (com: ICompiler) (_: Context) r (t: Type) (i: CallInfo) (_: Expr
     | "Item", [idx; ar] -> getExpr r t ar idx |> Some
     | "Get", [ar; idx] -> getExpr r t ar idx |> Some
     | "Set", [ar; idx; value] -> Set(ar, ExprSet idx, value, r) |> Some
-    | ("Take" | "Truncate"), [count; ar] ->
-        Helper.InstanceCall(ar, "slice", t, [makeIntConst 0; count], ?loc=r) |> Some
-    | "Skip", [count; ar] -> Helper.InstanceCall(ar, "slice", t, [count], ?loc=r) |> Some
     | "Copy", [ar] -> Helper.InstanceCall(ar, "slice", t, args, ?loc=r) |> Some
     | "ZeroCreate", [count] -> createArray count None |> Some
     | "Create", [count; value] -> createArray count (Some value) |> Some

--- a/src/dotnet/Fable.Compiler/Transforms/State.fs
+++ b/src/dotnet/Fable.Compiler/Transforms/State.fs
@@ -96,11 +96,14 @@ type Compiler(currentFile, project: Project, options, ?fableCore: string) =
         member __.Options = options
         member __.FableCore = fableCore
         member __.CurrentFile = currentFile
-        member __.GetRootModule(fileName) =
+        member x.GetRootModule(fileName) =
             let fileName = Path.normalizePathAndEnsureFsExtension fileName
             match Map.tryFind fileName project.RootModules with
             | Some rootModule -> rootModule
-            | None -> "" // failwithf "Cannot find root module for %s" fileName
+            | None ->
+                let msg = sprintf "Cannot find root module for %s" fileName
+                (x :> ICompiler).AddLog(msg, Severity.Warning)
+                "" // failwith msg
         member __.GetOrAddInlineExpr(fullName, generate) =
             project.InlineExprs.GetOrAdd(fullName, fun _ -> generate())
         member __.AddLog(msg, severity, ?range, ?fileName:string, ?tag: string) =

--- a/src/js/fable-core/Array.fs
+++ b/src/js/fable-core/Array.fs
@@ -111,32 +111,32 @@ let map (f: 'T -> 'U) (source: 'T[]) ([<Inject>] cons: IArrayCons<'U>): 'U[] =
     target
 
 let mapIndexed2 (f: int->'T1->'T2->'U) (source1: 'T1[]) (source2: 'T2[]) ([<Inject>] cons: IArrayCons<'U>): 'U[] =
-   if source1.Length <> source2.Length then failwith "Arrays had different lengths"
-   let result = cons.Create(source1.Length)
-   for i = 0 to source1.Length - 1 do
-      result.[i] <- f i source1.[i] source2.[i]
-   result
+    if source1.Length <> source2.Length then failwith "Arrays had different lengths"
+    let result = cons.Create(source1.Length)
+    for i = 0 to source1.Length - 1 do
+        result.[i] <- f i source1.[i] source2.[i]
+    result
 
 let map2 (f: 'T1->'T2->'U) (source1: 'T1[]) (source2: 'T2[]) ([<Inject>] cons: IArrayCons<'U>): 'U[] =
-   if source1.Length <> source2.Length then failwith "Arrays had different lengths"
-   let result = cons.Create(source1.Length)
-   for i = 0 to source1.Length - 1 do
-      result.[i] <- f source1.[i] source2.[i]
-   result
+    if source1.Length <> source2.Length then failwith "Arrays had different lengths"
+    let result = cons.Create(source1.Length)
+    for i = 0 to source1.Length - 1 do
+        result.[i] <- f source1.[i] source2.[i]
+    result
 
 let mapIndexed3 (f: int->'T1->'T2->'T3->'U) (source1: 'T1[]) (source2: 'T2[]) (source3: 'T3[]) ([<Inject>] cons: IArrayCons<'U>): 'U[] =
-   if source1.Length <> source2.Length || source2.Length <> source3.Length then failwith "Arrays had different lengths"
-   let result = cons.Create(source1.Length)
-   for i = 0 to source1.Length - 1 do
-      result.[i] <- f i source1.[i] source2.[i] source3.[i]
-   result
+    if source1.Length <> source2.Length || source2.Length <> source3.Length then failwith "Arrays had different lengths"
+    let result = cons.Create(source1.Length)
+    for i = 0 to source1.Length - 1 do
+        result.[i] <- f i source1.[i] source2.[i] source3.[i]
+    result
 
 let map3 f (source1: 'T[]) (source2: 'U[]) (source3: 'U[]) ([<Inject>] cons: IArrayCons<'W>): 'W[] =
-   if source1.Length <> source2.Length || source2.Length <> source3.Length then failwith "Arrays had different lengths"
-   let result = cons.Create(source1.Length)
-   for i = 0 to source1.Length - 1 do
-      result.[i] <- f source1.[i] source2.[i] source3.[i]
-   result
+    if source1.Length <> source2.Length || source2.Length <> source3.Length then failwith "Arrays had different lengths"
+    let result = cons.Create(source1.Length)
+    for i = 0 to source1.Length - 1 do
+        result.[i] <- f source1.[i] source2.[i] source3.[i]
+    result
 
 let mapFold<'T,'State,'Result> (mapping : 'State -> 'T -> 'Result * 'State) state (array: 'T[]) ([<Inject>] cons: IArrayCons<'Result>) =
     match array.Length with
@@ -325,7 +325,7 @@ let skip count (array:'T[]) ([<Inject>] cons: IArrayCons<'T>) =
     if count = array.Length then
         emptyImpl cons
     else
-        let count = if count > 0 then 0 else 0
+        let count = if count < 0 then 0 else count
         sliceFromImpl array count
 
 let skipWhile predicate (array: 'T[]) ([<Inject>] cons: IArrayCons<'T>) =
@@ -686,61 +686,61 @@ let tryItem index (array:'T[]) =
 //     List.ofArray array
 
 let foldBackIndexed<'T,'State> folder (array: 'T[]) (state:'State) =
-   let mutable acc = state
-   let size = array.Length
-   for i = 1 to size do
-      acc <- folder (i-1) array.[size - i] acc
-   acc
+    let mutable acc = state
+    let size = array.Length
+    for i = 1 to size do
+        acc <- folder (i-1) array.[size - i] acc
+    acc
 
 let foldBack<'T,'State> folder (array: 'T[]) (state:'State) =
-   foldBackIndexed (fun _ x acc -> folder x acc) array state
+    foldBackIndexed (fun _ x acc -> folder x acc) array state
 
 let foldIndexed2 folder state (array1: _[]) (array2: _[]) =
-   let mutable acc = state
-   if array1.Length <> array2.Length then failwith "Arrays have different lengths"
-   for i = 0 to array1.Length - 1 do
-      acc <- folder i acc array1.[i] array2.[i]
-   acc
+    let mutable acc = state
+    if array1.Length <> array2.Length then failwith "Arrays have different lengths"
+    for i = 0 to array1.Length - 1 do
+        acc <- folder i acc array1.[i] array2.[i]
+    acc
 
 let fold2<'T1, 'T2, 'State> folder (state: 'State) (array1: 'T1[]) (array2: 'T2[]) =
-   foldIndexed2 (fun _ acc x y -> folder acc x y) state array1 array2
+    foldIndexed2 (fun _ acc x y -> folder acc x y) state array1 array2
 
 let foldBackIndexed2<'T1, 'T2, 'State> folder (array1: 'T1[]) (array2: 'T2[]) (state:'State) =
-   let mutable acc = state
-   if array1.Length <> array2.Length then failwith "Arrays had different lengths"
-   let size = array1.Length
-   for i = 1 to size do
-      acc <- folder (i-1) array1.[size - i] array2.[size - i] acc
-   acc
+    let mutable acc = state
+    if array1.Length <> array2.Length then failwith "Arrays had different lengths"
+    let size = array1.Length
+    for i = 1 to size do
+        acc <- folder (i-1) array1.[size - i] array2.[size - i] acc
+    acc
 
 let foldBack2<'T1, 'T2, 'State> f (array1: 'T1[]) (array2: 'T2[]) (state: 'State) =
-   foldBackIndexed2 (fun _ x y acc -> f x y acc) array1 array2 state
+    foldBackIndexed2 (fun _ x y acc -> f x y acc) array1 array2 state
 
 let reduce reduction (array: 'T[]) =
-   if array.Length = 0 then invalidOp LanguagePrimitives.ErrorStrings.InputArrayEmptyString
-   else foldIndexed (fun i acc x -> if i = 0 then x else reduction acc x) Unchecked.defaultof<_> array
+    if array.Length = 0 then invalidOp LanguagePrimitives.ErrorStrings.InputArrayEmptyString
+    else foldIndexed (fun i acc x -> if i = 0 then x else reduction acc x) Unchecked.defaultof<_> array
 
 let reduceBack reduction (array: 'T[]) =
-   if array.Length = 0 then invalidOp LanguagePrimitives.ErrorStrings.InputArrayEmptyString
-   else foldBackIndexed (fun i x acc -> if i = 0 then x else reduction acc x) array Unchecked.defaultof<_>
+    if array.Length = 0 then invalidOp LanguagePrimitives.ErrorStrings.InputArrayEmptyString
+    else foldBackIndexed (fun i x acc -> if i = 0 then x else reduction acc x) array Unchecked.defaultof<_>
 
 let forAll2 predicate array1 array2 =
-   fold2 (fun acc x y -> acc && predicate x y) true array1 array2
+    fold2 (fun acc x y -> acc && predicate x y) true array1 array2
 
 let rec existsOffset predicate (array: 'T[]) index =
-   if index = array.Length then false
-   else predicate array.[index] || existsOffset predicate array (index+1)
+    if index = array.Length then false
+    else predicate array.[index] || existsOffset predicate array (index+1)
 
 let exists predicate array =
-   existsOffset predicate array 0
+    existsOffset predicate array 0
 
 let rec existsOffset2 predicate (array1: _[]) (array2: _[]) index =
-   if index = array1.Length then false
-   else predicate array1.[index] array2.[index] || existsOffset2 predicate array1 array2 (index+1)
+    if index = array1.Length then false
+    else predicate array1.[index] array2.[index] || existsOffset2 predicate array1 array2 (index+1)
 
 let rec exists2 predicate (array1: _[]) (array2: _[]) =
-   if array1.Length <> array2.Length then failwith "Arrays had different lengths"
-   existsOffset2 predicate array1 array2 0
+    if array1.Length <> array2.Length then failwith "Arrays had different lengths"
+    existsOffset2 predicate array1 array2 0
 
 // TODO!!!: Pass add function for non-number types
 let sum (array: float[]) : float =

--- a/src/js/fable-core/List.fs
+++ b/src/js/fable-core/List.fs
@@ -44,35 +44,35 @@ let equalsWith (comparer: 'T -> 'T -> int) (xs: 'T list) (ys: 'T list): bool =
     compareWith comparer xs ys = 0
 
 let rec foldIndexedAux f i acc = function
-   | [] -> acc
-   | x::xs -> foldIndexedAux f (i+1) (f i acc x) xs
+    | [] -> acc
+    | x::xs -> foldIndexedAux f (i+1) (f i acc x) xs
 
 let foldIndexed<'a,'acc> f (seed:'acc) (xs: 'a list) =
-   foldIndexedAux f 0 seed xs
+    foldIndexedAux f 0 seed xs
 
 let fold<'a,'acc> f (seed:'acc) (xs: 'a list) =
-   foldIndexed (fun _ acc x -> f acc x) seed xs
+    foldIndexed (fun _ acc x -> f acc x) seed xs
 
 let reverse xs =
-   fold (fun acc x -> x::acc) [] xs
+    fold (fun acc x -> x::acc) [] xs
 
 let foldBack<'a,'acc> f (xs: 'a list) (seed:'acc) =
-   fold (fun acc x -> f x acc) seed (reverse xs)
+    fold (fun acc x -> f x acc) seed (reverse xs)
 
 let rec foldIndexed2Aux f i acc bs cs =
-   match bs, cs with
-   | [], [] -> acc
-   | x::xs, y::ys -> foldIndexed2Aux f (i+1) (f i acc x y) xs ys
-   | _ -> invalidOp "Lists had different lengths"
+    match bs, cs with
+    | [], [] -> acc
+    | x::xs, y::ys -> foldIndexed2Aux f (i+1) (f i acc x y) xs ys
+    | _ -> invalidOp "Lists had different lengths"
 
 let foldIndexed2<'a, 'b, 'acc> f (seed:'acc) (xs: 'a list) (ys: 'b list) =
-   foldIndexed2Aux f 0 seed xs ys
+    foldIndexed2Aux f 0 seed xs ys
 
 let fold2<'a, 'b, 'acc> f (seed:'acc) (xs: 'a list) (ys: 'b list) =
-   foldIndexed2 (fun _ acc x y -> f acc x y) seed xs ys
+    foldIndexed2 (fun _ acc x y -> f acc x y) seed xs ys
 
 let foldBack2<'a, 'b, 'acc> f (xs: 'a list) (ys: 'b list) (seed:'acc) =
-   fold2 (fun acc x y -> f x y acc) seed (reverse xs) (reverse ys)
+    fold2 (fun acc x y -> f x y acc) seed (reverse xs) (reverse ys)
 
 let unfold f state =
     let rec unfoldInner acc state =
@@ -82,63 +82,63 @@ let unfold f state =
     unfoldInner [] state
 
 let rec foldIndexed3Aux f i acc bs cs ds =
-   match bs, cs, ds with
-   | [], [], [] -> acc
-   | x::xs, y::ys, z::zs -> foldIndexed3Aux f (i+1) (f i acc x y z) xs ys zs
-   | _ -> invalidOp "Lists had different lengths"
+    match bs, cs, ds with
+    | [], [], [] -> acc
+    | x::xs, y::ys, z::zs -> foldIndexed3Aux f (i+1) (f i acc x y z) xs ys zs
+    | _ -> invalidOp "Lists had different lengths"
 
 let foldIndexed3<'a, 'b, 'c, 'acc> f (seed:'acc) (xs: 'a list) (ys: 'b list) (zs: 'c list) =
-   foldIndexed3Aux f 0 seed xs ys zs
+    foldIndexed3Aux f 0 seed xs ys zs
 
 let fold3<'a, 'b, 'c, 'acc> f (seed:'acc) (xs: 'a list) (ys: 'b list) (zs: 'c list) =
-   foldIndexed3 (fun _ acc x y z -> f acc x y z) seed xs ys zs
+    foldIndexed3 (fun _ acc x y z -> f acc x y z) seed xs ys zs
 
 let scan<'a, 'acc> f (seed:'acc) (xs: 'a list) =
-   fold (fun acc x ->
-      match acc with
-      | [] -> failwith "never"
-      | y::_ -> f y x::acc) [seed] xs
-   |> reverse
+    fold (fun acc x ->
+        match acc with
+        | [] -> failwith "never"
+        | y::_ -> f y x::acc) [seed] xs
+    |> reverse
 
 let scanBack<'a, 'acc> f (xs: 'a list) (seed:'acc) =
-   scan (fun acc x -> f x acc) seed (reverse xs)
-   |> reverse
+    scan (fun acc x -> f x acc) seed (reverse xs)
+    |> reverse
 
 let length xs =
-   fold (fun acc _ -> acc + 1) 0 xs
+    fold (fun acc _ -> acc + 1) 0 xs
 
 let append xs ys =
-   fold (fun acc x -> x::acc) ys (reverse xs)
+    fold (fun acc x -> x::acc) ys (reverse xs)
 
 let collect f xs =
-   fold (fun acc x -> append (f x) acc) [] (reverse xs)
+    fold (fun acc x -> append (f x) acc) [] (reverse xs)
 
 let map f xs =
-   fold (fun acc x -> (f x::acc)) [] xs
-   |> reverse
+    fold (fun acc x -> (f x::acc)) [] xs
+    |> reverse
 
 let mapIndexed f xs =
-   foldIndexed (fun i acc x -> f i x::acc) [] xs
-   |> reverse
+    foldIndexed (fun i acc x -> f i x::acc) [] xs
+    |> reverse
 
 let indexed xs =
     mapIndexed (fun i x -> (i,x)) xs
 
 let map2 f xs ys =
-   fold2 (fun acc x y -> f x y::acc) [] xs ys
-   |> reverse
+    fold2 (fun acc x y -> f x y::acc) [] xs ys
+    |> reverse
 
 let mapIndexed2 f xs ys =
-   foldIndexed2 (fun i acc x y  -> f i x y:: acc) [] xs ys
-   |> reverse
+    foldIndexed2 (fun i acc x y  -> f i x y:: acc) [] xs ys
+    |> reverse
 
 let map3 f xs ys zs =
-   fold3 (fun acc x y z -> f x y z::acc) [] xs ys zs
-   |> reverse
+    fold3 (fun acc x y z -> f x y z::acc) [] xs ys zs
+    |> reverse
 
 let mapIndexed3 f xs ys zs =
-   foldIndexed3 (fun i acc x y z -> f i x y z:: acc) [] xs ys zs
-   |> reverse
+    foldIndexed3 (fun i acc x y z -> f i x y z:: acc) [] xs ys zs
+    |> reverse
 
 let mapFold (f: 'S -> 'T -> 'R * 'S) s xs =
     let foldFn (nxs, fs) x =
@@ -151,58 +151,58 @@ let mapFoldBack (f: 'T -> 'S -> 'R * 'S) xs s =
     mapFold (fun s v -> f v s) s (reverse xs)
 
 let iterate f xs =
-   fold (fun () x -> f x) () xs
+    fold (fun () x -> f x) () xs
 
 let iterate2 f xs ys =
-   fold2 (fun () x y -> f x y) () xs ys
+    fold2 (fun () x y -> f x y) () xs ys
 
 let iterateIndexed f xs =
-   foldIndexed (fun i () x -> f i x) () xs
+    foldIndexed (fun i () x -> f i x) () xs
 
 let iterateIndexed2 f xs ys =
-   foldIndexed2 (fun i () x y -> f i x y) () xs ys
+    foldIndexed2 (fun i () x y -> f i x y) () xs ys
 
 let ofArray xs =
-   Array.foldBack (fun x acc -> x::acc) xs []
+    Array.foldBack (fun x acc -> x::acc) xs []
 
 let empty<'a> : 'a list = []
 
 let isEmpty = function
-   | [] -> true
-   | _ -> false
+    | [] -> true
+    | _ -> false
 
 let rec tryPickIndexedAux f i = function
-   | [] -> None
-   | x::xs ->
-      let result = f i x
-      match result with
-      | Some _ -> result
-      | None -> tryPickIndexedAux f (i+1) xs
+    | [] -> None
+    | x::xs ->
+        let result = f i x
+        match result with
+        | Some _ -> result
+        | None -> tryPickIndexedAux f (i+1) xs
 
 let tryPickIndexed f xs =
-   tryPickIndexedAux f 0 xs
+    tryPickIndexedAux f 0 xs
 
 let tryPick f xs =
-   tryPickIndexed (fun _ x -> f x) xs
+    tryPickIndexed (fun _ x -> f x) xs
 
 let pick f xs =
-   match tryPick f xs with
-   | None -> invalidOp "List did not contain any matching elements"
-   | Some x -> x
+    match tryPick f xs with
+    | None -> invalidOp "List did not contain any matching elements"
+    | Some x -> x
 
 let tryFindIndexed f xs =
-   tryPickIndexed (fun i x -> if f i x then Some x else None) xs
+    tryPickIndexed (fun i x -> if f i x then Some x else None) xs
 
 let tryFind f xs =
-   tryPickIndexed (fun _ x -> if f x then Some x else None) xs
+    tryPickIndexed (fun _ x -> if f x then Some x else None) xs
 
 let findIndexed f xs =
-   match tryFindIndexed f xs with
-   | None -> invalidOp "List did not contain any matching elements"
-   | Some x -> x
+    match tryFindIndexed f xs with
+    | None -> invalidOp "List did not contain any matching elements"
+    | Some x -> x
 
 let find f xs =
-   findIndexed (fun _ x -> f x) xs
+    findIndexed (fun _ x -> f x) xs
 
 let findBack f xs =
     xs |> reverse |> find f
@@ -211,42 +211,42 @@ let tryFindBack f xs =
     xs |> reverse |> tryFind f
 
 let tryFindIndex f xs: int option =
-   tryPickIndexed (fun i x -> if f x then Some i else None) xs
+    tryPickIndexed (fun i x -> if f x then Some i else None) xs
 
 let tryFindIndexBack f xs: int option =
     List.toArray xs
     |> Array.tryFindIndexBack f
 
 let findIndex f xs: int =
-   match tryFindIndex f xs with
-   | None -> invalidOp "List did not contain any matching elements"
-   | Some x -> x
+    match tryFindIndex f xs with
+    | None -> invalidOp "List did not contain any matching elements"
+    | Some x -> x
 
 let findIndexBack f xs: int =
     List.toArray xs
     |> Array.findIndexBack f
 
 let item n xs =
-   findIndexed (fun i _ -> n = i) xs
+    findIndexed (fun i _ -> n = i) xs
 
 let tryItem n xs =
-   tryFindIndexed (fun i _ -> n = i) xs
+    tryFindIndexed (fun i _ -> n = i) xs
 
 let filter f xs =
-   foldBack (fun x acc ->
-      if f x then x::acc
-      else acc) xs []
+    foldBack (fun x acc ->
+        if f x then x::acc
+        else acc) xs []
 
 let partition f xs =
-   fold (fun (lacc, racc) x ->
-      if f x then x::lacc, racc
-      else lacc,x::racc) ([],[]) (reverse xs)
+    fold (fun (lacc, racc) x ->
+        if f x then x::lacc, racc
+        else lacc,x::racc) ([],[]) (reverse xs)
 
 let choose f xs =
-   fold (fun acc x ->
-      match f x with
-      | Some y -> y:: acc
-      | None -> acc) [] xs |> reverse
+    fold (fun acc x ->
+        match f x with
+        | Some y -> y:: acc
+        | None -> acc) [] xs |> reverse
 
 
 let contains<'T> (value: 'T) (list: 'T list) ([<Inject>] eq: IEqualityComparer<'T>) =
@@ -266,48 +266,48 @@ let except (itemsToExclude: seq<'t>) (array: 't list) ([<Inject>] eq: IEqualityC
         array |> filter cached.Add
 
 let initialize n f =
-   let mutable xs = []
-   for i = 1 to n do xs <- f (n - i):: xs
-   xs
+    let mutable xs = []
+    for i = 1 to n do xs <- f (n - i):: xs
+    xs
 
 let replicate n x =
-   initialize n (fun _ -> x)
+    initialize n (fun _ -> x)
 
 let reduce f = function
-   | [] -> invalidOp "List was empty"
-   | h::t -> fold f h t
+    | [] -> invalidOp "List was empty"
+    | h::t -> fold f h t
 
 let reduceBack f = function
-   | [] -> invalidOp "List was empty"
-   | h::t -> foldBack f t h
+    | [] -> invalidOp "List was empty"
+    | h::t -> foldBack f t h
 
 let forAll f xs =
-   fold (fun acc x -> acc && f x) true xs
+    fold (fun acc x -> acc && f x) true xs
 
 let forAll2 f xs ys =
-   fold2 (fun acc x y -> acc && f x y) true xs ys
+    fold2 (fun acc x y -> acc && f x y) true xs ys
 
 let rec exists f = function
-   | [] -> false
-   | x::xs -> f x || exists f xs
+    | [] -> false
+    | x::xs -> f x || exists f xs
 
 let rec exists2 f bs cs =
-   match bs, cs with
-   | [], [] -> false
-   | x::xs, y::ys -> f x y || exists2 f xs ys
-   | _ -> invalidOp "Lists had different lengths"
+    match bs, cs with
+    | [], [] -> false
+    | x::xs, y::ys -> f x y || exists2 f xs ys
+    | _ -> invalidOp "Lists had different lengths"
 
 let unzip xs =
-   foldBack (fun (x, y) (lacc, racc) -> x::lacc, y::racc) xs ([],[])
+    foldBack (fun (x, y) (lacc, racc) -> x::lacc, y::racc) xs ([],[])
 
 let unzip3 xs =
-   foldBack (fun (x, y, z) (lacc, macc, racc) -> x::lacc, y::macc, z::racc) xs ([],[],[])
+    foldBack (fun (x, y, z) (lacc, macc, racc) -> x::lacc, y::macc, z::racc) xs ([],[],[])
 
 let zip xs ys =
-   map2 (fun x y -> x, y) xs ys
+    map2 (fun x y -> x, y) xs ys
 
 let zip3 xs ys zs =
-   map3 (fun x y z -> x, y, z) xs ys zs
+    map3 (fun x y z -> x, y, z) xs ys zs
 
 let sort (xs : 'T list) ([<Inject>] comparer: IComparer<'T>): 'T list =
     Array.sortInPlaceWith (fun x y -> comparer.Compare(x, y)) (Array.ofList xs Array.DynamicArrayCons) |> ofArray
@@ -326,10 +326,10 @@ let sortWith (comparer: 'T -> 'T -> int) (xs : 'T list): 'T list =
 
 // TODO!!!: Pass add function for non-number types
 let sum (xs: float list) : float =
-   fold (+) 0. xs
+    fold (+) 0. xs
 
 let sumBy (f:'a -> float) (xs: 'a list) : float =
-   fold (fun acc x -> acc + f x) 0. xs
+    fold (fun acc x -> acc + f x) 0. xs
 
 let maxBy (projection:'a->'b) (xs:'a list) ([<Inject>] comparer: IComparer<'b>): 'a =
     reduce (fun x y -> if comparer.Compare(projection y, projection x) > 0 then y else x) xs
@@ -344,61 +344,75 @@ let min (xs:'a list) ([<Inject>] comparer: IComparer<'a>): 'a =
     reduce (fun x y -> if comparer.Compare(y, x) > 0 then x else y) xs
 
 let average (zs: float list) : float =
-   let total = sum zs
-   total / float(List.length zs)
+    let total = sum zs
+    total / float(List.length zs)
 
 let averageBy (g: 'a -> float ) (zs: 'a list) : float =
-   let total = sumBy g zs
-   total / float(List.length zs)
+    let total = sumBy g zs
+    total / float(List.length zs)
 
 let permute f xs =
-   xs
-   |> List.toArray
-   |> Array.permute f
-   |> ofArray
+    xs
+    |> List.toArray
+    |> Array.permute f
+    |> ofArray
+
+let skip i xs =
+    let rec skipInner i xs =
+        match i, xs with
+        | 0, _ -> xs
+        | _, [] -> failwith "The input sequence has an insufficient number of elements."
+        | _, _::xs -> skipInner (i - 1) xs
+    match i, xs with
+    | i, _ when i < 0 -> failwith "The input must be non-negative."
+    | 0, _ -> xs
+    | 1, _::xs -> xs
+    | i, xs -> skipInner i xs
+
+let rec skipWhile predicate xs =
+    match xs with
+    | h::t when predicate h -> skipWhile predicate t
+    | _ -> xs
 
 // TODO: Is there a more efficient algorithm?
 let rec takeSplitAux error i acc xs =
     match i, xs with
     | 0, _ -> reverse acc, xs
     | _, [] ->
-      if error then
-          failwith "The input sequence has an insufficient number of elements."
-      else
-          reverse acc, xs
+        if error then
+            failwith "The input sequence has an insufficient number of elements."
+        else
+            reverse acc, xs
     | _, x::xs -> takeSplitAux error (i - 1) (x::acc) xs
+
 let take i xs =
-  match i, xs with
-  | i, _ when i < 0 -> failwith "The input must be non-negative."
-  | 0, _ -> []
-  | 1, x::_ -> [x]
-  | i, xs -> takeSplitAux true i [] xs |> fst
+    match i, xs with
+    | i, _ when i < 0 -> failwith "The input must be non-negative."
+    | 0, _ -> []
+    | 1, x::_ -> [x]
+    | i, xs -> takeSplitAux true i [] xs |> fst
+
+let rec takeWhile predicate (xs: 'T list) =
+    match xs with
+    | [] -> xs
+    | x::([] as nil) -> if predicate x then xs else nil
+    | x::xs ->
+        if not (predicate x) then []
+        else x::(takeWhile predicate xs)
 
 let truncate i xs =
-  match i, xs with
-  | i, _ when i < 0 -> failwith "The input must be non-negative."
-  | 0, _ -> []
-  | 1, x::_ -> [x]
-  | i, xs -> takeSplitAux false i [] xs |> fst
+    match i, xs with
+    | i, _ when i < 0 -> failwith "The input must be non-negative."
+    | 0, _ -> []
+    | 1, x::_ -> [x]
+    | i, xs -> takeSplitAux false i [] xs |> fst
 
 let splitAt i xs =
-  match i, xs with
-  | i, _ when i < 0 -> failwith "The input must be non-negative."
-  | 0, _ -> [],xs
-  | 1, x::xs -> [x],xs
-  | i, xs -> takeSplitAux true i [] xs
-
-let skip i xs =
-  let rec skipInner i xs =
-      match i, xs with
-      | 0, _ -> xs
-      | _, [] -> failwith "The input sequence has an insufficient number of elements."
-      | _, _::xs -> skipInner (i - 1) xs
-  match i, xs with
-  | i, _ when i < 0 -> failwith "The input must be non-negative."
-  | 0, _ -> xs
-  | 1, _::xs -> xs
-  | i, xs -> skipInner i xs
+    match i, xs with
+    | i, _ when i < 0 -> failwith "The input must be non-negative."
+    | 0, _ -> [],xs
+    | 1, x::xs -> [x],xs
+    | i, xs -> takeSplitAux true i [] xs
 
 let toSeq (xs: 'a list): 'a seq =
     Seq.unfold (function [] -> None | x::xs -> Some(x, xs)) xs
@@ -447,6 +461,4 @@ let countBy (projection: 'T -> 'Key) (xs: 'T list)([<Inject>] eq: IEqualityCompa
         result <- (group.Key, group.Value.contents)::result
     result
 
-let skipWhile f = toSeq >> Seq.skipWhile f
-let takeWhile f = toSeq >> Seq.takeWhile f
-let where f = toSeq >> Seq.where f
+let where predicate xs = filter predicate xs

--- a/tests/Main/ArrayTests.fs
+++ b/tests/Main/ArrayTests.fs
@@ -800,4 +800,31 @@ let tests =
         Array.splitAt 0 ar |> equal ([||], [|1;2;3;4|])
         Array.splitAt 3 ar |> equal ([|1;2;3|], [|4|])
         Array.splitAt 4 ar |> equal ([|1;2;3;4|], [||])
+
+    testCase "Array.skip works" <| fun () ->
+        let xs = [|1.; 2.; 3.; 4.; 5.|]
+        let ys = xs |> Array.skip 1
+        ys |> Array.head
+        |> equal 2.
+
+    testCase "Array.skipWhile works" <| fun () ->
+        let xs = [|1.; 2.; 3.; 4.; 5.|]
+        xs |> Array.skipWhile (fun i -> i <= 3.)
+        |> Array.head
+        |> equal 4.
+
+    testCase "Array.take works" <| fun () ->
+        let xs = [|1.; 2.; 3.; 4.; 5.|]
+        xs |> Array.take 2
+        |> Array.last
+        |> equal 2.
+        // Array.take should throw an exception if there're not enough elements
+        try xs |> Array.take 20 |> Array.length with _ -> -1
+        |> equal -1
+
+    testCase "Array.takeWhile works" <| fun () ->
+        let xs = [|1.; 2.; 3.; 4.; 5.|]
+        xs |> Array.takeWhile (fun i -> i < 3.)
+        |> Array.last
+        |> equal 2.
   ]

--- a/tests/Main/ListTests.fs
+++ b/tests/Main/ListTests.fs
@@ -12,10 +12,10 @@ let testListChoose xss =
     xss |> f |> List.collect (fun xs -> [ for s in xs do yield s ])
 
 let rec sumFirstList (zs: float list) (n: int): float =
-   match n with
-   | 0 -> 0.
-   | 1 -> zs.Head
-   | _ -> zs.Head + sumFirstList zs.Tail (n-1)
+    match n with
+    | 0 -> 0.
+    | 1 -> zs.Head
+    | _ -> zs.Head + sumFirstList zs.Tail (n-1)
 
 type Point =
     { x: int; y: int }
@@ -25,31 +25,31 @@ type Point =
 
 let tests =
   testList "Lists" [
-      // TODO: Empty lists may be represented as null, make sure they don't conflict with None
-      testCase "Some [] works" <| fun () ->
-          let xs: int list option = Some []
-          let ys: int list option = None
-          Option.isSome xs |> equal true
-          Option.isNone ys |> equal true
+    // TODO: Empty lists may be represented as null, make sure they don't conflict with None
+    testCase "Some [] works" <| fun () ->
+        let xs: int list option = Some []
+        let ys: int list option = None
+        Option.isSome xs |> equal true
+        Option.isNone ys |> equal true
 
-      testCase "Pattern matching with lists works" <| fun () ->
-          match [] with [] -> true | _ -> false
-          |> equal true
-          match [1] with [] -> 0 | [x] -> 1 | x::xs -> 2
-          |> equal 1
-          match [1;2;3] with [] -> 0 | _::x::xs -> x | _ -> 3
-          |> equal 2
-          match [1.;2.;3.;4.] with [] -> 0 | [x] -> 1 | x::xs -> xs.Length
-          |> equal 3
-          match ["a";"b"] with [] -> 0 | ["a";"b"] -> 1 | _ -> 2
-          |> equal 1
+    testCase "Pattern matching with lists works" <| fun () ->
+        match [] with [] -> true | _ -> false
+        |> equal true
+        match [1] with [] -> 0 | [x] -> 1 | x::xs -> 2
+        |> equal 1
+        match [1;2;3] with [] -> 0 | _::x::xs -> x | _ -> 3
+        |> equal 2
+        match [1.;2.;3.;4.] with [] -> 0 | [x] -> 1 | x::xs -> xs.Length
+        |> equal 3
+        match ["a";"b"] with [] -> 0 | ["a";"b"] -> 1 | _ -> 2
+        |> equal 1
 
-      testCase "List.Length works" <| fun () ->
+    testCase "List.Length works" <| fun () ->
             let xs = [1; 2; 3; 4]
             equal 4 xs.Length
             equal 0 [].Length
 
-      testCase "List.IsEmpty works" <| fun () ->
+    testCase "List.IsEmpty works" <| fun () ->
             let xs = [1; 2; 3; 4]
             let ys = []
             equal false xs.IsEmpty
@@ -57,128 +57,128 @@ let tests =
             equal true ys.IsEmpty
             equal true [].IsEmpty
 
-      testCase "List.Equals works" <| fun () ->
+    testCase "List.Equals works" <| fun () ->
             let xs = [1;2;3]
             xs.Equals(xs) |> equal true
 
-      testCase "List.Head works" <| fun () ->
+    testCase "List.Head works" <| fun () ->
             let xs = [1; 2; 3; 4]
             equal 1 xs.Head
 
-      testCase "List.Tail works" <| fun () ->
+    testCase "List.Tail works" <| fun () ->
             let xs = [1; 2; 3; 4]
             equal 2 xs.Tail.Head
 
-      testCase "List.Item works" <| fun () ->
+    testCase "List.Item works" <| fun () ->
             let xs = [1; 2; 3; 4]
             equal 4 xs.[3]
 
-      testCase "List cons works" <| fun () ->
+    testCase "List cons works" <| fun () ->
             let xs = [1; 2; 3; 4]
             let ys = 3 :: xs
             let zs = List.Cons(4, xs)
             ys.Head + xs.Head
             |> equal zs.Head
 
-      testCase "List.empty works" <| fun () ->
+    testCase "List.empty works" <| fun () ->
             let xs = 1 :: List.Empty
             let ys = 1 :: List.empty
             xs.Length + ys.Length |> equal 2
 
-      testCase "List.append works" <| fun () ->
+    testCase "List.append works" <| fun () ->
             let xs = [1; 2; 3; 4]
             let ys = [0]
             let zs = List.append ys xs
             zs.Head + zs.Tail.Head
             |> equal 1
 
-      testCase "List.choose works" <| fun () ->
+    testCase "List.choose works" <| fun () ->
             let xs = [1; 2; 3; 4]
             let result = xs |> List.choose (fun x ->
-                  if x > 2 then Some x
-                  else None)
+                if x > 2 then Some x
+                else None)
             result.Head + result.Tail.Head
             |> equal 7
 
-      testCase "List.exists works" <| fun () ->
+    testCase "List.exists works" <| fun () ->
             let xs = [1; 2; 3; 4]
             xs |> List.exists (fun x -> x = 2)
             |> equal true
 
-      testCase "List.exists2 works" <| fun () ->
+    testCase "List.exists2 works" <| fun () ->
             let xs = [1; 2; 3; 4]
             let ys = [1; 2; 3; 4]
             List.exists2 (fun x y -> x * y = 16) xs ys
             |> equal true
 
-      testCase "List.filter works" <| fun () ->
+    testCase "List.filter works" <| fun () ->
             let xs = [1; 2; 3; 4]
             let ys = xs |> List.filter (fun x -> x > 5)
             equal ys.IsEmpty true
 
-      testCase "List.find works" <| fun () ->
+    testCase "List.find works" <| fun () ->
             [1; 2; 3; 4]
             |> List.find ((=) 2)
             |> equal 2
 
-      testCase "List.findIndex works" <| fun () ->
+    testCase "List.findIndex works" <| fun () ->
             [1; 2; 3; 4]
             |> List.findIndex ((=) 2)
             |> equal 1
 
-      testCase "List.fold works" <| fun () ->
+    testCase "List.fold works" <| fun () ->
             [1; 2; 3; 4]
             |> List.fold (+) 0
             |> equal 10
 
-      testCase "List.fold2 works" <| fun () ->
+    testCase "List.fold2 works" <| fun () ->
             let xs = [1; 2; 3; 4]
             let ys = [1; 2; 3; 4]
             List.fold2 (fun x y z -> x + y + z) 0 xs ys
             |> equal 20
 
-      testCase "List.foldBack works" <| fun () ->
+    testCase "List.foldBack works" <| fun () ->
             [1; 2; 3; 4]
             |> List.foldBack (fun x acc -> acc - x) <| 100
             |> equal 90
 
-      testCase "List.foldBack with composition works" <| fun () ->
+    testCase "List.foldBack with composition works" <| fun () ->
             [1; 2; 3; 4]
             |> List.foldBack (fun x acc -> acc >> (+) x) <| id <| 2
             |> equal 12
 
-      testCase "List.forall works" <| fun () ->
+    testCase "List.forall works" <| fun () ->
             [1; 2; 3; 4]
             |> List.forall (fun x -> x < 5)
             |> equal true
 
-      testCase "List.forall2 works" <| fun () ->
+    testCase "List.forall2 works" <| fun () ->
             ([1; 2; 3; 4], [1; 2; 3; 4])
             ||> List.forall2 (=)
             |> equal true
 
-      testCase "List.head works" <| fun () ->
+    testCase "List.head works" <| fun () ->
             [1; 2; 3; 4]
             |> List.head
             |> equal 1
 
-      testCase "List.init works" <| fun () ->
+    testCase "List.init works" <| fun () ->
             let xs = List.init 4 float
             xs.Head + xs.Tail.Head
             |> equal 1.
 
-      testCase "List.isEmpty works" <| fun () ->
+    testCase "List.isEmpty works" <| fun () ->
             List.isEmpty [1] |> equal false
             List.isEmpty [] |> equal true
 
-      testCase "List.iter works" <| fun () ->
+    testCase "List.iter works" <| fun () ->
             let xs = [1; 2; 3; 4]
             let mutable total = 0
             xs |> List.iter (fun x ->
             total <- total + x)
             equal 10 total
 
-      testCase "List.iter2 works" <| fun () ->
+    testCase "List.iter2 works" <| fun () ->
             let xs = [1; 2; 3; 4]
             let ys = [2; 4; 6; 8]
             let total = ref 0
@@ -187,14 +187,14 @@ let tests =
             ) xs ys
             equal 10 !total
 
-      testCase "List.iteri works" <| fun () ->
+    testCase "List.iteri works" <| fun () ->
             let mutable total = 0
             [1; 2; 3; 4]
             |> List.iteri (fun i x ->
-                  total <- total + (i * x))
+                total <- total + (i * x))
             equal 20 total
 
-      testCase "List.iteri2 works" <| fun () ->
+    testCase "List.iteri2 works" <| fun () ->
             let mutable total = 0
             let xs = [1; 2; 3; 4]
             let ys = [2; 4; 6; 8]
@@ -203,31 +203,31 @@ let tests =
             ) xs ys
             equal 20 total
 
-      testCase "List.length works" <| fun () ->
+    testCase "List.length works" <| fun () ->
             let xs = [1; 2; 3; 4]
             List.length xs
             |> equal 4
 
-      testCase "List.item works" <| fun () ->
+    testCase "List.item works" <| fun () ->
             [1; 2] |> List.item 1 |> equal 2
 
-      testCase "List.map works" <| fun () ->
+    testCase "List.map works" <| fun () ->
             let xs = [1;2;3]
             let ys = xs |> List.map ((*) 2)
             equal 4 ys.Tail.Head
 
-      testCase "List.mapi works" <| fun () ->
+    testCase "List.mapi works" <| fun () ->
             let xs = [1]
             let ys = xs |> List.mapi (fun i x -> i * x)
             equal 0 ys.Head
 
-      testCase "List.map2 works" <| fun () ->
+    testCase "List.map2 works" <| fun () ->
             let xs = [1;2]
             let ys = [2;3]
             let zs = List.map2 (fun x y -> x - y) xs ys
             equal -1 zs.Head
 
-      testCase "List.ofArray works" <| fun () ->
+    testCase "List.ofArray works" <| fun () ->
             let xs = [|1; 2|]
             let ys = List.ofArray xs
             ys.Head |> equal 1
@@ -236,172 +236,198 @@ let tests =
             let ys1 = List.ofArray xs1
             sumFirstList ys1 3 |> equal 6.
 
-      testCase "List.ofSeq works" <| fun () ->
+    testCase "List.ofSeq works" <| fun () ->
             // let xs = [|1; 2|] :> _ seq
             let ys = List.ofSeq <| seq { yield 1; yield 2 }
             ys.Head |> equal 1
             ys.Length |> equal 2
 
-      testCase "List.pick works" <| fun () ->
+    testCase "List.pick works" <| fun () ->
             let xs = [1; 2]
             xs |> List.pick (fun x ->
-                  match x with
-                  | 2 -> Some x
-                  | _ -> None)
+                match x with
+                | 2 -> Some x
+                | _ -> None)
             |> equal 2
 
-      testCase "List.reduce works" <| fun () ->
+    testCase "List.reduce works" <| fun () ->
             let xs = [1; 2]
             xs |> List.reduce (+)
             |> equal 3
 
-      testCase "List.reduceBack works" <| fun () ->
+    testCase "List.reduceBack works" <| fun () ->
             let xs = [1; 2]
             xs |> List.reduceBack (+)
             |> equal 3
 
-      testCase "List.replicate works" <| fun () ->
+    testCase "List.replicate works" <| fun () ->
             List.replicate 3 3
             |> List.sum |> equal 9
 
-      testCase "List.rev works" <| fun () ->
+    testCase "List.rev works" <| fun () ->
             let xs = [1; 2]
             let ys = xs |> List.rev
             equal 2 ys.Head
 
-      testCase "List.scan works" <| fun () ->
+    testCase "List.scan works" <| fun () ->
             let xs = [1; 2; 3; 4]
             let ys = (0, xs) ||> List.scan (fun acc x -> acc - x)
             ys.[3] + ys.[4]
             |> equal -16
 
-      testCase "List.scanBack works" <| fun () ->
+    testCase "List.scanBack works" <| fun () ->
             let xs = [1; 2; 3]
             let ys = List.scanBack (fun x acc -> acc - x) xs 0
             ys.Head + ys.Tail.Head
             |> equal -11
 
-      testCase "List.sort works" <| fun () ->
-          let xs = [3; 4; 1; -3; 2; 10]
-          xs |> List.sort |> List.take 3 |> List.sum |> equal 0
-          let ys = ["a"; "c"; "B"; "d"]
-          ys |> List.sort |> List.item 1 |> equal "a"
+    testCase "List.sort works" <| fun () ->
+        let xs = [3; 4; 1; -3; 2; 10]
+        xs |> List.sort |> List.take 3 |> List.sum |> equal 0
+        let ys = ["a"; "c"; "B"; "d"]
+        ys |> List.sort |> List.item 1 |> equal "a"
 
-      testCase "List.sortBy works" <| fun () ->
+    testCase "List.sortBy works" <| fun () ->
             let xs = [3; 1; 4; 2]
             let ys = xs |> List.sortBy (fun x -> -x)
             ys.Head + ys.Tail.Head
             |> equal 7
 
-      testCase "List.sortWith works" <| fun () ->
+    testCase "List.sortWith works" <| fun () ->
             let xs = [3; 4; 1; 2]
             let ys = xs |> List.sortWith (fun x y -> int(x - y))
             ys.Head + ys.Tail.Head
             |> equal 3
 
-      testCase "List.sortDescending works" <| fun () ->
-          let xs = [3; 4; 1; -3; 2; 10]
-          xs |> List.sortDescending |> List.take 3 |> List.sum |> equal 17
-          let ys = ["a"; "c"; "B"; "d"]
-          ys |> List.sortDescending |> List.item 1 |> equal "c"
+    testCase "List.sortDescending works" <| fun () ->
+        let xs = [3; 4; 1; -3; 2; 10]
+        xs |> List.sortDescending |> List.take 3 |> List.sum |> equal 17
+        let ys = ["a"; "c"; "B"; "d"]
+        ys |> List.sortDescending |> List.item 1 |> equal "c"
 
-      testCase "List.max works" <| fun () ->
+    testCase "List.max works" <| fun () ->
             let xs = [1; 2]
             xs |> List.max
             |> equal 2
 
-      testCase "List.maxBy works" <| fun () ->
+    testCase "List.maxBy works" <| fun () ->
             let xs = [1; 2]
             xs |> List.maxBy (fun x -> -x)
             |> equal 1
 
-      testCase "List.min works" <| fun () ->
+    testCase "List.min works" <| fun () ->
             let xs = [1; 2]
             xs |> List.min
             |> equal 1
 
-      testCase "List.minBy works" <| fun () ->
+    testCase "List.minBy works" <| fun () ->
             let xs = [1; 2]
             xs |> List.minBy (fun x -> -x)
             |> equal 2
 
-      testCase "List.sum works" <| fun () ->
+    testCase "List.sum works" <| fun () ->
             [1; 2] |> List.sum
             |> equal 3
 
-      testCase "List.sumBy works" <| fun () ->
+    testCase "List.sumBy works" <| fun () ->
             [1; 2] |> List.sumBy (fun x -> x*2)
             |> equal 6
 
-      // TODO!!!
-      // testCase "List.sum with non numeric types works" <| fun () ->
-      //   let p1 = {x=1; y=10}
-      //   let p2 = {x=2; y=20}
-      //   [p1; p2] |> List.sum |> (=) {x=3;y=30} |> equal true
+    // TODO!!!
+    // testCase "List.sum with non numeric types works" <| fun () ->
+    //   let p1 = {x=1; y=10}
+    //   let p2 = {x=2; y=20}
+    //   [p1; p2] |> List.sum |> (=) {x=3;y=30} |> equal true
 
-      // testCase "List.sumBy with non numeric types works" <| fun () ->
-      //   let p1 = {x=1; y=10}
-      //   let p2 = {x=2; y=20}
-      //   [p1; p2] |> List.sumBy Point.Neg |> (=) {x = -3; y = -30} |> equal true
+    // testCase "List.sumBy with non numeric types works" <| fun () ->
+    //   let p1 = {x=1; y=10}
+    //   let p2 = {x=2; y=20}
+    //   [p1; p2] |> List.sumBy Point.Neg |> (=) {x = -3; y = -30} |> equal true
 
-      // testCase "List.sumBy with numeric projection works" <| fun () ->
-      //   let p1 = {x=1; y=10}
-      //   let p2 = {x=2; y=20}
-      //   [p1; p2] |> List.sumBy (fun p -> p.y) |> equal 30
+    // testCase "List.sumBy with numeric projection works" <| fun () ->
+    //   let p1 = {x=1; y=10}
+    //   let p2 = {x=2; y=20}
+    //   [p1; p2] |> List.sumBy (fun p -> p.y) |> equal 30
 
-      testCase "List.tail works" <| fun () ->
+    testCase "List.skip works" <| fun () ->
+        let xs = [1.; 2.; 3.; 4.; 5.]
+        let ys = xs |> List.skip 1
+        ys |> List.head
+        |> equal 2.
+
+    testCase "List.skipWhile works" <| fun () ->
+        let xs = [1.; 2.; 3.; 4.; 5.]
+        xs |> List.skipWhile (fun i -> i <= 3.)
+        |> List.head
+        |> equal 4.
+
+    testCase "List.take works" <| fun () ->
+        let xs = [1.; 2.; 3.; 4.; 5.]
+        xs |> List.take 2
+        |> List.last
+        |> equal 2.
+        // List.take should throw an exception if there're not enough elements
+        try xs |> List.take 20 |> List.length with _ -> -1
+        |> equal -1
+
+    testCase "List.takeWhile works" <| fun () ->
+        let xs = [1.; 2.; 3.; 4.; 5.]
+        xs |> List.takeWhile (fun i -> i < 3.)
+        |> List.last
+        |> equal 2.
+
+    testCase "List.tail works" <| fun () ->
             let xs = [1; 2]
             let ys = xs |> List.tail
             equal 1 ys.Length
 
-      testCase "List.toArray works" <| fun () ->
+    testCase "List.toArray works" <| fun () ->
             let ys = List.toArray [1; 2]
             ys.[0] + ys.[1] |> equal 3
             let xs = [1; 1]
             let ys2 = List.toArray (2::xs)
             ys2.[0] + ys2.[1] + ys2.[2] |> equal 4
 
-      testCase "List.toSeq works" <| fun () ->
+    testCase "List.toSeq works" <| fun () ->
             [1; 2]
             |> List.toSeq
             |> Seq.tail |> Seq.head
             |> equal 2
 
-      testCase "List.tryPick works" <| fun () ->
+    testCase "List.tryPick works" <| fun () ->
             [1; 2]
             |> List.tryPick (function
-                  | 2 -> Some 2
-                  | _ -> None)
+                | 2 -> Some 2
+                | _ -> None)
             |> function
             | Some x -> x
             | None -> 0
             |> equal 2
 
-      testCase "List.tryFind works" <| fun () ->
+    testCase "List.tryFind works" <| fun () ->
             [1; 2]
             |> List.tryFind ((=) 5)
             |> equal None
 
-      testCase "List.tryFindIndex works" <| fun () ->
+    testCase "List.tryFindIndex works" <| fun () ->
             let xs = [1; 2]
             let ys = xs |> List.tryFindIndex ((=) 2)
             ys.Value |> equal 1
             xs |> List.tryFindIndex ((=) 5) |> equal None
 
-
-      testCase "List.unzip works" <| fun () ->
+    testCase "List.unzip works" <| fun () ->
             let xs = [1, 2]
             let ys, zs = xs |> List.unzip
             ys.Head + zs.Head
             |> equal 3
 
-      testCase "List.unzip3 works" <| fun () ->
+    testCase "List.unzip3 works" <| fun () ->
             let xs = [(1, 2, 3); (4, 5, 6)]
             let ys, zs, ks = xs |> List.unzip3
             ys.[1] + zs.[1] + ks.[1]
             |> equal 15
 
-      testCase "List.zip works" <| fun () ->
+    testCase "List.zip works" <| fun () ->
             let xs = [1; 2; 3]
             let ys = [4; 5; 6]
             let zs = List.zip xs ys
@@ -409,20 +435,20 @@ let tests =
             equal 2 x
             equal 5 y
 
-      testCase "List snail to append works" <| fun () ->
+    testCase "List snail to append works" <| fun () ->
             let xs = [1; 2; 3; 4]
             let ys = [0]
             let zs = ys @ xs
             zs.Head + zs.Tail.Head
             |> equal 1
 
-      testCase "List slice works" <| fun () ->
+    testCase "List slice works" <| fun () ->
             let xs = [1; 2; 3; 4]
             xs.[..2] |> List.sum |> equal 6
             xs.[2..] |> List.sum |> equal 7
             xs.[1..2] |> List.sum |> equal 5
 
-      testCase "List.truncate works" <| fun () ->
+    testCase "List.truncate works" <| fun () ->
             [1..3] = (List.truncate 3 [1..5]) |> equal true
             [1..5] = (List.truncate 10 [1..5]) |> equal true
             [] = (List.truncate 0 [1..5]) |> equal true
@@ -430,11 +456,11 @@ let tests =
             [] = (List.truncate 0 []) |> equal true
             [] = (List.truncate 1 []) |> equal true
 
-      testCase "List.choose works with generic arguments" <| fun () ->
-          let res = testListChoose [ Some [ "a" ] ]
-          equal ["a"] res
+    testCase "List.choose works with generic arguments" <| fun () ->
+        let res = testListChoose [ Some [ "a" ] ]
+        equal ["a"] res
 
-      testCase "List.collect works" <| fun () ->
+    testCase "List.collect works" <| fun () ->
             let xs = [[1]; [2]; [3]; [4]]
             let ys = xs |> List.collect id
             ys.Head + ys.Tail.Head
@@ -449,7 +475,7 @@ let tests =
             sumFirstList ys 5
             |> equal 15.
 
-      testCase "List.concat works" <| fun () ->
+    testCase "List.concat works" <| fun () ->
             let xs = [[1]; [2]; [3]; [4]]
             let ys = xs |> List.concat
             ys.Head  + ys.Tail.Head
@@ -460,12 +486,12 @@ let tests =
             sumFirstList ys1 7
             |> equal 28.
 
-      testCase "List.contains works" <| fun () ->
+    testCase "List.contains works" <| fun () ->
             let xs = [1; 2; 3; 4]
             xs |> List.contains 2 |> equal true
             xs |> List.contains 0 |> equal false
 
-      testCase "List.contains lambda doesn't clash" <| fun () ->
+    testCase "List.contains lambda doesn't clash" <| fun () ->
             let modifyList current x =
                 let contains = current |> List.contains x
                 match contains with
@@ -475,73 +501,73 @@ let tests =
             (modifyList l 1) |> List.contains 1 |> equal false
             (modifyList l 5) |> List.contains 5 |> equal true
 
-      testCase "List.average works" <| fun () ->
+    testCase "List.average works" <| fun () ->
             List.average [1.; 2.; 3.; 4.]
             |> equal 2.5
 
-      testCase "List.averageBy works" <| fun () ->
+    testCase "List.averageBy works" <| fun () ->
             [1.; 2.; 3.; 4.]
             |> List.averageBy (fun x -> x * 2.)
             |> equal 5.
 
-      testCase "List.distinct works" <| fun () ->
-          let xs = [1; 1; 1; 2; 2; 3; 3]
-          let ys = xs |> List.distinct
-          ys |> List.length |> equal 3
-          ys |> List.sum |> equal 6
+    testCase "List.distinct works" <| fun () ->
+        let xs = [1; 1; 1; 2; 2; 3; 3]
+        let ys = xs |> List.distinct
+        ys |> List.length |> equal 3
+        ys |> List.sum |> equal 6
 
-      testCase "List.distinct with tuples works" <| fun () ->
-          let xs = [(1, 2); (2, 3); (1, 2)]
-          let ys = xs |> List.distinct
-          ys |> List.length |> equal 2
-          ys |> List.sumBy fst |> equal 3
+    testCase "List.distinct with tuples works" <| fun () ->
+        let xs = [(1, 2); (2, 3); (1, 2)]
+        let ys = xs |> List.distinct
+        ys |> List.length |> equal 2
+        ys |> List.sumBy fst |> equal 3
 
-      testCase "List.distinctBy works" <| fun () ->
-          let xs = [4; 4; 4; 6; 6; 5; 5]
-          let ys = xs |> List.distinctBy (fun x -> x % 2)
-          ys |> List.length |> equal 2
-          ys |> List.head >= 4 |> equal true
+    testCase "List.distinctBy works" <| fun () ->
+        let xs = [4; 4; 4; 6; 6; 5; 5]
+        let ys = xs |> List.distinctBy (fun x -> x % 2)
+        ys |> List.length |> equal 2
+        ys |> List.head >= 4 |> equal true
 
-      testCase "List.distinctBy with tuples works" <| fun () ->
-          let xs = [4,1; 4,2; 4,3; 6,4; 6,5; 5,6; 5,7]
-          let ys = xs |> List.distinctBy (fun (x,_) -> x % 2)
-          ys |> List.length |> equal 2
-          ys |> List.head |> fst >= 4 |> equal true
+    testCase "List.distinctBy with tuples works" <| fun () ->
+        let xs = [4,1; 4,2; 4,3; 6,4; 6,5; 5,6; 5,7]
+        let ys = xs |> List.distinctBy (fun (x,_) -> x % 2)
+        ys |> List.length |> equal 2
+        ys |> List.head |> fst >= 4 |> equal true
 
-      testCase "List.findBack works" <| fun () ->
-          let xs = [1.; 2.; 3.; 4.]
-          xs |> List.find ((>) 4.) |> equal 1.
-          xs |> List.findBack ((>) 4.) |> equal 3.
+    testCase "List.findBack works" <| fun () ->
+        let xs = [1.; 2.; 3.; 4.]
+        xs |> List.find ((>) 4.) |> equal 1.
+        xs |> List.findBack ((>) 4.) |> equal 3.
 
-      testCase "List.findIndexBack works" <| fun () ->
-          let xs = [1.; 2.; 3.; 4.]
-          xs |> List.findIndex ((>) 4.) |> equal 0
-          xs |> List.findIndexBack ((>) 4.) |> equal 2
+    testCase "List.findIndexBack works" <| fun () ->
+        let xs = [1.; 2.; 3.; 4.]
+        xs |> List.findIndex ((>) 4.) |> equal 0
+        xs |> List.findIndexBack ((>) 4.) |> equal 2
 
-      testCase "List.tryFindBack works" <| fun () ->
-          let xs = [1.; 2.; 3.; 4.]
-          xs |> List.tryFind ((>) 4.) |> equal (Some 1.)
-          xs |> List.tryFindBack ((>) 4.) |> equal (Some 3.)
-          xs |> List.tryFindBack ((=) 5.) |> equal None
+    testCase "List.tryFindBack works" <| fun () ->
+        let xs = [1.; 2.; 3.; 4.]
+        xs |> List.tryFind ((>) 4.) |> equal (Some 1.)
+        xs |> List.tryFindBack ((>) 4.) |> equal (Some 3.)
+        xs |> List.tryFindBack ((=) 5.) |> equal None
 
-      testCase "List.tryFindIndexBack works" <| fun () ->
-          let xs = [1.; 2.; 3.; 4.]
-          xs |> List.tryFindIndex ((>) 4.) |> equal (Some 0)
-          xs |> List.tryFindIndexBack ((>) 4.) |> equal (Some 2)
-          xs |> List.tryFindIndexBack ((=) 5.) |> equal None
+    testCase "List.tryFindIndexBack works" <| fun () ->
+        let xs = [1.; 2.; 3.; 4.]
+        xs |> List.tryFindIndex ((>) 4.) |> equal (Some 0)
+        xs |> List.tryFindIndexBack ((>) 4.) |> equal (Some 2)
+        xs |> List.tryFindIndexBack ((=) 5.) |> equal None
 
-      testCase "List.foldBack2 works" <| fun () ->
+    testCase "List.foldBack2 works" <| fun () ->
             ([1; 2; 3; 4], [1; 2; 3; 4], 0)
             |||> List.foldBack2 (fun x y acc -> acc - y * x)
             |> equal -30
 
-      testCase "List.indexed works" <| fun () ->
-          let xs = ["a"; "b"; "c"] |> List.indexed
-          xs.Length |> equal 3
-          fst xs.[2] |> equal 2
-          snd xs.[2] |> equal "c"
+    testCase "List.indexed works" <| fun () ->
+        let xs = ["a"; "b"; "c"] |> List.indexed
+        xs.Length |> equal 3
+        fst xs.[2] |> equal 2
+        snd xs.[2] |> equal "c"
 
-      testCase "List.map3 works" <| fun () ->
+    testCase "List.map3 works" <| fun () ->
             let xs = [1;2;3]
             let ys = [5;4;3]
             let zs = [7;8;9]
@@ -549,57 +575,57 @@ let tests =
             List.sum ks
             |> equal 6
 
-      testCase "List.mapi2 works" <| fun () ->
+    testCase "List.mapi2 works" <| fun () ->
             let xs = [7;8;9]
             let ys = [5;4;3]
             let zs = List.mapi2 (fun i x y -> i * (x - y)) xs ys
             List.sum zs |> equal 16
 
-      testCase "List.mapFold works" <| fun () ->
-          let xs = [1y; 2y; 3y; 4y]
-          let result = xs |> List.mapFold (fun acc x -> (x * 2y, acc + x)) 0y
-          fst result |> List.sum |> equal 20y
-          snd result |> equal 10y
+    testCase "List.mapFold works" <| fun () ->
+        let xs = [1y; 2y; 3y; 4y]
+        let result = xs |> List.mapFold (fun acc x -> (x * 2y, acc + x)) 0y
+        fst result |> List.sum |> equal 20y
+        snd result |> equal 10y
 
-      testCase "List.mapFoldBack works" <| fun () ->
-          let xs = [1.; 2.; 3.; 4.]
-          let result = List.mapFoldBack (fun x acc -> (x * -2., acc - x)) xs 0.
-          fst result |> List.sum |> equal -20.
-          snd result |> equal -10.
+    testCase "List.mapFoldBack works" <| fun () ->
+        let xs = [1.; 2.; 3.; 4.]
+        let result = List.mapFoldBack (fun x acc -> (x * -2., acc - x)) xs 0.
+        fst result |> List.sum |> equal -20.
+        snd result |> equal -10.
 
-      // TODO: Runtime uncurry to arity 2
-      testCase "List.mapFold works II" <| fun () -> // See #842
-          let f x y = x,y
-          let xs,_ = List.mapFold f "a" ["b"]
-          equal "a" xs.Head
+    // TODO: Runtime uncurry to arity 2
+    testCase "List.mapFold works II" <| fun () -> // See #842
+        let f x y = x,y
+        let xs,_ = List.mapFold f "a" ["b"]
+        equal "a" xs.Head
 
-      testCase "List.mapFoldBack works II" <| fun () ->
-          let f x y = x,y
-          let xs,_ = List.mapFoldBack f ["a"] "b"
-          equal "a" xs.Head
+    testCase "List.mapFoldBack works II" <| fun () ->
+        let f x y = x,y
+        let xs,_ = List.mapFoldBack f ["a"] "b"
+        equal "a" xs.Head
 
-      testCase "List.partition works" <| fun () ->
+    testCase "List.partition works" <| fun () ->
             let xs = [1; 2; 3; 4; 5; 6]
             let ys, zs = xs |> List.partition (fun x -> x % 2 = 0)
             List.sum zs |> equal 9
             equal 2 ys.[0]
             equal 5 zs.[2]
 
-      testCase "List.permute works" <| fun () ->
+    testCase "List.permute works" <| fun () ->
             let xs = [1; 2; 3; 4; 5; 6]
             let ys = xs |> List.permute (fun i -> i + 1 - 2 * (i % 2))
             equal 4 ys.[2]
             equal 6 ys.[4]
 
-      testCase "List.range works" <| fun () ->
-          [1..5]
-          |> List.reduce (+)
-          |> equal 15
-          [0..2..9]
-          |> List.reduce (+)
-          |> equal 20
+    testCase "List.range works" <| fun () ->
+        [1..5]
+        |> List.reduce (+)
+        |> equal 15
+        [0..2..9]
+        |> List.reduce (+)
+        |> equal 20
 
-      testCase "List.zip3 works" <| fun () ->
+    testCase "List.zip3 works" <| fun () ->
             let xs = [1; 2; 3]
             let ys = [4; 5; 6]
             let zs = [7; 8; 9]
@@ -609,91 +635,89 @@ let tests =
             equal 6 y
             equal 9 z
 
-      testCase "List.tryItem works" <| fun () ->
-          let xs = [1.; 2.; 3.; 4.]
-          List.tryItem 3 xs |> equal (Some 4.)
-          List.tryItem 4 xs |> equal None
-          List.tryItem -1 xs |> equal None
+    testCase "List.tryItem works" <| fun () ->
+        let xs = [1.; 2.; 3.; 4.]
+        List.tryItem 3 xs |> equal (Some 4.)
+        List.tryItem 4 xs |> equal None
+        List.tryItem -1 xs |> equal None
 
-      testCase "List.tryHead works" <| fun () ->
-          let xs = [1.; 2.; 3.; 4.]
-          List.tryHead xs |> equal (Some 1.)
-          List.tryHead [] |> equal None
+    testCase "List.tryHead works" <| fun () ->
+        let xs = [1.; 2.; 3.; 4.]
+        List.tryHead xs |> equal (Some 1.)
+        List.tryHead [] |> equal None
 
-      testCase "List.last works" <| fun () ->
-          let xs = [1.; 2.; 3.; 4.]
-          xs |> List.last
-          |> equal 4.
+    testCase "List.last works" <| fun () ->
+        let xs = [1.; 2.; 3.; 4.]
+        xs |> List.last
+        |> equal 4.
 
-      testCase "List.tryLast works" <| fun () ->
-          let xs = [1.; 2.; 3.; 4.]
-          List.tryLast xs |> equal (Some 4.)
-          List.tryLast [] |> equal None
+    testCase "List.tryLast works" <| fun () ->
+        let xs = [1.; 2.; 3.; 4.]
+        List.tryLast xs |> equal (Some 4.)
+        List.tryLast [] |> equal None
 
-      testCase "List.countBy works" <| fun () ->
-          let xs = [1; 2; 3; 4]
-          xs |> List.countBy (fun x -> x % 2)
-          |> List.length |> equal 2
+    testCase "List.countBy works" <| fun () ->
+        let xs = [1; 2; 3; 4]
+        xs |> List.countBy (fun x -> x % 2)
+        |> List.length |> equal 2
 
-      testCase "List.groupBy returns valid list" <| fun () ->
-          let xs = [1; 2]
-          let worked =
+    testCase "List.groupBy returns valid list" <| fun () ->
+        let xs = [1; 2]
+        let worked =
             match List.groupBy (fun _ -> true) xs with
             | [true, [1; 2]] -> true
             | _ -> false
-          worked |> equal true
+        worked |> equal true
 
-      testCase "List.unfold works" <| fun () ->
-          let xs = 0. |> List.unfold (fun n -> if n < 3.0 then Some(n+1., n+1.) else None)
-          let sum =
+    testCase "List.unfold works" <| fun () ->
+        let xs = 0. |> List.unfold (fun n -> if n < 3.0 then Some(n+1., n+1.) else None)
+        let sum =
             match xs with
             | n1::n2::n3::[] -> n1 + n2 + n3
             | _ -> 0.0
-          sum |> equal 6.0
+        sum |> equal 6.0
 
-      testCase "List.splitAt works" <| fun () ->
-          let li = [1;2;3;4]
-          List.splitAt 0 li |> equal ([], [1;2;3;4])
-          List.splitAt 3 li |> equal ([1;2;3], [4])
-          List.splitAt 4 li |> equal ([1;2;3;4], [])
+    testCase "List.splitAt works" <| fun () ->
+        let li = [1;2;3;4]
+        List.splitAt 0 li |> equal ([], [1;2;3;4])
+        List.splitAt 3 li |> equal ([1;2;3], [4])
+        List.splitAt 4 li |> equal ([1;2;3;4], [])
 
-      testCase "Types with same name as imports work" <| fun () ->
+    testCase "Types with same name as imports work" <| fun () ->
             let li = [List 5]
             equal 5 li.Head.Value
 
-      testCase "List.Item throws exception when index is out of range" <| fun () ->
-          let xs = [0]
-          (try (xs.Item 1) |> ignore; false with | _ -> true) |> equal true
+    testCase "List.Item throws exception when index is out of range" <| fun () ->
+        let xs = [0]
+        (try (xs.Item 1) |> ignore; false with | _ -> true) |> equal true
 
-      testCase "List.except works" <| fun () ->
-          List.except [2] [1; 3; 2] |> List.last |> equal 3
-          List.except [2] [2; 4; 6] |> List.head |> equal 4
-          List.except [1] [1; 1; 1; 1] |> List.isEmpty |> equal true
-          List.except ['t'; 'e'; 's'; 't'] ['t'; 'e'; 's'; 't'] |> List.isEmpty |> equal true
-          List.except ['t'; 'e'; 's'; 't'] ['t'; 't'] |> List.isEmpty |> equal true
-          List.except [(1, 2)] [(1, 2)] |> List.isEmpty |> equal true
-          List.except [Map.empty |> (fun m -> m.Add(1, 2))] [Map.ofList [(1, 2)]] |> List.isEmpty |> equal true
-          List.except [{ Bar= "test" }] [{ Bar = "test" }] |> List.isEmpty |> equal true
+    testCase "List.except works" <| fun () ->
+        List.except [2] [1; 3; 2] |> List.last |> equal 3
+        List.except [2] [2; 4; 6] |> List.head |> equal 4
+        List.except [1] [1; 1; 1; 1] |> List.isEmpty |> equal true
+        List.except ['t'; 'e'; 's'; 't'] ['t'; 'e'; 's'; 't'] |> List.isEmpty |> equal true
+        List.except ['t'; 'e'; 's'; 't'] ['t'; 't'] |> List.isEmpty |> equal true
+        List.except [(1, 2)] [(1, 2)] |> List.isEmpty |> equal true
+        List.except [Map.empty |> (fun m -> m.Add(1, 2))] [Map.ofList [(1, 2)]] |> List.isEmpty |> equal true
+        List.except [{ Bar= "test" }] [{ Bar = "test" }] |> List.isEmpty |> equal true
 
-      testCase "List iterators from range do rewind" <| fun () ->
-          let xs = [1..5] |> List.toSeq
-          xs |> Seq.map string |> String.concat "," |> equal "1,2,3,4,5"
-          xs |> Seq.map string |> String.concat "," |> equal "1,2,3,4,5"
+    testCase "List iterators from range do rewind" <| fun () ->
+        let xs = [1..5] |> List.toSeq
+        xs |> Seq.map string |> String.concat "," |> equal "1,2,3,4,5"
+        xs |> Seq.map string |> String.concat "," |> equal "1,2,3,4,5"
 
-      testCase "List comprehensions returning None work" <| fun () ->
-          let spam : string option list = [for _ in 0..5 -> None]
-          List.length spam |> equal 6
+    testCase "List comprehensions returning None work" <| fun () ->
+        let spam : string option list = [for _ in 0..5 -> None]
+        List.length spam |> equal 6
 
-      testCase "Int list tail doesn't get wrapped with `| 0`" <| fun () -> // See #1447
-          let revert xs =
-              let rec rev acc (ls: int list) =
-                  match ls with
-                  | [] -> acc
-                  | h::t -> rev (h::acc) t
-              rev [] xs
-          let res = revert [2;3;4]
-          equal 3 res.Length
-          equal 4 res.Head
-
-
+    testCase "Int list tail doesn't get wrapped with `| 0`" <| fun () -> // See #1447
+        let revert xs =
+            let rec rev acc (ls: int list) =
+                match ls with
+                | [] -> acc
+                | h::t -> rev (h::acc) t
+            rev [] xs
+        let res = revert [2;3;4]
+        equal 3 res.Length
+        equal 4 res.Head
   ]


### PR DESCRIPTION
This PR adds some tests and fixes the REPL.

P.S. This one was a bear, it took a *looong* time to figure out why the REPL was skipping some bindings, turned out to be a problem with List.takeWhile/skipWhile. Also, we probably should do another pass at evaluating if any of the core modules generated implementations are inefficient and can be improved.