### PR TITLE
Pass babel options from splitter config when transforming js file.

### DIFF
--- a/src/js/fable-splitter/src/index.ts
+++ b/src/js/fable-splitter/src/index.ts
@@ -256,7 +256,7 @@ async function getBabelAst(path: string, options: FableSplitterOptions, info: Co
         // return Babel AST from JS file
         path = JAVASCRIPT_EXT.test(path) ? path : path + ".js";
         if (fs.existsSync(path)) {
-            ast = await getBabelAstFromJsFile(path, info);
+            ast = await getBabelAstFromJsFile(path, info, options.babel);
         } else {
             console.log(`fable: Skip missing JS file: ${path}`);
         }
@@ -264,9 +264,10 @@ async function getBabelAst(path: string, options: FableSplitterOptions, info: Co
     return ast;
 }
 
-function getBabelAstFromJsFile(path: string, info: CompilationInfo) {
+function getBabelAstFromJsFile(path: string, info: CompilationInfo, babel: Babel.TransformOptions) {
+    const transformOptions = Object.assign({}, babel, { code: false, ast: true });
     return new Promise<Babel.types.Program | null>((resolve) => {
-        Babel.transformFile(path, { code: false, ast: true }, (error, res) => {
+        Babel.transformFile(path, transformOptions, (error, res) => {
             if (error != null) {
                 const log = `${path}(1,1): error BABEL: ${error.message}`;
                 addLogs({ error: [log] }, info);


### PR DESCRIPTION
I had a problem when importing a JS file that needs a Babel transform plugin in F# when using the splitter.
At first it seemed strange as I did list the plugin in my `splitter.config.js`.

```js
const path = require("path");

function resolve(relativePath) {
    return path.join(__dirname, relativePath);
}

module.exports = {
    entry: resolve("src/MyProj.fsproj"),
    outDir: resolve("out"),
    fable: {
        define: ["DEBUG"]
    },
    babel: {
        plugins: ["@babel/plugin-proposal-class-properties"]
    }
}
```

But I got:

```
C:/Users/nojaf/Projects/ronnies.be/src/RonniesClient/.fable/Fable.ReactGoogleMaps.0.6.0/mapComponent.js(1,1): error BABEL: C:\Users\nojaf\Projects\ronnies.be\src\RonniesClient\.fable\Fable.ReactGoogleMaps.0.6.0\mapComponent.js: Support for the experimental syntax '
classProperties' isn't currently enabled (60:10):

  58 | 
  59 | export class GoogleMapComponent extends React.PureComponent {
> 60 |     refs = {}
     |          ^
  61 |     searchBoxRef = {}
  62 |     state = {
  63 |       isMarkerShown: false,

Add @babel/plugin-proposal-class-properties (https://git.io/vb4SL) to the 'plugins' section of your Babel config to enable transformation.
```

This plugin is needed to deal with a newer JS feature used in [Fable.React.GoogleMaps](https://github.com/fable-compiler/fable-react/blob/master/src/Fable.ReactGoogleMaps/mapComponent.js#L60).

This PR passes the Babel options when transforming a JS file.