### PR TITLE
Fix TimeSpan.ToString for negative values

### DIFF
--- a/src/fable-library/TimeSpan.ts
+++ b/src/fable-library/TimeSpan.ts
@@ -3,6 +3,16 @@ import { comparePrimitives, padLeftAndRightWithZeros, padWithZeros } from "./Uti
 
 // TimeSpan in runtime just becomes a number representing milliseconds
 
+/**
+ * Calls:
+ * - `Math.ceil` if the `value` is **negative**
+ * - `Math.floor` if the `value` is **positive**
+ * @param value Value to round
+ */
+function signedRound(value : number) {
+    return value < 0 ? Math.ceil(value) : Math.floor(value);
+}
+
 export function create(d: number = 0, h: number = 0, m: number = 0, s: number = 0, ms: number = 0) {
   switch (arguments.length) {
     case 1:
@@ -40,23 +50,23 @@ export function fromSeconds(s: number) {
 }
 
 export function days(ts: number) {
-  return Math.floor(ts / 86400000);
+  return signedRound(ts / 86400000);
 }
 
 export function hours(ts: number) {
-  return Math.floor(ts % 86400000 / 3600000);
+  return signedRound(ts % 86400000 / 3600000);
 }
 
 export function minutes(ts: number) {
-  return Math.floor(ts % 3600000 / 60000);
+  return signedRound(ts % 3600000 / 60000);
 }
 
 export function seconds(ts: number) {
-  return Math.floor(ts % 60000 / 1000);
+  return signedRound(ts % 60000 / 1000);
 }
 
 export function milliseconds(ts: number) {
-  return Math.floor(ts % 1000);
+  return signedRound(ts % 1000);
 }
 
 export function ticks(ts: number /* Long */) {
@@ -105,13 +115,14 @@ export function toString(ts: number, format = "c") {
   if (["c", "g", "G"].indexOf(format) === -1) {
     throw new Error("Custom formats are not supported");
   }
-  const d = days(ts);
-  const h = hours(ts);
-  const m = minutes(ts);
-  const s = seconds(ts);
-  const ms = milliseconds(ts);
+  const d = Math.abs(days(ts));
+  const h = Math.abs(hours(ts));
+  const m = Math.abs(minutes(ts));
+  const s = Math.abs(seconds(ts));
+  const ms = Math.abs(milliseconds(ts));
+  const sign = ts < 0 ? "-" : "";
   // tslint:disable-next-line:max-line-length
-  return `${d === 0 && (format === "c" || format === "g") ? "" : format === "c" ? d + "." : d + ":" }${format === "g" ? h : padWithZeros(h, 2)}:${padWithZeros(m, 2)}:${padWithZeros(s, 2)}${ms === 0 && (format === "c" || format === "g") ? "" : format === "g" ? "." + padWithZeros(ms, 3) : "." + padLeftAndRightWithZeros(ms, 3, 7)}`;
+  return `${sign}${d === 0 && (format === "c" || format === "g") ? "" : format === "c" ? d + "." : d + ":" }${format === "g" ? h : padWithZeros(h, 2)}:${padWithZeros(m, 2)}:${padWithZeros(s, 2)}${ms === 0 && (format === "c" || format === "g") ? "" : format === "g" ? "." + padWithZeros(ms, 3) : "." + padLeftAndRightWithZeros(ms, 3, 7)}`;
 }
 
 export function parse(str: string) {

--- a/tests/Main/TimeSpanTests.fs
+++ b/tests/Main/TimeSpanTests.fs
@@ -14,6 +14,10 @@ let tests =
             TimeSpan.FromDays(18.).ToString() |> equal "18.00:00:00"
             TimeSpan.FromMilliseconds(25.).ToString() |> equal "00:00:00.0250000"
 
+        testCase "TimeSpan.ToString() works for negative TimeSpan" <| fun () ->
+            TimeSpan.FromSeconds(-5.).ToString() |> equal "-00:00:05"
+            TimeSpan.FromDays(-5.23).ToString() |> equal "-5.05:31:12"
+
         testCase "TimeSpan.ToString(\"c\", CultureInfo.InvariantCulture) works" <| fun () ->
             TimeSpan(0L).ToString("c", CultureInfo.InvariantCulture) |> equal "00:00:00"
             TimeSpan.FromSeconds(12345.).ToString("c", CultureInfo.InvariantCulture) |> equal "03:25:45"
@@ -497,4 +501,54 @@ let tests =
         //     ts.TotalMilliseconds |> equal 456000.0
         //     ts.TotalSeconds |> equal 456.
         //     ts.TotalMinutes |> equal 7.6
+
+        testCase "TimeSpan.Milliseconds works with positive TimeSpan" <| fun () ->
+            let actual = TimeSpan.Parse("1.23:45:06.789").Milliseconds
+            let expected = 789
+            equal actual expected
+
+        testCase "TimeSpan.Milliseconds works with negative TimeSpan" <| fun () ->
+            let actual = TimeSpan.Parse("-1.23:45:06.78999").Milliseconds
+            let expected = -789
+            equal actual expected
+
+        testCase "TimeSpan.Seconds works with positive TimeSpan" <| fun () ->
+            let actual = TimeSpan.Parse("1.23:45:06.789").Seconds
+            let expected = 6
+            equal actual expected
+
+        testCase "TimeSpan.Seconds works with negative TimeSpan" <| fun () ->
+            let actual = TimeSpan.Parse("-1.23:45:06.78999").Seconds
+            let expected = -6
+            equal actual expected
+
+        testCase "TimeSpan.Minutes works with positive TimeSpan" <| fun () ->
+            let actual = TimeSpan.Parse("1.23:45:06.789").Minutes
+            let expected = 45
+            equal actual expected
+
+        testCase "TimeSpan.Minutes works with negative TimeSpan" <| fun () ->
+            let actual = TimeSpan.Parse("-1.23:45:06.78999").Minutes
+            let expected = -45
+            equal actual expected
+
+        testCase "TimeSpan.Hours works with positive TimeSpan" <| fun () ->
+            let actual = TimeSpan.Parse("1.23:45:06.789").Hours
+            let expected = 23
+            equal actual expected
+
+        testCase "TimeSpan.Hours works with negative TimeSpan" <| fun () ->
+            let actual = TimeSpan.Parse("-1.23:45:06.78999").Hours
+            let expected = -23
+            equal actual expected
+
+        testCase "TimeSpan.Days works with positive TimeSpan" <| fun () ->
+            let actual = TimeSpan.Parse("1.23:45:06.789").Days
+            let expected = 1
+            equal actual expected
+
+        testCase "TimeSpan.Days works with negative TimeSpan" <| fun () ->
+            let actual = TimeSpan.Parse("-1.23:45:06.78999").Days
+            let expected = -1
+            equal actual expected
     ]


### PR DESCRIPTION
This also fix:
- TimeSpan.Milliseconds
- TimeSpan.Seconds
- TimeSpan.Minutes
- TimeSpan.Hours
- TimeSpan.Days

for negative values

Related to https://github.com/MangelMaxime/Thoth/issues/152