### PR TITLE
Array sprints without braces

### DIFF
--- a/tests/Main/ArrayTests.fs
+++ b/tests/Main/ArrayTests.fs
@@ -52,6 +52,10 @@ let tests =
         match [|"a";"b"|] with [|"a";"b"|] -> 1 | _ -> 2
         |> equal 1
 
+    testCase "sprintf works on arrays" <| fun () ->
+        let xs = [|1.; 2.; 3.; 4.|]
+        sprintf "%A" xs |> equal "[|1.0; 2.0; 3.0; 4.0|]"
+
     testCase "ParamArrayAttribute works" <| fun () ->
         ParamArrayTest.Add(1, 2) |> equal 3
 

--- a/tests/Main/ListTests.fs
+++ b/tests/Main/ListTests.fs
@@ -60,6 +60,11 @@ let tests =
         match ["a";"b"] with [] -> 0 | ["a";"b"] -> 1 | _ -> 2
         |> equal 1
 
+
+    testCase "sprintf works on lists" <| fun () ->
+        let xs = [1.; 2.; 3.; 4.]
+        sprintf "%A" xs |> equal "[1.0; 2.0; 3.0; 4.0]"
+
     testCase "List.Length works" <| fun () ->
             let xs = [1; 2; 3; 4]
             equal 4 xs.Length


### PR DESCRIPTION
my chrome console output for `[|1.; 2.; 3.; 4.|]` is `1,2,3,4` - which seems wrong