### PR TITLE
WIP: Feature/add enum reflection

### DIFF
--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -1029,8 +1029,8 @@ let defaultof com ctx (t: Type) =
     | Number _ -> makeIntConst 0
     | Boolean -> makeBoolConst false
     | Builtin BclTimeSpan
-    | Builtin BclDateTime 
-    | Builtin BclDateTimeOffset 
+    | Builtin BclDateTime
+    | Builtin BclDateTimeOffset
     | Builtin (BclInt64|BclUInt64)
     | Builtin BclBigInt
     | Builtin BclDecimal -> getZero com ctx t
@@ -2720,6 +2720,11 @@ let types (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr optio
         | "get_IsArray" ->
             match exprType with Array _ -> true | _ -> false
             |> BoolConstant |> makeValue r |> Some
+        | "get_IsEnum" ->
+            match exprType with
+            | Enum t -> true
+            | _ -> false
+            |> BoolConstant |> makeValue r |> Some
         | "GetElementType" ->
             match exprType with
             | Array t -> TypeInfo t |> makeValue r |> Some
@@ -2739,7 +2744,7 @@ let types (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr optio
         | "get_GenericTypeArguments" | "GetGenericArguments" ->
             Helper.CoreCall("Reflection", "getGenerics", t, [thisArg], ?loc=r) |> Some
         | "get_FullName" | "get_Namespace" | "get_IsArray" | "GetElementType"
-        | "get_IsGenericType" | "GetGenericTypeDefinition" ->
+        | "get_IsGenericType" | "GetGenericTypeDefinition" | "get_IsEnum" ->
             let meth = Naming.removeGetSetPrefix i.CompiledName |> Naming.lowerFirst
             Helper.CoreCall("Reflection", meth, t, [thisArg], ?loc=r) |> Some
         | "GetTypeInfo" -> Some thisArg

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -2299,16 +2299,13 @@ let unchecked (com: ICompiler) (ctx: Context) r t (i: CallInfo) (_: Expr option)
     | "Compare" -> Helper.CoreCall("Util", "compare", t, args, i.SignatureArgTypes, ?loc=r) |> Some
     | _ -> None
 
-let enums (_: ICompiler) (ctx: Context) r _ (i: CallInfo) (thisArg: Expr option) (args: Expr list) =
+let enums (com: ICompiler) (ctx: Context) r _ (i: CallInfo) (thisArg: Expr option) (args: Expr list) =
     match thisArg, i.CompiledName, args with
     | Some this, "HasFlag", [arg] ->
         // x.HasFlags(y) => (int x) &&& (int y) <> 0
         makeBinOp r (Number Int32) this arg BinaryAndBitwise
         |> fun bitwise -> makeEqOp r bitwise (makeIntConst 0) BinaryUnequal
         |> Some
-    | None, "GetEnumUnderlyingType", args ->
-        false
-        |> BoolConstant |> makeValue r |> Some
     | _ -> None
 
 let log (_: ICompiler) r t (i: CallInfo) (_: Expr option) (args: Expr list) =
@@ -2747,7 +2744,8 @@ let types (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr optio
         | "get_GenericTypeArguments" | "GetGenericArguments" ->
             Helper.CoreCall("Reflection", "getGenerics", t, [thisArg], ?loc=r) |> Some
         | "get_FullName" | "get_Namespace" | "get_IsArray" | "GetElementType"
-        | "get_IsGenericType" | "GetGenericTypeDefinition" | "get_IsEnum" | "GetEnumUnderlyingType" ->
+        | "get_IsGenericType" | "GetGenericTypeDefinition" | "get_IsEnum" | "GetEnumUnderlyingType"
+        | "GetEnumValues" ->
             let meth = Naming.removeGetSetPrefix i.CompiledName |> Naming.lowerFirst
             Helper.CoreCall("Reflection", meth, t, [thisArg], ?loc=r) |> Some
         | "GetTypeInfo" -> Some thisArg

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -2306,6 +2306,9 @@ let enums (_: ICompiler) (ctx: Context) r _ (i: CallInfo) (thisArg: Expr option)
         makeBinOp r (Number Int32) this arg BinaryAndBitwise
         |> fun bitwise -> makeEqOp r bitwise (makeIntConst 0) BinaryUnequal
         |> Some
+    | None, "GetEnumUnderlyingType", args ->
+        false
+        |> BoolConstant |> makeValue r |> Some
     | _ -> None
 
 let log (_: ICompiler) r t (i: CallInfo) (_: Expr option) (args: Expr list) =
@@ -2744,7 +2747,7 @@ let types (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr optio
         | "get_GenericTypeArguments" | "GetGenericArguments" ->
             Helper.CoreCall("Reflection", "getGenerics", t, [thisArg], ?loc=r) |> Some
         | "get_FullName" | "get_Namespace" | "get_IsArray" | "GetElementType"
-        | "get_IsGenericType" | "GetGenericTypeDefinition" | "get_IsEnum" ->
+        | "get_IsGenericType" | "GetGenericTypeDefinition" | "get_IsEnum" | "GetEnumUnderlyingType" ->
             let meth = Naming.removeGetSetPrefix i.CompiledName |> Naming.lowerFirst
             Helper.CoreCall("Reflection", meth, t, [thisArg], ?loc=r) |> Some
         | "GetTypeInfo" -> Some thisArg

--- a/src/fable-library/Reflection.ts
+++ b/src/fable-library/Reflection.ts
@@ -162,6 +162,10 @@ export function isGenericType(t: TypeInfo) {
   return t.generics != null && t.generics.length > 0;
 }
 
+export function isEnum(t: TypeInfo) {
+    return t.enumCases != null && t.enumCases.length > 0;
+}
+
 /**
  * This doesn't replace types for fields (records) or cases (unions)
  * but it should be enough for type comparison purposes

--- a/src/fable-library/Reflection.ts
+++ b/src/fable-library/Reflection.ts
@@ -178,6 +178,14 @@ export function getEnumUnderlyingType(t: TypeInfo) {
     return t.generics[0];
 }
 
+export function getEnumValues(t : TypeInfo) {
+    if (isEnum(t)) {
+        return t.enumCases;
+    } else {
+        throw new Error(`${t.fullname} is not an F# enum type`);
+    }
+}
+
 // FSharpType
 
 export function getUnionCases(t: TypeInfo): CaseInfo[] {

--- a/src/fable-library/Reflection.ts
+++ b/src/fable-library/Reflection.ts
@@ -174,6 +174,10 @@ export function getGenericTypeDefinition(t: TypeInfo) {
   return t.generics == null ? t : new TypeInfo(t.fullname, t.generics.map(() => obj));
 }
 
+export function getEnumUnderlyingType(t: TypeInfo) {
+    return t.generics[0];
+}
+
 // FSharpType
 
 export function getUnionCases(t: TypeInfo): CaseInfo[] {


### PR DESCRIPTION
Hello @alfonsogarciacaro , I have a hard time figuring two things.

In order to add support for the methods under `System.Enum` like:

- `System.Enum.GetValues(t)`
- `System.Enum.Parse(t, "0")`

I have to access the `EnumType` information from at [this place](https://github.com/fable-compiler/Fable/blob/feature/add_enum_reflection/src/Fable.Transforms/Replacements.fs#L2302-L2309). But I can't find a way to extract the enum information from the info I have access to here.

----------------

Another problem I am facing is that Enum is replaced by their number representation at compile time. That's probably the reason why Fable only support enum of type integer and not `enum<char>` etc.

So `let v = MyEnum.Foo` gives `const v = 5;`.

However, when using `t.GetEnumValues()` we get all the enum info (key + value) which is expected.

So this code fails on Fable, because `MyEnum.Foo` is a number while `extractedFoo` is the complete info about Enum `[Foo, 5]`

I found, that [this opmisation](https://github.com/fable-compiler/Fable/blob/feature/add_enum_reflection/src/Fable.Transforms/Fable2Babel.fs#L283-L290) should probably be removed for the enums. Because when doing `(t.GetEnumValues() |> Seq.cast<MyEnum> |> Seq.item 1)` it returns `0` instead of the expected `key/value`.

*Code as use to test that reflection thing (works under FSI)*

```fs
type MyEnum =
    | Foo = 0y
    | Bar = 5y

let t = MyEnum.Foo.GetType()
let extractedFoo = (t.GetEnumValues() |> Seq.cast<MyEnum> |> Seq.item 1)
let res = MyEnum.Foo = extractedFoo
// Should return true
```

Could you please help me understand what I should look at?