### PR TITLE
Fix assigning nulls through Babel macro

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "babel-loader": "^8.0.6",
     "concurrently": "^4.1.2",
     "download-cli": "^1.1.1",
-    "fable-babel-plugins": "^2.2.0",
+    "fable-babel-plugins": "file://./src/fable-babel-plugins",
     "fable-compiler": "^2.4.12",
     "fable-compiler-js": "^1.2.1",
     "fable-loader": "^2.1.8",

--- a/src/fable-babel-plugins/index.js
+++ b/src/fable-babel-plugins/index.js
@@ -86,7 +86,7 @@ function getTransformMacroExpressions(babelTemplate) {
                     })
                     .replace(/\{\{([^\}]*\$(\d+).*?)\}\}/g, (_, g1, g2) => {
                         const i = parseInt(g2, 10);
-                        return typeof args[i] === "object" && args[i].type !== "NullLiteral" ? g1 : "";
+                        return typeof args[i] === "object" ? g1 : "";
                     })
                     .replace(/\$(\d+)!/, (_, i) => {
                         const arg = args[parseInt(i, 10)]

--- a/tests/Main/JsInteropTests.fs
+++ b/tests/Main/JsInteropTests.fs
@@ -6,6 +6,7 @@ open Util.Testing
 #if FABLE_COMPILER
 open Fable.Core
 open Fable.Core.JsInterop
+open Fable.Core.DynamicExtensions
 open Fable.Core.Experimental
 
 [<Global>]
@@ -270,6 +271,13 @@ let tests =
         let style = createEmpty<TextStyle>
         style.Bar |> equal "foo"
         style.Add(3,5) |> equal 8
+
+    testCase "Assigning null with emit works" <| fun () ->
+        let x = createEmpty<obj>
+        x.["prop"] <- "prop value"
+        x.["prop"] |> isNull |> equal false
+        x.["prop"] <- null
+        x.["prop"] |> equal null
 
     testCase "Emit attribute conditional parameters works" <| fun () ->
         let style = createEmpty<TextStyle>


### PR DESCRIPTION
I'm trying to add a failing test first for #1982. For some reason, `npm run test` fails with around 50 failing tests. Anyone knows whats up with this?