### PR TITLE
Added usePolling flag for fable-splitter/chokidar

### DIFF
--- a/src/fable-splitter/src/cli.ts
+++ b/src/fable-splitter/src/cli.ts
@@ -53,6 +53,8 @@ Arguments:
   --commonjs        [FLAG] Compile to commonjs modules
   --run             [FLAG] Run script with node after compilation
                     Arguments after --run will be passed to the script
+  --usePolling      [FLAG] Option for watch mode, may help capture file
+                    save events in certain editors (suboptimal)
 
 Examples:
   fable-splitter src/App.fsproj -o dist/
@@ -210,6 +212,7 @@ function run(entry, args) {
                 .watch(Array.from(info.compiledPaths), {
                     ignored: /node_modules/,
                     persistent: true,
+                    usePolling: findFlag(args, ["--usePolling"])
                 })
                 .on("ready", () => {
                     console.log("fable: Watching...");


### PR DESCRIPTION
Workaround for issue in chokidar file watcher used by fable-splitter as per https://github.com/fable-compiler/Fable/issues/1885.

This issue only seems to show up on certain editors and the impact is that file save events are only captured on the very first file save action.

The workaround allows us to specify `--usePolling` as a command line switch to `fable-splitter`.