### PR TITLE
Implement (Array|List).splitInto

### DIFF
--- a/src/fable-library/Array.fs
+++ b/src/fable-library/Array.fs
@@ -892,3 +892,22 @@ let windowed (windowSize: int) (source: 'T[]): 'T[][] =
     for i = windowSize to source.Length do
         res.[i - windowSize] <- source.[i-windowSize..i-1]
     res
+
+let splitInto (chunks: int) (array: 'T[]): 'T[][] =
+    if chunks < 1 then
+        invalidArg "chunks" "The input must be positive."
+    if array.Length = 0 then
+        [| [||] |]
+    else
+        let result: 'T[][] = [||]
+        let chunks = FSharp.Core.Operators.min chunks array.Length
+        let minChunkSize = array.Length / chunks
+        let chunksWithExtraItem = array.Length % chunks
+
+        for i = 0 to chunks - 1 do
+            let chunkSize = if i < chunksWithExtraItem then minChunkSize + 1 else minChunkSize
+            let start = i * minChunkSize + (FSharp.Core.Operators.min chunksWithExtraItem i)
+            let slice = subArrayImpl array start chunkSize
+            pushImpl result slice |> ignore
+
+        result

--- a/src/fable-library/List.fs
+++ b/src/fable-library/List.fs
@@ -508,3 +508,10 @@ let windowed (windowSize: int) (source: 'T list): 'T list list =
     for i = length source downto windowSize do
         res <- (slice (Some(i-windowSize)) (Some(i-1)) source) :: res
     res
+
+let splitInto (chunks: int) (source: 'T list): 'T list list =
+    source
+    |> List.toArray
+    |> Array.splitInto chunks
+    |> List.ofArray
+    |> List.map List.ofArray

--- a/tests/Main/ArrayTests.fs
+++ b/tests/Main/ArrayTests.fs
@@ -942,4 +942,11 @@ let tests =
         let destination = [| "a"; "b"; "c" |]
         Array.Copy(source, 1, destination, 1, 2)
         equal [| "a"; "xx"; "xyz" |] destination
+
+    testCase "Array.splitInto works" <| fun () ->
+        Array.splitInto 3 [|1..10|] |> equal [| [|1..4|]; [|5..7|]; [|8..10|] |]
+        Array.splitInto 3 [|1..11|] |> equal [| [|1..4|]; [|5..8|]; [|9..11|] |]
+        Array.splitInto 3 [|1..12|] |> equal [| [|1..4|]; [|5..8|]; [|9..12|] |]
+        Array.splitInto 4 [|1..5|] |> equal [| [|1..2|]; [|3|]; [|4|]; [|5|] |]
+        Array.splitInto 20 [|1..4|] |> equal [| [|1|]; [|2|]; [|3|]; [|4|] |]
   ]

--- a/tests/Main/ListTests.fs
+++ b/tests/Main/ListTests.fs
@@ -812,4 +812,11 @@ let tests =
         makeList true |> List.sum |> equal 6
         makeList false |> List.sum |> equal 3
     // #endif
+
+    testCase "List.splitInto works" <| fun () ->
+        List.splitInto 3 [1..10] |> equal [ [1..4]; [5..7]; [8..10] ]
+        List.splitInto 3 [1..11] |> equal [ [1..4]; [5..8]; [9..11] ]
+        List.splitInto 3 [1..12] |> equal [ [1..4]; [5..8]; [9..12] ]
+        List.splitInto 4 [1..5] |> equal [ [1..2]; [3]; [4]; [5] ]
+        List.splitInto 20 [1..4] |> equal [ [1]; [2]; [3]; [4] ]
   ]


### PR DESCRIPTION
List.splitInto calls Array.splitInto. There's a precedent for this in the module, hope it's OK. The tests are lifted from FSharp.Core