### PR TITLE
Add undefined

### DIFF
--- a/src/dotnet/Fable.Core/Fable.Import.JS.fs
+++ b/src/dotnet/Fable.Core/Fable.Import.JS.fs
@@ -1200,3 +1200,5 @@ module JS =
     let [<Global>] clearInterval (token:SetIntervalToken): unit = jsNative
 
     let [<Emit("debugger;")>] debugger () : unit = jsNative
+    
+    let [<Emit("undefined")>] undefined<'a> : 'a = jsNative


### PR DESCRIPTION
I think an `undefined` literal should definitely be part of Fable. This simple change defines it in such a way that it's trivial to do "type-safe" comparisons against `undefined` for any type, e.g.:

```f#
type Foo =
  abstract Bar : int with get, set

let x = createEmpty<Foo>

let hasBar = x.Bar <> undefined
```
