### PR TITLE
PublishUtil.fs: Fix the path of temp directory when releasing a nuget

### DIFF
--- a/src/fable-publish-utils/PublishUtils.fs
+++ b/src/fable-publish-utils/PublishUtils.fs
@@ -344,7 +344,7 @@ module Publish =
             try
                 let tempDir = projDir </> "temp"
                 removeDirRecursive tempDir
-                runList ["dotnet pack"; projDir; "-c Release -o temp"]
+                runList ["dotnet pack"; projDir; sprintf "-c Release -o %s" tempDir]
                 let pkgName = filenameWithoutExtension projFile
                 let nupkg =
                     dirFiles tempDir


### PR DESCRIPTION
Fix the output directory of publish utilities because in the arguments only the constant `temp` is used which is then resolved to `{rootDir}/temp` instead of `{rootDir}/{projDir}/temp`