### PR TITLE
add test for struct without explicit ctor

### DIFF
--- a/tests/Main/TypeTests.fs
+++ b/tests/Main/TypeTests.fs
@@ -222,6 +222,11 @@ type ValueType1<'T>(value: 'T) =
 [<Struct>]
 type ValueType2(i: int, j: int) =
     member x.Value = i + j
+    
+type ValueType3 =
+  struct
+    val mutable public X : int
+  end
 
 [<Struct>]
 type StructUnion = Value of string
@@ -622,6 +627,18 @@ let tests =
         test2.Value |> equal 7
         let p = Point2D(2.)
         p.Y |> equal 2.
+
+    testCase "struct without explicit ctor works" <| fun () ->
+        let t1 = ValueType3(X=10)
+        t1.X |> equal 10
+        let mutable t2 = ValueType3()
+        t2.X |> equal 0
+        t1 |> notEqual t2
+        (compare t1 t2) |> equal 1
+        t2.X <- 10
+        t1 |> equal t2
+
+        (compare t1 t2) |> equal 0
 
     testCase "Custom F# exceptions work" <| fun () ->
         try


### PR DESCRIPTION
fable repl example:


```f#
type T =
    struct
        val mutable public X : int
    end

let t1 = T(X=1)
let t2 = T(X=2)
```

[repl link](https://fable.io/repl/#?code=C4TwDgpgBAKlC8BYAUFNUDOwBOBXAxsCuiVAG4CGANlALa7AUBGV0YuLAlvlABpQAuKJwB2RVOggiAJihStgUYAEYEsABS94ygJRA&html=DwCwLgtgNgfAsAKEaApgQwCbwQAjz4CFMNHcMABwFoUBHAVwEsA3AXgHIBhAewDswU-KgBUAnhRTscAYz4D+HAQA8wAenDQA3DJBoATgGdiremABmVABzts+Agel7GFMDgN7prAEQB9HwAkAeQBlYT9VKEYAIwNVPXRpMAA6Cj1uDHpExj4kiEZeJIArAy8YYFUHJxdbfGBK51d3T18AkLCfCOjY+LREqgxuCBS0jKycvILi0vL66uR1dCxEZCj00RkoNAMDbzQKall+NHyUPVLEO2AMFhxGDG8UKDyDECo9ii8NrZ2vR+fX97TVTXZjYcqrDCibDzDSwRBAA&css=BYFwtgNgNAsAUAIwPYBMCeACA3vDeMBmSAdiALQDOAlgF4CmAXBgIwBsADgB4Dc8AvvHgA6MAEMqxMgGMSIccToAnbLnwoqFdhFFomBCHR6q8AdyooQwJswAMNgKS84+DMDpUA5qGt3HxjABWAK4UIFQEaNKydKRMUjEgSk4uohCeklSJYBRxCUn++oZk6op0UmEkcUgQQWDETgJwwhLsQSAqzvjsoijqxB5MQgBMAKylYMn4RKSUtIwsHEadpuaWTKM2XJN4YooeEmTIICBIYNbjDfBAA)

![image](https://user-images.githubusercontent.com/4236651/62486567-ef200380-b7bf-11e9-9be2-2921e42ffab5.png)