### PR TITLE
Use lower case path for dedup

### DIFF
--- a/src/js/fable-splitter/src/index.ts
+++ b/src/js/fable-splitter/src/index.ts
@@ -117,10 +117,10 @@ function getOutPath(path: string, info: CompilationInfo): string {
         // dedup output path
         let i = 0;
         outPath = newPath;
-        while (info.dedupOutPaths.has(outPath)) {
+        while (info.dedupOutPaths.has(outPath.toLowerCase())) {
             outPath = `${newPath}.${++i}`;
         }
-        info.dedupOutPaths.add(outPath);
+        info.dedupOutPaths.add(outPath.toLowerCase());
         info.mapInOutPaths.set(path, outPath);
     }
     return outPath;


### PR DESCRIPTION
This fixes a bug with case insensitive filesystems where files such as "program.fs" and "Program.fs" would not be deduped and would overwrite each other. The fix also preserves the casing of the original file. 

It might look a bit wasteful to do `.ToLower()` twice, but alternative did not look any better (if we want to preserve the casing):
```
let outPathLower = outPath.toLowerCase();
while (info.dedupOutPaths.has(outPathLower)) {
    outPath = `${newPath}.${++i}`;
    outPathLower = outPath.toLowerCase();
}
```