### PR TITLE
Raise type resolve error for non-inlined functions requiring Type.Name

### DIFF
--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -2789,7 +2789,11 @@ let tryCall (com: ICompiler) (ctx: Context) r t (info: CallInfo) (thisArg: Expr 
         | Some c, "GetFields" -> Helper.CoreCall("Reflection", "getUnionCaseFields", t, [c], ?loc=r) |> Some
         | Some c, "get_Name" ->
             match c with
-            | Value(TypeInfo exprType,_) ->
+            | Value(TypeInfo exprType, loc) ->
+                match exprType with
+                | GenericParam name -> genericTypeInfoError com ctx.InlinePath loc name
+                | _ -> ()
+
                 let fullname = getTypeFullName false exprType
                 let fullname =
                     match fullname.IndexOf("[") with


### PR DESCRIPTION
Consider the function:
```fs
let getTypeName<'t> = typeof<'t>.Name
``` 
It compiles fine but when you actually use it, the resolved it type is always `'t`:
```fs
let integerType : string = getTypeName<int> // returns "'t" instead of "Int32" 
```
The compiler should raise an error saying that the function `getTypeName` should be inlined for the generic parameters to correctly get resolved. This PR addresses the issue