### PR TITLE
Swap the parameter order in Testing.Assert.AreEqual

### DIFF
--- a/src/Fable.Core/Fable.Core.Util.fs
+++ b/src/Fable.Core/Fable.Core.Util.fs
@@ -22,8 +22,8 @@ module Experimental =
 
 module Testing =
     type Assert =
-        static member AreEqual(expected: 'T, actual: 'T, ?msg: string): unit = jsNative
-        static member NotEqual(expected: 'T, actual: 'T, ?msg: string): unit = jsNative
+        static member AreEqual(actual: 'T, expected: 'T, ?msg: string): unit = jsNative
+        static member NotEqual(actual: 'T, expected: 'T, ?msg: string): unit = jsNative
 
 
 module Reflection =


### PR DESCRIPTION
`Testing.Assert.AreEqual`/`NotEqual` are currently defined as taking `expected` parameter before `actual`.

But the underlying functions take `actual` before `expected` -- [reference](https://github.com/fable-compiler/Fable/blob/1f2f48d2fdcbfb4ac2423d664102622eac011e40/src/fable-library/Util.ts#L101).

So if you obey the current definition and pass `expected` first, you get incorrect output:

```fs
Fable.Core.Testing.Assert.AreEqual("EXPECTEDVALUE", "ACTUALVALUE")

// Error: Expected: ACTUALVALUE - Actual: EXPECTEDVALUE
```