### PR TITLE
Initial work on improving "toHex"

### DIFF
--- a/src/js/fable-core/String.ts
+++ b/src/js/fable-core/String.ts
@@ -1,4 +1,5 @@
 import { toString as dateToString } from "./Date";
+import Long, { toString as longToString } from "./Long";
 import { escape } from "./RegExp";
 import { isArray, toString } from "./Util";
 
@@ -120,10 +121,8 @@ export function indexOfAny(str: string, anyOf: number[], ...args: number[]) {
   return -1;
 }
 
-function toHex(value: number) {
-  return value < 0
-    ? "ff" + (16777215 - (Math.abs(value) - 1)).toString(16)
-    : value.toString(16);
+function toHex(x: any) {
+  return x instanceof Long ? longToString(x, 16) : (Number(x) >>> 0).toString(16);
 }
 
 export type IPrintfFormatContinuation =
@@ -173,9 +172,9 @@ function formatOnce(str2: any, rep: any) {
         case "A":
           rep = toString(rep, true); break;
         case "x":
-          rep = toHex(Number(rep)); break;
+          rep = toHex(rep); break;
         case "X":
-          rep = toHex(Number(rep)).toUpperCase(); break;
+          rep = toHex(rep).toUpperCase(); break;
       }
       const plusPrefix = flags.indexOf("+") >= 0 && parseInt(rep, 10) >= 0;
       pad = parseInt(pad, 10);
@@ -220,7 +219,7 @@ export function format(str: string, ...args: any[]) {
     (match: any, idx: any, pad: any, pattern: any) => {
       let rep = args[idx];
       let padSymbol = 32; // " ";
-      if (typeof rep === "number") {
+      if (typeof rep === "number" || rep instanceof Long) {
         switch ((pattern || "").substring(0, 1)) {
           case "f": case "F":
             rep = pattern.length > 1 ? rep.toFixed(pattern.substring(1)) : rep.toFixed(2);

--- a/tests/Main/StringTests.fs
+++ b/tests/Main/StringTests.fs
@@ -146,12 +146,34 @@ let tests =
       #endif
 
       testCase "sprintf \"%X\" works" <| fun () ->
-            sprintf "%X" 255 |> equal "FF"
-            sprintf "%x" 255 |> equal "ff"
-            sprintf "%X" -255 |> equal "FFFFFF01"
-            String.Format("{0:X}", 255) |> equal "FF"
-            String.Format("{0:x}", 255) |> equal "ff"
-            String.Format("{0:X}", -255) |> equal "FFFFFF01"
+            //These should all be the Native JS Versions (except int64 / uint64)
+            //See #1530 for more information.
+
+            sprintf "255: %X" 255 |> equal "255: FF"
+            sprintf "255: %x" 255 |> equal "255: ff"
+            sprintf "-255: %X" -255 |> equal "-255: FFFFFF01"
+            sprintf "4095L: %X" 4095L |> equal "4095L: FFF"
+            sprintf "-4095L: %X" -4095L |> equal "-4095L: -FFF"
+            sprintf "1 <<< 31: %x" (1 <<< 31) |> equal "1 <<< 31: 80000000"
+            sprintf "1u <<< 31: %x" (1u <<< 31) |> equal "1u <<< 31: 80000000"
+            sprintf "2147483649L: %x" 2147483649L |> equal "2147483649L: 80000001"
+            sprintf "2147483650uL: %x" 2147483650uL |> equal "2147483650uL: 80000002"
+            sprintf "1L <<< 63: %x" (1L <<< 63) |> equal "1L <<< 63: -8000000000000000"
+            sprintf "1uL <<< 63: %x" (1uL <<< 63) |> equal "1uL <<< 63: 8000000000000000"
+
+      testCase "String.Format {0:x} works" <| fun () ->
+            //See above comment on expected values
+            String.Format("255: {0:X}", 255) |> equal "255: FF"
+            String.Format("255: {0:x}", 255) |> equal "255: ff"
+            String.Format("-255: {0:X}", -255) |> equal "-255: FFFFFF01"
+            String.Format("4095L: {0:X}", 4095L) |> equal "4095L: FFF"
+            String.Format("-4095L: {0:X}", -4095L) |> equal "-4095L: -FFF"
+            String.Format("1 <<< 31: {0:x}", (1 <<< 31)) |> equal "1 <<< 31: 80000000"
+            String.Format("1u <<< 31: {0:x}", (1u <<< 31)) |> equal "1u <<< 31: 80000000"
+            String.Format("2147483649L: {0:x}", 2147483649L) |> equal "2147483649L: 80000001"
+            String.Format("2147483650uL: {0:x}", 2147483650uL) |> equal "2147483650uL: 80000002"
+            String.Format("1L <<< 63: {0:x}", (1L <<< 63)) |> equal "1L <<< 63: -8000000000000000"
+            String.Format("1uL <<< 63: {0:x}", (1uL <<< 63)) |> equal "1uL <<< 63: 8000000000000000"
 
       testCase "Printf works with generic argument" <| fun () ->
           spr "bar %s" "a" |> equal "bar a"


### PR DESCRIPTION
As per the discussion on #1530 there are some improvements needed to the `toHex` function.

This is the first set of changes and the behaviour in Javascript.
There are some failing tests still from running the codes in F#.

The first failure is:

```
Expected string to equal:
"-4095L: -FFF"

The string differs at index 8.
"-4095L: FFFFFFFFFFFFF001"
```

I'm not sure how to progress these now, any suggestions?