### PR TITLE
[Not working] Prototype implementation for support TypeScript with fable-splitter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -968,9 +968,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.11.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.11.1.tgz",
-      "integrity": "sha512-eWQGP3qtxwL8FGneRrC5DwrJLGN4/dH1clNTuLfN81HCrxVtxRjygDTUoZJ5ASlDEeo0ppYFQjQIlXhtXpOn6g=="
+      "version": "13.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.2.tgz",
+      "integrity": "sha512-LB2R1Oyhpg8gu4SON/mfforE525+Hi/M1ineICEDftqNVTyFg1aRIeGuTvXAoWHc4nbrFncWtJgMmoyRvuGh7A=="
     },
     "@webassemblyjs/ast": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.9.0",
     "@babel/preset-env": "^7.9.0",
     "@babel/register": "^7.9.0",
-    "@types/node": "^13.11.1",
+    "@types/node": "^13.13.2",
     "babel-loader": "^8.1.0",
     "concurrently": "^5.1.0",
     "download-cli": "^1.1.1",

--- a/src/Fable.Cli/Agent.fs
+++ b/src/Fable.Cli/Agent.fs
@@ -133,7 +133,7 @@ let createProject (msg: Parser.Message) projFile (prevProject: ProjectExtra opti
             else proj
     | None ->
         let projectOptions, fableLibraryDir =
-            getFullProjectOpts msg.define msg.rootDir projFile
+            getFullProjectOpts msg.define msg.rootDir msg.typescript projFile
         Log.verbose(lazy
             let proj = getRelativePath projectOptions.ProjectFileName
             let opts = projectOptions.OtherOptions |> String.concat "\n   "

--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -114,6 +114,12 @@ let setGlobalParams(args: string[]) =
         | Some _, _ -> Verbosity.Verbose
         | None, Some _ -> Verbosity.Silent
         | None, None -> Verbosity.Normal
+
+    let isTypeScript =
+        match tryFindArgValue "--typescript" args with
+        | Some _ -> true
+        | None -> false
+
     GlobalParams.Singleton.SetValues(
         verbosity = verbosity,
         forcePkgs = (tryFindArgValue "--force-pkgs" args |> Option.isSome),

--- a/src/Fable.Cli/Parser.fs
+++ b/src/Fable.Cli/Parser.fs
@@ -11,6 +11,7 @@ type Message =
       define: string[]
       typedArrays: bool
       clampByteArrays: bool
+      typescript : bool
       extra: IDictionary<string,string> }
 
 let private parseStringArray (def: string[]) (key: string) (o: JObject)  =
@@ -53,7 +54,7 @@ let private parseDic (key: string) (o: JObject): IDictionary<string,string> =
 let toCompilerOptions (msg: Message): CompilerOptions =
     { typedArrays = msg.typedArrays
       clampByteArrays = msg.clampByteArrays
-      typeDecls = msg.extra.ContainsKey("typescript")
+      typeDecls = msg.typescript
       debugMode = Array.contains "DEBUG" msg.define
       verbosity = GlobalParams.Singleton.Verbosity
       outputPublicInlinedFunctions = Array.contains "FABLE_REPL_LIB" msg.define
@@ -74,4 +75,5 @@ let parse (msg: string) =
         |> Array.distinct
       typedArrays = parseBoolean true "typedArrays" json
       clampByteArrays = parseBoolean false "clampByteArrays" json
+      typescript = parseBoolean false "typescript" json
       extra = parseDic "extra" json }

--- a/src/Fable.Cli/Util.fs
+++ b/src/Fable.Cli/Util.fs
@@ -80,8 +80,8 @@ type GlobalParams private (verbosity, forcePkgs, fableLibraryPath, workingDir) =
               |> Path.GetDirectoryName
             let defaultFableLibraryPaths =
                 [ "../fable-library"                         // running from npm package
-                  "../../fable-library/"                     // running from nuget package
-                  "../../../../../build/fable-library/" ] // running from bin/Release/netcoreapp2.0
+                  "../../fable-library"                     // running from nuget package
+                  "../../../../../build/fable-library" ] // running from development release located at bin/Release/netcoreapp2.0
                 |> List.map (fun x -> Path.GetFullPath(Path.Combine(execDir, x)))
             let fableLibraryPath =
                 defaultFableLibraryPaths
@@ -93,7 +93,18 @@ type GlobalParams private (verbosity, forcePkgs, fableLibraryPath, workingDir) =
 
     member __.Verbosity: Fable.Verbosity = _verbosity
     member __.ForcePkgs: bool = _forcePkgs
-    member __.FableLibraryPath: string = _fableLibraryPath
+    member __.FableLibraryPath (isTypeScript : bool) : string =
+        // Check if FableLibrary is at the root level
+        // This check is needed when fable-library itself, because the path to import it then is "/" or "${outDir}" when working with fable-splitter
+        // I don't think this check is needed for a normal project
+        let trimed = _fableLibraryPath.Replace('\\', '/').Trim('/')
+        if trimed = "force:${outDir}" || trimed = "${outDir}" || trimed = "" then
+            _fableLibraryPath
+        else
+            if isTypeScript then
+                _fableLibraryPath.TrimEnd('/') + "-ts"
+            else
+                _fableLibraryPath.TrimEnd('/') + "-js"
     member __.WorkingDir: string = _workingDir
     member __.ReplaceFiles = _replaceFiles
     member __.Experimental = _experimental

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -2014,7 +2014,13 @@ module Compiler =
                 let sanitizedPath =
                     match kind with
                     | Fable.CustomImport | Fable.Internal -> path
-                    | Fable.Library -> com.LibraryDir + "/" + path + Naming.targetFileExtension
+                    | Fable.Library ->
+                        let extension =
+                            if com.Options.typeDecls then
+                                Naming.typeScriptFileExtension
+                            else
+                                Naming.javaScriptFileExtension
+                        com.LibraryDir + "/" + path + extension
                 let cachedName = sanitizedPath + "::" + selector
                 match imports.TryGetValue(cachedName) with
                 | true, i ->

--- a/src/Fable.Transforms/Global/Prelude.fs
+++ b/src/Fable.Transforms/Global/Prelude.fs
@@ -126,7 +126,8 @@ module Naming =
 
     /// This used to be "" for compatibility with Require.js
     /// Mainly used for fable-library imports
-    let targetFileExtension = ".js"
+    let javaScriptFileExtension = ".js"
+    let typeScriptFileExtension = ""
 
     let [<Literal>] fableCompilerConstant = "FABLE_COMPILER"
     let [<Literal>] placeholder = "__PLACE-HOLDER__"

--- a/src/fable-compiler/package-lock.json
+++ b/src/fable-compiler/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@types/node": {
-      "version": "10.12.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.8.tgz",
-      "integrity": "sha512-INamyRZG4rW3lDCUmwVd5Xho/bXvQm/v1yP8V0UN1RuInU7RoWoaO570b+yLX4Ia/0szsx1wa8VzcsVlsvbWLA==",
+      "version": "13.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.2.tgz",
+      "integrity": "sha512-LB2R1Oyhpg8gu4SON/mfforE525+Hi/M1ineICEDftqNVTyFg1aRIeGuTvXAoWHc4nbrFncWtJgMmoyRvuGh7A==",
       "dev": true
     }
   }

--- a/src/fable-compiler/package.json
+++ b/src/fable-compiler/package.json
@@ -19,6 +19,6 @@
   },
   "homepage": "https://github.com/fable-compiler/Fable#readme",
   "devDependencies": {
-    "@types/node": "^10.12.8"
+    "@types/node": "^13.13.2"
   }
 }

--- a/src/fable-library/splitter.config.js
+++ b/src/fable-library/splitter.config.js
@@ -15,7 +15,7 @@ const fableOptions = {
 
 const outDir = useCommonjs
   ? "../../build/fable-library-commonjs"
-  : "../../build/fable-library";
+  : "../../build/fable-library-js";
 
 module.exports = {
   cli: {

--- a/src/fable-library/tsconfig.json
+++ b/src/fable-library/tsconfig.json
@@ -4,7 +4,7 @@
   ],
   "compilerOptions": {
     /* Basic Options */
-    "outDir": "../../build/fable-library",    /* Redirect output structure to the directory. */
+    "outDir": "../../build/fable-library-js",    /* Redirect output structure to the directory. */
     "target": "es2015",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
     "module": "es2015",                       /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "allowJs": true,                          /* Allow javascript files to be compiled. */

--- a/src/fable-splitter/package-lock.json
+++ b/src/fable-splitter/package-lock.json
@@ -292,6 +292,15 @@
         "@babel/plugin-syntax-async-generators": "^7.8.0"
       }
     },
+    "@babel/plugin-proposal-export-default-from": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.8.3.tgz",
+      "integrity": "sha512-PYtv2S2OdCdp7GSPDg5ndGZFm9DmWFvuLoS5nBxZCgOBggluLnhTScspJxng96alHQzPyrrHxvC9/w4bFuspeA==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-export-default-from": "^7.8.3"
+      }
+    },
     "@babel/plugin-proposal-object-rest-spread": {
       "version": "7.9.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.9.5.tgz",
@@ -320,6 +329,14 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-export-default-from": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.8.3.tgz",
+      "integrity": "sha512-a1qnnsr73KLNIQcQlcQ4ZHxqqfBKM6iNQZW2OMTyxNbA2WC7SHWHtGVpFzWtQAuS2pspkWVzdEBXXx8Ik0Za4w==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
     "@babel/plugin-syntax-object-rest-spread": {
@@ -470,9 +487,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.11.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.11.1.tgz",
-      "integrity": "sha512-eWQGP3qtxwL8FGneRrC5DwrJLGN4/dH1clNTuLfN81HCrxVtxRjygDTUoZJ5ASlDEeo0ppYFQjQIlXhtXpOn6g==",
+      "version": "13.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.2.tgz",
+      "integrity": "sha512-LB2R1Oyhpg8gu4SON/mfforE525+Hi/M1ineICEDftqNVTyFg1aRIeGuTvXAoWHc4nbrFncWtJgMmoyRvuGh7A==",
       "dev": true
     },
     "ansi-align": {
@@ -4417,6 +4434,11 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
       "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
       "dev": true
+    },
+    "typescript": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w=="
     },
     "uid2": {
       "version": "0.0.3",

--- a/src/fable-splitter/package.json
+++ b/src/fable-splitter/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@types/fs-extra": "^5.0.4",
-    "@types/node": "^13.11.1",
+    "@types/node": "^13.13.2",
     "ava": "^1.4.1",
     "shelljs": "^0.8.3"
   }

--- a/src/fable-splitter/src/cli.ts
+++ b/src/fable-splitter/src/cli.ts
@@ -2,7 +2,7 @@
 
 import * as fs from "fs";
 import * as path from "path";
-import fableSplitter, { CompilationInfo } from "./index";
+import fableSplitter, { CompilationInfo, FableSplitterOptions } from "./index";
 import runScript from "./run";
 
 const chokidarLazy = requireLazy("chokidar");
@@ -173,7 +173,7 @@ function onCompiled(args: string[], opts: any, info: CompilationInfo, mustFinish
 function run(entry, args) {
     const cfgFile = findArgValue(args, ["-c", "--config"]);
 
-    const opts = cfgFile
+    const opts : FableSplitterOptions = cfgFile
         ? readConfig(cfgFile, true)
         : (readConfig("fable-splitter.config.js") || readConfig("splitter.config.js") || {});
 
@@ -189,6 +189,12 @@ function run(entry, args) {
     if (findFlag(args, ["-d", "--debug"])) {
         const fableOpts = opts.fable || {};
         fableOpts.define = concatSafe(fableOpts.define, "DEBUG");
+        opts.fable = fableOpts;
+    }
+
+    if (findFlag(args, "--typescript")) {
+        const fableOpts = opts.fable || {};
+        fableOpts.typescript = true;
         opts.fable = fableOpts;
     }
 


### PR DESCRIPTION
The implementation doesn't work yet because we need a way to handle the TS imports.

Indeed, when detecting an import of an existing TypeScript file we should copy the TS file without passing via Babel and also detect all the import/require from that file to copy with and so on.

I think we need a different toolchain when handling JavaScript or TypeScript generation.

@ncave Any idea, how to get the TypeScript imports? One solution I had is to use the TypeScript compiler in order to get the AST but getting the imports list from it doesn't seem to be easy.

The idea is to remove the `fable-library` folder and have `fable-library-js` and `fable-library-ts` and Fable choose which folder to use depending on the target.