### PR TITLE
Print decimals for aDateTime.ToString("dd:mm:ss.fff")

### DIFF
--- a/src/fable-library/Date.ts
+++ b/src/fable-library/Date.ts
@@ -67,6 +67,7 @@ function dateToStringWithCustomFormat(date: Date, format: string, utc: boolean) 
         rep = h > 12 ? h % 12 : h; break;
       case "m": rep = utc ? date.getUTCMinutes() : date.getMinutes(); break;
       case "s": rep = utc ? date.getUTCSeconds() : date.getSeconds(); break;
+      case "f": rep = utc ? date.getUTCMilliseconds() : date.getMilliseconds(); break;
     }
     if (rep !== match && rep < 10 && match.length > 1) {
       rep = "0" + rep;

--- a/tests/Main/DateTimeTests.fs
+++ b/tests/Main/DateTimeTests.fs
@@ -27,6 +27,10 @@ let tests =
         DateTime(2017, 9, 5).ToString("yyyyMM")
         |> equal "201709"
 
+    testCase "DateTime.ToString with milliseconds" <| fun () -> // See #1726
+        DateTime(2014, 9, 11, 16, 37, 11, 345).ToString("ss.fff")
+        |> equal "11.345"
+
     testCase "DateTime.ToString with Round-trip format works for Utc" <| fun () ->
         let str = DateTime(2014, 9, 11, 16, 37, 2, DateTimeKind.Utc).ToString("O")
         System.Text.RegularExpressions.Regex.Replace(str, "0{3,}", "000")


### PR DESCRIPTION
Added a case 'f' which means milliseconds can now be printed out by aDateTime.ToString("hh:mm:ss.fff"). Addresses issue [fable-compiler#1726](https://github.com/fable-compiler/Fable/issues/1726) in a very basic way. The .net format string allows you to control how many decimal should be printed but this PR does not distinguish between the following: dd:hh:mm:ss.f, dd:hh:mm:ss.ff , dd:hh:mm:ss.fff, dd:hh:mm:ss.ffff ect. All print out the un-padded millisecond value.