### PR TITLE
Fix AppVeyor artifacts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,11 +27,11 @@ build_script:
 test: off
 # version: 0.0.1.{build}
 artifacts:
-# https://ci.appveyor.com/api/projects/fable-compiler/Fable/artifacts/src/dotnet/Fable.JS/repl.zip
-  - path: src\dotnet\Fable.JS\out
+# https://ci.appveyor.com/api/projects/fable-compiler/Fable/artifacts/src/dotnet/Fable.Repl/repl.zip
+  - path: src\dotnet\Fable.Repl\out
     name: repl
     type: zip
-# https://ci.appveyor.com/api/projects/fable-compiler/Fable/artifacts/src/dotnet/Fable.JS/repl-bundle.zip
-  - path: src\dotnet\Fable.JS\bundle
+# https://ci.appveyor.com/api/projects/fable-compiler/Fable/artifacts/src/dotnet/Fable.Repl/repl-bundle.zip
+  - path: src\dotnet\Fable.Repl\bundle
     name: repl-bundle
     type: zip


### PR DESCRIPTION
After the rename of Fable.JS to Fable.Repl in 812168d this was missed.

I plan on sending a PR for the Repl2 repo to look in the right place if
this works.