### PR TITLE
Fix local imports

### DIFF
--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -819,10 +819,10 @@ module Util =
     let transformBindingExprBody (com: IBabelCompiler) ctx (var: Fable.Ident) (value: Fable.Expr) =
         match value with
         // Check imports with name placeholder
-        | Fable.Import((Fable.Value(Fable.StringConstant Naming.placeholder,_)), path, kind, _, r) ->
-            transformImport com ctx r (makeStrConst var.Name) path kind
-        | Fable.Function(_,Fable.Import((Fable.Value(Fable.StringConstant Naming.placeholder,_)), path, kind, _, r),_) ->
-            transformImport com ctx r (makeStrConst var.Name) path kind
+        | Fable.Import((Fable.Value(Fable.StringConstant selector,_)), path, kind, _, r)
+        | Fable.Function(_,Fable.Import((Fable.Value(Fable.StringConstant selector,_)), path, kind, _, r),_) ->
+            let selector = if selector = Naming.placeholder then var.Name else selector
+            transformImport com ctx r (makeStrConst selector) path kind
         | Fable.Function(args, body, _) ->
             let args =
                 match args with

--- a/tests/Main/JsInteropTests.fs
+++ b/tests/Main/JsInteropTests.fs
@@ -331,6 +331,8 @@ let tests =
     testCase "Local import with curried signatures works" <| fun () ->
         let add (x:int) (y:int): int = importMember "./js/1foo.js"
         3 |> add 2 |> equal 5
+        let add2 (x:int) (y:int): int = import "add" "./js/1foo.js"
+        3 |> add2 2 |> equal 5
 
     testCase "TypedArray element can be set and get using index" <| fun () ->
         let arr = JS.Uint8Array.Create(5)


### PR DESCRIPTION
Local import expressions (except for importMember) were failing when written as a function. See "Local import with curried signatures works" in JsInteropTests.

> The fix seems to cause an issue with fable-standalone or fable-compiler-js. Investigating.