### PR TITLE
Add support for more TimeSpan.ToString options

### DIFF
--- a/src/js/fable-library/TimeSpan.ts
+++ b/src/js/fable-library/TimeSpan.ts
@@ -1,5 +1,5 @@
 import { fromNumber, op_Division, op_Multiply, toNumber } from "./Long";
-import { comparePrimitives, padWithZeros } from "./Util";
+import { comparePrimitives, padLeftAndRightWithZeros, padWithZeros } from "./Util";
 
 // TimeSpan in runtime just becomes a number representing milliseconds
 
@@ -98,14 +98,17 @@ export function duration(x: number) {
   return Math.abs(x as number);
 }
 
-export function toString(ts: number) {
+export function toString(ts: number, format = "c") {
+  if (["c", "g", "G"].indexOf(format) === -1) {
+    throw new Error("Custom formats are not supported");
+  }
   const d = days(ts);
   const h = hours(ts);
   const m = minutes(ts);
   const s = seconds(ts);
   const ms = milliseconds(ts);
   // tslint:disable-next-line:max-line-length
-  return `${d === 0 ? "" : d + "."}${padWithZeros(h, 2)}:${padWithZeros(m, 2)}:${padWithZeros(s, 2)}${ms === 0 ? "" : "." + padWithZeros(ms, 3)}`;
+  return `${d === 0 && (format === "c" || format === "g") ? "" : format === "c" ? d + "." : d + ":" }${format === "g" ? h : padWithZeros(h, 2)}:${padWithZeros(m, 2)}:${padWithZeros(s, 2)}${ms === 0 && (format === "c" || format === "g") ? "" : format === "g" ? "." + padWithZeros(ms, 3) : "." + padLeftAndRightWithZeros(ms, 3, 7)}`;
 }
 
 export function parse(str: string) {

--- a/src/js/fable-library/Util.ts
+++ b/src/js/fable-library/Util.ts
@@ -152,6 +152,17 @@ export function padWithZeros(i: number, length: number) {
   return str;
 }
 
+export function padLeftAndRightWithZeros(i: number, lengthLeft: number, lengthRight: number) {
+  let str = i.toString(10);
+  while (str.length < lengthLeft) {
+    str =  "0" + str;
+  }
+  while (str.length < lengthRight) {
+    str =  str + "0";
+  }
+  return str;
+}
+
 export function dateOffset(date: IDateTime | IDateTimeOffset): number {
   const date1 = date as IDateTimeOffset;
   return typeof date1.offset === "number"

--- a/tests/Main/TimeSpanTests.fs
+++ b/tests/Main/TimeSpanTests.fs
@@ -3,6 +3,7 @@ module Fable.Tests.TimeSpan
 open System
 open Util.Testing
 open Fable.Tests
+open System.Globalization
 
 let tests =
     testList "TimeSpan" [
@@ -11,7 +12,25 @@ let tests =
             TimeSpan(0L).ToString() |> equal "00:00:00"
             TimeSpan.FromSeconds(12345.).ToString() |> equal "03:25:45"
             TimeSpan.FromDays(18.).ToString() |> equal "18.00:00:00"
-            TimeSpan.FromMilliseconds(25.).ToString().TrimEnd('0') |> equal "00:00:00.025"
+            TimeSpan.FromMilliseconds(25.).ToString() |> equal "00:00:00.0250000"
+
+        testCase "TimeSpan.ToString(\"c\", CultureInfo.InvariantCulture) works" <| fun () ->
+            TimeSpan(0L).ToString("c", CultureInfo.InvariantCulture) |> equal "00:00:00"
+            TimeSpan.FromSeconds(12345.).ToString("c", CultureInfo.InvariantCulture) |> equal "03:25:45"
+            TimeSpan.FromDays(18.).ToString("c", CultureInfo.InvariantCulture) |> equal "18.00:00:00"
+            TimeSpan.FromMilliseconds(25.).ToString("c", CultureInfo.InvariantCulture) |> equal "00:00:00.0250000"
+
+        testCase "TimeSpan.ToString(\"g\", CultureInfo.InvariantCulture) works" <| fun () ->
+            TimeSpan(0L).ToString("g", CultureInfo.InvariantCulture) |> equal "0:00:00"
+            TimeSpan.FromSeconds(12345.).ToString("g", CultureInfo.InvariantCulture) |> equal "3:25:45"
+            TimeSpan.FromDays(18.).ToString("g", CultureInfo.InvariantCulture) |> equal "18:0:00:00"
+            TimeSpan.FromMilliseconds(25.).ToString("g", CultureInfo.InvariantCulture) |> equal "0:00:00.025"
+
+        testCase "TimeSpan.ToString(\"G\", CultureInfo.InvariantCulture) works" <| fun () ->
+            TimeSpan(0L).ToString("G", CultureInfo.InvariantCulture) |> equal "0:00:00:00.0000000"
+            TimeSpan.FromSeconds(12345.).ToString("G", CultureInfo.InvariantCulture) |> equal "0:03:25:45.0000000"
+            TimeSpan.FromDays(18.).ToString("G", CultureInfo.InvariantCulture) |> equal "18:00:00:00.0000000"
+            TimeSpan.FromMilliseconds(25.).ToString("G", CultureInfo.InvariantCulture) |> equal "0:00:00:00.0250000"
 
         // TODO
         // testCase "TimeSpan.ToString with format works" <| fun () ->


### PR DESCRIPTION
With format being "c", "g", "G", it enables :
- ToString(format)
- ToString(format, CultureInfo.InvariantCulture)

Custom format (ex : hh:mm) are not supported