### PR TITLE
Add bigint xor operator, bigint byte array conversions, and Random.NextBytes

### DIFF
--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -1887,6 +1887,8 @@ let bigints (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (thisArg: 
     match thisArg, i.CompiledName with
     | None, ".ctor" ->
         match i.SignatureArgTypes with
+        | [Array _] ->
+            Helper.CoreCall("BigInt", "fromByteArray", t, args, i.SignatureArgTypes, ?loc=r) |> Some
         | [Builtin(BclInt64|BclUInt64)] ->
             Helper.CoreCall("BigInt", "fromInt64", t, args, i.SignatureArgTypes, ?loc=r) |> Some
         | _ ->

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -2355,6 +2355,12 @@ let random (_: ICompiler) (ctx: Context) r t (i: CallInfo) (_: Expr option) (arg
         Helper.CoreCall("Util", "randomNext", t, [min; max], [min.Type; max.Type], ?loc=r) |> Some
     | "NextDouble" ->
         Helper.GlobalCall ("Math", t, [], [], memb="random") |> Some
+    | "NextBytes" ->
+        let byteArray =
+            match args with
+            | [b] -> b
+            | _ -> failwith "Unexpected arg count for Random.NextBytes"
+        Helper.CoreCall("Util", "randomBytes", t, [byteArray], [byteArray.Type], ?loc=r) |> Some
     | _ -> None
 
 let cancels (_: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr option) (args: Expr list) =

--- a/src/fable-library/BigInt.fs
+++ b/src/fable-library/BigInt.fs
@@ -66,6 +66,7 @@ let op_RightShift = bigint.(>>>)
 let op_LeftShift = bigint.(<<<)
 let op_BitwiseAnd = bigint.(&&&)
 let op_BitwiseOr = bigint.(|||)
+let op_ExclusiveOr = bigint.(^^^)
 
 let op_LessThan = bigint.op_LessThan
 let op_LessThanOrEqual = bigint.op_LessThanOrEqual

--- a/src/fable-library/BigInt/n.fs
+++ b/src/fable-library/BigInt/n.fs
@@ -1433,6 +1433,19 @@ module internal BigNatModule =
         normN r
 
     //----------------------------------------------------------------------------
+    // bitwise xor
+    //--------------------------------------------------------------------------
+
+    let bitXor a b =
+        let rbound = maxInt a.bound b.bound
+        let r = createN rbound
+        for i = 0 to a.bound-1 do
+            r.digits.[i] <- r.digits.[i] ^^^ a.digits.[i]
+        for i = 0 to b.bound-1 do
+            r.digits.[i] <- r.digits.[i] ^^^ b.digits.[i]
+        normN r
+
+    //----------------------------------------------------------------------------
     // hcf
     //--------------------------------------------------------------------------
 

--- a/src/fable-library/BigInt/n.fsi
+++ b/src/fable-library/BigInt/n.fsi
@@ -25,6 +25,7 @@ module internal BigNatModule =
     val rem        : BigNat -> BigNat -> BigNat
     val bitAnd     : BigNat -> BigNat -> BigNat
     val bitOr      : BigNat -> BigNat -> BigNat
+    val bitXor     : BigNat -> BigNat -> BigNat
     val hcf        : BigNat -> BigNat -> BigNat
 
     val min        : BigNat -> BigNat -> BigNat

--- a/src/fable-library/BigInt/z.fs
+++ b/src/fable-library/BigInt/z.fs
@@ -230,6 +230,9 @@ namespace BigInt
         static member (|||) (x:BigInteger,y:BigInteger) =
             BigInteger.posn (BigNatModule.bitOr x.V y.V)  // sign is ignored
 
+        static member (^^^) (x:BigInteger,y:BigInteger) =
+            BigInteger.posn (BigNatModule.bitXor x.V y.V)  // sign is ignored
+
         static member GreatestCommonDivisor (x:BigInteger,y:BigInteger) =
             match x.SignInt,y.SignInt with
             |  0, 0 -> BigInteger.Zero

--- a/src/fable-library/BigInt/z.fsi
+++ b/src/fable-library/BigInt/z.fsi
@@ -35,6 +35,8 @@ namespace BigInt
         static member (&&&)      : x:BigInteger * y:BigInteger -> BigInteger
         /// Return the bitwise or of two big integers
         static member (|||)      : x:BigInteger * y:BigInteger -> BigInteger
+        /// Return the bitwise xor of two big integers
+        static member (^^^)      : x:BigInteger * y:BigInteger -> BigInteger
 
         /// Convert a big integer to a 8-bit signed integer
         member ToSByte : sbyte

--- a/src/fable-library/Util.ts
+++ b/src/fable-library/Util.ts
@@ -497,6 +497,20 @@ export function randomNext(min: number, max: number) {
   return Math.floor(Math.random() * (max - min)) + min;
 }
 
+export function randomBytes(buffer: Uint8Array) {
+  if (buffer == null) { throw new Error("Buffer cannot be null"); }
+  for (let i = 0; i < buffer.length; i += 6) {
+    // Pick random 48-bit number. Fill buffer in 2 24-bit chunks to avoid bitwise truncation.
+    let r = Math.floor(Math.random() * 281474976710656) // Low 24 bits = chunk 1.
+    let rhi = Math.floor(r / 16777216) // High 24 bits shifted via division = chunk 2.
+    for (let j = 0; j < 6 && i+j < buffer.length; j++) {
+      if (j === 3) { r = rhi }
+      buffer[i+j] = r & 255;
+      r >>>= 8;
+    }
+  }
+}
+
 export function unescapeDataString(s: string): string {
   // https://stackoverflow.com/a/4458580/524236
   return decodeURIComponent((s).replace(/\+/g, "%20"));

--- a/tests/Main/ArithmeticTests.fs
+++ b/tests/Main/ArithmeticTests.fs
@@ -500,6 +500,26 @@ let tests =
         equal(0, compareTo y x)
         equal(1, compareTo z x)
 
+    testCase "Big integer to byte array works" <| fun () ->
+        // values with high bit both 0 and 1 for different array lengths
+        equal(32767I.ToByteArray(), [|255uy; 127uy|])
+        equal(32768I.ToByteArray(), [|0uy; 128uy; 0uy|])
+        equal(-32768I.ToByteArray(), [|0uy; 128uy|])
+        equal(-32769I.ToByteArray(), [|255uy; 127uy; 255uy|])
+        // large numbers
+        equal(111222333444555666777888999I.ToByteArray(), [|231uy; 216uy; 2uy; 164uy; 86uy; 149uy; 8uy; 199uy; 62uy; 0uy; 92uy|])
+        equal(-111222333444555666777888999I.ToByteArray(), [|25uy; 39uy; 253uy; 91uy; 169uy; 106uy; 247uy; 56uy; 193uy; 255uy; 163uy|])
+
+    testCase "Big integer from byte array works" <| fun () ->
+        // values with high bit both 0 and 1 for different array lengths
+        equal(Numerics.BigInteger([|255uy; 127uy|]), 32767I)
+        equal(Numerics.BigInteger([|0uy; 128uy; 0uy|]), 32768I)
+        equal(Numerics.BigInteger([|0uy; 128uy|]), -32768I)
+        equal(Numerics.BigInteger([|255uy; 127uy; 255uy|]), -32769I)
+        // large numbers
+        equal(Numerics.BigInteger([|231uy; 216uy; 2uy; 164uy; 86uy; 149uy; 8uy; 199uy; 62uy; 0uy; 92uy|]), 111222333444555666777888999I)
+        equal(Numerics.BigInteger([|25uy; 39uy; 253uy; 91uy; 169uy; 106uy; 247uy; 56uy; 193uy; 255uy; 163uy|]), -111222333444555666777888999I)
+
     testCase "Member values of decimal type can be compared" <| fun () -> // See #747
         equal(true, decimalOne < decimalTwo)
         equal(false, decimalOne > decimalTwo)

--- a/tests/Main/ArithmeticTests.fs
+++ b/tests/Main/ArithmeticTests.fs
@@ -459,6 +459,12 @@ let tests =
         let y = rnd.NextDouble()
         equal(true, y >= 0.0 && y < 1.0)
 
+    // Note: Test could fail sometime during life of universe, if it picks all zeroes.
+    testCase "System.Random.NextBytes works" <| fun () ->
+        let buffer = Array.create 16 0uy // guid-sized buffer
+        System.Random().NextBytes(buffer)
+        equal(buffer = Array.create 16 0uy, false)
+
     testCase "Long integers equality works" <| fun () ->
         let x = 5L
         let y = 5L

--- a/tests/Main/ArithmeticTests.fs
+++ b/tests/Main/ArithmeticTests.fs
@@ -264,6 +264,9 @@ let tests =
     testCase "BigInt Bitwise or can be generated" <| fun () ->
         equal (4I ||| 2I, 6I)
 
+    testCase "BigInt Bitwise xor can be generated" <| fun () ->
+        equal (6I ^^^ 2I, 4I)
+
     testCase "BigInt Bitwise shift left can be generated" <| fun () ->
         equal (4I <<< 2, 16I)
 


### PR DESCRIPTION
F# bigint supports ^^^ (but not ~~~, see below) so here it is.

```
> 2I ^^^ 3I;;
val it : System.Numerics.BigInteger = 1 {IsEven = false;
                                         IsOne = true;
                                         IsPowerOfTwo = true;
                                         IsZero = false;
                                         Sign = 1;}

> ~~~2I;;

  ~~~2I;;
  ---^^

error FS0001: The type 'System.Numerics.BigInteger' does not support the operator '~~~'
```

Edit: Also added implementations for:
* BigInteger.ToByteArray()
* BigInteger(byte array) ctor
* Random.NextBytes(byte array)