### PR TITLE
Fix timespan and Guid reflection

### DIFF
--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -470,8 +470,8 @@ module Util =
             match ent, generics with
             | Replacements.BuiltinEntity kind ->
                 match kind with
-                | Replacements.BclGuid -> primitiveTypeInfo "string"
-                | Replacements.BclTimeSpan -> primitiveTypeInfo "float64"
+                | Replacements.BclGuid
+                | Replacements.BclTimeSpan
                 | Replacements.BclDateTime
                 | Replacements.BclDateTimeOffset
                 | Replacements.BclTimer


### PR DESCRIPTION
Related to https://github.com/MangelMaxime/Thoth/issues/152

Currently, Fable seems to generate the runtime representation of `Guid` and `Timespan` when generating the reflection info.

It should generate the "real type info" otherwise when using `reflection` at runtime we detect a `float` inside of a `Timespan` for example.

```fs
let timespanType = typeof<System.TimeSpan>
let guidType = typeof<System.Guid>

// Before the fix
const timespanType = _Reflection.float64;
const guidType = _Reflection.string;

// After the fix
const timespanType = (0, _Reflection.type)("System.TimeSpan");
const guidType = (0, _Reflection.type)("System.Guid");
```