### PR TITLE
[dotnet-fable] Return non-zero error code when CLI arguments are wrong

### DIFF
--- a/src/dotnet/Fable.Compiler/CLI/Main.fs
+++ b/src/dotnet/Fable.Compiler/CLI/Main.fs
@@ -219,4 +219,4 @@ let main argv =
         else
             defaultArg args.commandArgs ""
             |> startServerWithProcess pkgJsonDir args.port binPath
-    | None -> printfn "Command missing. Use `dotnet fable --help` to see available options."; 0
+    | None -> printfn "Command missing. Use `dotnet fable --help` to see available options."; -1


### PR DESCRIPTION
Refers to #1513 