### PR TITLE
Optimize tailcalls returning units

### DIFF
--- a/src/dotnet/Fable.Compiler/AST/AST.Babel.fs
+++ b/src/dotnet/Fable.Compiler/AST/AST.Babel.fs
@@ -189,9 +189,9 @@ type ContinueStatement(?label, ?loc) =
 // type WithStatement
 
 // Control Flow
-type ReturnStatement(?argument, ?loc) =
+type ReturnStatement(argument, ?loc) =
     inherit Statement("ReturnStatement", ?loc = loc)
-    member __.Argument: Expression option = argument
+    member __.Argument: Expression = argument
 
 // type LabeledStatement
 // type BreakStatement

--- a/src/dotnet/Fable.Compiler/AST/AST.Babel.fs
+++ b/src/dotnet/Fable.Compiler/AST/AST.Babel.fs
@@ -189,9 +189,9 @@ type ContinueStatement(?label, ?loc) =
 // type WithStatement
 
 // Control Flow
-type ReturnStatement(argument, ?loc) =
+type ReturnStatement(?argument, ?loc) =
     inherit Statement("ReturnStatement", ?loc = loc)
-    member __.Argument: Expression = argument
+    member __.Argument: Expression option = argument
 
 // type LabeledStatement
 // type BreakStatement

--- a/src/dotnet/Fable.Compiler/Transforms/Fable2Babel.fs
+++ b/src/dotnet/Fable.Compiler/Transforms/Fable2Babel.fs
@@ -8,6 +8,7 @@ open System.Collections.Generic
 
 type ReturnStrategy =
     | Return
+    | ReturnUnit
     | Assign of Expression // TODO: Add SourceLocation?
     | Target of Identifier
 
@@ -646,7 +647,7 @@ module Util =
 
     let resolveExpr t strategy babelExpr: Statement =
         match strategy with
-        | None -> upcast ExpressionStatement babelExpr
+        | None | Some ReturnUnit -> upcast ExpressionStatement babelExpr
         // TODO: Where to put these int wrappings? Add them also for function arguments?
         | Some Return -> upcast ReturnStatement(wrapIntExpression t babelExpr)
         | Some(Assign left) -> upcast ExpressionStatement(assign None left babelExpr)
@@ -716,7 +717,7 @@ module Util =
             List.length i.Args + (if Option.isSome i.ThisArg then 1 else 0)
         // TODO: Warn when there's a recursive call that couldn't be optimized?
         match returnStrategy, ctx.TailCallOpportunity, opKind with
-        | Some Return, Some tc, Fable.Call(Fable.StaticCall funcExpr, argInfo)
+        | Some(Return|ReturnUnit), Some tc, Fable.Call(Fable.StaticCall funcExpr, argInfo)
                                 when not argInfo.IsBaseOrSelfConstructorCall
                                 && tc.IsRecursiveRef(funcExpr)
                                 && argsLen argInfo = List.length tc.Args ->
@@ -725,7 +726,7 @@ module Util =
                 | Some thisArg -> thisArg::argInfo.Args
                 | None -> argInfo.Args
             optimizeTailCall com ctx tc args
-        | Some Return, Some tc, Fable.CurriedApply(funcExpr, args)
+        | Some(Return|ReturnUnit), Some tc, Fable.CurriedApply(funcExpr, args)
                                 when tc.IsRecursiveRef(funcExpr)
                                 && List.sameLength args tc.Args ->
             optimizeTailCall com ctx tc args
@@ -761,7 +762,10 @@ module Util =
             match com.TransformAsStatements(ctx, ret, expr) with
             | [||] -> IfStatement(guardExpr, thenStmnt)
             | [|:? ExpressionStatement as e|] when (e.Expression :? NullLiteral) ->
-                IfStatement(guardExpr, thenStmnt)
+                match ret, ctx.TailCallOpportunity with
+                // In functions returning unit, make sure to return in case the function is being tail-call optimized
+                | Some ReturnUnit, Some _ -> IfStatement(guardExpr, thenStmnt, BlockStatement [|ReturnStatement()|])
+                | _ -> IfStatement(guardExpr, thenStmnt)
             | statements -> IfStatement(guardExpr, thenStmnt, BlockStatement statements)
 
     let transformGet (com: IBabelCompiler) ctx range typ fableExpr (getKind: Fable.GetKind) =
@@ -1172,7 +1176,7 @@ module Util =
         | Fable.IfThenElse(guardExpr, thenExpr, elseExpr) ->
             let asStatement =
                 match returnStrategy with
-                | None -> true
+                | None | Some ReturnUnit -> true
                 | Some(Target _) -> true // Compile as statement so values can be bound
                 | Some(Assign _) -> (isJsStatement ctx false thenExpr) || (isJsStatement ctx false elseExpr)
                 | Some Return ->
@@ -1234,7 +1238,7 @@ module Util =
                        OptimizeTailCall = fun () -> isTailCallOptimized <- true }
         let body: U2<BlockStatement, Expression> =
             if body.Type = Fable.Unit
-            then transformBlock com ctx None body |> U2.Case1
+            then transformBlock com ctx (Some ReturnUnit) body |> U2.Case1
             elif isJsStatement ctx (Option.isSome tailcallChance) body
             then transformBlock com ctx (Some Return) body |> U2.Case1
             else transformAsExpr com ctx body |> U2.Case2


### PR DESCRIPTION
See [discussion](https://github.com/fable-compiler/Fable/issues/1368#issuecomment-435245905).

@GordonBGood @ncave I think I got it right now. The only concern is we may have now more useless `return` statements as not all unit functions will be actually tail called.