### PR TITLE
Improve compatibility of Fable REPL Lib files

### DIFF
--- a/src/dotnet/Fable.Compiler/AST/AST.Fable.fs
+++ b/src/dotnet/Fable.Compiler/AST/AST.Fable.fs
@@ -214,6 +214,7 @@ type ReplaceCallInfo =
     /// See ArgIngo.SignatureArgTypes
     SignatureArgTypes: Type list
     Spread: SpreadKind
+    IsModuleValue: bool
     DeclaringEntityFullName: string
     GenericArgs: (string * Type) list }
 

--- a/src/dotnet/Fable.Compiler/AST/AST.Fable.fs
+++ b/src/dotnet/Fable.Compiler/AST/AST.Fable.fs
@@ -215,6 +215,7 @@ type ReplaceCallInfo =
     SignatureArgTypes: Type list
     Spread: SpreadKind
     IsModuleValue: bool
+    IsInterface: bool
     DeclaringEntityFullName: string
     GenericArgs: (string * Type) list }
 

--- a/src/dotnet/Fable.Compiler/CLI/Parser.fs
+++ b/src/dotnet/Fable.Compiler/CLI/Parser.fs
@@ -91,6 +91,7 @@ let toCompilerOptions (msg: Message): CompilerOptions =
       clampByteArrays = msg.clampByteArrays
       verbose = GlobalParams.Singleton.Verbose
       outputPublicInlinedFunctions = Array.contains "FABLE_REPL_LIB" msg.define
+      precompiledLib = None
     }
 
 let parse (msg: string) =

--- a/src/dotnet/Fable.Compiler/CLI/Parser.fs
+++ b/src/dotnet/Fable.Compiler/CLI/Parser.fs
@@ -90,6 +90,7 @@ let toCompilerOptions (msg: Message): CompilerOptions =
     { typedArrays = msg.typedArrays
       clampByteArrays = msg.clampByteArrays
       verbose = GlobalParams.Singleton.Verbose
+      outputPublicInlinedFunctions = Array.contains "FABLE_REPL_LIB" msg.define
     }
 
 let parse (msg: string) =

--- a/src/dotnet/Fable.Compiler/Global/Compiler.fs
+++ b/src/dotnet/Fable.Compiler/Global/Compiler.fs
@@ -4,7 +4,10 @@ type CompilerOptions =
     { typedArrays: bool
       clampByteArrays: bool
       verbose: bool
-    }
+      // This option is meant for precompiled libraries (like the Repl Lib)
+      // to make public inlined functions part of the JS
+      outputPublicInlinedFunctions: bool
+  }
 
 [<RequireQualifiedAccess>]
 type Severity =

--- a/src/dotnet/Fable.Compiler/Global/Compiler.fs
+++ b/src/dotnet/Fable.Compiler/Global/Compiler.fs
@@ -4,9 +4,11 @@ type CompilerOptions =
     { typedArrays: bool
       clampByteArrays: bool
       verbose: bool
-      // This option is meant for precompiled libraries (like the Repl Lib)
-      // to make public inlined functions part of the JS
+      /// Meant for precompiled libraries (like the Repl Lib)
+      /// to make public inlined functions part of the JS
       outputPublicInlinedFunctions: bool
+      /// Mainly intended for the REPL to compile REPL lib calls
+      precompiledLib: (string -> (string*string) option) option
   }
 
 [<RequireQualifiedAccess>]

--- a/src/dotnet/Fable.Compiler/Global/Prelude.fs
+++ b/src/dotnet/Fable.Compiler/Global/Prelude.fs
@@ -309,8 +309,11 @@ module Path =
 
     /// Checks if path starts with "./", ".\" or ".."
     let isRelativePath (path: string) =
-        if path.[0] = '.' then
-            if path.Length = 1
+        let len = path.Length
+        if len = 0
+        then false
+        elif path.[0] = '.' then
+            if len = 1
             then true
             // Some folders start with a dot, see #1599
             // For simplicity, ignore folders starting with TWO dots
@@ -356,6 +359,7 @@ module Path =
             let fromPath = addDummyFile fromIsDir fromFullPath
             let toPath = addDummyFile toIsDir toFullPath
             match (pathDifference fromPath toPath).Replace(Naming.dummyFile, "") with
+            | "" -> "."
             // Some folders start with a period, see #1599
             | path when isRelativePath path -> path
             | path -> "./" + path

--- a/src/dotnet/Fable.Compiler/Global/Prelude.fs
+++ b/src/dotnet/Fable.Compiler/Global/Prelude.fs
@@ -241,13 +241,15 @@ module Naming =
             else entityName, InstanceMemberPart(memberCompiledName, overloadSuffix))
         ||> buildName id
 
+    let checkJsKeywords name =
+        if jsKeywords.Contains name
+        then name + "$"
+        else name
+
     let sanitizeIdent conflicts name part =
         // Replace Forbidden Chars
-        let sanitizedName = buildName sanitizeIdentForbiddenChars name part
-        // Check if it's a keyword or clashes with module ident pattern
-        (if jsKeywords.Contains sanitizedName
-            then sanitizedName + "$"
-            else sanitizedName)
+        buildName sanitizeIdentForbiddenChars name part
+        |> checkJsKeywords
         // Check if it already exists
         |> preventConflicts conflicts
 

--- a/src/dotnet/Fable.Compiler/Transforms/FSharp2Fable.Util.fs
+++ b/src/dotnet/Fable.Compiler/Transforms/FSharp2Fable.Util.fs
@@ -805,12 +805,16 @@ module Util =
                 DeclaringEntityFullName = ent.FullName
                 Spread = argInfo.Spread
                 IsModuleValue = isModuleValue
+                // TODO: We should also check for
+                // memb.IsOverrideOrExplicitInterfaceImplementation
+                // memb.IsDispatchSlot
+                IsInterface = ent.IsInterface
                 CompiledName = memb.CompiledName
                 OverloadSuffix = lazy if ent.IsFSharpModule then "" else OverloadSuffix.getHash ent memb
                 GenericArgs = genArgs.Value }
             match com.TryReplace(ctx, r, typ, info, argInfo.ThisArg, argInfo.Args) with
             | Some e -> Some e
-            | None when ent.IsInterface ->
+            | None when info.IsInterface ->
                 callInstanceMember com ctx r typ argInfo ent memb |> Some
             | None ->
                 sprintf "Cannot resolve %s.%s" info.DeclaringEntityFullName info.CompiledName

--- a/src/dotnet/Fable.Compiler/Transforms/FSharp2Fable.fs
+++ b/src/dotnet/Fable.Compiler/Transforms/FSharp2Fable.fs
@@ -60,6 +60,9 @@ let private transformTraitCall com (ctx: Context) r typ (sourceTypes: FSharpType
           DeclaringEntityFullName = entityFullName
           Spread = Fable.NoSpread
           IsModuleValue = false
+          // We only need this for types with own entries in Fable AST
+          // (no interfaces, see below) so it's safe to set this to false
+          IsInterface = false
           CompiledName = traitName
           OverloadSuffix = lazy ""
           GenericArgs =

--- a/src/dotnet/Fable.Compiler/Transforms/FSharp2Fable.fs
+++ b/src/dotnet/Fable.Compiler/Transforms/FSharp2Fable.fs
@@ -59,6 +59,7 @@ let private transformTraitCall com (ctx: Context) r typ (sourceTypes: FSharpType
         { SignatureArgTypes = argTypes
           DeclaringEntityFullName = entityFullName
           Spread = Fable.NoSpread
+          IsModuleValue = false
           CompiledName = traitName
           OverloadSuffix = lazy ""
           GenericArgs =

--- a/src/dotnet/Fable.Compiler/Transforms/Fable2Babel.fs
+++ b/src/dotnet/Fable.Compiler/Transforms/Fable2Babel.fs
@@ -191,7 +191,7 @@ module Util =
     let entityRefMaybeImported (com: IBabelCompiler) ctx ent =
         if FSharp2Fable.Util.isReplacementCandidate ent then
             // Some unions like Choice or Result belong to FSharp.Core
-            match Replacements.tryEntityRef ent with
+            match Replacements.tryEntityRef com ent with
             | Some entRef -> com.TransformAsExpr(ctx, entRef)
             | None ->
                 sprintf "Cannot find %s constructor" ent.FullName

--- a/src/dotnet/Fable.Compiler/Transforms/Replacements.fs
+++ b/src/dotnet/Fable.Compiler/Transforms/Replacements.fs
@@ -2580,10 +2580,11 @@ let tryCall (com: ICompiler) (ctx: Context) r t (info: CallInfo) (thisArg: Expr 
             | c ->
                 Helper.CoreCall("Reflection", "name", t, [c], ?loc=r) |> Some
         | _ -> None
-    | _ ->
+    | _ when not info.IsInterface ->
         com.Options.precompiledLib
         |> Option.bind (fun tryLib -> tryLib info.DeclaringEntityFullName)
         |> Option.map (precompiledLib r t info thisArg args)
+    | _ -> None
 
 // TODO: Add other entities (see Fable 1 Replacements.tryReplaceEntity)
 let tryEntityRef (com: Fable.ICompiler) (ent: FSharpEntity) =

--- a/src/dotnet/Fable.Repl/Interfaces.fs
+++ b/src/dotnet/Fable.Repl/Interfaces.fs
@@ -59,5 +59,5 @@ type IFableManager =
     abstract GetDeclarationLocation: parseResults: IParseResults * line: int * col: int * lineText: string -> Async<Range option>
     abstract GetToolTipText: parseResults: IParseResults * line: int * col: int * lineText: string -> Async<string[]>
     abstract GetCompletionsAtLocation: parseResults: IParseResults * line: int * col: int * lineText: string -> Async<Completion[]>
-    abstract CompileToBabelAst: fableCore: string * parseResults: IParseResults * fileName: string * optimized: bool -> obj * Error[]
+    abstract CompileToBabelAst: fableCore: string * parseResults: IParseResults * fileName: string * optimized: bool * ?precompiledLib: (string->(string*string) option) -> obj * Error[]
     abstract FSharpAstToString: parseResults: IParseResults * fileName: string * optimized: bool -> string

--- a/src/dotnet/Fable.Repl/Main.fs
+++ b/src/dotnet/Fable.Repl/Main.fs
@@ -243,7 +243,8 @@ let makeCompiler fableCore fileName (project: Project) =
     let options: Fable.CompilerOptions =
         { typedArrays = true
           clampByteArrays = false
-          verbose = false }
+          verbose = false
+          outputPublicInlinedFunctions = false }
     let com = Compiler(fileName, project, options, fableCore)
     com
 

--- a/src/dotnet/Fable.Repl/Main.fs
+++ b/src/dotnet/Fable.Repl/Main.fs
@@ -239,12 +239,13 @@ let getCompletionsAtLocation (parseResults: ParseResults) (line: int) (col: int)
         return [||]
 }
 
-let makeCompiler fableCore fileName (project: Project) =
+let makeCompiler fableCore fileName (project: Project) precompiledLib =
     let options: Fable.CompilerOptions =
         { typedArrays = true
           clampByteArrays = false
           verbose = false
-          outputPublicInlinedFunctions = false }
+          outputPublicInlinedFunctions = false
+          precompiledLib = precompiledLib }
     let com = Compiler(fileName, project, options, fableCore)
     com
 
@@ -288,10 +289,10 @@ let init () =
             let res = parseResults :?> ParseResults
             getCompletionsAtLocation res line col lineText
 
-        member __.CompileToBabelAst(fableCore:string, parseResults:IParseResults, fileName:string, optimized: bool) =
+        member __.CompileToBabelAst(fableCore:string, parseResults:IParseResults, fileName:string, optimized: bool, ?precompiledLib) =
             let res = parseResults :?> ParseResults
             let project = if optimized then res.OptimizedProject else res.UnoptimizedProject
-            let com = makeCompiler fableCore fileName project
+            let com = makeCompiler fableCore fileName project precompiledLib
             let ast = compileAst com project
             let errors =
                 com.GetLogs()

--- a/src/js/fable-splitter/RELEASE_NOTES.md
+++ b/src/js/fable-splitter/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### 2.0.2
+
+* Add "externals" option (similar to Webpack's but only for global values)
+
 ### 2.0.1
 
 * Improve relative path check

--- a/src/js/fable-splitter/package.json
+++ b/src/js/fable-splitter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fable-splitter",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "File splitter for Fable (F# to JavaScript compiler)",
   "author": "ncave",
   "license": "Apache-2.0",


### PR DESCRIPTION
See https://github.com/fable-compiler/repl2/pull/56/files

This PR adds some features to enable better compatibility for the REPL Lib (see link above). I'm not very happy because I has to add quite a number of extra fields to compiler and replacement options, but maybe it's not that bad.

What do you think @ncave @MangelMaxime? Is this solution OK for now or should we try to compile library sources directly in the browser?