### PR TITLE
Several fixes

### DIFF
--- a/src/Fable.Core/Fable.Core.JsInterop.fs
+++ b/src/Fable.Core/Fable.Core.JsInterop.fs
@@ -82,7 +82,7 @@ let importSideEffects (path: string): unit = jsNative
 let importDynamic<'T> (path: string): JS.Promise<'T> = jsNative
 
 /// Imports a reference from an external file dynamically at runtime
-/// ATENTION: Needs fable-compiler 2.3, pass the reference directly in argument position (avoid pipes)
+/// ATTENTION: Needs fable-compiler 2.3, pass the reference directly in argument position (avoid pipes)
 let importValueDynamic (x: 'T): JS.Promise<'T> = jsNative
 
 /// Used when you need to send an F# record to a JS library accepting only plain JS objects (POJOs)

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -123,7 +123,7 @@ module Util =
         StringLiteral s :> Expression
 
     let memberFromName memberName: Expression * bool =
-        if Naming.hasIdentForbiddenChars memberName
+        if Naming.hasIdentForbiddenChars Naming.isIdentChar memberName
         then upcast StringLiteral(memberName), true
         else upcast Identifier(memberName), false
 
@@ -1627,7 +1627,7 @@ module Util =
                     :> ModuleDeclaration |> U2.Case2 |> Some))
         |> Seq.toList
 
-    let getLocalIdent (ctx: Context) (imports: Dictionary<string,Import>) (path: string) (selector: string) =
+    let getLocalIdentForImport (ctx: Context) (imports: Dictionary<string,Import>) (path: string) (selector: string) =
         match selector with
         | "" -> None
         | "*" | "default" ->
@@ -1635,9 +1635,15 @@ module Util =
             x.Substring(x.LastIndexOf '/' + 1) |> Some
         | selector -> Some selector
         |> Option.map (fun selector ->
-            (selector, Naming.NoMemberPart) ||> Naming.sanitizeIdent (fun s ->
-            ctx.File.UsedVarNames.Contains s
-                || (imports.Values |> Seq.exists (fun i -> i.LocalIdent = Some s))))
+            // Imported members will contain the dollar sign as Fable uses it for mangling
+            // so allow it in the local identifier to prevent re-mangling
+            Naming.sanitizeIdentWith
+                (fun idx char -> Naming.isIdentChar idx char || char = '$')
+                (fun s ->
+                    ctx.File.UsedVarNames.Contains s
+                    || (imports.Values |> Seq.exists (fun i -> i.LocalIdent = Some s)))
+                selector
+                Naming.NoMemberPart)
 
 module Compiler =
     open Util
@@ -1658,7 +1664,7 @@ module Compiler =
                     | Some localIdent -> upcast Identifier(localIdent)
                     | None -> upcast NullLiteral ()
                 | false, _ ->
-                    let localId = getLocalIdent ctx imports path selector
+                    let localId = getLocalIdentForImport ctx imports path selector
                     let i =
                       { Selector =
                             if selector = Naming.placeholder
@@ -1688,7 +1694,7 @@ module Compiler =
             member __.AddLog(msg, severity, ?range, ?fileName:string, ?tag: string) =
                 com.AddLog(msg, severity, ?range=range, ?fileName=fileName, ?tag=tag)
 
-    let makeCompiler com = new BabelCompiler(com)
+    let makeCompiler com = BabelCompiler(com)
 
     let createFacade (sourceFiles: string[]) (facadeFile: string) =
         // Remove signature files so fable-splitter doesn't try to compile them

--- a/src/quicktest/QuickTest.fs
+++ b/src/quicktest/QuickTest.fs
@@ -2,7 +2,7 @@ module QuickTest
 
 // Run `npm run build quicktest` and then add tests to this file,
 // when you save they will be run automatically with latest changes in compiler and fable-library.
-// When everything works, move the tests to the appropiate file in tests/Main.
+// When everything works, move the tests to the appropriate file in tests/Main.
 // You can check the compiled JS in the "bin" folder within this directory.
 // Please don't add this file to your commits.
 

--- a/tests/Main/DateTimeOffsetTests.fs
+++ b/tests/Main/DateTimeOffsetTests.fs
@@ -37,9 +37,9 @@ let tests =
         |> equal "2014-09-11T16:37:02.000+00:00"
 
     testCase "DateTimeOffset from Year 1 to 99 works" <| fun () ->
-        let date = DateTimeOffset(1, 1, 1, 0, 0, 0, TimeSpan.Zero)
+        let date = DateTimeOffset(1, 1, 2, 0, 0, 0, TimeSpan.Zero)
         date.Year |> equal 1
-        let date = DateTimeOffset(99, 1, 1, 0, 0, 0, TimeSpan.Zero)
+        let date = DateTimeOffset(99, 1, 2, 0, 0, 0, TimeSpan.Zero)
         date.Year |> equal 99
 
     // TODO: These two tests give different values for .NET and JS because DateTimeOffset

--- a/tests/Main/DateTimeTests.fs
+++ b/tests/Main/DateTimeTests.fs
@@ -45,15 +45,15 @@ let tests =
     //     |> equal "2014-09-11T16:37:02.000+02:00" // Here the time zone is Europte/Paris (GMT+2)
 
     testCase "DateTime from Year 1 to 99 works" <| fun () ->
-        let date = DateTime(1, 1, 1)
+        let date = DateTime(1, 1, 2)
         date.Year |> equal 1
-        let date = DateTime(99, 1, 1)
+        let date = DateTime(99, 1, 2)
         date.Year |> equal 99
 
     testCase "DateTime UTC from Year 1 to 99 works" <| fun () ->
-        let date = DateTime(1, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        let date = DateTime(1, 1, 2, 0, 0, 0, DateTimeKind.Utc)
         date.Year |> equal 1
-        let date = DateTime(99, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        let date = DateTime(99, 1, 2, 0, 0, 0, DateTimeKind.Utc)
         date.Year |> equal 99
 
     // TODO: These two tests give different values for .NET and JS because DateTime

--- a/tests/Main/JsInteropTests.fs
+++ b/tests/Main/JsInteropTests.fs
@@ -9,6 +9,9 @@ open Fable.Core.JsInterop
 open Fable.Core.DynamicExtensions
 open Fable.Core.Experimental
 
+let inline getNameofLambda (f: 'T->'U) =
+    nameofLambda f
+
 [<Global>]
 module GlobalModule =
     [<Emit("var GlobalModule = { add(x, y) { return x + y }, foo: 'bar' }")>]
@@ -306,6 +309,9 @@ let tests =
     testCase "nameofLambda works" <| fun () ->
         nameofLambda(fun (x:Record) -> x.String) |> equal "String"
         nameofLambda(fun (x:Record) -> x.Int) |> equal "Int"
+
+    testCase "nameofLambda works in inlined functions" <| fun () ->
+        getNameofLambda (fun (x:Record) -> x.String) |> equal "String"
 
     testCase "StringEnum attribute works" <| fun () ->
         Vertical |> unbox |> equal "vertical"


### PR DESCRIPTION
**EDIT** I've removed the second commit as it seems to cause problems with fable standalone.

This fixes some issues I've been finding recently in my projects:

- `Fable.Core.Experimental.nameofLambda` didn't work in inlined functions
- ~~Local import expressions (except for `importMember`) were failing when written as a function. See "Local import with curried signatures works" in JsInteropTests.~~
- Because Fable adds a hash to class members to tell overloads apart, when the hash changes (e.g. when changing the number or type of the arguments) the files calling this member don't get recompiled by Webpack and we get warnings (see screenshot below). Now calls to such members add to the `InlineDependencies` so fable-loader recompiles the dependent files (as with inline functions).
- Don't re-mangle imported members that use the dollar sign (also see screenshot).


<img width="939" alt="screenshot" src="https://user-images.githubusercontent.com/8275461/80451536-1080db00-895f-11ea-8beb-ed5607361b0d.png">
