### PR TITLE
Fix splitter on fsx files.

### DIFF
--- a/src/fable-splitter/src/cli.ts
+++ b/src/fable-splitter/src/cli.ts
@@ -13,8 +13,20 @@ function requireLazy(module) {
 }
 
 function getMainScriptPath(options, info) {
-    const lastFile = info.projectFiles[info.projectFiles.length - 1];
-    const mainScript = path.join(options.outDir, info.mapInOutPaths.get(lastFile));
+
+    function getFromFsproj(projectInfo) {
+        const lastFile = projectInfo.projectFiles[projectInfo.projectFiles.length - 1];
+        return projectInfo.mapInOutPaths.get(lastFile);
+    }
+
+    function getFromScript(scriptInfo) {
+        return scriptInfo.mapInOutPaths.get(scriptInfo.entry);
+    }
+
+    const mainScriptName =
+        info.projectFiles.length > 0 ? getFromFsproj(info) : getFromScript(info);
+
+    const mainScript = path.join(options.outDir, mainScriptName);
     return mainScript.endsWith(".js") ? mainScript : mainScript + ".js";
 }
 


### PR DESCRIPTION
The getMainScript function was only working when splitting fsproj
files.

When it wasn't given a project, there was "lastFile" to create the
entry point for.

This change uses the "entry" script as the name when there are not
any projectFiles available - assuming it must be a single FSX.

Attempt to fix #1801 

Not sure if there's more I should do here, it works for me, but I could be missing something...

So please review :)