### PR TITLE
System.Decimal.MaxValue can be compiled

### DIFF
--- a/tests/Main/ArithmeticTests.fs
+++ b/tests/Main/ArithmeticTests.fs
@@ -22,6 +22,8 @@ let compareTo (x:'a) (y:'a) = compare x y
 
 let decimalOne = 1M
 let decimalTwo = 2M
+let decimalMinValue = System.Decimal.MinValue
+let decimalMaxValue = System.Decimal.MaxValue
 
 let tests =
   testList "Arithmetic" [


### PR DESCRIPTION
    let x = System.Decimal.MaxValue

gives

    error FABLE: Cannot compile ILFieldGet(DeclaredType (Decimal,[]), MaxValue)

But I saw it's defined in Decimal.js