### PR TITLE
fixed typo in MapConstructor

### DIFF
--- a/src/Fable.Core/Fable.Core.JS.fs
+++ b/src/Fable.Core/Fable.Core.JS.fs
@@ -176,7 +176,7 @@ module JS =
         abstract values: unit -> seq<'V>
 
     and [<AllowNullLiteral>] MapConstructor =
-        [<Emit("new $0($1..)")>] abstract Create: ?iterable: seq<'K * 'V> -> Map<'K, 'V>
+        [<Emit("new $0($1...)")>] abstract Create: ?iterable: seq<'K * 'V> -> Map<'K, 'V>
 
     and [<AllowNullLiteral>] WeakMap<'K, 'V> =
         abstract clear: unit -> unit


### PR DESCRIPTION
typo was causing babel error when compiling.

``` 
Module build failed (from ./node_modules/fable-loader/index.js):
Error: unknown: BABEL ERROR: Failed to parse macro: new $0($1..) -> new $0($1..)
MACRO ARGUMENTS: $0,$1
Unexpected token (2:10)
```

Code that made it fail:
```fsharp
let sheetsManager : Map<obj, obj> = Constructors.Map.Create ()
```
