### PR TITLE
fable-splitter: fix env package name in config example

### DIFF
--- a/src/fable-splitter/README.md
+++ b/src/fable-splitter/README.md
@@ -44,7 +44,7 @@ module.exports = {
   entry: "src/App.fsproj",
   outDir: "out",
   babel: {
-    presets: [["env", { modules: "commonjs" }]],
+    presets: [["@babel/preset-env", { modules: "commonjs" }]],
     sourceMaps: false,
   }
 }


### PR DESCRIPTION
This package has moved and the key changed in Babel 7

Otherwise this would fail with a message like:

```
fable: Error transforming Babel AST Error: Cannot find module 'babel-preset-env' from '...'
- Did you mean "@babel/env"?
[...]
```