### PR TITLE
Fixed #1705

### DIFF
--- a/src/dotnet/Fable.Compiler/Transforms/MonadicTrampoline.fs
+++ b/src/dotnet/Fable.Compiler/Transforms/MonadicTrampoline.fs
@@ -1,51 +1,23 @@
-﻿// Source: http://fssnip.net/dK/title/Monadic-Trampoline
-module MonadicTrampoline
+﻿module MonadicTrampoline
 
 #if NETSTANDARD2_0 || !FABLE_COMPILER
-type TrampolineValue<'T> =
-    | DelayValue of Delay<'T>
-    | ReturnValue of Return<'T>
-    | BindValue of IBind<'T>
 
-and ITrampoline<'T> =
-    abstract member Value : TrampolineValue<'T>
-    abstract member Run : unit -> 'T
+type Thunk<'T> =
+    | DelayValue of (unit -> Thunk<'T>)
+    | ReturnValue of 'T
 
-and Delay<'T>(f : unit -> ITrampoline<'T>) =
-    member self.Func = f
-    interface ITrampoline<'T> with
-        member self.Value = DelayValue self
-        member self.Run () = (f ()).Run()
-
-and Return<'T>(x :'T) =
-    member self.Value = x
-    interface ITrampoline<'T> with
-        member self.Value = ReturnValue self
-        member self.Run () = x
-
-and IBind<'T> =
-    abstract Bind<'R> : ('T -> ITrampoline<'R>) -> ITrampoline<'R>
-
-and Bind<'T, 'R>(trampoline : ITrampoline<'T>, f : ('T -> ITrampoline<'R>)) =
-    interface IBind<'R> with
-        member self.Bind<'K>(f' : 'R -> ITrampoline<'K>) : ITrampoline<'K> =
-            new Bind<'T, 'K>(trampoline, fun t -> new Bind<'R, 'K>(f t, (fun r -> f' r)) :> _) :> _
-    interface ITrampoline<'R> with
-        member self.Value = BindValue self
-        member self.Run () =
-            match trampoline.Value with
-            | BindValue b -> b.Bind(f).Run()
-            | ReturnValue r -> (f r.Value).Run()
-            | DelayValue d -> (new Bind<'T, 'R>(d.Func (), f) :> ITrampoline<'R>).Run()
+let rec run = function
+    | DelayValue f -> f () |> run
+    | ReturnValue x -> x
 
 type TrampolineBuilder() =
-    member self.Bind(tr, f) = new Bind<'T, 'R>(tr, f) :> ITrampoline<'R>
-    member self.Delay f = new Delay<_>(f) :> ITrampoline<_>
-    member self.Return a = new Return<_>(a) :> ITrampoline<_>
-    member self.ReturnFrom a = a
+    member __.Bind(thunk, f) = DelayValue (fun () -> run thunk |> f)
+    member __.Delay f = DelayValue f
+    member __.Return a = ReturnValue a
+    member __.ReturnFrom (a: Thunk<'T>) = a
 
-let inline run (tr : ITrampoline<'T>) = tr.Run()
 #else
+
 // Fable cannot tail-call optimize mutually recursive functions, rendering
 // the implementation above useless, so we use the following one instead.
 // However, take note this uses unsafe boxing/unboxing, which is ok
@@ -71,9 +43,10 @@ type TrampolineBuilder() =
     member __.Delay f = DelayValue f
     member __.Return a = ReturnValue a
     member __.ReturnFrom (a: Thunk) = a
+
 #endif
 
-let trampoline = new TrampolineBuilder()
+let trampoline = TrampolineBuilder()
 
 let rec trampolineListMapAcc acc f xs =
     trampoline {

--- a/src/dotnet/Fable.Compiler/Transforms/Replacements.fs
+++ b/src/dotnet/Fable.Compiler/Transforms/Replacements.fs
@@ -1550,6 +1550,12 @@ let resizeArrays (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (this
         Helper.InstanceCall(ar, "push", t, args, ?loc=r) |> Some
     | "Remove", Some ar, [arg] ->
         Helper.CoreCall("Array", "removeInPlace", t, [arg; ar], ?loc=r) |> Some
+    | "RemoveAll", Some ar, [arg] ->
+        Helper.CoreCall("Array", "removeAllInPlace", t, [arg; ar], ?loc=r) |> Some
+    | "FindIndex", Some ar, [arg] ->
+        Helper.InstanceCall(ar, "findIndex", t, [arg], ?loc=r) |> Some
+    | "FindLastIndex", Some ar, [arg] ->
+        Helper.CoreCall("Array", "findLastIndex", t, [arg; ar], ?loc=r) |> Some
     | "GetEnumerator", Some ar, _ -> getEnumerator r t ar |> Some
     // ICollection members, implemented in dictionaries and sets too. We need runtime checks (see #1120)
     | "get_Count", Some ar, _ ->

--- a/src/dotnet/Fable.Repl/bench-compiler/Properties/launchSettings.json
+++ b/src/dotnet/Fable.Repl/bench-compiler/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "bench-compiler": {
       "commandName": "Project",
-      "commandLineArgs": "./bench-compiler.fsproj",
+      "commandLineArgs": "bench-compiler.fsproj out-node",
       "workingDirectory": "$(SolutionDir)"
     }
   }

--- a/src/dotnet/Fable.Repl/bench-compiler/package.json
+++ b/src/dotnet/Fable.Repl/bench-compiler/package.json
@@ -15,8 +15,9 @@
     "build-tests-node": "node out/app ../../../../tests/Main/Fable.Tests.fsproj out-tests && node transform out-tests --commonjs",
     "build-tests-dotnet": "dotnet run -c Release ../../../../tests/Main/Fable.Tests.fsproj out-tests && node transform out-tests --commonjs",
     "run-tests": "../../../../node_modules/.bin/mocha --colors out-test/tests/Main/Main.js",
-    "profile": "node --prof out/app",
-    "process": "chcp 65001 > nul && for %x in (isolate-*.log) do node --prof-process %x > %x.txt",
-    "trace": "node --trace-deopt out/app > deopt.txt"
+    "profile": "node --prof out-node/app bench-compiler.fsproj out-node2",
+    "process": "node --prof-process --preprocess -j isolate-*.log > profile.v8log.json",
+    "flamegraph": "speedscope profile.v8log.json",
+    "trace": "node --trace-deopt out-node/app bench-compiler.fsproj out-node2 > deopt.txt"
   }
 }

--- a/src/js/fable-library/Array.fs
+++ b/src/js/fable-library/Array.fs
@@ -554,16 +554,11 @@ let tryFindIndexBack predicate (array: _[]) =
         else loop (i - 1)
     loop (array.Length - 1)
 
-let choose (f: 'T->'U option) (source: 'T[]) ([<Inject>] cons: IArrayCons<'U>) =
-    let res = cons.Create 0
-    let mutable j = 0
-    for i = 0 to source.Length - 1 do
-        match f source.[i] with
-        | Some y ->
-            res.[j] <- y
-            j <- j + 1
-        | None -> ()
-    res
+let choose (chooser: 'T->'U option) (array: 'T[]) ([<Inject>] cons: IArrayCons<'U>) =
+    let f x = chooser x |> Option.isSome
+    let g x = chooser x |> Option.get
+    let arr = filterImpl f array
+    map g arr cons
 
 let foldIndexed folder (state: 'State) (array: 'T[]) =
     // if isTypedArrayImpl array then

--- a/src/js/fable-library/Array.fs
+++ b/src/js/fable-library/Array.fs
@@ -453,6 +453,16 @@ let removeInPlace (item: 'T) (array: 'T[]) =
     else
         false
 
+let removeAllInPlace predicate (array: 'T[]) =
+    let rec countRemoveAll count =
+        let i = findIndexImpl predicate array
+        if i > -1 then
+            spliceImpl array i 1 |> ignore
+            countRemoveAll count + 1
+        else
+            count
+    countRemoveAll 0
+
 let copyTo (source: JS.ArrayLike<'T>) sourceIndex (target: JS.ArrayLike<'T>) targetIndex count =
     let diff = targetIndex - sourceIndex
     for i = sourceIndex to sourceIndex + count - 1 do
@@ -520,6 +530,13 @@ let tryFindBack predicate (array: _[]) =
     let rec loop i =
         if i < 0 then None
         elif predicate array.[i] then Some array.[i]
+        else loop (i - 1)
+    loop (array.Length - 1)
+
+let findLastIndex predicate (array: _[]) =
+    let rec loop i =
+        if i < 0 then -1
+        elif predicate array.[i] then i
         else loop (i - 1)
     loop (array.Length - 1)
 

--- a/tests/Main/ArrayTests.fs
+++ b/tests/Main/ArrayTests.fs
@@ -269,7 +269,14 @@ let tests =
         [|{ MyNumber = MyNumber 5 }; { MyNumber = MyNumber 4 }; { MyNumber = MyNumber 3 }|]
         |> Array.averageBy (fun x -> x.MyNumber) |> equal (MyNumber 4)
 
-    testCase "Array.choose works" <| fun () ->
+    testCase "Array.choose with ints works" <| fun () ->
+        let xs = [| 1; 2; 3; 4; 5; 6; 7; 8; 9; 10 |]
+        let result = xs |> Array.choose (fun i ->
+            if i % 2 = 1 then Some i
+            else None)
+        result.Length |> equal 5
+
+    testCase "Array.choose with longs works" <| fun () ->
         let xs = [|1L; 2L; 3L; 4L|]
         let result = xs |> Array.choose (fun x ->
            if x > 2L then Some x

--- a/tests/Main/ResizeArrayTests.fs
+++ b/tests/Main/ResizeArrayTests.fs
@@ -86,6 +86,18 @@ let tests =
         System.Predicate<_> (fun _ -> false)  |> li.FindLast |> equal None
         System.Predicate<_> Option.isSome  |> li.FindLast |> equal (Some 1)
 
+    testCase "ResizeArray.FindIndex works" <| fun () ->
+        let li = ResizeArray<_>()
+        li.Add(1.); li.Add(2.); li.Add(3.); li.Add(2.); li.Add(5.)
+        System.Predicate<_> (fun x -> x = 2.) |> li.FindIndex |> equal 1
+        System.Predicate<_> (fun x -> x = 0.) |> li.FindIndex |> equal -1
+
+    testCase "ResizeArray.FindLastIndex works" <| fun () ->
+        let li = ResizeArray<_>()
+        li.Add(1.); li.Add(2.); li.Add(3.); li.Add(2.); li.Add(5.)
+        System.Predicate<_> (fun x -> x = 2.) |> li.FindLastIndex |> equal 3
+        System.Predicate<_> (fun x -> x = 0.) |> li.FindLastIndex |> equal -1
+
     testCase "ResizeArray indexer getter works" <| fun () ->
         let li = ResizeArray<_>()
         li.Add(1.); li.Add(2.); li.Add(3.); li.Add(4.); li.Add(5.)
@@ -134,6 +146,15 @@ let tests =
         li.Add("ch")
         li.Remove("ab") |> equal true
         li.Remove("cd") |> equal false
+
+    testCase "ResizeArray.RemoveAll works" <| fun () ->
+        let li = ResizeArray<_>()
+        li.Add("ab")
+        li.Add("ch")
+        li.Add("ab")
+        System.Predicate<_> (fun x -> x = "ab") |> li.RemoveAll |> equal 2
+        System.Predicate<_> (fun x -> x = "ab") |> li.RemoveAll |> equal 0
+        li.[0] |> equal "ch"
 
     testCase "ResizeArray.RemoveRange works" <| fun () ->
         let xs = ResizeArray<int>()


### PR DESCRIPTION
- Reverted trampoline to @alfonsogarciacaro's simpler version
- Added `RemoveAll`, `FindIndex`, `FindLastIndex` for `ResizeArray`
- Fixed #1705 (`Array.choose`)