### PR TITLE
More aggressive binding erasing

### DIFF
--- a/src/dotnet/Fable.Compiler/Transforms/FableTransforms.fs
+++ b/src/dotnet/Fable.Compiler/Transforms/FableTransforms.fs
@@ -248,17 +248,23 @@ module private Transforms =
         match e with
         // Don't try to optimize bindings with multiple ident-value pairs
         // as they can reference each other
-        | Let([ident, Function(args, funBody, currentName)], letBody)
-            when ident.IsCompilerGenerated && not ident.IsMutable
-                && (countReferences 1 ident.Name letBody <= 1) ->
-            if Option.isSome currentName then
-                sprintf "Unexpected named function when erasing binding (%s > %s)" currentName.Value ident.Name
-                |> addWarning com ident.Range
-            let replacement = Function(args, funBody, Some ident.Name)
-            replaceValues (Map [ident.Name, replacement]) letBody
-        | Let([ident, value], body) when ident.IsCompilerGenerated && not ident.IsMutable
-                                        && not(hasDoubleEvalRisk value) ->
-            replaceValues (Map [ident.Name, value]) body
+        | Let([ident, value], letBody) when not ident.IsMutable ->
+            match value with
+            // Match automatic destructuring of tuple arguments in inner functions
+            | Get(IdentExpr tupleIdent,_,_, _) as value
+                    when tupleIdent.IsCompilerGenerated ->
+                replaceValues (Map [ident.Name, value]) letBody
+            | Function(args, funBody, currentName)
+                    when ident.IsCompilerGenerated
+                    && (countReferences 1 ident.Name letBody <= 1) ->
+                if Option.isSome currentName then
+                    sprintf "Unexpected named function when erasing binding (%s > %s)" currentName.Value ident.Name
+                    |> addWarning com ident.Range
+                let replacement = Function(args, funBody, Some ident.Name)
+                replaceValues (Map [ident.Name, replacement]) letBody
+            | value when ident.IsCompilerGenerated && canInlineArg ident.Name value letBody ->
+                replaceValues (Map [ident.Name, value]) letBody
+            | _ -> e
         | e -> e
 
     /// Returns arity of lambda (or lambda option) types

--- a/src/dotnet/Fable.Compiler/Transforms/FableTransforms.fs
+++ b/src/dotnet/Fable.Compiler/Transforms/FableTransforms.fs
@@ -245,12 +245,14 @@ module private Transforms =
         | e -> e
 
     let bindingBetaReduction (com: ICompiler) e =
+        let isTuple = function
+            | Tuple _ -> true
+            | _ -> false
         match e with
-        // Don't try to optimize bindings with multiple ident-value pairs
-        // as they can reference each other
+        // Don't try to optimize bindings with multiple ident-value pairs as they can reference each other
         | Let([ident, value], letBody) when not ident.IsMutable ->
             match value with
-            // Match automatic destructuring of tuple arguments in inner functions
+            // Erase bindings for getters of compiler-generated tuples (as in pattern matching or lambdas destructuring tuple args)
             | Get(IdentExpr tupleIdent, TupleGet _, _, _) as value when tupleIdent.IsCompilerGenerated ->
                 replaceValues (Map [ident.Name, value]) letBody
             | Function(args, funBody, currentName) when ident.IsCompilerGenerated
@@ -261,6 +263,9 @@ module private Transforms =
                 let replacement = Function(args, funBody, Some ident.Name)
                 replaceValues (Map [ident.Name, replacement]) letBody
             | value when ident.IsCompilerGenerated
+                    // Don't erase the binding if the compiler-generated ident is a tuple, because the getters
+                    // will be erased later (see above) and there's a risk the expression gets totally removed
+                    && not(isTuple ident.Type)
                     && canInlineArg ident.Name value letBody ->
                 replaceValues (Map [ident.Name, value]) letBody
             | _ -> e

--- a/src/dotnet/Fable.Compiler/Transforms/FableTransforms.fs
+++ b/src/dotnet/Fable.Compiler/Transforms/FableTransforms.fs
@@ -250,10 +250,10 @@ module private Transforms =
         // as they can reference each other
         | Let([ident, value], letBody) when not ident.IsMutable ->
             match value with
-            // Match automatic destructuring of tuple arguments in inner functions
-            | Get(IdentExpr tupleIdent,_,_, _) as value
-                    when tupleIdent.IsCompilerGenerated ->
-                replaceValues (Map [ident.Name, value]) letBody
+            // // Match automatic destructuring of tuple arguments in inner functions
+            // | Get(IdentExpr tupleIdent,_,_, _) as value
+            //         when tupleIdent.IsCompilerGenerated ->
+            //     replaceValues (Map [ident.Name, value]) letBody
             | Function(args, funBody, currentName)
                     when ident.IsCompilerGenerated
                     && (countReferences 1 ident.Name letBody <= 1) ->


### PR DESCRIPTION
Found the problem that caused wrong compilation in the REPL: if removing bindings for accessing fields of compiler-generated bundles (happens a lot in pattern matching and lambdas with tuple arguments), we need to be sure we don't remove bindings for compiler-generated tuples. I couldn't localize an exact spot, but it seems this made some expressions disappear from the generated code. Should be working now :)