### PR TITLE
add using function implementation to Fable.Core.Utils

### DIFF
--- a/src/Fable.Core/Fable.Core.Util.fs
+++ b/src/Fable.Core/Fable.Core.Util.fs
@@ -9,6 +9,10 @@ module Util =
         try failwith "JS only" // try/catch is just for padding so it doesn't get optimized
         with ex -> raise ex
 
+    let using (resource : 'T when 'T :> System.IDisposable) action =
+        try action(resource)
+        finally match (box resource) with null -> () | _ -> resource.Dispose()
+
 module Experimental =
     /// Reads the name of an identifier, a property or a type
     let inline nameof(expr: 'a): string = jsNative

--- a/src/Fable.Core/Fable.Core.Util.fs
+++ b/src/Fable.Core/Fable.Core.Util.fs
@@ -9,10 +9,6 @@ module Util =
         try failwith "JS only" // try/catch is just for padding so it doesn't get optimized
         with ex -> raise ex
 
-    let using (resource : 'T when 'T :> System.IDisposable) action =
-        try action(resource)
-        finally match (box resource) with null -> () | _ -> resource.Dispose()
-
 module Experimental =
     /// Reads the name of an identifier, a property or a type
     let inline nameof(expr: 'a): string = jsNative

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -1358,6 +1358,7 @@ let operators (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr o
     |  "LazyPattern"     // (|Lazy|_|)
     |  "Lock"            // lock
     |  "NullArg"         // nullArg
+    |  "Using"           // using
        ), _ -> fsharpModule com ctx r t i thisArg args
     // Exceptions
     | "FailWith", [msg] | "InvalidOp", [msg] ->

--- a/src/fable-library/FSharp.Core.fs
+++ b/src/fable-library/FSharp.Core.fs
@@ -28,6 +28,11 @@ module Operators =
     [<CompiledName("NullArg")>]
     let nullArg x = raise(System.ArgumentNullException(x))
 
+    [<CompiledName("Using")>]
+    let using (resource : 'T when 'T :> System.IDisposable) (action: 'T -> 'a) =
+        try action(resource)
+        finally match (box resource) with null -> () | _ -> resource.Dispose()
+
     [<CompiledName("Lock")>]
     let lock _lockObj action = action() // no locking, just invoke
 

--- a/tests/Main/ComparisonTests.fs
+++ b/tests/Main/ComparisonTests.fs
@@ -373,6 +373,21 @@ let tests =
             false
         |> equal false
 
+    testCase "using function disposes the resource when action finishes" <| fun () ->
+        let mutable disposed = false
+        let resource = { new IDisposable with member __.Dispose() = disposed <- true }
+        using resource (fun _resource -> ())
+        equal disposed true
+
+    testCase "using function disposes the resource when action fails" <| fun () ->
+        let mutable disposed = false
+        let resource = { new IDisposable with member __.Dispose() = disposed <- true }
+        try
+            using resource (fun _resource -> failwith "action failed")
+        with
+        | _ -> () // ignore
+        equal disposed true
+
     testCase "isNull with primitives works" <| fun () ->
         isNull null |> equal true
         isNull "" |> equal false


### PR DESCRIPTION
I was trying to make hedgehog library fable friendly and I found out that the using function is missing in fable.

I copied the implementation from FSharp.Core and added it to Fable.Core.Utils.

Hope this is OK.