### PR TITLE
Restore bench project

### DIFF
--- a/src/dotnet/Fable.Compiler/AST/AST.Babel.fs
+++ b/src/dotnet/Fable.Compiler/AST/AST.Babel.fs
@@ -55,9 +55,10 @@ type Pattern = interface end
 /// Not in Babel specs, disguised as StringLiteral
 type MacroExpression(value, args, ?loc) =
     inherit Literal("StringLiteral", ?loc = loc)
+    let macro = true
     member __.Value: string = value
     member __.Args: Expression array = args
-    member __.Macro = true
+    member __.Macro = macro
 
 // Template Literals
 type TemplateElement(value: string, tail, ?loc) =

--- a/src/dotnet/Fable.JS/Interfaces.fs
+++ b/src/dotnet/Fable.JS/Interfaces.fs
@@ -41,5 +41,5 @@ type IFableManager =
     abstract GetParseErrors: parseResults: IParseResults -> Error[]
     abstract GetToolTipText: parseResults: IParseResults * line: int * col: int * lineText: string -> Async<string[]>
     abstract GetCompletionsAtLocation: parseResults: IParseResults * line: int * col: int * lineText: string -> Async<Completion[]>
-    abstract CompileToBabelAst: fableCore: string * parseResults: IParseResults * fileName: string * optimized: bool -> Fable.AST.Babel.Program
+    abstract CompileToBabelAst: fableCore: string * parseResults: IParseResults * fileName: string * optimized: bool -> obj
     abstract FSharpAstToString: parseResults: IParseResults * optimized: bool -> string

--- a/src/dotnet/Fable.JS/Main.fs
+++ b/src/dotnet/Fable.JS/Main.fs
@@ -202,7 +202,7 @@ let init () =
             let res = parseResults :?> ParseResults
             let project = makeProject fileName optimized res
             let com = makeCompiler fableCore fileName project
-            compileAst com project
+            compileAst com project :> obj
         member __.FSharpAstToString(parseResults:IParseResults, optimized: bool) =
             let res = parseResults :?> ParseResults
             if not optimized then res.CheckProject.AssemblyContents.ImplementationFiles

--- a/src/dotnet/Fable.JS/bench/app.fs
+++ b/src/dotnet/Fable.JS/bench/app.fs
@@ -1,4 +1,4 @@
-module App
+module Bench.App
 
 open Bench.Platform
 
@@ -11,6 +11,7 @@ let metadataPath =
 
 [<EntryPoint>]
 let main argv =
+    let testScriptPath = "test_script.fsx"
     let metadataPath, testScriptPath, compiledScriptPath =
         match argv with
         | [|metadataPath; testScriptPath; compiledScriptPath|] -> metadataPath, testScriptPath, compiledScriptPath
@@ -32,14 +33,14 @@ let main argv =
             errors |> Array.iter (printfn "Error: %A")
             if errors.Length > 0 then failwith "Too many errors."
             let ms2, babelAst = measureTime parseFable fsAst
-            if i = 1 then
+            // if i = 1 then
                 // if writeAst then
                 //     let fsAstStr = fable.FSharpAstToString(fsAst, optimized)
                 //     printfn "Typed AST (unoptimized): %s" fsAstStr
                 //     writeAllText fsAstFile fsAstStr
                 //     printfn "Babel AST: %s" (toJson babelAst)
                 //     writeAllText babelAstFile (toJson babelAst)
-                writeJs compiledScriptPath babelAst
+                // writeJs compiledScriptPath babelAst
             printfn "iteration %d, FCS time: %d ms, Fable time: %d ms" i ms1 ms2
         [1..10] |> List.iter bench
     with ex ->

--- a/src/dotnet/Fable.JS/bench/bench.fsproj
+++ b/src/dotnet/Fable.JS/bench/bench.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <DefineConstants>$(DefineConstants);DOTNET_FILE_SYSTEM</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="../../../../build/fable/Fable.Core.dll" />
+    <ProjectReference Include="../Fable.JS.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="platform.fs"/>
+    <Compile Include="app.fs"/>
+  </ItemGroup>
+
+</Project>

--- a/src/dotnet/Fable.JS/bench/package.json
+++ b/src/dotnet/Fable.JS/bench/package.json
@@ -3,14 +3,16 @@
   "scripts": {
     "fable": "dotnet ../../../../build/fable/dotnet-fable.dll start --port 61225",
     "build": "dotnet ../../../../build/fable/dotnet-fable.dll yarn-splitter --fable-core ../../../../build/fable-core",
+    "build-es6": "dotnet ../../../../build/fable/dotnet-fable.dll yarn-splitter-es6 --fable-core ../../../../build/fable-core",
     "build-v1": "dotnet fable yarn-splitter",
     "rename": "cd out && for /r %x in (*.js) do ren \"%x\" *.mjs",
-    "rollup": "node ../../../../node_modules/rollup/bin/rollup -i ./out/bench/app.js -o ./out/bundle.js --format cjs",
-    "webpack": "node ../../../../node_modules/webpack-command/lib/cli.js -p --entry ./out/bench/app.js --output ./out/bundle.js",
-    "splitter": "node ../../../../src/js/fable-splitter/dist/cli",
-    "start": "node out/bench/app",
-    "profile": "node --prof out/bench/app",
+    "rollup": "node ../../../../node_modules/rollup/bin/rollup -i ./out/app.js -o ./out/bundle.js --format cjs",
+    "webpack": "node ../../../../node_modules/webpack-command/lib/cli.js -p --entry ./out/app.js --output ./out/bundle.js",
+    "splitter": "node ../../../js/fable-splitter/dist/cli --commonjs",
+    "splitter-es6": "node ../../../js/fable-splitter/dist/cli",
+    "start": "node out/app",
+    "profile": "node --prof out/app",
     "process": "chcp 65001 > nul && for %x in (isolate-*.log) do node --prof-process %x > %x.txt",
-    "trace": "node --trace-deopt out/bench/app > deopt.txt"
+    "trace": "node --trace-deopt out/app > deopt.txt"
   }
 }

--- a/src/dotnet/Fable.JS/bench/platform.fs
+++ b/src/dotnet/Fable.JS/bench/platform.fs
@@ -1,0 +1,59 @@
+module Bench.Platform
+
+#if DOTNET_FILE_SYSTEM
+
+let fableCoreDir = System.IO.Path.Combine(__SOURCE_DIRECTORY__, "../../../build/fable-core")
+
+let initFable () = Fable.JS.Main.init ()
+let readAllBytes metadataPath (fileName:string) = System.IO.File.ReadAllBytes (metadataPath + fileName)
+let readAllText (filePath:string) = System.IO.File.ReadAllText (filePath, System.Text.Encoding.UTF8)
+let writeAllText (filePath:string) (text:string) = System.IO.File.WriteAllText (filePath, text)
+
+let measureTime (f: 'a -> 'b) x =
+    let sw = System.Diagnostics.Stopwatch.StartNew()
+    let res = f x
+    sw.Stop()
+    sw.ElapsedMilliseconds, res
+
+let writeJs (filePath:string) (babelAst:obj) =
+    () // Does nothing in .NET for now
+
+#else
+
+let fableCoreDir = "${entryDir}/../../../build/fable-core"
+
+type IFileSystem =
+    abstract readFileSync: string -> byte[]
+    abstract readFileSync: string * string -> string
+    abstract writeFileSync: string * string -> unit
+
+type IProcess =
+    abstract hrtime: unit -> float []
+    abstract hrtime: float[] -> float[]
+
+let FileSystem: IFileSystem = Fable.Core.JsInterop.importAll "fs"
+let Process: IProcess = Fable.Core.JsInterop.importAll "process"
+
+// let initFable (): Fable.JS.IFableManager = Fable.Core.JsInterop.import "init" "${entryDir}/../out/Main"
+let initFable () = Fable.JS.Main.init ()
+let readAllBytes metadataPath (fileName:string) = FileSystem.readFileSync(metadataPath + fileName)
+let readAllText (filePath:string) = FileSystem.readFileSync (filePath, "utf8")
+let writeAllText (filePath:string) (text:string) = FileSystem.writeFileSync (filePath, text)
+
+let measureTime (f: 'a -> 'b) x =
+    let startTime = Process.hrtime()
+    let res = f x
+    let elapsed = Process.hrtime(startTime)
+    int64 (elapsed.[0] * 1e3 + elapsed.[1] / 1e6), res
+
+type private IBabelResult =
+    abstract code: string
+
+let private transformFromAst (babelAst: obj): IBabelResult =
+    Fable.Core.JsInterop.importMember "babel-core"
+
+let writeJs (filePath:string) (babelAst:obj) =
+    let res = transformFromAst babelAst
+    writeAllText filePath res.code
+
+#endif

--- a/src/dotnet/Fable.JS/bench/platform.js/splitter.config.js
+++ b/src/dotnet/Fable.JS/bench/platform.js/splitter.config.js
@@ -1,0 +1,12 @@
+const babelOptions = {
+  plugins: [
+    ["transform-es2015-modules-commonjs"],
+  ],
+};
+
+module.exports = {
+  entry: "./bench.js.fsproj",
+  outDir: "./out",
+  // port: 61225,
+  babel: babelOptions,
+};

--- a/src/dotnet/Fable.JS/bench/splitter.config.js
+++ b/src/dotnet/Fable.JS/bench/splitter.config.js
@@ -1,12 +1,32 @@
-const babelOptions = {
-  plugins: [
-    ["transform-es2015-modules-commonjs"],
+let babelOptions = {};
+
+if (process.argv.find(v => v === "--commonjs")) {
+  babelOptions = {
+    plugins: ["transform-es2015-modules-commonjs"],
+  };
+  console.log("Compiling to commmonjs...");
+} else {
+  console.log("Compiling to ES2015 modules...");
+}
+
+const fableOptions = {
+  define: [
+    "FX_NO_CORHOST_SIGNER",
+    "FX_NO_LINKEDRESOURCES",
+    "FX_NO_PDB_READER",
+    "FX_NO_PDB_WRITER",
+    "FX_NO_WEAKTABLE",
+    "FX_REDUCED_EXCEPTIONS",
+    "NO_COMPILER_BACKEND",
+    "NO_EXTENSIONTYPING",
+    "NO_INLINE_IL_PARSER"
   ],
 };
 
 module.exports = {
-  entry: "./platform.js/bench.js.fsproj",
+  entry: "./bench.fsproj",
   outDir: "./out",
   // port: 61225,
   babel: babelOptions,
+  fable: fableOptions,
 };

--- a/src/dotnet/Fable.JS/webpack.config.js
+++ b/src/dotnet/Fable.JS/webpack.config.js
@@ -7,7 +7,9 @@ module.exports = {
   entry: "./out/Main.js",
   output: {
     path: path.join(__dirname, "bundle"),
-    filename: "bundle.min.js"
+    filename: "bundle.min.js",
+    libraryTarget: 'var',
+    library: 'Fable',
   },
   plugins: [
     // Inlining is causing problems in minified code


### PR DESCRIPTION
This PR restores the `bench` project's ability to run on dual F#/JS platform.

It's quite valuable to have the `bench` project build everything from scratch, as it is used to track performance regressions, and a two-step build is counter-productive. Its driver app code doesn't change often so it does not benefit (in fact, it's hindered) from linking to already built repl component. This two-step build is more suitable to the `testapp` project, which is probably what the CI should be running.

@alfonsogarciacaro I have left the platform sub-projects for now, but would like to remove them if possible, to keep it simple. If you can move whatever functionality you need to retain into the testapp project, that would help a lot.