### PR TITLE
Fixed #1951, updated fable-compiler-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4074,9 +4074,9 @@
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
     },
     "handlebars": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
-      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -7063,9 +7063,9 @@
       "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ=="
     },
     "uglify-js": {
-      "version": "3.6.8",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.8.tgz",
-      "integrity": "sha512-XhHJ3S3ZyMwP8kY1Gkugqx3CJh2C3O0y8NPiSxtm1tyD/pktLAkFZsFGpuNfTZddKDQ/bbDBLAd2YyA1pbi8HQ==",
+      "version": "3.6.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.9.tgz",
+      "integrity": "sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==",
       "dev": true,
       "optional": true,
       "requires": {

--- a/src/Fable.Transforms/ReplacementsInject.fs
+++ b/src/Fable.Transforms/ReplacementsInject.fs
@@ -60,6 +60,7 @@ let fableReplacementsModules =
       "averageBy", [("Fable.Core.IGenericAverager`1", 1)]
       "ofSeq", [(Types.arrayCons, 0)]
       "ofList", [(Types.arrayCons, 0)]
+      "transpose", [(Types.arrayCons, 0)]
     ]
     "List", Map [
       "contains", [(Types.equalityComparer, 0)]
@@ -82,7 +83,7 @@ let fableReplacementsModules =
       "countBy", [(Types.equalityComparer, 1)]
     ]
     "Set", Map [
-      "FSharpSet$$Map$$38806891", [(Types.comparer, 1)]
+      "FSharpSet$$Map$$7597B8F7", [(Types.comparer, 1)]
       "singleton", [(Types.comparer, 0)]
       "unionMany", [(Types.comparer, 0)]
       "empty", [(Types.comparer, 0)]

--- a/src/fable-compiler-js/RELEASE_NOTES.md
+++ b/src/fable-compiler-js/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 ### 1.2.1
 
 * fable-standalone 1.3.0
+* removed perf_hooks dependency
 
 ### 1.2.0
 

--- a/src/fable-compiler-js/RELEASE_NOTES.md
+++ b/src/fable-compiler-js/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### 1.2.1
+
+* fable-standalone 1.3.0
+
 ### 1.2.0
 
 * Added NuGet packages support

--- a/src/fable-compiler-js/package-lock.json
+++ b/src/fable-compiler-js/package-lock.json
@@ -262,9 +262,9 @@
       "integrity": "sha512-28MgVBeDA38sqaZnMvyI12DRMQ+YaOnJRUjIptgFBFYIwn569LNom1rGZEH8uLYTbWYcG5moFOh+Ltxor87BPA=="
     },
     "fable-standalone": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/fable-standalone/-/fable-standalone-1.2.3.tgz",
-      "integrity": "sha512-pUS12/m2C55C4Yqf49uwRP6SRmqAqQ0DTTu/uFJdHrLaRSdVbQSzITJZfZE1Fgru9+Zlal/e+/+0AaRh0V/ofA=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fable-standalone/-/fable-standalone-1.3.0.tgz",
+      "integrity": "sha512-Uv+J1vmmYy9ZtSVjTravFaMom2WKXHIncFPMv1+628B9R46dg56jGv84SXNWazOedbpUdpkx07A4u8IWk/akww=="
     },
     "function-bind": {
       "version": "1.1.1",

--- a/src/fable-compiler-js/package.json
+++ b/src/fable-compiler-js/package.json
@@ -26,6 +26,6 @@
     "@babel/plugin-transform-modules-commonjs": "^7.6.0",
     "fable-babel-plugins": "^2.2.0",
     "fable-metadata": "^1.2.0",
-    "fable-standalone": "^1.2.3"
+    "fable-standalone": "^1.3.0"
   }
 }

--- a/src/fable-compiler-js/src/Platform.fs
+++ b/src/fable-compiler-js/src/Platform.fs
@@ -14,8 +14,9 @@ module JS =
         abstract platform: unit -> string
         abstract arch: unit -> string
 
-    type IPerformance =
-        abstract now: unit -> float
+    type IProcess =
+        abstract hrtime: unit -> float []
+        abstract hrtime: float[] -> float[]
 
     type IPath =
         abstract resolve: string -> string
@@ -31,19 +32,19 @@ module JS =
 
     let fs: IFileSystem = importAll "fs"
     let os: IOperSystem = importAll "os"
+    let proc: IProcess = importAll "process"
     let path: IPath = importAll "path"
     let util: IUtil = importAll "./util.js"
-    let performance: IPerformance = importMember "perf_hooks"
 
 let readAllBytes (filePath: string) = JS.fs.readFileSync(filePath)
 let readAllText (filePath: string) = JS.fs.readFileSync(filePath, "utf8").TrimStart('\uFEFF')
 let writeAllText (filePath: string) (text: string) = JS.fs.writeFileSync(filePath, text)
 
 let measureTime (f: 'a -> 'b) x =
-    let t0 = JS.performance.now()
+    let startTime = JS.proc.hrtime()
     let res = f x
-    let t1 = JS.performance.now()
-    res, int64 (t1 - t0)
+    let elapsed = JS.proc.hrtime(startTime)
+    res, int64 (elapsed.[0] * 1e3 + elapsed.[1] / 1e6)
 
 let getVersion = JS.util.getVersion
 let ensureDirExists = JS.util.ensureDirExists

--- a/src/fable-compiler-js/src/Platform.fs
+++ b/src/fable-compiler-js/src/Platform.fs
@@ -65,6 +65,7 @@ let getDirFiles (path: string) (extension: string) =
     JS.util.getDirFiles(path)
     |> Array.filter (fun x -> x.EndsWith(extension))
     |> Array.map (fun x -> x.Replace('\\', '/'))
+    |> Array.sort
 
 
 module Path =

--- a/src/fable-compiler-js/src/ProjectParser.fs
+++ b/src/fable-compiler-js/src/ProjectParser.fs
@@ -66,9 +66,11 @@ let resolvePackage (pkgName, pkgVersion) =
         let binaryPaths = getDirFiles libPath ".dll"
         let nuspecPaths = getDirFiles pkgPath ".nuspec"
         let fsprojPaths = getDirFiles fablePath ".fsproj"
+        if Array.isEmpty nuspecPaths then
+            printfn "ERROR: Cannot find package %s" pkgPath
         let binaryOpt = binaryPaths |> Array.tryLast
-        let dependOpt = nuspecPaths |> Array.tryHead |> Option.map parsePackageSpec
-        let fsprojOpt = fsprojPaths |> Array.tryHead |> Option.map ProjectReference
+        let dependOpt = nuspecPaths |> Array.tryLast |> Option.map parsePackageSpec
+        let fsprojOpt = fsprojPaths |> Array.tryLast |> Option.map ProjectReference
         let pkgRefs, dllPaths =
             match binaryOpt, dependOpt, fsprojOpt with
             | _, _, Some projRef ->

--- a/src/fable-library/List.fs
+++ b/src/fable-library/List.fs
@@ -522,3 +522,9 @@ let splitInto (chunks: int) (source: 'T list): 'T list list =
     |> Array.splitInto chunks
     |> ofArray
     |> map ofArray
+
+let transpose (lists: seq<'T list>): 'T list list =
+    lists
+    |> Seq.transpose
+    |> Seq.map ofSeq
+    |> ofSeq

--- a/src/fable-library/Seq.ts
+++ b/src/fable-library/Seq.ts
@@ -862,3 +862,31 @@ export function windowed<T>(windowSize: number, source: Iterable<T>): Iterable<T
     },
   } as Iterable<T[]>;
 }
+
+export function transpose<T>(source: Iterable<Iterable<T>>): Iterable<Iterable<T>> {
+  return {
+    [Symbol.iterator]: () => {
+      const iters = Array.from(source, (x) => x[Symbol.iterator]());
+      return {
+        next: () => {
+          if (iters.length === 0) {
+            return { done: true }; // empty sequence
+          }
+          const results = Array.from(iters, (iter) => iter.next());
+          if (results[0].done) {
+            if (!results.every((x) => x.done)) {
+              throw new Error("Sequences have different lengths");
+            }
+            return { done: true };
+          } else {
+            if (!results.every((x) => !x.done)) {
+              throw new Error("Sequences have different lengths");
+            }
+            const values = results.map((x) => x.value);
+            return { done: false, value: values };
+          }
+        },
+      };
+    },
+  } as Iterable<Iterable<T>>;
+}

--- a/src/fable-standalone/test/bench-compiler/Platform.fs
+++ b/src/fable-standalone/test/bench-compiler/Platform.fs
@@ -86,8 +86,9 @@ module JS =
         abstract platform: unit -> string
         abstract arch: unit -> string
 
-    type IPerformance =
-        abstract now: unit -> float
+    type IProcess =
+        abstract hrtime: unit -> float []
+        abstract hrtime: float[] -> float[]
 
     type IPath =
         abstract resolve: string -> string
@@ -98,21 +99,31 @@ module JS =
         abstract ensureDirExists: dir: string -> unit
         abstract getDirFiles: dir: string -> string[]
 
+    // type IPerformance =
+    //     abstract now: unit -> float
+
     let fs: IFileSystem = importAll "fs"
     let os: IOperSystem = importAll "os"
+    let proc: IProcess = importAll "process"
     let path: IPath = importAll "path"
     let util: IUtil = importAll "./util.js"
-    let performance: IPerformance = importMember "perf_hooks"
+    // let performance: IPerformance = importMember "perf_hooks"
 
 let readAllBytes (filePath: string) = JS.fs.readFileSync(filePath)
 let readAllText (filePath: string) = JS.fs.readFileSync(filePath, "utf8").TrimStart('\uFEFF')
 let writeAllText (filePath: string) (text: string) = JS.fs.writeFileSync(filePath, text)
 
+// let measureTime (f: 'a -> 'b) x =
+//     let t0 = JS.performance.now()
+//     let res = f x
+//     let t1 = JS.performance.now()
+//     res, int64 (t1 - t0)
+
 let measureTime (f: 'a -> 'b) x =
-    let t0 = JS.performance.now()
+    let startTime = JS.proc.hrtime()
     let res = f x
-    let t1 = JS.performance.now()
-    res, int64 (t1 - t0)
+    let elapsed = JS.proc.hrtime(startTime)
+    res, int64 (elapsed.[0] * 1e3 + elapsed.[1] / 1e6)
 
 let serializeToJson = JS.util.serializeToJson
 let ensureDirExists = JS.util.ensureDirExists

--- a/src/fable-standalone/test/bench-compiler/Platform.fs
+++ b/src/fable-standalone/test/bench-compiler/Platform.fs
@@ -69,6 +69,7 @@ let getDirFiles (path: string) (extension: string) =
     if not (Directory.Exists(path)) then [||]
     else Directory.GetFiles(path, "*" + extension, SearchOption.AllDirectories)
     |> Array.map (fun x -> x.Replace('\\', '/'))
+    |> Array.sort
 
 #else
 
@@ -141,6 +142,7 @@ let getDirFiles (path: string) (extension: string) =
     JS.util.getDirFiles(path)
     |> Array.filter (fun x -> x.EndsWith(extension))
     |> Array.map (fun x -> x.Replace('\\', '/'))
+    |> Array.sort
 
 #endif
 

--- a/src/fable-standalone/test/bench-compiler/ProjectParser.fs
+++ b/src/fable-standalone/test/bench-compiler/ProjectParser.fs
@@ -66,9 +66,11 @@ let resolvePackage (pkgName, pkgVersion) =
         let binaryPaths = getDirFiles libPath ".dll"
         let nuspecPaths = getDirFiles pkgPath ".nuspec"
         let fsprojPaths = getDirFiles fablePath ".fsproj"
+        if Array.isEmpty nuspecPaths then
+            printfn "ERROR: Cannot find package %s" pkgPath
         let binaryOpt = binaryPaths |> Array.tryLast
-        let dependOpt = nuspecPaths |> Array.tryHead |> Option.map parsePackageSpec
-        let fsprojOpt = fsprojPaths |> Array.tryHead |> Option.map ProjectReference
+        let dependOpt = nuspecPaths |> Array.tryLast |> Option.map parsePackageSpec
+        let fsprojOpt = fsprojPaths |> Array.tryLast |> Option.map ProjectReference
         let pkgRefs, dllPaths =
             match binaryOpt, dependOpt, fsprojOpt with
             | _, _, Some projRef ->

--- a/src/fable-standalone/test/bench-compiler/app.fs
+++ b/src/fable-standalone/test/bench-compiler/app.fs
@@ -4,7 +4,7 @@ open Fable.Compiler.Platform
 open Fable.Compiler.ProjectParser
 
 let references = Fable.Standalone.Metadata.references_core
-let metadataPath = Path.Combine(__SOURCE_DIRECTORY__, "../../../fable-metadata/lib/") // .NET BCL binaries
+let metadataPath = "../../../fable-metadata/lib/" // .NET BCL binaries
 
 let printErrors showWarnings (errors: Fable.Standalone.Error[]) =
     let printError (e: Fable.Standalone.Error) =

--- a/src/tools/InjectProcessor/InjectProcessor.fsproj
+++ b/src/tools/InjectProcessor/InjectProcessor.fsproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="../../Fable.Cli/ProjectCoreCracker.fs" />
+    <Compile Include="../../Fable.Transforms/Global/Fable.Core.fs" />
     <Compile Include="../../Fable.Transforms/Global/Prelude.fs" />
     <Compile Include="../../Fable.Transforms/OverloadSuffix.fs" />
     <Compile Include="InjectProcessor.fs" />

--- a/tests/Main/ArrayTests.fs
+++ b/tests/Main/ArrayTests.fs
@@ -2,6 +2,7 @@ module Fable.Tests.Arrays
 
 open System
 open Util.Testing
+open Fable.Tests.Util
 
 type ParamArrayTest =
     static member Add([<ParamArray>] xs: int[]) = Array.sum xs
@@ -969,5 +970,29 @@ let tests =
         equal [|(1, 2); (2, 3); (3, 4)|] xs2
         xs2 |> Array.map (fun (x, y) -> sprintf "%i%i" x y)
         |> String.concat ""
-        |> equal "122334"            
+        |> equal "122334"
+
+    testCase "Array.transpose works" <| fun () ->
+        // integer array
+        Array.transpose (seq [[|1..3|]; [|4..6|]])
+        |> equal [|[|1;4|]; [|2;5|]; [|3;6|]|]
+        Array.transpose [|[|1..3|]|]
+        |> equal [|[|1|]; [|2|]; [|3|]|]
+        Array.transpose [|[|1|]; [|2|]|]
+        |> equal [|[|1..2|]|]
+        // string array
+        Array.transpose (seq [[|"a";"b";"c"|]; [|"d";"e";"f"|]])
+        |> equal [|[|"a";"d"|]; [|"b";"e"|]; [|"c";"f"|]|]
+        // empty array
+        Array.transpose [| |]
+        |> equal [| |]
+        // array of empty arrays - m x 0 array transposes to 0 x m (i.e. empty)
+        Array.transpose [| [||] |]
+        |> equal [| |]
+        Array.transpose [| [||]; [||] |]
+        |> equal [| |]
+        // jagged arrays
+        throwsAnyError (fun () -> Array.transpose [| [|1; 2|]; [|3|] |])
+        throwsAnyError (fun () -> Array.transpose [| [|1|]; [|2; 3|] |])
+
   ]

--- a/tests/Main/DictionaryTests.fs
+++ b/tests/Main/DictionaryTests.fs
@@ -230,7 +230,7 @@ let tests =
         let dic = Dictionary<_,_>()
         dic.Add("A", 65)
         // throwsError "The given key 'B' was not present in the dictionary." (fun _ -> dic.["B"] |> ignore)
-        throwsAnyError (fun _ -> dic.["B"] |> ignore)
+        throwsAnyError (fun () -> dic.["B"])
 
     testCase "conversion from array works" <| fun () ->
         let dic = [| "A",1; "B",2|] |> dict

--- a/tests/Main/ListTests.fs
+++ b/tests/Main/ListTests.fs
@@ -1,6 +1,7 @@
 module Fable.Tests.Lists
 
 open Util.Testing
+open Fable.Tests.Util
 
 type List(x: int) =
     member val Value = x
@@ -830,4 +831,31 @@ let tests =
         List.splitInto 3 [1..12] |> equal [ [1..4]; [5..8]; [9..12] ]
         List.splitInto 4 [1..5] |> equal [ [1..2]; [3]; [4]; [5] ]
         List.splitInto 20 [1..4] |> equal [ [1]; [2]; [3]; [4] ]
+
+    testCase "List.transpose works" <| fun () ->
+        // integer list
+        List.transpose (seq [[1..3]; [4..6]])
+        |> equal [[1; 4]; [2; 5]; [3; 6]]
+        List.transpose [[1..3]]
+        |> equal [[1]; [2]; [3]]
+        List.transpose [[1]; [2]]
+        |> equal [[1..2]]
+        // string list
+        List.transpose (seq [["a";"b";"c"]; ["d";"e";"f"]])
+        |> equal [["a";"d"]; ["b";"e"]; ["c";"f"]]
+        // empty list
+        List.transpose []
+        |> equal []
+        // list of empty lists - m x 0 list transposes to 0 x m (i.e. empty)
+        List.transpose [[]]
+        |> equal []
+        List.transpose [[]; []]
+        |> equal []
+        // jagged lists
+        throwsAnyError (fun () -> List.transpose [[1; 2]; [3]])
+        throwsAnyError (fun () -> List.transpose [[1]; [2; 3]])
+        throwsAnyError (fun () -> List.transpose [[]; [1; 2]; [3; 4]])
+        throwsAnyError (fun () -> List.transpose [[1; 2]; []; [3; 4]])
+        throwsAnyError (fun () -> List.transpose [[1; 2]; [3; 4]; []])
+
   ]

--- a/tests/Main/SeqTests.fs
+++ b/tests/Main/SeqTests.fs
@@ -876,4 +876,33 @@ let tests =
         accY |> equal 1
         equal expected res1
         equal expected res2
+
+    testCase "Seq.transpose works" <| fun () ->
+        let seqEqual (expected: seq<'T seq>) (actual: seq<'T seq>) =
+            (actual |> Seq.map Seq.toArray |> Seq.toArray)
+            |> equal (expected |> Seq.map Seq.toArray |> Seq.toArray)
+        // integer seq
+        Seq.transpose (seq [seq {1..3}; seq {4..6}])
+        |> seqEqual [seq [1; 4]; seq [2; 5]; seq [3; 6]]
+        Seq.transpose (seq [seq {1..3}])
+        |> seqEqual [seq [1]; seq [2]; seq [3]]
+        Seq.transpose (seq [seq [1]; seq [2]])
+        |> seqEqual [seq {1..2}]
+        // string seq
+        Seq.transpose (seq [seq ["a";"b";"c"]; seq ["d";"e";"f"]])
+        |> seqEqual [seq ["a";"d"]; seq ["b";"e"]; seq ["c";"f"]]
+        // empty seq
+        Seq.transpose Seq.empty
+        |> seqEqual Seq.empty
+        // seq of empty seqs - m x 0 seq transposes to 0 x m (i.e. empty)
+        Seq.transpose (seq [Seq.empty])
+        |> seqEqual Seq.empty
+        Seq.transpose (seq [Seq.empty; Seq.empty])
+        |> seqEqual Seq.empty
+        // sequences of lists
+        Seq.transpose [["a";"b"]; ["c";"d"]]
+        |> seqEqual [seq ["a";"c"]; seq ["b";"d"]]
+        Seq.transpose (seq { yield ["a";"b"]; yield ["c";"d"] })
+        |> seqEqual [seq ["a";"c"]; seq ["b";"d"]]
+
   ]


### PR DESCRIPTION
- Fixed npm audit issues.
- Fixed #1951

`fable-compiler-js`:
- Updated `fable-standalone` reference.
- Removed perf_hooks dependency to enable `fable-compiler-js` to run on older node.js versions (although that is not recommended as they're up to 3x slower).
- Added error output on missing packages.