### PR TITLE
webpack for repl

### DIFF
--- a/src/dotnet/Fable.JS/package.json
+++ b/src/dotnet/Fable.JS/package.json
@@ -4,14 +4,6 @@
     "build": "dotnet ../../../build/fable/dotnet-fable.dll yarn-splitter --args \"--commonjs\" --fable-core ../../../build/fable-core",
     "build-modules": "dotnet ../../../build/fable/dotnet-fable.dll yarn-splitter --fable-core ../../../build/fable-core",
     "splitter": "node ../../js/fable-splitter/dist/cli",
-    "bundle": "rollup out/Main.js --file bundle/bundle.js --format iife --name Fable",
-    "postbundle": "uglifyjs bundle/bundle.js -o bundle/bundle.min.js -c -m"
-  },
-  "devDependencies": {
-    "babel-core": "^6.26.3",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
-    "babel-preset-es2015": "^6.24.1",
-    "rollup": "^0.63.2",
-    "uglify-js": "^3.4.5"
+    "bundle": "node ../../../node_modules/webpack-command/lib/cli.js"
   }
 }

--- a/src/dotnet/Fable.JS/splitter.config.js
+++ b/src/dotnet/Fable.JS/splitter.config.js
@@ -4,10 +4,10 @@ console.log("Compiling to " + (useCommonjs ? "commonjs" : "ES2015 modules") + ".
 const babelOptions = useCommonjs
   ? { plugins: ["transform-es2015-modules-commonjs"] }
   : {
-    presets: [
-      // Uglify-js will fail if we don't compile to ES5
-      ["es2015", { modules: false }]
-    ]
+    // presets: [
+    //   // Uglify-js will fail if we don't compile to ES5
+    //   ["es2015", { modules: false }]
+    // ]
   };
 
 const fableOptions = {

--- a/src/dotnet/Fable.JS/webpack.config.js
+++ b/src/dotnet/Fable.JS/webpack.config.js
@@ -1,0 +1,13 @@
+const path = require("path");
+
+module.exports = {
+  mode: "production",
+  devtool: "source-map",
+  entry: "./out/Main.js",
+  output: {
+    path: path.join(__dirname, "bundle"),
+    filename: "bundle.min.js",
+    libraryTarget: 'var',
+    library: 'Fable',
+  }
+};


### PR DESCRIPTION
You don't have to merge this, it's just an example that it works (with uglify-es replaced by terser).
Anyway, the minified rollup size is a bit better than webpack (3.6 MB vs 3.8 MB), possibly because its tree shaking is better.