### PR TITLE
[fable-compiler-js] Added project options parsing

### DIFF
--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -2630,6 +2630,11 @@ let tryField returnTyp ownerTyp fieldName =
         Helper.CoreCall(coreModFor BclDateTime, Naming.lowerFirst fieldName, returnTyp, []) |> Some
     | Builtin BclDateTimeOffset, ("MaxValue" | "MinValue") ->
         Helper.CoreCall(coreModFor BclDateTimeOffset, Naming.lowerFirst fieldName, returnTyp, []) |> Some
+    | DeclaredType(ent, genArgs), fieldName ->
+        match ent.TryFullName with
+        | Some "System.BitConverter" ->
+            Helper.CoreCall("BitConverter", Naming.lowerFirst fieldName, returnTyp, []) |> Some
+        | _ -> None
     | _ -> None
 
 let private replacedModules =

--- a/src/fable-compiler-js/src/platform.fs
+++ b/src/fable-compiler-js/src/platform.fs
@@ -29,9 +29,9 @@ let private FileSystem: IFileSystem = importAll "fs"
 let private Process: IProcess = importAll "process"
 let private Path: IPath = importAll "path"
 
-let readAllBytes (fileName:string) = FileSystem.readFileSync(fileName)
-let readAllText (filePath:string) = (FileSystem.readFileSync (filePath, "utf8")).TrimStart('\uFEFF')
-let writeAllText (filePath:string) (text:string) = FileSystem.writeFileSync (filePath, text)
+let readAllBytes (filePath: string) = FileSystem.readFileSync(filePath)
+let readAllText (filePath: string) = FileSystem.readFileSync(filePath, "utf8").TrimStart('\uFEFF')
+let writeAllText (filePath: string) (text: string) = FileSystem.writeFileSync(filePath, text)
 
 let measureTime (f: 'a -> 'b) x =
     let startTime = Process.hrtime()

--- a/src/fable-standalone/src/Interfaces.fs
+++ b/src/fable-standalone/src/Interfaces.fs
@@ -48,7 +48,7 @@ type IBabelResult =
 
 type IFableManager =
     abstract CreateChecker: references: string[] * readAllBytes: (string -> byte[]) * defines: string[] * optimize: bool -> IChecker
-    [<System.Obsolete>] abstract CreateChecker: references: string[] * readAllBytes: (string -> byte[]) * definesOpt: string[] option -> IChecker
+    abstract CreateChecker: references: string[] * readAllBytes: (string -> byte[]) * otherOptions: string[] -> IChecker
     abstract ClearParseCaches: checker: IChecker -> unit
     abstract ParseFSharpScript: checker: IChecker * fileName: string * source: string -> IParseResults
     abstract ParseFSharpProject: checker: IChecker * projectFileName: string * fileNames: string[] * sources: string[] -> IParseResults

--- a/src/fable-standalone/src/index.fs
+++ b/src/fable-standalone/src/index.fs
@@ -239,11 +239,8 @@ let init () =
             InteractiveChecker.Create(references, readAllBytes, defines, optimize)
             |> CheckerImpl :> IChecker
 
-        // obsolete
-        member __.CreateChecker(references, readAllBytes, definesOpt) =
-            let defines = defaultArg definesOpt [| "FABLE_COMPILER"; "DEBUG" |]
-            let optimize = false
-            InteractiveChecker.Create(references, readAllBytes, defines, optimize)
+        member __.CreateChecker(references, readAllBytes, otherOptions) =
+            InteractiveChecker.Create(references, readAllBytes, otherOptions)
             |> CheckerImpl :> IChecker
 
         member __.ClearParseCaches(checker) =

--- a/src/fable-standalone/test/bench-compiler/platform.fs
+++ b/src/fable-standalone/test/bench-compiler/platform.fs
@@ -1,10 +1,14 @@
 module Bench.Platform
 
+let __dirname = "."
+
 #if DOTNET_FILE_SYSTEM && !FABLE_COMPILER
 
-let readAllBytes metadataPath (fileName:string) = System.IO.File.ReadAllBytes (metadataPath + fileName)
-let readAllText (filePath:string) = System.IO.File.ReadAllText (filePath, System.Text.Encoding.UTF8)
-let writeAllText (filePath:string) (text:string) = System.IO.File.WriteAllText (filePath, text)
+open System.IO
+
+let readAllBytes (filePath: string) = File.ReadAllBytes(filePath)
+let readAllText (filePath: string) = File.ReadAllText(filePath, System.Text.Encoding.UTF8)
+let writeAllText (filePath: string) (text: string) = File.WriteAllText(filePath, text)
 
 let measureTime (f: 'a -> 'b) x =
     let sw = System.Diagnostics.Stopwatch.StartNew()
@@ -50,13 +54,13 @@ module Json =
 let serializeToJson = Json.serializeToJson
 
 let ensureDirExists (dir: string): unit =
-    System.IO.Directory.CreateDirectory(dir) |> ignore
+    Directory.CreateDirectory(dir) |> ignore
 
 let normalizeFullPath (path: string) =
-    System.IO.Path.GetFullPath(path).Replace('\\', '/')
+    Path.GetFullPath(path).Replace('\\', '/')
 
 let getRelativePath (pathFrom: string) (pathTo: string) =
-    System.IO.Path.GetRelativePath(pathFrom, pathTo).Replace('\\', '/')
+    Path.GetRelativePath(pathFrom, pathTo).Replace('\\', '/')
 
 #else
 
@@ -79,9 +83,9 @@ let private FileSystem: IFileSystem = importAll "fs"
 let private Process: IProcess = importAll "process"
 let private Path: IPath = importAll "path"
 
-let readAllBytes metadataPath (fileName:string) = FileSystem.readFileSync(metadataPath + fileName)
-let readAllText (filePath:string) = (FileSystem.readFileSync (filePath, "utf8")).TrimStart('\uFEFF')
-let writeAllText (filePath:string) (text:string) = FileSystem.writeFileSync (filePath, text)
+let readAllBytes (filePath: string) = FileSystem.readFileSync(filePath)
+let readAllText (filePath: string) = FileSystem.readFileSync(filePath, "utf8").TrimStart('\uFEFF')
+let writeAllText (filePath: string) (text: string) = FileSystem.writeFileSync(filePath, text)
 
 let measureTime (f: 'a -> 'b) x =
     let startTime = Process.hrtime()
@@ -120,6 +124,11 @@ module Path =
         let normPath = path.Replace("\\", "/").TrimEnd('/')
         let i = normPath.LastIndexOf("/")
         normPath.Substring(i + 1)
+
+    let GetFileNameWithoutExtension (path: string) =
+        let path = GetFileName path
+        let i = path.LastIndexOf(".")
+        path.Substring(0, i)
 
     let GetDirectoryName (path: string) =
         let normPath = path.Replace("\\", "/")

--- a/src/fable-standalone/test/bench/app.fs
+++ b/src/fable-standalone/test/bench/app.fs
@@ -34,7 +34,8 @@ let main argv =
         let fileName = testScriptPath
         let source = readAllText testScriptPath
         let fable = Fable.Standalone.Main.init ()
-        let createChecker () = fable.CreateChecker(references, readAllBytes metadataPath, [||], optimize)
+        let readAllBytes dllName = readAllBytes (metadataPath + dllName)
+        let createChecker () = fable.CreateChecker(references, readAllBytes, [||], optimize)
         let ms0, checker = measureTime createChecker ()
         printfn "InteractiveChecker created in %d ms" ms0
         // let parseFSharpScript () = fable.ParseFSharpScript(checker, fileName, source)

--- a/src/fable-standalone/test/bench/platform.fs
+++ b/src/fable-standalone/test/bench/platform.fs
@@ -2,9 +2,11 @@ module Bench.Platform
 
 #if DOTNET_FILE_SYSTEM
 
-let readAllBytes metadataPath (fileName:string) = System.IO.File.ReadAllBytes (metadataPath + fileName)
-let readAllText (filePath:string) = System.IO.File.ReadAllText (filePath, System.Text.Encoding.UTF8)
-let writeAllText (filePath:string) (text:string) = System.IO.File.WriteAllText (filePath, text)
+open System.IO
+
+let readAllBytes (filePath: string) = File.ReadAllBytes(filePath)
+let readAllText (filePath: string) = File.ReadAllText(filePath, System.Text.Encoding.UTF8)
+let writeAllText (filePath: string) (text: string) = File.WriteAllText(filePath, text)
 
 let measureTime (f: 'a -> 'b) x =
     let sw = System.Diagnostics.Stopwatch.StartNew()
@@ -29,9 +31,9 @@ type private IProcess =
 let private FileSystem: IFileSystem = Fable.Core.JsInterop.importAll "fs"
 let private Process: IProcess = Fable.Core.JsInterop.importAll "process"
 
-let readAllBytes metadataPath (fileName:string) = FileSystem.readFileSync(metadataPath + fileName)
-let readAllText (filePath:string) = (FileSystem.readFileSync (filePath, "utf8")).TrimStart('\uFEFF')
-let writeAllText (filePath:string) (text:string) = FileSystem.writeFileSync (filePath, text)
+let readAllBytes (filePath: string) = FileSystem.readFileSync(filePath)
+let readAllText (filePath: string) = FileSystem.readFileSync(filePath, "utf8").TrimStart('\uFEFF')
+let writeAllText (filePath: string) (text: string) = FileSystem.writeFileSync(filePath, text)
 
 let measureTime (f: 'a -> 'b) x =
     let startTime = Process.hrtime()

--- a/src/fcs-fable/TcImports_shim.fs
+++ b/src/fcs-fable/TcImports_shim.fs
@@ -1,0 +1,262 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+// Open up the compiler as an incremental service for parsing,
+// type checking and intellisense-like environment-reporting.
+
+namespace Microsoft.FSharp.Compiler.SourceCodeServices
+
+open Internal.Utilities
+open Internal.Utilities.Collections
+open Microsoft.FSharp.Collections
+open Microsoft.FSharp.Control
+
+open System
+open System.Text
+open System.Threading
+open System.Collections.Concurrent
+open System.Collections.Generic
+
+open Microsoft.FSharp.Compiler
+open Microsoft.FSharp.Compiler.AbstractIL
+open Microsoft.FSharp.Compiler.AbstractIL.IL
+open Microsoft.FSharp.Compiler.AbstractIL.ILBinaryReader
+open Microsoft.FSharp.Compiler.AbstractIL.Diagnostics
+open Microsoft.FSharp.Compiler.AbstractIL.Internal
+open Microsoft.FSharp.Compiler.AbstractIL.Internal.Library
+
+open Microsoft.FSharp.Compiler.AccessibilityLogic
+open Microsoft.FSharp.Compiler.Ast
+open Microsoft.FSharp.Compiler.CompileOps
+open Microsoft.FSharp.Compiler.CompileOptions
+open Microsoft.FSharp.Compiler.ErrorLogger
+open Microsoft.FSharp.Compiler.Lib
+open Microsoft.FSharp.Compiler.ReferenceResolver
+open Microsoft.FSharp.Compiler.PrettyNaming
+open Microsoft.FSharp.Compiler.Parser
+open Microsoft.FSharp.Compiler.Range
+open Microsoft.FSharp.Compiler.Lexhelp
+open Microsoft.FSharp.Compiler.Layout
+open Microsoft.FSharp.Compiler.Tast
+open Microsoft.FSharp.Compiler.Tastops
+open Microsoft.FSharp.Compiler.Tastops.DebugPrint
+open Microsoft.FSharp.Compiler.TcGlobals
+open Microsoft.FSharp.Compiler.Infos
+open Microsoft.FSharp.Compiler.InfoReader
+open Microsoft.FSharp.Compiler.NameResolution
+open Microsoft.FSharp.Compiler.TypeChecker
+
+module TcImports =
+
+    let internal BuildTcImports (tcConfig: TcConfig, references: string[], readAllBytes: string -> byte[]) =
+        let tcImports = TcImports ()
+        let ilGlobals = IL.EcmaMscorlibILGlobals
+
+        let sigDataReaders ilModule =
+            [ for resource in ilModule.Resources.AsList do
+                if IsSignatureDataResource resource then 
+                    let _ccuName = GetSignatureDataResourceName resource
+                    yield resource.GetBytes() ]
+
+        let optDataReaders ilModule =
+            [ for resource in ilModule.Resources.AsList do
+                if IsOptimizationDataResource resource then
+                    let _ccuName = GetOptimizationDataResourceName resource
+                    yield resource.GetBytes() ]
+
+        let LoadMod (ccuName: string) =
+            let fileName =
+                if ccuName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
+                then ccuName
+                else ccuName + ".dll"
+            let bytes = readAllBytes fileName
+            let opts: ILReaderOptions =
+                  { ilGlobals = ilGlobals
+                    metadataOnly = MetadataOnlyFlag.Yes
+                    reduceMemoryUsage = ReduceMemoryFlag.Yes
+                    pdbDirPath = None
+                    tryGetMetadataSnapshot = (fun _ -> None) }
+
+            let reader = ILBinaryReader.OpenILModuleReaderFromBytes fileName bytes opts
+            reader.ILModuleDef //reader.ILAssemblyRefs
+
+        let GetSignatureData (fileName:string, ilScopeRef, ilModule:ILModuleDef option, bytes:byte[]) = 
+            TastPickle.unpickleObjWithDanglingCcus fileName ilScopeRef ilModule TastPickle.unpickleCcuInfo bytes
+
+        let GetOptimizationData (fileName:string, ilScopeRef, ilModule:ILModuleDef option, bytes:byte[]) = 
+            TastPickle.unpickleObjWithDanglingCcus fileName ilScopeRef ilModule Optimizer.u_CcuOptimizationInfo bytes
+
+        let memoize_mod = new MemoizationTable<_,_> (LoadMod, keyComparer=HashIdentity.Structural)
+
+        let LoadSigData ccuName =
+            let ilModule = memoize_mod.Apply ccuName
+            let ilShortAssemName = ilModule.ManifestOfAssembly.Name
+            let ilScopeRef = ILScopeRef.Assembly (mkSimpleAssemblyRef ilShortAssemName)
+            let fileName = ilModule.Name //TODO: try with ".sigdata" extension
+            match sigDataReaders ilModule with
+            | [] -> None
+            | bytes::_ -> Some (GetSignatureData (fileName, ilScopeRef, Some ilModule, bytes))
+
+        let LoadOptData ccuName =
+            let ilModule = memoize_mod.Apply ccuName
+            let ilShortAssemName = ilModule.ManifestOfAssembly.Name
+            let ilScopeRef = ILScopeRef.Assembly (mkSimpleAssemblyRef ilShortAssemName)
+            let fileName = ilModule.Name //TODO: try with ".optdata" extension
+            match optDataReaders ilModule with
+            | [] -> None
+            | bytes::_ -> Some (GetOptimizationData (fileName, ilScopeRef, Some ilModule, bytes))
+
+        let memoize_sig = new MemoizationTable<_,_> (LoadSigData, keyComparer=HashIdentity.Structural)
+        let memoize_opt = new MemoizationTable<_,_> (LoadOptData, keyComparer=HashIdentity.Structural)
+
+        let GetCustomAttributesOfIlModule (ilModule: ILModuleDef) = 
+            (match ilModule.Manifest with Some m -> m.CustomAttrs | None -> ilModule.CustomAttrs).AsList 
+
+        let GetAutoOpenAttributes ilg ilModule = 
+            ilModule |> GetCustomAttributesOfIlModule |> List.choose (TryFindAutoOpenAttr ilg)
+
+        let GetInternalsVisibleToAttributes ilg ilModule = 
+            ilModule |> GetCustomAttributesOfIlModule |> List.choose (TryFindInternalsVisibleToAttr ilg)
+
+        let HasAnyFSharpSignatureDataAttribute ilModule = 
+            let attrs = GetCustomAttributesOfIlModule ilModule
+            List.exists IsSignatureDataVersionAttr attrs
+
+        let mkCcuInfo ilg ilScopeRef ilModule ccu : ImportedAssembly =
+              { ILScopeRef = ilScopeRef
+                FSharpViewOfMetadata = ccu
+                AssemblyAutoOpenAttributes = GetAutoOpenAttributes ilg ilModule
+                AssemblyInternalsVisibleToAttributes = GetInternalsVisibleToAttributes ilg ilModule
+#if !NO_EXTENSIONTYPING
+                IsProviderGenerated = false
+                TypeProviders = []
+#endif
+                FSharpOptimizationData = notlazy None }
+
+        let GetCcuIL m ccuName =
+            let auxModuleLoader = function
+                | ILScopeRef.Local -> failwith "Unsupported reference"
+                | ILScopeRef.Module x -> memoize_mod.Apply x.Name
+                | ILScopeRef.Assembly x -> memoize_mod.Apply x.Name
+            let ilModule = memoize_mod.Apply ccuName
+            let ilShortAssemName = ilModule.ManifestOfAssembly.Name
+            let ilScopeRef = ILScopeRef.Assembly (mkSimpleAssemblyRef ilShortAssemName)
+            let fileName = ilModule.Name
+            let invalidateCcu = new Event<_>()
+            let ccu = Import.ImportILAssembly(
+                        tcImports.GetImportMap, m, auxModuleLoader, ilScopeRef,
+                        tcConfig.implicitIncludeDir, Some fileName, ilModule, invalidateCcu.Publish)
+            let ccuInfo = mkCcuInfo ilGlobals ilScopeRef ilModule ccu
+            ccuInfo, None
+
+        let GetCcuFS m ccuName =
+            let sigdata = memoize_sig.Apply ccuName
+            let ilModule = memoize_mod.Apply ccuName
+            let ilShortAssemName = ilModule.ManifestOfAssembly.Name
+            let ilScopeRef = ILScopeRef.Assembly (mkSimpleAssemblyRef ilShortAssemName)
+            let fileName = ilModule.Name
+            let GetRawTypeForwarders ilModule =
+                match ilModule.Manifest with 
+                | Some manifest -> manifest.ExportedTypes
+                | None -> mkILExportedTypes []
+#if !NO_EXTENSIONTYPING
+            let invalidateCcu = new Event<_>()
+#endif
+            let minfo: PickledCcuInfo = sigdata.Value.RawData //TODO: handle missing sigdata
+            let codeDir = minfo.compileTimeWorkingDir
+            let ccuData: CcuData = 
+                  { ILScopeRef = ilScopeRef
+                    Stamp = newStamp()
+                    FileName = Some fileName 
+                    QualifiedName = Some (ilScopeRef.QualifiedName)
+                    SourceCodeDirectory = codeDir
+                    IsFSharp = true
+                    Contents = minfo.mspec
+#if !NO_EXTENSIONTYPING
+                    InvalidateEvent=invalidateCcu.Publish
+                    IsProviderGenerated = false
+                    ImportProvidedType = (fun ty -> Import.ImportProvidedType (tcImports.GetImportMap()) m ty)
+#endif
+                    UsesFSharp20PlusQuotations = minfo.usesQuotations
+                    MemberSignatureEquality = (fun ty1 ty2 -> Tastops.typeEquivAux EraseAll (tcImports.GetTcGlobals()) ty1 ty2)
+                    TryGetILModuleDef = (fun () -> Some ilModule)
+                    TypeForwarders = Import.ImportILAssemblyTypeForwarders(tcImports.GetImportMap, m, GetRawTypeForwarders ilModule)
+                    }
+
+            let optdata = lazy (
+                match memoize_opt.Apply ccuName with 
+                | None -> None
+                | Some data ->
+                    let findCcuInfo name = tcImports.FindCcu (m, name)
+                    Some (data.OptionalFixup findCcuInfo) )
+
+            let ccu = CcuThunk.Create(ilShortAssemName, ccuData)
+            let ccuInfo = mkCcuInfo ilGlobals ilScopeRef ilModule ccu
+            let ccuOptInfo = { ccuInfo with FSharpOptimizationData = optdata }
+            ccuOptInfo, sigdata
+
+        let rec GetCcu m ccuName =
+            let ilModule = memoize_mod.Apply ccuName
+            if HasAnyFSharpSignatureDataAttribute ilModule then
+                GetCcuFS m ccuName
+            else
+                GetCcuIL m ccuName
+
+        let fixupCcuInfo refCcusUnfixed =
+            let refCcus = refCcusUnfixed |> List.map fst
+            let findCcuInfo name =
+                refCcus
+                |> List.tryFind (fun (x: ImportedAssembly) -> x.FSharpViewOfMetadata.AssemblyName = name)
+                |> Option.map (fun x -> x.FSharpViewOfMetadata)
+            let fixup (data: TastPickle.PickledDataWithReferences<_>) =
+                data.OptionalFixup findCcuInfo |> ignore
+            refCcusUnfixed |> List.choose snd |> List.iter fixup
+            refCcus
+
+        let m = range.Zero
+        let refCcusUnfixed = List.ofArray references |> List.map (GetCcu m)
+        let refCcus = fixupCcuInfo refCcusUnfixed
+        let sysCcus = refCcus |> List.filter (fun x -> x.FSharpViewOfMetadata.AssemblyName <> "FSharp.Core")
+        let fslibCcu = refCcus |> List.find (fun x -> x.FSharpViewOfMetadata.AssemblyName = "FSharp.Core")
+
+        let ccuInfos = [fslibCcu] @ sysCcus
+        let ccuMap = ccuInfos |> List.map (fun ccuInfo -> ccuInfo.FSharpViewOfMetadata.AssemblyName, ccuInfo) |> Map.ofList
+
+        // search over all imported CCUs for each cached type
+        let ccuHasType (ccu: CcuThunk) (nsname: string list) (tname: string) =
+            let findEntity (entityOpt: Entity option) n =
+                match entityOpt with
+                | None -> None
+                | Some entity -> entity.ModuleOrNamespaceType.AllEntitiesByCompiledAndLogicalMangledNames.TryFind n
+            let entityOpt = (Some ccu.Contents, nsname) ||> List.fold findEntity
+            match entityOpt with
+            | Some ns ->
+                match Map.tryFind tname ns.ModuleOrNamespaceType.TypesByMangledName with
+                | Some _ -> true
+                | None -> false
+            | None -> false
+
+        // Search for a type
+        let tryFindSysTypeCcu nsname typeName =
+            let search = sysCcus |> List.tryFind (fun ccuInfo -> ccuHasType ccuInfo.FSharpViewOfMetadata nsname typeName)
+            match search with
+            | Some x -> Some x.FSharpViewOfMetadata
+            | None ->
+#if DEBUG
+                printfn "Cannot find type %s.%s" (String.concat "." nsname) typeName
+#endif
+                None
+
+        let tcGlobals = TcGlobals (
+                            tcConfig.compilingFslib, ilGlobals, fslibCcu.FSharpViewOfMetadata,
+                            tcConfig.implicitIncludeDir, tcConfig.mlCompatibility,
+                            tcConfig.isInteractive, tryFindSysTypeCcu,
+                            tcConfig.emitDebugInfoInQuotations, tcConfig.noDebugData)
+
+#if DEBUG
+        // the global_g reference cell is used only for debug printing
+        do global_g := Some tcGlobals
+#endif
+        // do this prior to parsing, since parsing IL assembly code may refer to mscorlib
+        do tcImports.SetCcuMap(ccuMap)
+        do tcImports.SetTcGlobals(tcGlobals)
+        tcImports, tcGlobals

--- a/src/fcs-fable/fcs-fable.fsproj
+++ b/src/fcs-fable/fcs-fable.fsproj
@@ -213,6 +213,7 @@
     <!-- <Compile Include="$(FSharpSourcesRoot)/fsharp/service/ServiceAnalysis.fs"/> -->
     <!-- <Compile Include="$(FSharpSourcesRoot)/fsharp/fsi/fsi.fsi"/> -->
     <!-- <Compile Include="$(FSharpSourcesRoot)/fsharp/fsi/fsi.fs"/> -->
+    <Compile Include="TcImports_shim.fs"/>
     <Compile Include="service_slim.fs"/>
     <Compile Include="ast_print.fs"/>
   </ItemGroup>

--- a/src/fcs-fable/service_slim.fs
+++ b/src/fcs-fable/service_slim.fs
@@ -5,8 +5,6 @@
 
 namespace Microsoft.FSharp.Compiler.SourceCodeServices
 
-#nowarn "1182"
-
 open Internal.Utilities
 open Internal.Utilities.Collections
 open Microsoft.FSharp.Collections
@@ -58,235 +56,25 @@ type internal TcErrors = FSharpErrorInfo[]
 type InteractiveChecker internal (tcConfig, tcGlobals, tcImports, tcInitialState, ctok, reactorOps, parseCache, checkCache) =
     let userOpName = "Unknown"
 
-    static member internal BuildTcImports (tcConfig: TcConfig, references: string[], readAllBytes: string -> byte[]) =
-        let tcImports = TcImports ()
-        let ilGlobals = IL.EcmaMscorlibILGlobals
-
-        let sigDataReaders ilModule =
-            [ for resource in ilModule.Resources.AsList do
-                if IsSignatureDataResource resource then 
-                    let ccuName = GetSignatureDataResourceName resource
-                    yield resource.GetBytes() ]
-
-        let optDataReaders ilModule =
-            [ for resource in ilModule.Resources.AsList do
-                if IsOptimizationDataResource resource then
-                    let ccuName = GetOptimizationDataResourceName resource
-                    yield resource.GetBytes() ]
-
-        let LoadMod (ccuName: string) =
-            let fileName =
-                if ccuName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
-                then ccuName
-                else ccuName + ".dll"
-            let bytes = readAllBytes fileName
-            let opts: ILReaderOptions =
-                  { ilGlobals = ilGlobals
-                    metadataOnly = MetadataOnlyFlag.Yes
-                    reduceMemoryUsage = ReduceMemoryFlag.Yes
-                    pdbDirPath = None
-                    tryGetMetadataSnapshot = (fun _ -> None) }
-
-            let reader = ILBinaryReader.OpenILModuleReaderFromBytes fileName bytes opts
-            reader.ILModuleDef //reader.ILAssemblyRefs
-
-        let GetSignatureData (fileName:string, ilScopeRef, ilModule:ILModuleDef option, bytes:byte[]) = 
-            TastPickle.unpickleObjWithDanglingCcus fileName ilScopeRef ilModule TastPickle.unpickleCcuInfo bytes
-
-        let GetOptimizationData (fileName:string, ilScopeRef, ilModule:ILModuleDef option, bytes:byte[]) = 
-            TastPickle.unpickleObjWithDanglingCcus fileName ilScopeRef ilModule Optimizer.u_CcuOptimizationInfo bytes
-
-        let memoize_mod = new MemoizationTable<_,_> (LoadMod, keyComparer=HashIdentity.Structural)
-
-        let LoadSigData ccuName =
-            let ilModule = memoize_mod.Apply ccuName
-            let ilShortAssemName = ilModule.ManifestOfAssembly.Name
-            let ilScopeRef = ILScopeRef.Assembly (mkSimpleAssemblyRef ilShortAssemName)
-            let fileName = ilModule.Name //TODO: try with ".sigdata" extension
-            match sigDataReaders ilModule with
-            | [] -> None
-            | bytes::_ -> Some (GetSignatureData (fileName, ilScopeRef, Some ilModule, bytes))
-
-        let LoadOptData ccuName =
-            let ilModule = memoize_mod.Apply ccuName
-            let ilShortAssemName = ilModule.ManifestOfAssembly.Name
-            let ilScopeRef = ILScopeRef.Assembly (mkSimpleAssemblyRef ilShortAssemName)
-            let fileName = ilModule.Name //TODO: try with ".optdata" extension
-            match optDataReaders ilModule with
-            | [] -> None
-            | bytes::_ -> Some (GetOptimizationData (fileName, ilScopeRef, Some ilModule, bytes))
-
-        let memoize_sig = new MemoizationTable<_,_> (LoadSigData, keyComparer=HashIdentity.Structural)
-        let memoize_opt = new MemoizationTable<_,_> (LoadOptData, keyComparer=HashIdentity.Structural)
-
-        let GetCustomAttributesOfIlModule (ilModule: ILModuleDef) = 
-            (match ilModule.Manifest with Some m -> m.CustomAttrs | None -> ilModule.CustomAttrs).AsList 
-
-        let GetAutoOpenAttributes ilg ilModule = 
-            ilModule |> GetCustomAttributesOfIlModule |> List.choose (TryFindAutoOpenAttr ilg)
-
-        let GetInternalsVisibleToAttributes ilg ilModule = 
-            ilModule |> GetCustomAttributesOfIlModule |> List.choose (TryFindInternalsVisibleToAttr ilg)
-
-        let HasAnyFSharpSignatureDataAttribute ilModule = 
-            let attrs = GetCustomAttributesOfIlModule ilModule
-            List.exists IsSignatureDataVersionAttr attrs
-
-        let mkCcuInfo ilg ilScopeRef ilModule ccu : ImportedAssembly =
-              { ILScopeRef = ilScopeRef
-                FSharpViewOfMetadata = ccu
-                AssemblyAutoOpenAttributes = GetAutoOpenAttributes ilg ilModule
-                AssemblyInternalsVisibleToAttributes = GetInternalsVisibleToAttributes ilg ilModule
-#if !NO_EXTENSIONTYPING
-                IsProviderGenerated = false
-                TypeProviders = []
-#endif
-                FSharpOptimizationData = notlazy None }
-
-        let GetCcuIL m ccuName =
-            let auxModuleLoader = function
-                | ILScopeRef.Local -> failwith "Unsupported reference"
-                | ILScopeRef.Module x -> memoize_mod.Apply x.Name
-                | ILScopeRef.Assembly x -> memoize_mod.Apply x.Name
-            let ilModule = memoize_mod.Apply ccuName
-            let ilShortAssemName = ilModule.ManifestOfAssembly.Name
-            let ilScopeRef = ILScopeRef.Assembly (mkSimpleAssemblyRef ilShortAssemName)
-            let fileName = ilModule.Name
-            let invalidateCcu = new Event<_>()
-            let ccu = Import.ImportILAssembly(
-                        tcImports.GetImportMap, m, auxModuleLoader, ilScopeRef,
-                        tcConfig.implicitIncludeDir, Some fileName, ilModule, invalidateCcu.Publish)
-            let ccuInfo = mkCcuInfo ilGlobals ilScopeRef ilModule ccu
-            ccuInfo, None
-
-        let GetCcuFS m ccuName =
-            let sigdata = memoize_sig.Apply ccuName
-            let ilModule = memoize_mod.Apply ccuName
-            let ilShortAssemName = ilModule.ManifestOfAssembly.Name
-            let ilScopeRef = ILScopeRef.Assembly (mkSimpleAssemblyRef ilShortAssemName)
-            let fileName = ilModule.Name
-            let GetRawTypeForwarders ilModule =
-                match ilModule.Manifest with 
-                | Some manifest -> manifest.ExportedTypes
-                | None -> mkILExportedTypes []
-#if !NO_EXTENSIONTYPING
-            let invalidateCcu = new Event<_>()
-#endif
-            let minfo: PickledCcuInfo = sigdata.Value.RawData //TODO: handle missing sigdata
-            let codeDir = minfo.compileTimeWorkingDir
-            let ccuData: CcuData = 
-                  { ILScopeRef = ilScopeRef
-                    Stamp = newStamp()
-                    FileName = Some fileName 
-                    QualifiedName = Some (ilScopeRef.QualifiedName)
-                    SourceCodeDirectory = codeDir
-                    IsFSharp = true
-                    Contents = minfo.mspec
-#if !NO_EXTENSIONTYPING
-                    InvalidateEvent=invalidateCcu.Publish
-                    IsProviderGenerated = false
-                    ImportProvidedType = (fun ty -> Import.ImportProvidedType (tcImports.GetImportMap()) m ty)
-#endif
-                    UsesFSharp20PlusQuotations = minfo.usesQuotations
-                    MemberSignatureEquality = (fun ty1 ty2 -> Tastops.typeEquivAux EraseAll (tcImports.GetTcGlobals()) ty1 ty2)
-                    TryGetILModuleDef = (fun () -> Some ilModule)
-                    TypeForwarders = Import.ImportILAssemblyTypeForwarders(tcImports.GetImportMap, m, GetRawTypeForwarders ilModule)
-                    }
-
-            let optdata = lazy (
-                match memoize_opt.Apply ccuName with 
-                | None -> None
-                | Some data ->
-                    let findCcuInfo name = tcImports.FindCcu (m, name)
-                    Some (data.OptionalFixup findCcuInfo) )
-
-            let ccu = CcuThunk.Create(ilShortAssemName, ccuData)
-            let ccuInfo = mkCcuInfo ilGlobals ilScopeRef ilModule ccu
-            let ccuOptInfo = { ccuInfo with FSharpOptimizationData = optdata }
-            ccuOptInfo, sigdata
-
-        let rec GetCcu m ccuName =
-            let ilModule = memoize_mod.Apply ccuName
-            if HasAnyFSharpSignatureDataAttribute ilModule then
-                GetCcuFS m ccuName
-            else
-                GetCcuIL m ccuName
-
-        let fixupCcuInfo refCcusUnfixed =
-            let refCcus = refCcusUnfixed |> List.map fst
-            let findCcuInfo name =
-                refCcus
-                |> List.tryFind (fun (x: ImportedAssembly) -> x.FSharpViewOfMetadata.AssemblyName = name)
-                |> Option.map (fun x -> x.FSharpViewOfMetadata)
-            let fixup (data: TastPickle.PickledDataWithReferences<_>) =
-                data.OptionalFixup findCcuInfo |> ignore
-            refCcusUnfixed |> List.choose snd |> List.iter fixup
-            refCcus
-
-        let m = range.Zero
-        let refCcusUnfixed = List.ofArray references |> List.map (GetCcu m)
-        let refCcus = fixupCcuInfo refCcusUnfixed
-        let sysCcus = refCcus |> List.filter (fun x -> x.FSharpViewOfMetadata.AssemblyName <> "FSharp.Core")
-        let fslibCcu = refCcus |> List.find (fun x -> x.FSharpViewOfMetadata.AssemblyName = "FSharp.Core")
-
-        let ccuInfos = [fslibCcu] @ sysCcus
-        let ccuMap = ccuInfos |> List.map (fun ccuInfo -> ccuInfo.FSharpViewOfMetadata.AssemblyName, ccuInfo) |> Map.ofList
-
-        // search over all imported CCUs for each cached type
-        let ccuHasType (ccu: CcuThunk) (nsname: string list) (tname: string) =
-            let findEntity (entityOpt: Entity option) n =
-                match entityOpt with
-                | None -> None
-                | Some entity -> entity.ModuleOrNamespaceType.AllEntitiesByCompiledAndLogicalMangledNames.TryFind n
-            let entityOpt = (Some ccu.Contents, nsname) ||> List.fold findEntity
-            match entityOpt with
-            | Some ns ->
-                match Map.tryFind tname ns.ModuleOrNamespaceType.TypesByMangledName with
-                | Some _ -> true
-                | None -> false
-            | None -> false
-
-        // Search for a type
-        let tryFindSysTypeCcu nsname typeName =
-            let search = sysCcus |> List.tryFind (fun ccuInfo -> ccuHasType ccuInfo.FSharpViewOfMetadata nsname typeName)
-            match search with
-            | Some x -> Some x.FSharpViewOfMetadata
-            | None ->
-#if DEBUG
-                printfn "Cannot find type %s.%s" (String.concat "." nsname) typeName
-#endif
-                None
-
-        let tcGlobals = TcGlobals (
-                            tcConfig.compilingFslib, ilGlobals, fslibCcu.FSharpViewOfMetadata,
-                            tcConfig.implicitIncludeDir, tcConfig.mlCompatibility,
-                            tcConfig.isInteractive, tryFindSysTypeCcu,
-                            tcConfig.emitDebugInfoInQuotations, tcConfig.noDebugData)
-
-#if DEBUG
-        // the global_g reference cell is used only for debug printing
-        do global_g := Some tcGlobals
-#endif
-        // do this prior to parsing, since parsing IL assembly code may refer to mscorlib
-        do tcImports.SetCcuMap(ccuMap)
-        do tcImports.SetTcGlobals(tcGlobals)
-        tcImports, tcGlobals
-
     static member Create(references: string[], readAllBytes: string -> byte[], defines: string[], optimize: bool) =
-        let dllName (fileName: string) =
-            if fileName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
-            then fileName
-            else fileName + ".dll"
-        let argv = [|
+        let otherOptions = [|
             for d in defines do yield "-d:" + d
-            for r in references do yield "-r:" + (dllName r)
             yield "--optimize" + (if optimize then "+" else "-")
         |]
-        let options: FSharpProjectOptions =
-          { ProjectFileName = "Project"
+        InteractiveChecker.Create(references, readAllBytes, otherOptions)
+
+    static member Create(references: string[], readAllBytes: string -> byte[], otherOptions: string[]) =
+        let projectFileName = "Project"
+        let toRefOption (fileName: string) =
+            if fileName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
+            then "-r:" + fileName
+            else "-r:" + fileName + ".dll"
+        let otherOptions = references |> Array.map toRefOption |> Array.append otherOptions
+        let projectOptions: FSharpProjectOptions = {
+            ProjectFileName = projectFileName
             ProjectId = None
             SourceFiles = [| |]
-            OtherOptions = argv
+            OtherOptions = otherOptions
             ReferencedProjects = [| |]
             IsIncompleteTypeCheckEnvironment = false
             UseScriptResolutionRules = false
@@ -294,32 +82,32 @@ type InteractiveChecker internal (tcConfig, tcGlobals, tcImports, tcInitialState
             UnresolvedReferences = None
             OriginalLoadReferences = []
             ExtraProjectInfo = None
-            Stamp = None }
+            Stamp = None
+        }
+        InteractiveChecker.Create(readAllBytes, projectOptions)
 
-        InteractiveChecker.Create(readAllBytes, options)
-
-    static member Create(readAllBytes: string -> byte[], options: FSharpProjectOptions) =
+    static member Create(readAllBytes: string -> byte[], projectOptions: FSharpProjectOptions) =
         let references =
-            options.OtherOptions
+            projectOptions.OtherOptions
             |> Array.filter (fun s -> s.StartsWith("-r:"))
             |> Array.map (fun s -> s.Replace("-r:", ""))
 
         let tcConfig =
             let tcConfigB = TcConfigBuilder.Initial
-            let sourceFiles = options.SourceFiles |> Array.toList
-            let argv = options.OtherOptions |> Array.toList
+            let sourceFiles = projectOptions.SourceFiles |> Array.toList
+            let argv = projectOptions.OtherOptions |> Array.toList
             let _sourceFiles = ApplyCommandLineArgs(tcConfigB, sourceFiles, argv)
             TcConfig.Create(tcConfigB, validate=false)
 
+        let ctok = CompilationThreadToken()
         let tcImports, tcGlobals =
-            InteractiveChecker.BuildTcImports (tcConfig, references, readAllBytes)
+            TcImports.BuildTcImports (tcConfig, references, readAllBytes)
 
-        let assemblyName = "Project"
         let niceNameGen = NiceNameGenerator()
+        let assemblyName = projectOptions.ProjectFileName |> System.IO.Path.GetFileNameWithoutExtension
         let tcInitialEnv = GetInitialTcEnv (assemblyName, rangeStartup, tcConfig, tcImports, tcGlobals)
         let tcInitialState = GetInitialTcState (rangeStartup, assemblyName, tcConfig, tcGlobals, tcImports, niceNameGen, tcInitialEnv)
 
-        let ctok = CompilationThreadToken()
         let reactorOps = 
             { new IReactorOperations with
                 member __.EnqueueAndAwaitOpAsync (userOpName, opName, opArg, op) =
@@ -386,7 +174,7 @@ type InteractiveChecker internal (tcConfig, tcGlobals, tcImports, tcInitialState
 
     member private x.CheckFile (projectFileName: string, parseResults: FSharpParseFileResults, tcState: TcState, moduleNamesDict: ModuleNamesDict) =
         match parseResults.ParseTree with
-        | Some input ->
+        | Some _input ->
             let sink = TcResultsSinkImpl(tcGlobals)
             let tcSink = TcResultsSink.WithSink sink
             let (tcResult, tcErrors), (tcState, moduleNamesDict) =
@@ -410,7 +198,7 @@ type InteractiveChecker internal (tcConfig, tcGlobals, tcImports, tcInitialState
         | None ->
             None
 
-    member private x.TypeCheckClosedInputSet (parseResults: FSharpParseFileResults[], tcConfig, tcImports, tcGlobals, tcState) =
+    member private x.TypeCheckClosedInputSet (parseResults: FSharpParseFileResults[], tcState) =
         let cachedTypeCheck (tcState, moduleNamesDict) (parseRes: FSharpParseFileResults) =
             let checkCacheKey = parseRes.FileName
             let typeCheckOneInput _fileName =
@@ -473,7 +261,7 @@ type InteractiveChecker internal (tcConfig, tcGlobals, tcImports, tcInitialState
 
         // type check files
         let tcState, topAttrs, tcImplFiles, _tcEnvAtEnd, _moduleNamesDict, tcErrors =
-            x.TypeCheckClosedInputSet (parseResults, tcConfig, tcImports, tcGlobals, tcInitialState)
+            x.TypeCheckClosedInputSet (parseResults, tcInitialState)
 
         // make project results
         let parseErrors = parseResults |> Array.collect (fun p -> p.Errors)
@@ -501,7 +289,7 @@ type InteractiveChecker internal (tcConfig, tcGlobals, tcImports, tcInitialState
 
         // type check files before file
         let tcState, topAttrs, tcImplFiles, _tcEnvAtEnd, moduleNamesDict, tcErrors =
-            x.TypeCheckClosedInputSet (parseResults, tcConfig, tcImports, tcGlobals, tcInitialState)
+            x.TypeCheckClosedInputSet (parseResults, tcInitialState)
 
         // parse and type check file
         let parseFileResults = parseFile (fileName, sources.[fileIndex])

--- a/src/fcs-fable/src/fsharp/LexFilter.fs
+++ b/src/fcs-fable/src/fsharp/LexFilter.fs
@@ -413,19 +413,13 @@ type PositionTuple =
     new (x: Position, y: Position) = { X = x; Y = y }
 
 /// Used to save the state related to a token
-#if FABLE_COMPILER
-type TokenTup (token,state,lastTokenPos) =
-    member x.Token : token = token
-    member x.LexbufState : LexbufState = state
-    member x.LastTokenPos: PositionTuple = lastTokenPos
-#else
 [<Class>]
 type TokenTup = 
     val Token : token
     val LexbufState : LexbufState
     val LastTokenPos: PositionTuple
     new (token,state,lastTokenPos) = { Token=token; LexbufState=state;LastTokenPos=lastTokenPos }
-#endif
+
     /// Returns starting position of the token
     member x.StartPos = x.LexbufState.StartPos
     /// Returns end position of the token

--- a/src/fcs-fable/test/Platform.fs
+++ b/src/fcs-fable/test/Platform.fs
@@ -4,9 +4,9 @@ module Platform
 
 open System.IO
 
-let readAllBytes metadataPath (fileName:string) = File.ReadAllBytes (metadataPath + fileName)
-let readAllText (filePath:string) = File.ReadAllText (filePath, System.Text.Encoding.UTF8)
-let writeAllText (filePath:string) (text:string) = File.WriteAllText (filePath, text)
+let readAllBytes (filePath: string) = File.ReadAllBytes(filePath)
+let readAllText (filePath: string) = File.ReadAllText(filePath, System.Text.Encoding.UTF8)
+let writeAllText (filePath: string) (text:string) = File.WriteAllText(filePath, text)
 
 let measureTime (f: 'a -> 'b) x =
     let sw = System.Diagnostics.Stopwatch.StartNew()
@@ -41,9 +41,9 @@ let private File: IFileSystem = importAll "fs"
 let private Process: IProcess = importAll "process"
 let private Path: IPath = importAll "path"
 
-let readAllBytes metadataPath (fileName:string) = File.readFileSync (metadataPath + fileName)
-let readAllText (filePath:string) = (File.readFileSync (filePath, "utf8")).TrimStart('\uFEFF')
-let writeAllText (filePath:string) (text:string) = File.writeFileSync (filePath, text)
+let readAllBytes (filePath: string) = File.readFileSync(filePath)
+let readAllText (filePath: string) = File.readFileSync(filePath, "utf8").TrimStart('\uFEFF')
+let writeAllText (filePath: string) (text:string) = File.writeFileSync(filePath, text)
 
 let measureTime (f: 'a -> 'b) x =
     let startTime = Process.hrtime()

--- a/src/fcs-fable/test/bench.fs
+++ b/src/fcs-fable/test/bench.fs
@@ -106,7 +106,8 @@ let parseFiles projectPath outDir optimized =
     let fileNames = dedupFileNames fileNames
 
     // create checker
-    let createChecker () = InteractiveChecker.Create(references, readAllBytes metadataPath, defines, optimize=false)
+    let readAllBytes dllName = readAllBytes (metadataPath + dllName)
+    let createChecker () = InteractiveChecker.Create(references, readAllBytes, defines, optimize=false)
     let ms0, checker = measureTime createChecker ()
     printfn "--------------------------------------------"
     printfn "InteractiveChecker created in %d ms" ms0

--- a/src/fcs-fable/test/test.fs
+++ b/src/fcs-fable/test/test.fs
@@ -13,7 +13,8 @@ let main argv =
 
     let defines = [||]
     let optimize = false
-    let checker = InteractiveChecker.Create(references, readAllBytes metadataPath, defines, optimize)
+    let readAllBytes dllName = readAllBytes (metadataPath + dllName)
+    let checker = InteractiveChecker.Create(references, readAllBytes, defines, optimize)
 
     let projectFileName = "project"
     let fileName = "test_script.fsx"

--- a/tests/Main/ConvertTests.fs
+++ b/tests/Main/ConvertTests.fs
@@ -847,6 +847,9 @@ let tests =
     // System.BitConverter
     //-------------------------------------
 
+    testCase "BitConverter.IsLittleEndian works" <| fun () ->
+        BitConverter.IsLittleEndian |> equal true
+
     testCase "BitConverter.GetBytes Boolean works" <| fun () ->
         let value = true
         let bytes = BitConverter.GetBytes(value)


### PR DESCRIPTION
- Handle duplicate external imports
- Added F# compiler options parsing
- Fixed #1747

@alfonsogarciacaro Needs new `fable-standalone` to be published and referenced by `fable-compiler-js`. Hopefully the API is more stable now that you can pass compiler options.