### PR TITLE
Number parsing update

### DIFF
--- a/src/dotnet/Fable.Compiler/Transforms/FSharp2Fable.Util.fs
+++ b/src/dotnet/Fable.Compiler/Transforms/FSharp2Fable.Util.fs
@@ -363,10 +363,24 @@ module Patterns =
     /// like Dictionary.TryGetValue (see #154)
     let (|TryGetValue|_|) = function
         | Let((outArg1, (DefaultValue _ as def)),
-                NewTuple(_, [Call(callee, memb, typArgs, methTypArgs,
-                                    [arg; AddressOf(Value outArg2)]); Value outArg3]))
-            when outArg1 = outArg2 && outArg1 = outArg3 ->
-            Some (callee, memb, typArgs, methTypArgs, [arg; def])
+                NewTuple(_, [Call(callee, memb, ownerGenArgs, membGenArgs,
+                                    [arg1; AddressOf(Value outArg2)]); Value outArg3]))
+            when outArg1 = outArg2 && outArg1 = outArg3 && memb.CompiledName = "TryGetValue" ->
+            Some (callee, memb, ownerGenArgs, membGenArgs, [arg1; def])
+        | _ -> None
+
+    /// This matches the boilerplate generated for .TryParse
+    let (|TryParse|_|) = function
+        | Let((outArg1, (DefaultValue _)),
+                NewTuple(_, [Call(callee, memb, ownerGenArgs, membGenArgs,
+                                    [arg1; AddressOf(Value outArg2)]); Value outArg3]))
+            when outArg1 = outArg2 && outArg1 = outArg3 && memb.CompiledName = "TryParse" ->
+            Some (callee, memb, ownerGenArgs, membGenArgs, [arg1])
+        | Let((outArg1, (DefaultValue _)),
+                NewTuple(_, [Call(callee, memb, ownerGenArgs, membGenArgs,
+                                    [arg1; arg2; arg3; AddressOf(Value outArg2)]); Value outArg3]))
+            when outArg1 = outArg2 && outArg1 = outArg3 && memb.CompiledName = "TryParse" ->
+            Some (callee, memb, ownerGenArgs, membGenArgs, [arg1; arg2; arg3])
         | _ -> None
 
     /// This matches the boilerplate generated to wrap .NET events from F#

--- a/src/dotnet/Fable.Compiler/Transforms/FSharp2Fable.fs
+++ b/src/dotnet/Fable.Compiler/Transforms/FSharp2Fable.fs
@@ -291,6 +291,13 @@ let private transformExpr (com: IFableCompiler) (ctx: Context) fsExpr =
         let typ = makeType com ctx.GenericArgs fsExpr.Type
         return makeCallFrom com ctx (makeRangeFrom fsExpr) typ false genArgs callee args memb
 
+    | TryParse (callee, memb, ownerGenArgs, membGenArgs, membArgs) ->
+        let! callee = transformExprOpt com ctx callee
+        let! args = transformExprList com ctx membArgs
+        let genArgs = ownerGenArgs @ membGenArgs |> Seq.map (makeType com ctx.GenericArgs)
+        let typ = makeType com ctx.GenericArgs fsExpr.Type
+        return makeCallFrom com ctx (makeRangeFrom fsExpr) typ false genArgs callee args memb
+
     | CreateEvent (callee, eventName, memb, ownerGenArgs, membGenArgs, membArgs) ->
         let! callee = transformExpr com ctx callee
         let! args = transformExprList com ctx membArgs


### PR DESCRIPTION
- Minor number parsing updates to make it work even when it doesn't match the boilerplate active pattern.

Side note: The dichotomy of Js Number vs Bcl numbers probably makes this part of Fable a bit harder to maintain and reason about for new contributors, but it's fine, *this is fine*.