### PR TITLE
TimeSpan Parse and TryParse

### DIFF
--- a/src/js/fable-library/TimeSpan.ts
+++ b/src/js/fable-library/TimeSpan.ts
@@ -1,5 +1,6 @@
 import { fromNumber, op_Division, op_Multiply, toNumber } from "./Long";
 import { comparePrimitives } from "./Util";
+// import { comparePrimitives, padWithZeros } from "./Util";
 
 // TimeSpan in runtime just becomes a number representing milliseconds
 
@@ -96,4 +97,60 @@ export const compareTo = comparePrimitives;
 
 export function duration(x: number) {
   return Math.abs(x as number);
+}
+
+// export function toString(ts: number) {
+//   const d = days(ts);
+//   const h = hours(ts);
+//   const m = minutes(ts);
+//   const s = seconds(ts);
+//   const ms = milliseconds(ts);
+//   if (d === 0) {
+//     return padWithZeros(h, 2) + ":" + padWithZeros(m, 2) + ":" + padWithZeros(s, 2) + "." + ms;
+//   } else {
+//     return d + "." + padWithZeros(h, 2) + ":" + padWithZeros(m, 2) + ":" + padWithZeros(s, 2) + "." + ms;
+//   }
+// }
+
+export function parse(str: string) {
+  const firstDot = str.search("\\.");
+  const firstColon = str.search("\\:");
+  if (firstDot === -1 && firstColon === -1 ) { // There is only a day ex: 4
+    const d = parseInt(str, 0);
+    if (isNaN(d)) {
+      throw new Error("String was not recognized as a valid TimeSpan.");
+    } else {
+      return create(d, 0, 0, 0, 0);
+    }
+  }
+  if (firstColon > 0) { // process time part
+    // tslint:disable-next-line:max-line-length
+    const r = /^((\d+)\.)?(?:0*)([0-9]|0[0-9]|1[0-9]|2[0-3]):(?:0*)([0-5][0-9]|[0-9])(:(?:0*)([0-5][0-9]|[0-9]))?\.?(\d+)?$/.exec(str);
+    if (r != null && r[3] != null && r[4] != null) {
+      let d = 0;
+      let ms = 0;
+      let s = 0;
+      const h = +r[3];
+      const m = +r[4];
+      if (r[2] != null) {
+        d = +r[2];
+      }
+      if (r[6] != null) {
+        s = +r[6];
+      }
+      if (r[7] != null) {
+        ms = +r[7];
+      }
+      return create(d, h, m, s, ms);
+    }
+  }
+  throw new Error("String was not recognized as a valid TimeSpan.");
+}
+
+export function tryParse(v: any): [boolean, number] {
+  try {
+    return [true, parse(v)];
+  } catch (_err) {
+    return [false, 0];
+  }
 }

--- a/tests/Main/DateTimeTests.fs
+++ b/tests/Main/DateTimeTests.fs
@@ -3,7 +3,6 @@ module Fable.Tests.DateTime
 open System
 open Util.Testing
 open Fable.Tests
-open Fable.Tests
 
 let toSigFigs nSigFigs x =
     let absX = abs x
@@ -27,11 +26,6 @@ let tests =
     testCase "DateTime.ToString without separator works" <| fun () -> // See #1131
         DateTime(2017, 9, 5).ToString("yyyyMM")
         |> equal "201709"
-
-    // TODO
-    // testCase "TimeSpan.ToString with format works" <| fun () ->
-    //     TimeSpan.FromMinutes(234.).ToString("hh\:mm\:ss")
-    //     |> equal "03:54:00"
 
     testCase "DateTime.ToString with Round-trip format works for Utc" <| fun () ->
         let str = DateTime(2014, 9, 11, 16, 37, 2, DateTimeKind.Utc).ToString("O")
@@ -188,7 +182,7 @@ let tests =
         equal d2.Ticks d3.Ticks
 
     testCase "DateTime <-> Ticks isomorphism" <| fun () ->
-        let checkIsomorphism (d: DateTime) = 
+        let checkIsomorphism (d: DateTime) =
             try
                 let ticks = d.Ticks
                 let kind = d.Kind
@@ -201,7 +195,7 @@ let tests =
                 equal ticks fromTicksWithKind.Ticks
                 equal kind fromTicksWithKind.Kind
             with e ->
-                failwithf "%A: %O" d e      
+                failwithf "%A: %O" d e
 
             try
                 equal d.Ticks (DateTime d.Ticks).Ticks
@@ -500,155 +494,6 @@ let tests =
         let t = d.TimeOfDay
 
         t |> equal (TimeSpan(0, 13, 23, 30, 1))
-
-    testCase "TimeSpan constructors work" <| fun () ->
-        let t1 = TimeSpan(20000L)
-        let t2 = TimeSpan(3, 3, 3)
-        let t3 = TimeSpan(5, 5, 5, 5)
-        let t4 = TimeSpan(7, 7, 7, 7, 7)
-
-        t1.TotalMilliseconds |> equal 2.0
-        t2.TotalMilliseconds |> equal 10983000.0
-        t3.TotalMilliseconds |> equal 450305000.0
-        t4.TotalMilliseconds |> equal 630427007.0
-
-        t1.TotalMilliseconds + t2.TotalMilliseconds + t3.TotalMilliseconds + t4.TotalMilliseconds
-        |> equal 1091715009.0
-
-    testCase "TimeSpan static creation works" <| fun () ->
-        let t1 = TimeSpan.FromTicks(20000L)
-        let t2 = TimeSpan.FromMilliseconds(2.)
-        let t3 = TimeSpan.FromDays   (2.)
-        let t4 = TimeSpan.FromHours  (2.)
-        let t5 = TimeSpan.FromMinutes(2.)
-        let t6 = TimeSpan.FromSeconds(2.)
-        let t7 = TimeSpan.Zero
-        t1.TotalMilliseconds + t2.TotalMilliseconds + t3.TotalMilliseconds + t4.TotalMilliseconds +
-           t5.TotalMilliseconds + t6.TotalMilliseconds + t7.TotalMilliseconds
-        |> equal 180122004.0
-
-    testCase "TimeSpan components work" <| fun () ->
-        let t = TimeSpan.FromMilliseconds(96441615.)
-        t.Days + t.Hours + t.Minutes + t.Seconds + t.Milliseconds |> float
-        |> equal 686.
-
-    testCase "TimeSpan.Ticks works" <| fun () ->
-        let t = TimeSpan.FromTicks(20000L)
-        t.Ticks
-        |> equal 20000L
-
-    // NOTE: This test fails because of very small fractions, so I cut the fractional part
-    testCase "TimeSpan totals work" <| fun () ->
-        let t = TimeSpan.FromMilliseconds(96441615.)
-        t.TotalDays + t.TotalHours + t.TotalMinutes + t.TotalSeconds |> floor
-        |> equal 98076.0
-
-    testCase "TimeSpan.Duration works" <| fun () ->
-        let test ms expected =
-            let t = TimeSpan.FromMilliseconds(ms)
-            t.Duration().TotalMilliseconds
-            |> equal expected
-        test 1. 1.
-        test -1. 1.
-        test 0. 0.
-
-    testCase "TimeSpan.Negate works" <| fun () ->
-        let test ms expected =
-            let t = TimeSpan.FromMilliseconds(ms)
-            t.Negate().TotalMilliseconds
-            |> equal expected
-        test 1. -1.
-        test -1. 1.
-        test 0. 0.
-
-    testCase "TimeSpan Addition works" <| fun () ->
-        let test ms1 ms2 expected =
-            let t1 = TimeSpan.FromMilliseconds(ms1)
-            let t2 = TimeSpan.FromMilliseconds(ms2)
-            let res1 = t1.Add(t2).TotalMilliseconds
-            let res2 = (t1 + t2).TotalMilliseconds
-            equal true (res1 = res2)
-            equal expected res1
-        test 1000. 2000. 3000.
-        test 200. -1000. -800.
-        test -2000. 1000. -1000.
-        test -200. -300. -500.
-        test 0. 1000. 1000.
-        test -2000. 0. -2000.
-        test 0. 0. 0.
-
-    testCase "TimeSpan Subtraction works" <| fun () ->
-        let test ms1 ms2 expected =
-            let t1 = TimeSpan.FromMilliseconds(ms1)
-            let t2 = TimeSpan.FromMilliseconds(ms2)
-            let res1 = t1.Subtract(t2).TotalMilliseconds
-            let res2 = (t1 - t2).TotalMilliseconds
-            equal true (res1 = res2)
-            equal expected res1
-        test 1000. 2000. -1000.
-        test 200. -2000. 2200.
-        test -2000. 1000. -3000.
-        test 200. -300. 500.
-        test 0. 1000. -1000.
-        test 1000. 1000. 0.
-        test 0. 0. 0.
-
-    testCase "TimeSpan Comparison works" <| fun () ->
-        let test ms1 ms2 expected =
-            let t1 = TimeSpan.FromMilliseconds(ms1)
-            let t2 = TimeSpan.FromMilliseconds(ms2)
-            let res1 = compare t1 t2
-            let res2 = t1.CompareTo(t2)
-            let res3 = TimeSpan.Compare(t1, t2)
-            equal true (res1 = res2 && res2 = res3)
-            equal expected res1
-        test 1000. 2000. -1
-        test 2000. 1000. 1
-        test -2000. -2000. 0
-        test 200. -200. 1
-        test 0. 1000. -1
-        test 1000. 1000. 0
-        test 0. 0. 0
-
-    testCase "TimeSpan GreaterThan works" <| fun () ->
-        let test ms1 ms2 expected =
-            let t1 = TimeSpan.FromMilliseconds(ms1)
-            let t2 = TimeSpan.FromMilliseconds(ms2)
-            t1 > t2
-            |> equal expected
-        test 1000. 2000. false
-        test 2000. 1000. true
-        test -2000. -2000. false
-
-    testCase "TimeSpan LessThan works" <| fun () ->
-        let test ms1 ms2 expected =
-            let t1 = TimeSpan.FromMilliseconds(ms1)
-            let t2 = TimeSpan.FromMilliseconds(ms2)
-            t1 < t2
-            |> equal expected
-        test 1000. 2000. true
-        test 2000. 1000. false
-        test -2000. -2000. false
-
-    testCase "TimeSpan Equality works" <| fun () ->
-        let test ms1 ms2 expected =
-            let t1 = TimeSpan.FromMilliseconds(ms1)
-            let t2 = TimeSpan.FromMilliseconds(ms2)
-            t1 = t2
-            |> equal expected
-        test 1000. 2000. false
-        test 2000. 1000. false
-        test -2000. -2000. true
-
-    testCase "TimeSpan Inequality works" <| fun () ->
-        let test ms1 ms2 expected =
-            let t1 = TimeSpan.FromMilliseconds(ms1)
-            let t2 = TimeSpan.FromMilliseconds(ms2)
-            t1 <> t2
-            |> equal expected
-        test 1000. 2000. true
-        test 2000. 1000. true
-        test -2000. -2000. false
 
     testCaseAsync "Timer with AutoReset = true works" <| fun () ->
         async {

--- a/tests/Main/Fable.Tests.fsproj
+++ b/tests/Main/Fable.Tests.fsproj
@@ -61,6 +61,7 @@
     <Compile Include="TypeTests.fs" />
     <Compile Include="UnionTypeTests.fs" />
     <Compile Include="UriTests.fs" />
+    <Compile Include="TimeSpanTests.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
 </Project>

--- a/tests/Main/Main.fs
+++ b/tests/Main/Main.fs
@@ -1,4 +1,5 @@
 module Fable.Tests.Main
+open System
 
 let allTests =
   [|
@@ -38,6 +39,7 @@ let allTests =
     Strings.tests
     Sudoku.tests
     TailCalls.tests
+    TimeSpan.tests
     TupleTypes.tests
     TypeTests.tests
     UnionTypes.tests

--- a/tests/Main/TimeSpanTests.fs
+++ b/tests/Main/TimeSpanTests.fs
@@ -1,0 +1,402 @@
+module Fable.Tests.TimeSpan
+
+open System
+open Util.Testing
+open Fable.Tests
+
+let tests =
+    testList "TimeSpan" [
+
+        // TODO
+        // testCase "TimeSpan.ToString with format works" <| fun () ->
+        //     TimeSpan.FromMinutes(234.).ToString("hh\:mm\:ss")
+        //     |> equal "03:54:00"
+
+        testCase "TimeSpan constructors work" <| fun () ->
+            let t1 = TimeSpan(20000L)
+            let t2 = TimeSpan(3, 3, 3)
+            let t3 = TimeSpan(5, 5, 5, 5)
+            let t4 = TimeSpan(7, 7, 7, 7, 7)
+
+            t1.TotalMilliseconds |> equal 2.0
+            t2.TotalMilliseconds |> equal 10983000.0
+            t3.TotalMilliseconds |> equal 450305000.0
+            t4.TotalMilliseconds |> equal 630427007.0
+
+            t1.TotalMilliseconds + t2.TotalMilliseconds + t3.TotalMilliseconds + t4.TotalMilliseconds
+            |> equal 1091715009.0
+
+        testCase "TimeSpan static creation works" <| fun () ->
+            let t1 = TimeSpan.FromTicks(20000L)
+            let t2 = TimeSpan.FromMilliseconds(2.)
+            let t3 = TimeSpan.FromDays   (2.)
+            let t4 = TimeSpan.FromHours  (2.)
+            let t5 = TimeSpan.FromMinutes(2.)
+            let t6 = TimeSpan.FromSeconds(2.)
+            let t7 = TimeSpan.Zero
+            t1.TotalMilliseconds + t2.TotalMilliseconds + t3.TotalMilliseconds + t4.TotalMilliseconds +
+               t5.TotalMilliseconds + t6.TotalMilliseconds + t7.TotalMilliseconds
+            |> equal 180122004.0
+
+        testCase "TimeSpan components work" <| fun () ->
+            let t = TimeSpan.FromMilliseconds(96441615.)
+            t.Days + t.Hours + t.Minutes + t.Seconds + t.Milliseconds |> float
+            |> equal 686.
+
+        testCase "TimeSpan.Ticks works" <| fun () ->
+            let t = TimeSpan.FromTicks(20000L)
+            t.Ticks
+            |> equal 20000L
+
+        // NOTE: This test fails because of very small fractions, so I cut the fractional part
+        testCase "TimeSpan totals work" <| fun () ->
+            let t = TimeSpan.FromMilliseconds(96441615.)
+            t.TotalDays + t.TotalHours + t.TotalMinutes + t.TotalSeconds |> floor
+            |> equal 98076.0
+
+        testCase "TimeSpan.Duration works" <| fun () ->
+            let test ms expected =
+                let t = TimeSpan.FromMilliseconds(ms)
+                t.Duration().TotalMilliseconds
+                |> equal expected
+            test 1. 1.
+            test -1. 1.
+            test 0. 0.
+
+        testCase "TimeSpan.Negate works" <| fun () ->
+            let test ms expected =
+                let t = TimeSpan.FromMilliseconds(ms)
+                t.Negate().TotalMilliseconds
+                |> equal expected
+            test 1. -1.
+            test -1. 1.
+            test 0. 0.
+
+        testCase "TimeSpan Addition works" <| fun () ->
+            let test ms1 ms2 expected =
+                let t1 = TimeSpan.FromMilliseconds(ms1)
+                let t2 = TimeSpan.FromMilliseconds(ms2)
+                let res1 = t1.Add(t2).TotalMilliseconds
+                let res2 = (t1 + t2).TotalMilliseconds
+                equal true (res1 = res2)
+                equal expected res1
+            test 1000. 2000. 3000.
+            test 200. -1000. -800.
+            test -2000. 1000. -1000.
+            test -200. -300. -500.
+            test 0. 1000. 1000.
+            test -2000. 0. -2000.
+            test 0. 0. 0.
+
+        testCase "TimeSpan Subtraction works" <| fun () ->
+            let test ms1 ms2 expected =
+                let t1 = TimeSpan.FromMilliseconds(ms1)
+                let t2 = TimeSpan.FromMilliseconds(ms2)
+                let res1 = t1.Subtract(t2).TotalMilliseconds
+                let res2 = (t1 - t2).TotalMilliseconds
+                equal true (res1 = res2)
+                equal expected res1
+            test 1000. 2000. -1000.
+            test 200. -2000. 2200.
+            test -2000. 1000. -3000.
+            test 200. -300. 500.
+            test 0. 1000. -1000.
+            test 1000. 1000. 0.
+            test 0. 0. 0.
+
+        testCase "TimeSpan Comparison works" <| fun () ->
+            let test ms1 ms2 expected =
+                let t1 = TimeSpan.FromMilliseconds(ms1)
+                let t2 = TimeSpan.FromMilliseconds(ms2)
+                let res1 = compare t1 t2
+                let res2 = t1.CompareTo(t2)
+                let res3 = TimeSpan.Compare(t1, t2)
+                equal true (res1 = res2 && res2 = res3)
+                equal expected res1
+            test 1000. 2000. -1
+            test 2000. 1000. 1
+            test -2000. -2000. 0
+            test 200. -200. 1
+            test 0. 1000. -1
+            test 1000. 1000. 0
+            test 0. 0. 0
+
+        testCase "TimeSpan GreaterThan works" <| fun () ->
+            let test ms1 ms2 expected =
+                let t1 = TimeSpan.FromMilliseconds(ms1)
+                let t2 = TimeSpan.FromMilliseconds(ms2)
+                t1 > t2
+                |> equal expected
+            test 1000. 2000. false
+            test 2000. 1000. true
+            test -2000. -2000. false
+
+        testCase "TimeSpan LessThan works" <| fun () ->
+            let test ms1 ms2 expected =
+                let t1 = TimeSpan.FromMilliseconds(ms1)
+                let t2 = TimeSpan.FromMilliseconds(ms2)
+                t1 < t2
+                |> equal expected
+            test 1000. 2000. true
+            test 2000. 1000. false
+            test -2000. -2000. false
+
+        testCase "TimeSpan Equality works" <| fun () ->
+            let test ms1 ms2 expected =
+                let t1 = TimeSpan.FromMilliseconds(ms1)
+                let t2 = TimeSpan.FromMilliseconds(ms2)
+                t1 = t2
+                |> equal expected
+            test 1000. 2000. false
+            test 2000. 1000. false
+            test -2000. -2000. true
+
+        testCase "TimeSpan Inequality works" <| fun () ->
+            let test ms1 ms2 expected =
+                let t1 = TimeSpan.FromMilliseconds(ms1)
+                let t2 = TimeSpan.FromMilliseconds(ms2)
+                t1 <> t2
+                |> equal expected
+            test 1000. 2000. true
+            test 2000. 1000. true
+            test -2000. -2000. false
+
+    // **************************************************
+    // Test Cases From :
+    // https://docs.microsoft.com/en-us/dotnet/api/system.timespan.tryparse
+    //
+    // **************************************************
+    //
+    //            String to Parse                TimeSpan
+    //            ---------------   ---------------------
+    //                          0        00:00:00
+    //                         14     14.00:00:00
+    //                      1:2:3        01:02:03
+    //                  0:0:0.250        00:00:00.2500000
+    //            10.20:30:40.050     10.20:30:40.0050000
+    //        99.23:59:59.9990000     99.23:59:59.9999000
+    //        0023:0059:0059.0009        23:59:59.0009000
+    //                     23:0:0        23:00:00
+    //                     24:0:0   Parse operation failed. (actually not true, it's parsed to 24 days...)
+    //                     0:59:0        00:59:00
+    //                     0:60:0   Parse operation failed.
+    //                     0:0:59        00:00:59
+    //                     0:0:60   Parse operation failed.
+    //                        10:   Parse operation failed.
+    //                       10:0        10:00:00
+    //                        :10   Parse operation failed.
+    //                       0:10        00:10:00
+    //                     10:20:   Parse operation failed.
+    //                    10:20:0        10:20:00
+    //                       .123   Parse operation failed.
+    //                    0.12:00        12:00:00
+    //                        10.   Parse operation failed.
+    //                      10.12   Parse operation failed.
+    //                   10.12:00     10.12:00:00
+
+        testCase "TimeSpan 0 parse works" <| fun () ->
+            let actual = TimeSpan.Parse("0")
+            let expected = TimeSpan(0, 0, 0, 0, 0)
+            equal actual expected
+
+        testCase "TimeSpan 14 parse works" <| fun () ->
+            let actual = TimeSpan.Parse("14")
+            let expected = TimeSpan(14, 0, 0, 0, 0)
+            equal actual expected
+
+        testCase "TimeSpan 1:2:3 parse works" <| fun () ->
+            let actual = TimeSpan.Parse("1:2:3")
+            let expected = TimeSpan(0, 1, 2, 3, 0)
+            equal actual expected
+
+        testCase "TimeSpan 0:0:0.250 parse works" <| fun () ->
+            let actual = TimeSpan.Parse("0:0:0.250")
+            let expected = TimeSpan(0, 0, 0, 0, 250)
+            equal actual expected
+
+        testCase "TimeSpan 10.20:30:40.050 parse works" <| fun () ->
+            let actual = TimeSpan.Parse("10.20:30:40.050")
+            let expected = TimeSpan(10, 20, 30, 40, 50)
+            equal actual expected
+
+        testCase "TimeSpan 99.23:59:59.999 parse works" <| fun () ->
+            let actual = TimeSpan.Parse("99.23:59:59.999")
+            let expected = TimeSpan(99, 23, 59, 59, 999)
+            equal actual expected
+
+        testCase "TimeSpan 0023:0059:0059.0099 parse works" <| fun () ->
+            let actual = TimeSpan.Parse("0023:0059:0059.009")
+            let expected = TimeSpan(00, 23, 59, 59, 9)
+            equal actual expected
+
+        testCase "TimeSpan 23:0:0 parse works" <| fun () ->
+            let actual = TimeSpan.Parse("23:0:0")
+            let expected = TimeSpan(0, 23, 0, 0, 0)
+            equal actual expected
+#if FABLE_COMPILER
+        // msft assumes it's 24 days...
+        // https://docs.microsoft.com/en-us/dotnet/api/system.timespan.parse
+        // or
+        // https://github.com/dotnet/dotnet-api-docs/blob/7f6a3882631bc008b858adfadb43cd17bbd55d49/xml/System/TimeSpan.xml#L2772
+        testCase "TimeSpan 24:0:0 parse fails" <| fun () ->
+            (fun _ -> TimeSpan.Parse("24:0:0"))
+            |> Util.throwsError "String was not recognized as a valid TimeSpan."
+
+        testCase "TimeSpan 24:0:0 TryParse fails" <| fun () ->
+            let status, _ = TimeSpan.TryParse("24:0:0")
+            equal status false
+#endif
+
+        testCase "TimeSpan 0:0:59 parse works" <| fun () ->
+            let actual = TimeSpan.Parse("0:0:59")
+            let expected = TimeSpan(0, 0, 0, 59, 0)
+            equal actual expected
+
+        testCase "TimeSpan 0:60:0 parse fails" <| fun () ->
+            (fun _ -> TimeSpan.Parse("0:60:0"))
+#if FABLE_COMPILER            
+            |> Util.throwsError "String was not recognized as a valid TimeSpan."
+#else
+            |> Util.throwsError "The TimeSpan could not be parsed because at least one of the numeric components is out of range or contains too many digits."
+#endif
+        testCase "TimeSpan 10: parse fails" <| fun () ->
+            (fun _ -> TimeSpan.Parse("10:"))
+            |> Util.throwsError "String was not recognized as a valid TimeSpan."
+
+        testCase "TimeSpan 10:0 parse works" <| fun () ->
+            let actual = TimeSpan.Parse("10:0")
+            let expected = TimeSpan(0, 10, 0, 0, 0)
+            equal actual expected
+
+        testCase "TimeSpan 10:20: parse fails" <| fun () ->
+            (fun _ -> TimeSpan.Parse("10:20:"))
+            |> Util.throwsError "String was not recognized as a valid TimeSpan."
+
+        testCase "TimeSpan 10:20:0 parse works" <| fun () ->
+            let actual = TimeSpan.Parse("10:20:0")
+            let expected = TimeSpan(0, 10, 20, 0, 0)
+            equal actual expected
+
+        testCase "TimeSpan .123 parse fails" <| fun () ->
+            (fun _ -> TimeSpan.Parse(".123"))
+            |> Util.throwsError "String was not recognized as a valid TimeSpan."
+
+        testCase "TimeSpan 0.12:00 parse works" <| fun () ->
+            let actual = TimeSpan.Parse("0.12:00")
+            let expected = TimeSpan(0, 12, 00, 0, 0)
+            equal actual expected
+
+        testCase "TimeSpan 10. parse fails" <| fun () ->
+            (fun _ -> TimeSpan.Parse("10."))
+            |> Util.throwsError "String was not recognized as a valid TimeSpan."
+
+        testCase "TimeSpan 10.12 parse fails" <| fun () ->
+            (fun _ -> TimeSpan.Parse("10.12"))
+            |> Util.throwsError "String was not recognized as a valid TimeSpan."
+
+        testCase "TimeSpan 10.12:00 parse works" <| fun () ->
+            let actual = TimeSpan.Parse("10.12:00")
+            let expected = TimeSpan(10, 12, 00, 0, 0)
+            equal actual expected
+
+        testCase "TimeSpan 0 TryParse works" <| fun () ->
+            let status, actual = TimeSpan.TryParse("0")
+            let expected = TimeSpan(0, 0, 0, 0, 0)
+            equal status true
+            equal actual expected
+
+        testCase "TimeSpan 14 TryParse works" <| fun () ->
+            let status, actual = TimeSpan.TryParse("14")
+            let expected = TimeSpan(14, 0, 0, 0, 0)
+            equal status true
+            equal actual expected
+
+        testCase "TimeSpan 1:2:3 TryParse works" <| fun () ->
+            let status, actual = TimeSpan.TryParse("1:2:3")
+            let expected = TimeSpan(0, 1, 2, 3, 0)
+            equal status true
+            equal actual expected
+
+        testCase "TimeSpan 0:0:0.250 TryParse works" <| fun () ->
+            let status, actual = TimeSpan.TryParse("0:0:0.250")
+            let expected = TimeSpan(0, 0, 0, 0, 250)
+            equal status true
+            equal actual expected
+
+        testCase "TimeSpan 10.20:30:40.050 TryParse works" <| fun () ->
+            let status, actual = TimeSpan.TryParse("10.20:30:40.050")
+            let expected = TimeSpan(10, 20, 30, 40, 50)
+            equal status true
+            equal actual expected
+
+        testCase "TimeSpan 99.23:59:59.999 TryParse works" <| fun () ->
+            let status, actual = TimeSpan.TryParse("99.23:59:59.999")
+            let expected = TimeSpan(99, 23, 59, 59, 999)
+            equal status true
+            equal actual expected
+
+        testCase "TimeSpan 0023:0059:0059.009 TryParse works" <| fun () ->
+            let status, actual = TimeSpan.TryParse("0023:0059:0059.009")
+            let expected = TimeSpan(00, 23, 59, 59, 9)
+            equal status true
+            equal actual expected
+
+        testCase "TimeSpan 23:0:0 TryParse works" <| fun () ->
+            let status, actual = TimeSpan.TryParse("23:0:0")
+            let expected = TimeSpan(0, 23, 0, 0, 0)
+            equal status true
+            equal actual expected
+
+        testCase "TimeSpan 0:0:59 TryParse works" <| fun () ->
+            let status, actual = TimeSpan.TryParse("0:0:59")
+            let expected = TimeSpan(0, 0, 0, 59, 0)
+            equal status true
+            equal actual expected
+
+        testCase "TimeSpan 0:60:0 TryParse fails" <| fun () ->
+            let status, _ = TimeSpan.TryParse("0:60:0")
+            equal status false
+
+        testCase "TimeSpan 10: TryParse fails" <| fun () ->
+            let status, _ = TimeSpan.TryParse("10:")
+            equal status false
+        testCase "TimeSpan 10:0 TryParse works" <| fun () ->
+            let status, actual = TimeSpan.TryParse("10:0")
+            let expected = TimeSpan(0, 10, 0, 0, 0)
+            equal status true
+            equal actual expected
+
+        testCase "TimeSpan 10:20: TryParse fails" <| fun () ->
+            let status, _ = TimeSpan.TryParse("10:20:")
+            equal status false
+
+        testCase "TimeSpan 10:20:0 TryParse works" <| fun () ->
+            let status, actual = TimeSpan.TryParse("10:20:0")
+            let expected = TimeSpan(0, 10, 20, 0, 0)
+            equal status true
+            equal actual expected
+
+        testCase "TimeSpan .123 TryParse fails" <| fun () ->
+            let status, _ = TimeSpan.TryParse(".123")
+            equal status false
+
+        testCase "TimeSpan 0.12:00 TryParse works" <| fun () ->
+            let status, actual = TimeSpan.TryParse("0.12:00")
+            let expected = TimeSpan(0, 12, 00, 0, 0)
+            equal status true
+            equal actual expected
+
+        testCase "TimeSpan 10. TryParse fails" <| fun () ->
+            let status, _ = TimeSpan.TryParse("10.")
+            equal status false
+
+        testCase "TimeSpan 10.12 TryParse fails" <| fun () ->
+            let status, _ = TimeSpan.TryParse("10.12")
+            equal status false
+
+        testCase "TimeSpan 10.12:00 TryParse works" <| fun () ->
+            let status, actual = TimeSpan.TryParse("10.12:00")
+            let expected = TimeSpan(10, 12, 00, 0, 0)
+            equal status true
+            equal actual expected
+    ]


### PR DESCRIPTION
Moved TimeSpan tests from DateTimeTests to TimeSpanTests.
Also tried ToString(), but failed to amend Replacement.fs correctly.