### PR TITLE
Adding babelOptions.filename, since it is needed by other Babel plugins (like react-hot-loader).

### DIFF
--- a/src/fable-loader/index.js
+++ b/src/fable-loader/index.js
@@ -35,10 +35,12 @@ function getCompiler(webpack, args) {
 
 function transformBabelAst(babelAst, babelOptions, sourceMapOptions, callback) {
     var fsCode = null;
+    var fileName = sourceMapOptions.path.replace(/\\/g, '/');
     if (sourceMapOptions != null) {
         fsCode = sourceMapOptions.buffer.toString();
         babelOptions.sourceMaps = true;
-        babelOptions.sourceFileName = path.relative(process.cwd(), sourceMapOptions.path.replace(/\\/g, '/'));
+        babelOptions.filename = fileName;
+        babelOptions.sourceFileName = path.relative(process.cwd(), fileName);
     }
     babel.transformFromAst(babelAst, fsCode, babelOptions, callback);
 }


### PR DESCRIPTION
https://github.com/fable-compiler/Fable/issues/1733