### PR TITLE
Fix for #1594 Array.partition results are too long

### DIFF
--- a/src/dotnet/Fable.Compiler/Transforms/ReplacementsInject.fs
+++ b/src/dotnet/Fable.Compiler/Transforms/ReplacementsInject.fs
@@ -42,7 +42,6 @@ let fableCoreModules =
       "skipWhile", [(Types.arrayCons, 0)]
       "take", [(Types.arrayCons, 0)]
       "takeWhile", [(Types.arrayCons, 0)]
-      "partition", [(Types.arrayCons, 0)]
       "choose", [(Types.arrayCons, 0)]
       "sortInPlaceBy", [(Types.comparer, 1)]
       "sortInPlace", [(Types.comparer, 0)]

--- a/src/dotnet/Fable.Compiler/Transforms/ReplacementsInject.fs
+++ b/src/dotnet/Fable.Compiler/Transforms/ReplacementsInject.fs
@@ -42,6 +42,7 @@ let fableCoreModules =
       "skipWhile", [(Types.arrayCons, 0)]
       "take", [(Types.arrayCons, 0)]
       "takeWhile", [(Types.arrayCons, 0)]
+      "partition", [(Types.arrayCons, 0)]
       "choose", [(Types.arrayCons, 0)]
       "sortInPlaceBy", [(Types.comparer, 1)]
       "sortInPlace", [(Types.comparer, 0)]

--- a/src/js/fable-core/Array.fs
+++ b/src/js/fable-core/Array.fs
@@ -458,20 +458,17 @@ let copyTo (source: JS.ArrayLike<'T>) sourceIndex (target: JS.ArrayLike<'T>) tar
     for i = sourceIndex to sourceIndex + count - 1 do
         target.[i + diff] <- source.[i]
 
-let partition (f: 'T -> bool) (source: 'T[]) ([<Inject>] cons: IArrayCons<'T>) =
+let partition (f: 'T -> bool) (source: 'T[]) =
     let len = source.Length
-    let res1 = cons.Create len
-    let res2 = cons.Create len
-    let mutable iTrue = 0
-    let mutable iFalse = 0
+    let res1 = ResizeArray<'T>()
+    let res2 = ResizeArray<'T>()
     for i = 0 to len - 1 do
         if f source.[i] then
-            res1.[iTrue] <- source.[i]
-            iTrue <- iTrue + 1
+            res1.Add source.[i]
         else
-            res2.[iFalse] <- source.[i]
-            iFalse <- iFalse + 1
+            res2.Add source.[i]
     res1, res2
+
 
 let find (predicate: 'T -> bool) (array: 'T[]): 'T =
     match findImpl predicate array with

--- a/src/js/fable-core/Array.fs
+++ b/src/js/fable-core/Array.fs
@@ -458,16 +458,20 @@ let copyTo (source: JS.ArrayLike<'T>) sourceIndex (target: JS.ArrayLike<'T>) tar
     for i = sourceIndex to sourceIndex + count - 1 do
         target.[i + diff] <- source.[i]
 
-let partition (f: 'T -> bool) (source: 'T[]) =
+let partition (f: 'T -> bool) (source: 'T[]) ([<Inject>] cons: IArrayCons<'T>) =
     let len = source.Length
-    let res1 = ResizeArray<'T>()
-    let res2 = ResizeArray<'T>()
+    let res1 = cons.Create len
+    let res2 = cons.Create len
+    let mutable iTrue = 0
+    let mutable iFalse = 0
     for i = 0 to len - 1 do
         if f source.[i] then
-            res1.Add source.[i]
+            res1.[iTrue] <- source.[i]
+            iTrue <- iTrue + 1
         else
-            res2.Add source.[i]
-    res1, res2
+            res2.[iFalse] <- source.[i]
+            iFalse <- iFalse + 1
+    res1 |> Array.truncate iTrue, res2 |> Array.truncate iFalse
 
 
 let find (predicate: 'T -> bool) (array: 'T[]): 'T =

--- a/tests/Main/ArrayTests.fs
+++ b/tests/Main/ArrayTests.fs
@@ -502,10 +502,11 @@ let tests =
         ys.[0] |> equal 1
 
     testCase "Array.partition works" <| fun () ->
-        let xs = [|1.; 2.|]
+        let xs = [|1.; 2.; 3.|]
         let ys, zs = xs |> Array.partition (fun x -> x <= 1.)
-        ys.[0] - zs.[0]
-        |> equal -1.
+        Array.length ys |> equal 1
+        Array.length zs |> equal 2
+        ys.[0] - zs.[0] |> equal -1.
 
     testCase "Array.permute works" <| fun () ->
         let xs = [|1.; 2.|]

--- a/tests/Main/ArrayTests.fs
+++ b/tests/Main/ArrayTests.fs
@@ -504,9 +504,8 @@ let tests =
     testCase "Array.partition works" <| fun () ->
         let xs = [|1.; 2.; 3.|]
         let ys, zs = xs |> Array.partition (fun x -> x <= 1.)
-        Array.length ys |> equal 1
-        Array.length zs |> equal 2
-        ys.[0] - zs.[0] |> equal -1.
+        equal ys [| 1. |]
+        equal zs [| 2.; 3. |]
 
     testCase "Array.permute works" <| fun () ->
         let xs = [|1.; 2.|]


### PR DESCRIPTION
This makes the algorithm more or less match the original typescript.  However it doesn't use IArrayCons so I'm not sure if we're losing something if this is applied to typed arrays.  If that's important I could switch to use 2 passes over the input to count up the size of the results.