### PR TITLE
Repl edge

### DIFF
--- a/src/dotnet/Fable.Compiler/Transforms/Replacements.fs
+++ b/src/dotnet/Fable.Compiler/Transforms/Replacements.fs
@@ -2565,7 +2565,7 @@ let tryBaseConstructor com (ent: FSharpEntity) (memb: FSharpMemberOrFunctionOrVa
             | [Number _; IEqualityComparer], [_; eqComp] ->
                 [makeArray Any []; makeComparerFromEqualityComparer eqComp]
             | _ -> failwith "Unexpected dictionary constructor"
-        Some(makeCoreRef Any "Dictionary" "Types", args)
+        Some(makeCoreRef Any "Dictionary" "DictTypes", args)
     | Types.hashset ->
         let args =
             match FSharp2Fable.TypeHelpers.getArgTypes com memb, args with
@@ -2578,5 +2578,5 @@ let tryBaseConstructor com (ent: FSharpEntity) (memb: FSharpMemberOrFunctionOrVa
             | [IEqualityComparer], [eqComp] ->
                 [makeArray Any []; makeComparerFromEqualityComparer eqComp]
             | _ -> failwith "Unexpected hashset constructor"
-        Some(makeCoreRef Any "HashSet" "Types", args)
+        Some(makeCoreRef Any "HashSet" "DictTypes", args)
     | _ -> None

--- a/src/js/fable-core/DictTypes.js
+++ b/src/js/fable-core/DictTypes.js
@@ -1,0 +1,31 @@
+import { createMutable as createMutableMap } from "./Map";
+import { createMutable as createMutableSet } from "./Set";
+
+export const Dictionary = declare(function Dictionary(source, comparer) {
+  this.__mutableMap = createMutableMap(source, comparer);
+});
+Object.defineProperty(Dictionary.prototype, "size", { get: function() {
+  return this.__mutableMap.size;
+}});
+Dictionary.prototype.clear = function() { return this.__mutableMap.clear(); };
+Dictionary.prototype.delete = function(k) { return this.__mutableMap.delete(k); };
+Dictionary.prototype.entries = function() { return this.__mutableMap.entries(); };
+Dictionary.prototype.get = function(k) { return this.__mutableMap.get(k); };
+Dictionary.prototype.has = function(k) { return this.__mutableMap.has(k); };
+Dictionary.prototype.keys = function() { return this.__mutableMap.keys(); };
+Dictionary.prototype.set = function(k, v) { return this.__mutableMap.set(k, v); };
+Dictionary.prototype.values = function() { return this.__mutableMap.values(); };
+Dictionary.prototype[Symbol.iterator] = function() { return this.__mutableMap[Symbol.iterator](); };
+
+export const HashSet = declare(function HashSet(source, comparer) {
+  this.__mutableSet = createMutableSet(source, comparer);
+});
+Object.defineProperty(HashSet.prototype, "size", { get: function() {
+  return this.__mutableSet.size;
+}});
+HashSet.prototype.add = function(v) { return this.__mutableSet.add(v); };
+HashSet.prototype.clear = function() { return this.__mutableSet.clear(); };
+HashSet.prototype.delete = function(k) { return this.__mutableSet.delete(k); };
+HashSet.prototype.has = function(k) { return this.__mutableSet.has(k); };
+HashSet.prototype.values = function() { return this.__mutableSet.values(); };
+HashSet.prototype[Symbol.iterator] = function() { return this.__mutableSet[Symbol.iterator](); };

--- a/src/js/fable-core/DictTypes.js
+++ b/src/js/fable-core/DictTypes.js
@@ -1,5 +1,6 @@
 import { createMutable as createMutableMap } from "./Map";
 import { createMutable as createMutableSet } from "./Set";
+import { declare } from "./Types";
 
 export const Dictionary = declare(function Dictionary(source, comparer) {
   this.__mutableMap = createMutableMap(source, comparer);

--- a/src/js/fable-core/Types.js
+++ b/src/js/fable-core/Types.js
@@ -1,5 +1,3 @@
-import { createMutable as createMutableMap } from "./Map";
-import { createMutable as createMutableSet } from "./Set";
 import { combineHashCodes, compare, compareArrays, equals, equalArrays, identityHash, structuralHash, numberHash, toString } from "./Util";
 
 function sameType(x, y) {
@@ -278,34 +276,5 @@ export const MatchFailureException = declare(function MatchFailureException(arg1
   this.arg2 = arg2 | 0;
   this.arg3 = arg3 | 0;
 }, FSharpException);
-
-export const Dictionary = declare(function Dictionary(source, comparer) {
-  this.__mutableMap = createMutableMap(source, comparer);
-});
-Object.defineProperty(Dictionary.prototype, "size", { get: function() {
-  return this.__mutableMap.size;
-}});
-Dictionary.prototype.clear = function() { return this.__mutableMap.clear(); };
-Dictionary.prototype.delete = function(k) { return this.__mutableMap.delete(k); };
-Dictionary.prototype.entries = function() { return this.__mutableMap.entries(); };
-Dictionary.prototype.get = function(k) { return this.__mutableMap.get(k); };
-Dictionary.prototype.has = function(k) { return this.__mutableMap.has(k); };
-Dictionary.prototype.keys = function() { return this.__mutableMap.keys(); };
-Dictionary.prototype.set = function(k, v) { return this.__mutableMap.set(k, v); };
-Dictionary.prototype.values = function() { return this.__mutableMap.values(); };
-Dictionary.prototype[Symbol.iterator] = function() { return this.__mutableMap[Symbol.iterator](); };
-
-export const HashSet = declare(function HashSet(source, comparer) {
-  this.__mutableSet = createMutableSet(source, comparer);
-});
-Object.defineProperty(HashSet.prototype, "size", { get: function() {
-  return this.__mutableSet.size;
-}});
-HashSet.prototype.add = function(v) { return this.__mutableSet.add(v); };
-HashSet.prototype.clear = function() { return this.__mutableSet.clear(); };
-HashSet.prototype.delete = function(k) { return this.__mutableSet.delete(k); };
-HashSet.prototype.has = function(k) { return this.__mutableSet.has(k); };
-HashSet.prototype.values = function() { return this.__mutableSet.values(); };
-HashSet.prototype[Symbol.iterator] = function() { return this.__mutableSet[Symbol.iterator](); };
 
 export const Attribute = declare(function Attribute() { });


### PR DESCRIPTION
This PR remove the circular dependency that exists between `Set.fs`/`Map.fs` and `Types.js` by moving the definition of `Dictionary` and `HashSet` to a new file.

This will make the **repl2** compatible with Edge as the order of `import` statements in modules isn't defined in any specification they implemented it in a way that is unfriendly to circular dependencies

*(They plan to change it and mimic v8 behavior, it's sad I think it make a good point for using a language that doesn't allow theses like F# and then transpiling to JS).*

Related: https://github.com/fable-compiler/repl2/pull/51