### PR TITLE
Plumb through real case field names instead of generating fake ones

### DIFF
--- a/src/fable-library/Reflection.ts
+++ b/src/fable-library/Reflection.ts
@@ -10,7 +10,7 @@ export class CaseInfo {
     public declaringType: TypeInfo,
     public tag: number,
     public name: string,
-    public fields?: TypeInfo[]) {
+    public fields?: FieldInfo[]) {
   }
 }
 
@@ -78,7 +78,7 @@ export function anonRecord(...fields: FieldInfo[]): TypeInfo {
   return new TypeInfo("", undefined, undefined, () => fields);
 }
 
-export type CaseInfoInput = string | [string, TypeInfo[]];
+export type CaseInfoInput = string | [string, FieldInfo[]];
 
 export function union(
   fullname: string,
@@ -86,7 +86,9 @@ export function union(
   constructor: Constructor,
   cases: () => CaseInfoInput[]): TypeInfo {
   const t: TypeInfo = new TypeInfo(fullname, generics, constructor, undefined, () => cases().map((x, i) =>
-    typeof x === "string" ? new CaseInfo(t, i, x) : new CaseInfo(t, i, x[0], x[1])));
+    typeof x === "string"
+        ? new CaseInfo(t, i, x)
+        : new CaseInfo(t, i, x[0], x[1])));
   return t;
 }
 
@@ -319,7 +321,7 @@ export function getUnionFields(v: any, t: TypeInfo): [CaseInfo, any[]] {
 }
 
 export function getUnionCaseFields(uci: CaseInfo): FieldInfo[] {
-  return uci.fields == null ? [] : uci.fields.map((t, i) => ["Data" + i, t] as FieldInfo);
+  return uci.fields == null ? [] : uci.fields;
 }
 
 export function getRecordFields(v: any): any[] {

--- a/tests/Main/ReflectionTests.fs
+++ b/tests/Main/ReflectionTests.fs
@@ -27,11 +27,6 @@ type TestType3 = class end
 type TestType4 = class end
 type TestType5 = class end
 
-type TestType6 =
-    | CaseA of string
-    | CaseB of SomeField: string
-    | CaseC of string * SomeField: string
-
 type GenericRecord<'A,'B> = { a: 'A; b: 'B }
 
 type MyEnum =

--- a/tests/Main/ReflectionTests.fs
+++ b/tests/Main/ReflectionTests.fs
@@ -27,6 +27,11 @@ type TestType3 = class end
 type TestType4 = class end
 type TestType5 = class end
 
+type TestType6 =
+    | CaseA of string
+    | CaseB of SomeField: string
+    | CaseC of string * SomeField: string
+
 type GenericRecord<'A,'B> = { a: 'A; b: 'B }
 
 type MyEnum =
@@ -172,8 +177,8 @@ type TestRecord = {
 }
 
 type TestUnion =
-    | StringCase of String: string * string
-    | IntCase of Int: int
+    | StringCase of SomeString: string * string
+    | IntCase of SomeInt: int
 
 type RecordF = { F : int -> string }
 
@@ -354,8 +359,8 @@ let reflectionTests = [
     let unionCaseInfos = [| unionCase1Info; unionCase2Info |]
     let unionCaseValueFields = [| unionCase1ValueFields; unionCase2ValueFields |]
 
-    let expectedUnionCase1Fields = 0, "StringCase", [| typeof<string>; typeof<string> |], [| box "a"; box "b" |]
-    let expectedUnionCase2Fields = 1, "IntCase", [| typeof<int> |], [| box 1 |]
+    let expectedUnionCase1Fields = 0, "StringCase", [| typeof<string>; typeof<string> |], [| "SomeString"; "Item2" |], [| box "a"; box "b" |]
+    let expectedUnionCase2Fields = 1, "IntCase", [| typeof<int> |], [| "SomeInt" |], [| box 1 |]
     let expectedUnionFields = [| expectedUnionCase1Fields; expectedUnionCase2Fields |]
 
     let unionFields =
@@ -364,7 +369,10 @@ let reflectionTests = [
             let types =
                 info.GetFields()
                 |> Array.map (fun field -> field.PropertyType)
-            info.Tag, info.Name, types, values)
+            let names =
+                info.GetFields()
+                |> Array.map (fun field -> field.Name)
+            info.Tag, info.Name, types, names, values)
 
     let canMakeSameUnionCases =
         unbox<TestUnion> (FSharpValue.MakeUnion(unionCase1Info, unionCase1ValueFields)) = unionCase1


### PR DESCRIPTION
Implemented as per @inosik's guidance in #2017.