### PR TITLE
Resoved conflicts

### DIFF
--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -105,16 +105,16 @@ module Helpers =
         ||> Naming.sanitizeIdent (fun _ -> false)
 
     let getModuleReflectionName (com: ICompiler) (ent : FSharpEntity) =
-        if ent.IsFSharpModule then 
-            let name = 
+        if ent.IsFSharpModule then
+            let name =
                 (getEntityMangledName com true ent, Naming.NoMemberPart)
                 ||> Naming.sanitizeIdent (fun _ -> false)
-            if name = "" then 
+            if name = "" then
                 Some ""
-            else            
+            else
                 Some name
         else
-            None        
+            None
 
     let isUnit (typ: FSharpType) =
         let typ = nonAbbreviatedType typ
@@ -156,6 +156,7 @@ module Helpers =
             | Naming.StaticMemberPart(_, overloadSuffix) ->
                 String.IsNullOrEmpty(overloadSuffix) |> not
             | Naming.NoMemberPart -> false
+            | Naming.ReflectionMemberPart -> false
         sanitizedName, hasOverloadSuffix
 
     /// Used to identify members uniquely in the inline expressions dictionary

--- a/src/Fable.Transforms/FSharp2Fable.fs
+++ b/src/Fable.Transforms/FSharp2Fable.fs
@@ -331,8 +331,8 @@ let private transformAttribute (com: IFableCompiler) (ctx : Context) (a : FSharp
                     | :? float as v -> Fable.Value(Fable.NumberConstant(v, NumberKind.Float64), None)
                     | _ -> Fable.Value(Fable.StringConstant (string v), None)
                 )
-            
-            
+
+
             let typ = makeTypeFromDef com ctx.GenericArgs (System.Collections.Generic.List() :> IList<_>) a.AttributeType
             try
                 let x = makeCallFrom com ctx None typ false [] None args ctor
@@ -340,10 +340,10 @@ let private transformAttribute (com: IFableCompiler) (ctx : Context) (a : FSharp
                 | AST.Fable.Value(AST.Fable.Null AST.Fable.Any, None) ->
                     com.RemoveLastError()
                     None
-                | _ ->                
+                | _ ->
                     Some (fullname,x)
             with _ ->
-                None                   
+                None
         | _ ->
             None
     | _ ->
@@ -485,7 +485,8 @@ let private transformMemberInfo (com: IFableCompiler) ctx (m : FSharpMemberOrFun
                             Fable.Args = args
                             Fable.SignatureArgTypes = Fable.SignatureKind.NoUncurrying
                             Fable.Spread = Fable.SpreadKind.NoSpread
-                            Fable.IsBaseOrSelfConstructorCall = false
+                            Fable.IsBaseCall = false
+                            Fable.IsSelfConstructorCall = false
                         }
 
                     staticCall None decl info (makeValueFrom com ctx None m)
@@ -1613,7 +1614,7 @@ type FableCompiler(com: ICompiler, implFiles: IDictionary<string, FSharpImplemen
         member __.AddLog(msg, severity, ?range, ?fileName:string, ?tag: string) =
             com.AddLog(msg, severity, ?range=range, ?fileName=fileName, ?tag=tag)
 
-        member __.RemoveLastError() = 
+        member __.RemoveLastError() =
             com.RemoveLastError()
 
 let getRootModuleFullName (file: FSharpImplementationFileContents) =

--- a/src/fable-standalone/src/Main.fs
+++ b/src/fable-standalone/src/Main.fs
@@ -230,6 +230,7 @@ let makeCompilerOptions (config: CompilerConfig option) (otherFSharpOptions: str
       debugMode = isDebug
       verbosity = Fable.Verbosity.Normal
       outputPublicInlinedFunctions = false
+      quotations = false
       precompiledLib = config.precompiledLib }
 
 let compileAst (com: Compiler) (project: Project) =

--- a/tests/Main/ReflectionTests.fs
+++ b/tests/Main/ReflectionTests.fs
@@ -517,13 +517,13 @@ type MyRecord20 =
     { FieldA: int
       FieldB: string }
 
-type MyClass<'a>(value : 'a) =
+type MyClass3<'a>(value : 'a) =
   static member GetValue<'b>(a : 'a, b : 'b) = (a,b)
   member x.Value : 'a = value
 
 let fableTests = [
     testCase "Generic static method can be instantiated and invoked" <| fun () ->
-      let tm = typedefof<MyClass<_>>.MakeGenericType [| typeof<int> |]
+      let tm = typedefof<MyClass3<_>>.MakeGenericType [| typeof<int> |]
       let meth = tm.GetMethod("GetValue")
       let m = meth.MakeGenericMethod [| typeof<float> |]
       let pars = m.GetParameters() |> Array.map (fun p -> p.ParameterType, p.Name)
@@ -535,10 +535,10 @@ let fableTests = [
 
 
     testCase "Property can be read" <| fun () ->
-      let tm = typedefof<MyClass<_>>.MakeGenericType [| typeof<int> |]
+      let tm = typedefof<MyClass3<_>>.MakeGenericType [| typeof<int> |]
       let prop = tm.GetProperty("Value")
-      let v1 = prop.GetMethod.Invoke(MyClass(1), null) |> unbox<int>
-      let v2 = prop.GetValue(MyClass(1)) |> unbox<int>
+      let v1 = prop.GetMethod.Invoke(MyClass3(1), null) |> unbox<int>
+      let v2 = prop.GetValue(MyClass3(1)) |> unbox<int>
       v1 |> equal 1
       v2 |> equal 1
 


### PR DESCRIPTION
@alfonsogarciacaro I resolved what I could, without knowing much about the original PR.
It compiles, but reflection tags are probably wrong, since some don't exist anymore, you'll see when you run the tests. For example, this is probably not valid anymore:

Fable2Babel.fs, line 800:
```fs
        | Fable.Any -> primitiveTypeInfo "obj"
```