### PR TITLE
Update Rollup plugin

### DIFF
--- a/src/js/rollup-plugin-fable/index.js
+++ b/src/js/rollup-plugin-fable/index.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 const babel = require('@babel/core');
-const fableUtils = require ("fable-utils");
+const fableUtils = require('fable-utils');
 const { createFilter } = require('rollup-pluginutils');
 
 const DEFAULT_PORT =

--- a/src/js/rollup-plugin-fable/index.js
+++ b/src/js/rollup-plugin-fable/index.js
@@ -1,7 +1,7 @@
 /// @ts-check
 
 const path = require('path');
-const babel = require('babel-core');
+const babel = require('@babel/core');
 const fableUtils = require ("fable-utils");
 const { createFilter } = require('rollup-pluginutils');
 

--- a/src/js/rollup-plugin-fable/package.json
+++ b/src/js/rollup-plugin-fable/package.json
@@ -22,7 +22,7 @@
   "bugs": {
     "url": "https://github.com/fable-compiler/Fable/issues"
   },
-  "homepage": "https://github.com/fable-compiler/Fable/tree/master/src/typescript/rollup-plugin-fable#readme",
+  "homepage": "https://github.com/fable-compiler/Fable/tree/master/src/js/rollup-plugin-fable#readme",
   "devDependencies": {
     "eslint": "3.19.0",
     "eslint-config-prettier": "1.7.0",

--- a/src/js/rollup-plugin-fable/package.json
+++ b/src/js/rollup-plugin-fable/package.json
@@ -33,7 +33,7 @@
     "@babel/core": "^7.0.0"
   },
   "dependencies": {
-    "fable-utils": "^1.0.4",
-    "rollup-pluginutils": "2.0.1"
+    "fable-utils": "^1.1.0",
+    "rollup-pluginutils": "^2.3.3"
   }
 }

--- a/src/js/rollup-plugin-fable/package.json
+++ b/src/js/rollup-plugin-fable/package.json
@@ -30,7 +30,7 @@
     "prettier": "1.1.0"
   },
   "peerDependencies": {
-    "babel-core": "^6.24.1"
+    "@babel/core": "^7.0.0"
   },
   "dependencies": {
     "fable-utils": "^1.0.4",


### PR DESCRIPTION
I tested it with my [example VS Code extension](https://github.com/inosik/fable-vscode-rollup-sample) locally and it worked without problems after I changed the Babel options to use the new presets and plugins.