### PR TITLE
Added webpack option for REPL

### DIFF
--- a/src/dotnet/Fable.JS/package.json
+++ b/src/dotnet/Fable.JS/package.json
@@ -3,7 +3,9 @@
   "scripts": {
     "build": "dotnet ../../../build/fable/dotnet-fable.dll yarn-splitter --args \"--commonjs\" --fable-core ../../../build/fable-core",
     "build-modules": "dotnet ../../../build/fable/dotnet-fable.dll yarn-splitter --fable-core ../../../build/fable-core",
+    "build-es6": "dotnet ../../../build/fable/dotnet-fable.dll yarn-splitter --args \"--es6\" --fable-core ../../../build/fable-core",
     "splitter": "node ../../js/fable-splitter/dist/cli",
+    "webpack": "node ../../../node_modules/webpack-command/lib/cli.js -p --entry ./out/Main.js --output ./bundle/bundle.min.js --output-library Fable",
     "bundle": "rollup out/Main.js --file bundle/bundle.js --format iife --name Fable",
     "minify": "uglifyjs bundle/bundle.js -o bundle/bundle.min.js -c -m"
   },

--- a/src/dotnet/Fable.JS/splitter.config.js
+++ b/src/dotnet/Fable.JS/splitter.config.js
@@ -1,14 +1,10 @@
+const useES6 = process.argv.find(v => v === "--es6");
 const useCommonjs = process.argv.find(v => v === "--commonjs");
 console.log("Compiling to " + (useCommonjs ? "commonjs" : "ES2015 modules") + "...")
 
-const babelOptions = useCommonjs
-  ? { plugins: ["transform-es2015-modules-commonjs"] }
-  : {
-    presets: [
-      // Uglify-js will fail if we don't compile to ES5
-      ["es2015", { modules: false }]
-    ]
-  };
+const babelOptions = useES6 ? { } // no plugins, default presets
+  : useCommonjs ? { plugins: ["transform-es2015-modules-commonjs"] }
+  : { presets: [ ["es2015", { modules: false }] ] }; // Uglify-js requires ES5
 
 const fableOptions = {
   define: [


### PR DESCRIPTION
```
Minified bundle size:

ES5-rollup-uglifyjs: 3,748,680 bytes
ES6-webpack-terser:  3,751,254 bytes
```

No change, should be safe to merge.
Just added the option to bundle the REPL with webpack.