### PR TITLE
Attach interfaces members to prototype

### DIFF
--- a/src/dotnet/Fable.Compiler/AST/AST.Fable.fs
+++ b/src/dotnet/Fable.Compiler/AST/AST.Fable.fs
@@ -86,25 +86,16 @@ type ConstructorKind =
     | UnionConstructor of UnionConstructorInfo
     | CompilerGeneratedConstructor of CompilerGeneratedConstructorInfo
 
-type OverrideDeclarationInfo =
+type AttachedMemberDeclarationInfo =
     { Name: string
       Kind: ObjectMemberKind
       EntityName: string }
 
-type InterfaceImplementation =
-    { Name: string
-      IsPublic: bool
-      ImplementingType: FSharpEntity
-      InterfaceType: FSharpEntity
-      /// Name of the casting functions for inherited interfaces
-      InheritedInterfaces: string list
-      Members: ObjectMember list }
-
 type Declaration =
     | ActionDeclaration of Expr
     | ValueDeclaration of Expr * ValueDeclarationInfo
-    | OverrideDeclaration of args: Ident list * body: Expr * OverrideDeclarationInfo
-    | ConstructorDeclaration of ConstructorKind * InterfaceImplementation list
+    | AttachedMemberDeclaration of args: Ident list * body: Expr * AttachedMemberDeclarationInfo
+    | ConstructorDeclaration of ConstructorKind
 
 type File(sourcePath, decls, ?usedVarNames, ?dependencies) =
     member __.SourcePath: string = sourcePath

--- a/src/dotnet/Fable.Compiler/Global/Prelude.fs
+++ b/src/dotnet/Fable.Compiler/Global/Prelude.fs
@@ -123,6 +123,7 @@ module Naming =
               "System.IComparable"
               "System.Collections.Generic.IEnumerable"
               "System.Collections.IEnumerable"
+              "System.Collections.Generic.IEnumerator`1"
             ]
 
     let interfaceMethodsImplementedInPrototype =

--- a/src/dotnet/Fable.Compiler/Transforms/FSharp2Fable.Util.fs
+++ b/src/dotnet/Fable.Compiler/Transforms/FSharp2Fable.Util.fs
@@ -763,24 +763,24 @@ module Util =
         else
           match com.TryReplaceInterfaceCast(r, t, interfaceFullName, expr) with
           | Some expr -> expr
-          | None ->
-            match tryFindImplementingEntity sourceEntity interfaceFullName with
-            | None ->
-                (interfaceFullName, sourceEntity.TryFullName)
-                ||> sprintf "Cannot find type implementing interface %s in %A hierarchy, cast does nothing."
-                |> addWarning com ctx.InlinePath r
-                expr
-            | Some ent when isReplacementCandidate ent -> expr
-            | Some ent  ->
-                let cast expr =
-                    let entLoc = getEntityLocation ent
-                    let file = Path.normalizePathAndEnsureFsExtension entLoc.FileName
-                    let funcName = getInterfaceImplementationName com ent interfaceFullName
-                    if file = com.CurrentFile
-                    then makeIdent funcName |> Fable.IdentExpr
-                    else makeInternalImport Fable.Any funcName file
-                    |> staticCall None t (argInfo None [expr] Fable.NoUncurrying)
-                Fable.DelayedResolution(Fable.AsInterface(expr, cast, interfaceFullName), t, r)
+          | None -> expr
+            // match tryFindImplementingEntity sourceEntity interfaceFullName with
+            // | None ->
+            //     (interfaceFullName, sourceEntity.TryFullName)
+            //     ||> sprintf "Cannot find type implementing interface %s in %A hierarchy, cast does nothing."
+            //     |> addWarning com ctx.InlinePath r
+            //     expr
+            // | Some ent when isReplacementCandidate ent -> expr
+            // | Some ent  ->
+            //     let cast expr =
+            //         let entLoc = getEntityLocation ent
+            //         let file = Path.normalizePathAndEnsureFsExtension entLoc.FileName
+            //         let funcName = getInterfaceImplementationName com ent interfaceFullName
+            //         if file = com.CurrentFile
+            //         then makeIdent funcName |> Fable.IdentExpr
+            //         else makeInternalImport Fable.Any funcName file
+            //         |> staticCall None t (argInfo None [expr] Fable.NoUncurrying)
+            //     Fable.DelayedResolution(Fable.AsInterface(expr, cast, interfaceFullName), t, r)
 
     let callInstanceMember com ctx r typ (argInfo: Fable.ArgInfo) (entity: FSharpEntity) (memb: FSharpMemberOrFunctionOrValue) =
         let callee =

--- a/src/dotnet/Fable.Compiler/Transforms/FSharp2Fable.fs
+++ b/src/dotnet/Fable.Compiler/Transforms/FSharp2Fable.fs
@@ -803,22 +803,26 @@ let private transformInterfaceImplementationMember (com: FableCompiler) ctx (mem
     if Set.contains memb.CompiledName Naming.interfaceMethodsImplementedInPrototype
     then transformOverride com ctx memb args body
     else
-        match memb.DeclaringEntity, tryGetInterfaceDefinitionFromMethod memb with
-        | Some ent, Some interfaceEntity when not(Naming.ignoredInterfaces.Contains interfaceEntity.FullName) ->
-            let bodyCtx, args = bindMemberArgs com ctx args
-            let body = transformExpr com bodyCtx body |> run
-            let value = Fable.Function(Fable.Delegate args, body, None)
-            let kind =
-                if memb.IsPropertyGetterMethod && countNonCurriedParams memb = 0
-                then Fable.ObjectGetter
-                elif memb.IsPropertySetterMethod && countNonCurriedParams memb = 1
-                then Fable.ObjectSetter
-                else hasSeqSpread memb |> Fable.ObjectMethod
-            let objMember = Fable.ObjectMember(makeStrConst memb.DisplayName, value, kind)
-            let ifcImplName = getInterfaceImplementationName com ent interfaceEntity.FullName
-            com.InterfaceImplementationMembers.Add(ifcImplName, objMember)
-        | _ -> ()
-        []
+        match tryGetInterfaceDefinitionFromMethod memb with
+        | Some interfaceEntity when not(Naming.ignoredInterfaces.Contains interfaceEntity.FullName) ->
+            transformOverride com ctx memb args body
+        | _ -> []
+        // match memb.DeclaringEntity, tryGetInterfaceDefinitionFromMethod memb with
+        // | Some ent, Some interfaceEntity when not(Naming.ignoredInterfaces.Contains interfaceEntity.FullName) ->
+        //     let bodyCtx, args = bindMemberArgs com ctx args
+        //     let body = transformExpr com bodyCtx body |> run
+        //     let value = Fable.Function(Fable.Delegate args, body, None)
+        //     let kind =
+        //         if memb.IsPropertyGetterMethod && countNonCurriedParams memb = 0
+        //         then Fable.ObjectGetter
+        //         elif memb.IsPropertySetterMethod && countNonCurriedParams memb = 1
+        //         then Fable.ObjectSetter
+        //         else hasSeqSpread memb |> Fable.ObjectMethod
+        //     let objMember = Fable.ObjectMember(makeStrConst memb.DisplayName, value, kind)
+        //     let ifcImplName = getInterfaceImplementationName com ent interfaceEntity.FullName
+        //     com.InterfaceImplementationMembers.Add(ifcImplName, objMember)
+        // | _ -> ()
+        // []
 
 let private transformMemberDecl (com: FableCompiler) (ctx: Context) (memb: FSharpMemberOrFunctionOrValue)
                                 (args: FSharpMemberOrFunctionOrValue list list) (body: FSharpExpr) =

--- a/src/dotnet/Fable.Compiler/Transforms/Fable2Babel.fs
+++ b/src/dotnet/Fable.Compiler/Transforms/Fable2Babel.fs
@@ -1469,7 +1469,7 @@ module Util =
                         transformUnionConstructor com ctx info
                     | Fable.CompilerGeneratedConstructor info ->
                         transformCompilerGeneratedConstructor com ctx info
-                consDecls @ (ifcs |> List.map (transformInterfaceCast com ctx))
+                consDecls // @ (ifcs |> List.map (transformInterfaceCast com ctx))
                 |> List.append transformed
                 |> transformDeclarations com ctx restDecls
             | Fable.OverrideDeclaration(args, body, info) ->

--- a/src/dotnet/Fable.Compiler/Transforms/FableTransforms.fs
+++ b/src/dotnet/Fable.Compiler/Transforms/FableTransforms.fs
@@ -543,7 +543,7 @@ let rec optimizeDeclaration (com: ICompiler) = function
         ActionDeclaration(optimizeExpr com expr)
     | ValueDeclaration(value, info) ->
         ValueDeclaration(optimizeExpr com value, info)
-    | ConstructorDeclaration(kind, interfaces) ->
+    | ConstructorDeclaration kind ->
         let kind =
             match kind with
             | ClassImplicitConstructor info ->
@@ -559,14 +559,9 @@ let rec optimizeDeclaration (com: ICompiler) = function
                             info.Arguments, info.Body
                 ClassImplicitConstructor { info with Arguments = args; Body = body }
             | kind -> kind
-        let interfaces =
-            interfaces |> List.map (fun info ->
-                let members = info.Members |> List.map (fun (ObjectMember(k,v,kind)) ->
-                    ObjectMember(optimizeExpr com k, optimizeExpr com v, kind))
-                { info with Members = members })
-        ConstructorDeclaration(kind, interfaces)
-    | OverrideDeclaration(args, body, info) ->
-        OverrideDeclaration(args, optimizeExpr com body, info)
+        ConstructorDeclaration kind
+    | AttachedMemberDeclaration(args, body, info) ->
+        AttachedMemberDeclaration(args, optimizeExpr com body, info)
 
 let optimizeFile (com: ICompiler) (file: File) =
     let newDecls = List.map (optimizeDeclaration com) file.Declarations

--- a/src/js/fable-core/Util.ts
+++ b/src/js/fable-core/Util.ts
@@ -1,17 +1,6 @@
 // tslint:disable:ban-types
 import { compare as compareDates, toString as dateToString } from "./Date";
 
-export const THIS_REF = Symbol("this");
-
-// In case the object has been casted to an interface, test also agains THIS_REF
-export function instanceofExtended(obj: any, cons: FunctionConstructor) {
-  return obj instanceof cons || obj[THIS_REF] instanceof cons;
-}
-
-export function downcast(obj: any) {
-  return obj[THIS_REF] != null ? obj[THIS_REF] : obj;
-}
-
 // Object.assign flattens getters and setters
 // See https://stackoverflow.com/questions/37054596/js-es5-how-to-assign-objects-with-setters-and-getters
 export function extend(target: any, ...sources: any[]) {
@@ -437,7 +426,6 @@ export function createObj(fields: Iterable<any>, caseRule = CaseRules.None) {
     if (kvPair == null) {
       fail(kvPair);
     }
-    kvPair = downcast(kvPair); // The item may be casted to an interface
     if (typeof kvPair.toJSON === "function") { // Deflate unions
       kvPair = kvPair.toJSON();
     }

--- a/tests/Main/TypeTests.fs
+++ b/tests/Main/TypeTests.fs
@@ -176,15 +176,15 @@ type FooImplementorChild() =
 
 [<AbstractClass>]
 type AbstractFoo() =
-    abstract member Foo: unit -> string
+    abstract member Foo2: unit -> string
     interface IFoo with
-        member this.Foo() = this.Foo() + "FOO"
+        member this.Foo() = this.Foo2() + "FOO"
         member x.Bar = ""
         member x.MySetter with get() = 0 and set(v) = ()
 
 type ChildFoo() =
     inherit AbstractFoo()
-    override this.Foo() = "BAR"
+    override this.Foo2() = "BAR"
 
 type BaseClass () =
     abstract member Init: unit -> int
@@ -553,9 +553,10 @@ let tests =
         (foo :> IFoo).MySetter <- 7
         (foo :> IFoo).MySetter |> equal 19
 
+    // TODO: Interface and abstract methods with same name clash
     testCase "A type overloading an interface method can be inherited" <| fun () ->
         let foo = ChildFoo() :> AbstractFoo
-        foo.Foo() |> equal "BAR"
+        foo.Foo2() |> equal "BAR"
         (foo :> IFoo).Foo() |> equal "BARFOO"
         mangleFoo foo |> equal "BARFOO"
 


### PR DESCRIPTION
See discussion here #1547

We've decided to eliminate the interface casting introduced in Fable 2. This means name clashes are possible if two interfaces are implemented with a member with the same name, however we already have to take care with names of interfaces and abstract members (overloads are forbidden), and it increases performance and solves other issues like flexible generic parameters. So all in all it seems to be a good compromise.