### PR TITLE
[Fable 2] Add test for  Map.TryGetValue

### DIFF
--- a/tests/Main/Fable.Tests.fsproj
+++ b/tests/Main/Fable.Tests.fsproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Expecto" Version="5.1.2" />
+    <PackageReference Include="FSharp.Core" Version="4.5.2" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Fable.Core" HintPath="../../build/fable/Fable.Core.dll" />

--- a/tests/Main/MapTests.fs
+++ b/tests/Main/MapTests.fs
@@ -36,6 +36,11 @@ let tests =
             xs.Count
             |> equal 1
 
+        testCase "Map.TryGetValue works" <| fun () ->
+            let xs = Map.empty.Add(1, 1)
+            xs.TryGetValue(1)
+            |> equal (true, 1)
+
         testCase "Map.containsKey works" <| fun () ->
             let xs = Map.empty |> Map.add 1 1
             xs |> Map.containsKey 1 |> equal true


### PR DESCRIPTION
With an older version of Fable I get ``error FABLE: Cannot find replacement for Microsoft.FSharp.Collections.FSharpMap::TryGetValue``

I don't want to update right now, so let's see if this was added.