### PR TITLE
Add Length and Substring with firstIndex and length in StringBuilder

### DIFF
--- a/src/fable-library/System.Text.fs
+++ b/src/fable-library/System.Text.fs
@@ -12,3 +12,7 @@ type StringBuilder(value: string, capacity: int) =
     member x.AppendLine() = buf.Add(System.Environment.NewLine); x
     member x.AppendLine(s: string) = buf.Add(s); buf.Add(System.Environment.NewLine); x
     override __.ToString() = System.String.Concat(buf)
+    member x.Length = buf |> Seq.sumBy String.length
+    member x.ToString(firstIndex: int, length: int) =
+        let str = x.ToString()
+        str.Substring(firstIndex, length)

--- a/tests/Main/StringTests.fs
+++ b/tests/Main/StringTests.fs
@@ -43,6 +43,20 @@ let tests =
                               .ToString()
             sb.ToString() |> equal expected
 
+      testCase "StringBuilder.Lengh works" <| fun () ->
+            let sb = System.Text.StringBuilder()
+            sb.Append("Hello") |> ignore
+            // We don't test the AppendLine for Length because depending on the OS
+            // the result is different. Unix \n VS Windows \r\n 
+            // sb.AppendLine() |> ignore 
+            equal 5 sb.Length
+      
+      testCase "StringBuilder.ToString works with index and length" <| fun () ->
+            let sb = System.Text.StringBuilder()
+            sb.Append("Hello") |> ignore
+            sb.AppendLine() |> ignore
+            equal "ll" (sb.ToString(2, 2))
+
       testCase "kprintf works" <| fun () ->
             let f (s:string) = s + "XX"
             Printf.kprintf f "hello" |> equal "helloXX"


### PR DESCRIPTION
I was trying to make Hedgehog fable friendly and was missing this two functions in StringBuilder.

The ToString(firstIndex, length) is not implemented performant by I think it should be OK for the first version. Or is it?