### PR TITLE
Update getting started link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Fable is an F# to JavaScript compiler powered by [Babel](https://babeljs.io/), d
 
 ## Getting started
 
-Check [this document](docs/getting_started.md).
+Check [this page](https://fable.io/docs/getting_started.html).
 
 ## Building
 


### PR DESCRIPTION
Currently the link under the Getting Started heading leads to a doc that has broken links (Migration to Fable 2 link and REPL link). I thought it might be better to link to the Fable website so all the links work normally. Feel free to implement another solution and close this PR.