### PR TITLE
Make dictionary throw key not found when indexing

### DIFF
--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -2068,8 +2068,9 @@ let dictionaries (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Exp
         Helper.CoreCall("Util", "tryGetValue", t, args, i.SignatureArgTypes, ?thisArg=thisArg, ?loc=r) |> Some
     | "Add", _ ->
         Helper.CoreCall("Util", "addToDict", t, args, i.SignatureArgTypes, ?thisArg=thisArg, ?loc=r) |> Some
-    | ReplaceName ["get_Item",     "get"
-                   "set_Item",     "set"
+    | "get_Item", _ ->
+        Helper.CoreCall("Util", "getItemFromDict", t, args, i.SignatureArgTypes, ?thisArg=thisArg, ?loc=r) |> Some
+    | ReplaceName ["set_Item",     "set"
                    "get_Keys",     "keys"
                    "get_Values",   "values"
                    "ContainsKey",  "has"

--- a/src/fable-library/Util.ts
+++ b/src/fable-library/Util.ts
@@ -642,3 +642,11 @@ export function addToDict<K, V>(dict: Map<K, V>, k: K, v: V) {
   }
   dict.set(k, v);
 }
+
+export function getItemFromDict<K, V>(map: Map<K, V>, key: K): V {
+  if (map.has(key)) {
+    return map.get(key);
+  } else {
+    throw new Error("The given key was not present in the dictionary.");
+  }
+}

--- a/tests/Main/DictionaryTests.fs
+++ b/tests/Main/DictionaryTests.fs
@@ -226,6 +226,11 @@ let tests =
         dic.Add("A", 65)
         throwsError "An item with the same key has already been added. Key: A" (fun _ -> dic.Add("A", 95))
 
+    testCase "Indexer throws when key not found" <| fun () ->
+        let dic = Dictionary<_,_>()
+        dic.Add("A", 65)
+        throwsError "The given key was not present in the dictionary." (fun _ -> dic.["B"] |> ignore)
+
     // testCase "Dictionaries can be JSON serialized forth and back" <| fun () ->
     //     let x = Dictionary<_,_>()
     //     x.Add("a", { i=1; s="1" })


### PR DESCRIPTION
Map.get in JS returns undefined, whereas in .NET using an indexer
against a key not in the dictionary throws a key not found
exception.

Fixes #1798