### PR TITLE
Run test both in debug and production mode

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -135,10 +135,13 @@ let test() =
     if pathExists "build/fable-library" |> not then
         buildLibrary()
 
-    cleanDirs ["build/tests"]
-    buildSplitter "tests"
-    run "npx mocha build/tests --reporter dot -t 10000"
-    runInDir "tests/Main" "dotnet run"
+    let runTestsInNodeWithArgs args =
+        cleanDirs ["build/tests"]
+        buildSplitterWithArgs "tests" args
+        run "npx mocha build/tests --reporter dot -t 10000"
+
+    runTestsInNodeWithArgs "--debug"
+    runTestsInNodeWithArgs ""
     runInDir "tests/Fable.Cli.Test" "dotnet run"
 
     if envVarOrNone "APPVEYOR" |> Option.isSome then


### PR DESCRIPTION
As I'm doing now some [operations that depend of the `DEBUG` constant](https://github.com/fable-compiler/Fable/blob/e549bb1f9703dabf2d040273054790852447db83/src/Fable.Transforms/FableTransforms.fs#L226), I was trying to run the tests both in debug and production mode. However, this is causing Appveyor to fail and I don't understand why. The weird thing is it doesn't fail when running the tests but [later when compiling fable-compiler-js](https://ci.appveyor.com/project/alfonsogarciacaro/fable/builds/27301776#L789) even when I haven't touched that part.

Any ideas anyone?