### PR TITLE
API for fable-splitter in cli mode

### DIFF
--- a/src/fable-splitter/RELEASE_NOTES.md
+++ b/src/fable-splitter/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### 2.2.0
+
+* Add API for cli mode
+
 ### 2.1.14
 
 * Add --runInspect flag instead of checking debug mode

--- a/src/fable-splitter/package-lock.json
+++ b/src/fable-splitter/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fable-splitter",
-  "version": "2.1.14",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -50,23 +50,24 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
       "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+      "dev": true,
       "requires": {
         "@babel/highlight": "^7.8.3"
       }
     },
     "@babel/core": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
-      "integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
+      "version": "7.10.2",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.2.tgz",
+      "integrity": "sha512-KQmV9yguEjQsXqyOUGKjS4+3K8/DlOCE2pZcq4augdQmtTy5iv5EHtmMSJ7V4c1BIPjuwtZYqYLCq9Ga+hGBRQ==",
       "requires": {
-        "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.9.0",
-        "@babel/helper-module-transforms": "^7.9.0",
-        "@babel/helpers": "^7.9.0",
-        "@babel/parser": "^7.9.0",
-        "@babel/template": "^7.8.6",
-        "@babel/traverse": "^7.9.0",
-        "@babel/types": "^7.9.0",
+        "@babel/code-frame": "^7.10.1",
+        "@babel/generator": "^7.10.2",
+        "@babel/helper-module-transforms": "^7.10.1",
+        "@babel/helpers": "^7.10.1",
+        "@babel/parser": "^7.10.2",
+        "@babel/template": "^7.10.1",
+        "@babel/traverse": "^7.10.1",
+        "@babel/types": "^7.10.2",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
@@ -75,12 +76,116 @@
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
+          "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+          "requires": {
+            "@babel/highlight": "^7.10.1"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.2.tgz",
+          "integrity": "sha512-AxfBNHNu99DTMvlUPlt1h2+Hn7knPpH5ayJ8OqDWSeLld+Fi2AYBTC/IejWDM9Edcii4UzZRCsbUt0WlSDsDsA==",
+          "requires": {
+            "@babel/types": "^7.10.2",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.1.tgz",
+          "integrity": "sha512-fcpumwhs3YyZ/ttd5Rz0xn0TpIwVkN7X0V38B9TWNfVF42KEkhkAAuPCQ3oXmtTRtiPJrmZ0TrfS0GKF0eMaRQ==",
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.10.1",
+            "@babel/template": "^7.10.1",
+            "@babel/types": "^7.10.1"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz",
+          "integrity": "sha512-F5qdXkYGOQUb0hpRaPoetF9AnsXknKjWMZ+wmsIRsp5ge5sFh4c3h1eH2pRTTuy9KKAA2+TTYomGXAtEL2fQEw==",
+          "requires": {
+            "@babel/types": "^7.10.1"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
+          "integrity": "sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==",
+          "requires": {
+            "@babel/types": "^7.10.1"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
+          "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw=="
+        },
+        "@babel/highlight": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
+          "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.1",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.2.tgz",
+          "integrity": "sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ=="
+        },
+        "@babel/template": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
+          "integrity": "sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==",
+          "requires": {
+            "@babel/code-frame": "^7.10.1",
+            "@babel/parser": "^7.10.1",
+            "@babel/types": "^7.10.1"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.1.tgz",
+          "integrity": "sha512-C/cTuXeKt85K+p08jN6vMDz8vSV0vZcI0wmQ36o6mjbuo++kPMdpOYw23W2XH04dbRt9/nMEfA4W3eR21CD+TQ==",
+          "requires": {
+            "@babel/code-frame": "^7.10.1",
+            "@babel/generator": "^7.10.1",
+            "@babel/helper-function-name": "^7.10.1",
+            "@babel/helper-split-export-declaration": "^7.10.1",
+            "@babel/parser": "^7.10.1",
+            "@babel/types": "^7.10.1",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/types": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
+          "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.1",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/generator": {
       "version": "7.9.5",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.5.tgz",
       "integrity": "sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.9.5",
         "jsesc": "^2.5.1",
@@ -132,6 +237,7 @@
       "version": "7.9.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
       "integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
+      "dev": true,
       "requires": {
         "@babel/helper-get-function-arity": "^7.8.3",
         "@babel/template": "^7.8.3",
@@ -142,52 +248,155 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
       "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.8.3"
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
-      "integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.1.tgz",
+      "integrity": "sha512-u7XLXeM2n50gb6PWJ9hoO5oO7JFPaZtrh35t8RqKLT1jFKj9IWeD1zrcrYp1q1qiZTdEarfDWfTIP8nGsu0h5g==",
       "requires": {
-        "@babel/types": "^7.8.3"
+        "@babel/types": "^7.10.1"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
+          "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw=="
+        },
+        "@babel/types": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
+          "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.1",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-module-imports": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
       "integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.8.3"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
-      "integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.1.tgz",
+      "integrity": "sha512-RLHRCAzyJe7Q7sF4oy2cB+kRnU4wDZY/H2xJFGof+M+SJEGhZsb+GFj5j1AD8NiSaVBJ+Pf0/WObiXu/zxWpFg==",
       "requires": {
-        "@babel/helper-module-imports": "^7.8.3",
-        "@babel/helper-replace-supers": "^7.8.6",
-        "@babel/helper-simple-access": "^7.8.3",
-        "@babel/helper-split-export-declaration": "^7.8.3",
-        "@babel/template": "^7.8.6",
-        "@babel/types": "^7.9.0",
+        "@babel/helper-module-imports": "^7.10.1",
+        "@babel/helper-replace-supers": "^7.10.1",
+        "@babel/helper-simple-access": "^7.10.1",
+        "@babel/helper-split-export-declaration": "^7.10.1",
+        "@babel/template": "^7.10.1",
+        "@babel/types": "^7.10.1",
         "lodash": "^4.17.13"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
+          "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+          "requires": {
+            "@babel/highlight": "^7.10.1"
+          }
+        },
+        "@babel/helper-module-imports": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.1.tgz",
+          "integrity": "sha512-SFxgwYmZ3HZPyZwJRiVNLRHWuW2OgE5k2nrVs6D9Iv4PPnXVffuEHy83Sfx/l4SqF+5kyJXjAyUmrG7tNm+qVg==",
+          "requires": {
+            "@babel/types": "^7.10.1"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
+          "integrity": "sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==",
+          "requires": {
+            "@babel/types": "^7.10.1"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
+          "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw=="
+        },
+        "@babel/highlight": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
+          "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.1",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.2.tgz",
+          "integrity": "sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ=="
+        },
+        "@babel/template": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
+          "integrity": "sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==",
+          "requires": {
+            "@babel/code-frame": "^7.10.1",
+            "@babel/parser": "^7.10.1",
+            "@babel/types": "^7.10.1"
+          }
+        },
+        "@babel/types": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
+          "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.1",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-optimise-call-expression": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
-      "integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.1.tgz",
+      "integrity": "sha512-a0DjNS1prnBsoKx83dP2falChcs7p3i8VMzdrSbfLhuQra/2ENC4sbri34dz/rWmDADsmF1q5GbfaXydh0Jbjg==",
       "requires": {
-        "@babel/types": "^7.8.3"
+        "@babel/types": "^7.10.1"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
+          "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw=="
+        },
+        "@babel/types": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
+          "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.1",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-plugin-utils": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-      "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
+      "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
+      "dev": true
     },
     "@babel/helper-regex": {
       "version": "7.8.3",
@@ -212,29 +421,183 @@
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.8.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
-      "integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.1.tgz",
+      "integrity": "sha512-SOwJzEfpuQwInzzQJGjGaiG578UYmyi2Xw668klPWV5n07B73S0a9btjLk/52Mlcxa+5AdIYqws1KyXRfMoB7A==",
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.8.3",
-        "@babel/helper-optimise-call-expression": "^7.8.3",
-        "@babel/traverse": "^7.8.6",
-        "@babel/types": "^7.8.6"
+        "@babel/helper-member-expression-to-functions": "^7.10.1",
+        "@babel/helper-optimise-call-expression": "^7.10.1",
+        "@babel/traverse": "^7.10.1",
+        "@babel/types": "^7.10.1"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
+          "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+          "requires": {
+            "@babel/highlight": "^7.10.1"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.2.tgz",
+          "integrity": "sha512-AxfBNHNu99DTMvlUPlt1h2+Hn7knPpH5ayJ8OqDWSeLld+Fi2AYBTC/IejWDM9Edcii4UzZRCsbUt0WlSDsDsA==",
+          "requires": {
+            "@babel/types": "^7.10.2",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.1.tgz",
+          "integrity": "sha512-fcpumwhs3YyZ/ttd5Rz0xn0TpIwVkN7X0V38B9TWNfVF42KEkhkAAuPCQ3oXmtTRtiPJrmZ0TrfS0GKF0eMaRQ==",
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.10.1",
+            "@babel/template": "^7.10.1",
+            "@babel/types": "^7.10.1"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz",
+          "integrity": "sha512-F5qdXkYGOQUb0hpRaPoetF9AnsXknKjWMZ+wmsIRsp5ge5sFh4c3h1eH2pRTTuy9KKAA2+TTYomGXAtEL2fQEw==",
+          "requires": {
+            "@babel/types": "^7.10.1"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
+          "integrity": "sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==",
+          "requires": {
+            "@babel/types": "^7.10.1"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
+          "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw=="
+        },
+        "@babel/highlight": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
+          "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.1",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.2.tgz",
+          "integrity": "sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ=="
+        },
+        "@babel/template": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
+          "integrity": "sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==",
+          "requires": {
+            "@babel/code-frame": "^7.10.1",
+            "@babel/parser": "^7.10.1",
+            "@babel/types": "^7.10.1"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.1.tgz",
+          "integrity": "sha512-C/cTuXeKt85K+p08jN6vMDz8vSV0vZcI0wmQ36o6mjbuo++kPMdpOYw23W2XH04dbRt9/nMEfA4W3eR21CD+TQ==",
+          "requires": {
+            "@babel/code-frame": "^7.10.1",
+            "@babel/generator": "^7.10.1",
+            "@babel/helper-function-name": "^7.10.1",
+            "@babel/helper-split-export-declaration": "^7.10.1",
+            "@babel/parser": "^7.10.1",
+            "@babel/types": "^7.10.1",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/types": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
+          "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.1",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
-      "integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.1.tgz",
+      "integrity": "sha512-VSWpWzRzn9VtgMJBIWTZ+GP107kZdQ4YplJlCmIrjoLVSi/0upixezHCDG8kpPVTBJpKfxTH01wDhh+jS2zKbw==",
       "requires": {
-        "@babel/template": "^7.8.3",
-        "@babel/types": "^7.8.3"
+        "@babel/template": "^7.10.1",
+        "@babel/types": "^7.10.1"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
+          "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+          "requires": {
+            "@babel/highlight": "^7.10.1"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
+          "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw=="
+        },
+        "@babel/highlight": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
+          "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.1",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.2.tgz",
+          "integrity": "sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ=="
+        },
+        "@babel/template": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
+          "integrity": "sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==",
+          "requires": {
+            "@babel/code-frame": "^7.10.1",
+            "@babel/parser": "^7.10.1",
+            "@babel/types": "^7.10.1"
+          }
+        },
+        "@babel/types": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
+          "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.1",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-split-export-declaration": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
       "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.8.3"
       }
@@ -242,7 +605,8 @@
     "@babel/helper-validator-identifier": {
       "version": "7.9.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
-      "integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
+      "integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==",
+      "dev": true
     },
     "@babel/helper-wrap-function": {
       "version": "7.8.3",
@@ -257,19 +621,123 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.9.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.2.tgz",
-      "integrity": "sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==",
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.1.tgz",
+      "integrity": "sha512-muQNHF+IdU6wGgkaJyhhEmI54MOZBKsFfsXFhboz1ybwJ1Kl7IHlbm2a++4jwrmY5UYsgitt5lfqo1wMFcHmyw==",
       "requires": {
-        "@babel/template": "^7.8.3",
-        "@babel/traverse": "^7.9.0",
-        "@babel/types": "^7.9.0"
+        "@babel/template": "^7.10.1",
+        "@babel/traverse": "^7.10.1",
+        "@babel/types": "^7.10.1"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
+          "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+          "requires": {
+            "@babel/highlight": "^7.10.1"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.2.tgz",
+          "integrity": "sha512-AxfBNHNu99DTMvlUPlt1h2+Hn7knPpH5ayJ8OqDWSeLld+Fi2AYBTC/IejWDM9Edcii4UzZRCsbUt0WlSDsDsA==",
+          "requires": {
+            "@babel/types": "^7.10.2",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.1.tgz",
+          "integrity": "sha512-fcpumwhs3YyZ/ttd5Rz0xn0TpIwVkN7X0V38B9TWNfVF42KEkhkAAuPCQ3oXmtTRtiPJrmZ0TrfS0GKF0eMaRQ==",
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.10.1",
+            "@babel/template": "^7.10.1",
+            "@babel/types": "^7.10.1"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz",
+          "integrity": "sha512-F5qdXkYGOQUb0hpRaPoetF9AnsXknKjWMZ+wmsIRsp5ge5sFh4c3h1eH2pRTTuy9KKAA2+TTYomGXAtEL2fQEw==",
+          "requires": {
+            "@babel/types": "^7.10.1"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
+          "integrity": "sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==",
+          "requires": {
+            "@babel/types": "^7.10.1"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
+          "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw=="
+        },
+        "@babel/highlight": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
+          "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.1",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.2.tgz",
+          "integrity": "sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ=="
+        },
+        "@babel/template": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
+          "integrity": "sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==",
+          "requires": {
+            "@babel/code-frame": "^7.10.1",
+            "@babel/parser": "^7.10.1",
+            "@babel/types": "^7.10.1"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.1.tgz",
+          "integrity": "sha512-C/cTuXeKt85K+p08jN6vMDz8vSV0vZcI0wmQ36o6mjbuo++kPMdpOYw23W2XH04dbRt9/nMEfA4W3eR21CD+TQ==",
+          "requires": {
+            "@babel/code-frame": "^7.10.1",
+            "@babel/generator": "^7.10.1",
+            "@babel/helper-function-name": "^7.10.1",
+            "@babel/helper-split-export-declaration": "^7.10.1",
+            "@babel/parser": "^7.10.1",
+            "@babel/types": "^7.10.1",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/types": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
+          "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.1",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/highlight": {
       "version": "7.9.0",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
       "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
+      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.9.0",
         "chalk": "^2.0.0",
@@ -279,7 +747,8 @@
     "@babel/parser": {
       "version": "7.9.4",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
-      "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
+      "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==",
+      "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
       "version": "7.8.3",
@@ -372,14 +841,21 @@
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.9.0.tgz",
-      "integrity": "sha512-qzlCrLnKqio4SlgJ6FMMLBe4bySNis8DFn1VkGmOcxG9gqEyPIOzeQrA//u0HAKrWpJlpZbZMPB1n/OPa4+n8g==",
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.10.1.tgz",
+      "integrity": "sha512-AQG4fc3KOah0vdITwt7Gi6hD9BtQP/8bhem7OjbaMoRNCH5Djx42O2vYMfau7QnAzQCa+RJnhJBmFFMGpQEzrg==",
       "requires": {
-        "@babel/helper-module-transforms": "^7.9.0",
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/helper-simple-access": "^7.8.3",
-        "babel-plugin-dynamic-import-node": "^2.3.0"
+        "@babel/helper-module-transforms": "^7.10.1",
+        "@babel/helper-plugin-utils": "^7.10.1",
+        "@babel/helper-simple-access": "^7.10.1",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+          "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA=="
+        }
       }
     },
     "@babel/plugin-transform-parameters": {
@@ -396,6 +872,7 @@
       "version": "7.8.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
       "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
         "@babel/parser": "^7.8.6",
@@ -406,6 +883,7 @@
       "version": "7.9.5",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.5.tgz",
       "integrity": "sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
         "@babel/generator": "^7.9.5",
@@ -422,6 +900,7 @@
       "version": "7.9.5",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
       "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.9.5",
         "lodash": "^4.17.13",
@@ -709,9 +1188,9 @@
       }
     },
     "babel-plugin-dynamic-import-node": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
-      "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+      "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
       "requires": {
         "object.assign": "^4.1.0"
       }

--- a/src/fable-splitter/package.json
+++ b/src/fable-splitter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fable-splitter",
-  "version": "2.1.14",
+  "version": "2.2.0",
   "description": "File splitter for Fable (F# to JavaScript compiler)",
   "author": "ncave",
   "license": "Apache-2.0",

--- a/src/fable-splitter/src/cli.ts
+++ b/src/fable-splitter/src/cli.ts
@@ -2,31 +2,29 @@
 
 import * as fs from "fs";
 import * as path from "path";
-import fableSplitter, { CompilationInfo } from "./index";
+import fableSplitter, { CompilationInfo, FableSplitterOptions, RunOptions } from "./index";
 import runScript from "./run";
 
-const chokidarLazy = requireLazy("chokidar");
-
-function requireLazy(module) {
+function requireLazy(module: string) {
     let cache = null;
     return () => cache == null ? cache = require(module) : cache;
 }
 
-function getMainScriptPath(options, info) {
+function getMainScriptPath(options: FableSplitterOptions, info: CompilationInfo) {
 
-    function getFromFsproj(projectInfo) {
+    function getFromFsproj(projectInfo: CompilationInfo) {
         const lastFile = projectInfo.projectFiles[projectInfo.projectFiles.length - 1];
         return projectInfo.mapInOutPaths.get(lastFile);
     }
 
-    function getFromScript(scriptInfo) {
+    function getFromScript(scriptInfo: CompilationInfo) {
         return scriptInfo.mapInOutPaths.get(scriptInfo.entry);
     }
 
     const mainScriptName =
         info.projectFiles.length > 0 ? getFromFsproj(info) : getFromScript(info);
 
-    const mainScript = path.join(options.outDir, mainScriptName);
+    const mainScript = path.join(options.outDir, mainScriptName || "");
     return mainScript.endsWith(".js") ? mainScript : mainScript + ".js";
 }
 
@@ -64,15 +62,14 @@ Examples:
 `;
 }
 
-function findFlag(arr: string[], arg): true|null {
-    return findFlagIndex(arr, arg) > -1 ? true : null;
+function findFlag(arr: string[], ...flags: string[]): true|undefined {
+    return findFlagIndex(arr, ...flags) > -1 ? true : undefined;
 }
 
 // TODO: Stop after --run?
-function findFlagIndex(arr: string[], arg): number {
-    const args = Array.isArray(arg) ? arg : [arg];
+function findFlagIndex(arr: string[], ...flags: string[]): number {
     for (let i = 0; i < arr.length; i++) {
-        if (args.indexOf(arr[i]) >= 0) {
+        if (flags.indexOf(arr[i]) >= 0) {
             return i;
         }
     }
@@ -80,33 +77,66 @@ function findFlagIndex(arr: string[], arg): number {
 }
 
 // TODO: Stop after --run?
-function findArgValue(arr: string[], arg, f?): string|null {
-    const args = Array.isArray(arg) ? arg : [arg];
+function findArgValue(arr: string[], ...args: string[]): string|undefined {
     for (let i = 0; i < arr.length; i++) {
         if (args.indexOf(arr[i]) >= 0) {
-            return typeof f === "function" ? f(arr[i + 1]) : arr[i + 1];
+            return arr[i + 1];
         }
     }
-    return null;
+    return undefined;
 }
 
-function tooClose(filename: string, prev: [string, Date]|null): boolean {
+function buildOptionsFromCliArgs(args: string[]): FableSplitterOptions {
+    let entry = "";
+    let firstArg = args[0];
+    if (firstArg && !firstArg.startsWith("-")) {
+        entry = path.resolve(firstArg);
+        args = args.slice(1);
+    }
+
+    let run: RunOptions|undefined = undefined;
+    let runIndex = findFlagIndex(args, "--run");
+    if (runIndex >= 0) {
+        run = { args: args.slice(runIndex + 1) };
+    } else {
+        runIndex = findFlagIndex(args, "--runInspect");
+        if (runIndex >= 0) {
+            run = {
+                inspect: true,
+                args: args.slice(runIndex + 1)
+            };
+        }
+    }
+
+    return {
+        entry,
+        outDir: findArgValue(args, "-o", "--outDir") || "",
+        allFiles: findFlag(args, "--allFiles"),
+        debug: findFlag(args, "-d", "--debug"),
+        run,
+        commonjs: findFlag(args, "--commonjs"),
+        watch: findFlag(args, "-w", "--watch"),
+        usePolling: findFlag(args, "--usePolling")
+    };
+}
+
+function tooClose(filename: string, prev?: [string, Date]): boolean {
     return prev != null &&
         filename === prev[0] &&
         new Date().getTime() - prev[1].getTime() < 2000;
 }
 
-/** Like Object.assign but checks first if properties in the source are null */
-function objectAssignNonNull(target, source) {
+/** Like Object.assign but checks first if properties in the source are null or empty strings */
+function assignNonNullOrEmptyString(target: object, source: object) {
     for (const k in source) {
-        if (source[k] != null) {
+        if (source[k] != null && source[k] !== "") {
             target[k] = source[k];
         }
     }
     return target;
 }
 
-function concatSafe(ar, item): any[] {
+function concatSafe<T>(ar: T[]|undefined, item: T): T[] {
     if (ar == null) {
         return [item];
     } else {
@@ -119,15 +149,23 @@ function concatSafe(ar, item): any[] {
     }
 }
 
-function readConfig(filePath: string, force?: boolean) {
-    filePath = path.resolve(filePath);
-    if (fs.existsSync(filePath)) {
-        return require(filePath);
-    } else if (force) {
-        throw new Error("Cannot read config file: " + filePath);
-    } else {
-        return null;
+/** Reads config from first match in filePaths argument */
+function tryReadConfig(...filePaths: string[]): FableSplitterOptions|undefined {
+    for (let filePath of filePaths) {
+        filePath = path.resolve(filePath);
+        if (fs.existsSync(filePath)) {
+            return require(filePath);
+        }
     }
+    return undefined;
+}
+
+function forceReadConfig(filePath: string): FableSplitterOptions {
+    const cfg = tryReadConfig(filePath);
+    if (cfg == null) {
+        throw new Error("Cannot read config file: " + filePath);
+    }
+    return cfg;
 }
 
 function fixEntryPath(entry: string|null) {
@@ -145,35 +183,15 @@ function fixEntryPath(entry: string|null) {
     return entry;
 }
 
-function mustRun(args: string[]) {
-    let i = findFlagIndex(args, "--run");
-    if (i >= 0) {
-        return {
-            inspect: false,
-            args: args.slice(i + 1)
-        };
-    } else {
-        i = findFlagIndex(args, "--runInspect");
-        if (i >= 0) {
-            return {
-                inspect: true,
-                args: args.slice(i + 1)
-            };
-        } else {
-            return null;
-        }
-    }
-}
-
-function onCompiled(args: string[], opts: any, info: CompilationInfo, mustFinish = false) {
+function onCompiled(opts: FableSplitterOptions, info: CompilationInfo, mustFinish = false) {
     const hasError = Array.isArray(info.logs.error) && info.logs.error.length > 0;
     if (!hasError) {
         if (typeof opts.onCompiled === "function") {
             opts.onCompiled();
         }
-        const runOpts = mustRun(args);
-        if (runOpts) {
-            const job = runScript(getMainScriptPath(opts, info), runOpts.args, runOpts.inspect);
+        if (opts.run) {
+            const runOpts = typeof opts.run === "boolean" ? { args: [] } : opts.run;
+            const job = runScript(getMainScriptPath(opts, info), runOpts);
             if (mustFinish) {
                 job.then((code) => { process.exit(code); });
                 return;
@@ -186,56 +204,53 @@ function onCompiled(args: string[], opts: any, info: CompilationInfo, mustFinish
 
 }
 
-function run(entry, args) {
-    const cfgFile = findArgValue(args, ["-c", "--config"]);
+export default function run(entryOpts: FableSplitterOptions, cfgFile?: string) {
+    // Try read options from config file
+    const opts: FableSplitterOptions = cfgFile
+        ? forceReadConfig(cfgFile)
+        : (tryReadConfig("fable-splitter.config.js", "splitter.config.js") || {
+            entry: "",
+            outDir: ""
+        });
 
-    const opts = cfgFile
-        ? readConfig(cfgFile, true)
-        : (readConfig("fable-splitter.config.js") || readConfig("splitter.config.js") || {});
-
-    objectAssignNonNull(opts, {
-        entry,
-        outDir: findArgValue(args, ["-o", "--outDir"], path.resolve),
-        allFiles: findFlag(args, "--allFiles"),
-    });
-
+    // Merge options from config file with entry options and fix values
+    assignNonNullOrEmptyString(opts, entryOpts);
     opts.entry = fixEntryPath(opts.entry);
-    opts.outDir = opts.outDir || path.join(path.dirname(opts.entry), "bin");
-
-    if (findFlag(args, ["-d", "--debug"])) {
+    opts.outDir = opts.outDir ? path.resolve(opts.outDir) : path.join(path.dirname(opts.entry), "bin");
+    if (opts.debug) {
         const fableOpts = opts.fable || {};
         fableOpts.define = concatSafe(fableOpts.define, "DEBUG");
         opts.fable = fableOpts;
     }
-
     // If we're passing --run assume we're compiling for Node
     // TODO: In the future, we may want to use ES2015 modules and .mjs files
-    if (findFlag(args, ["--commonjs", "--run"])) {
+    if (opts.commonjs || opts.run) {
         const babelOpts = opts.babel || {};
         babelOpts.plugins = concatSafe(babelOpts.define, "@babel/plugin-transform-modules-commonjs");
         opts.babel = babelOpts;
     }
 
-    /// @ts-ignore
     console.log(`fable-splitter ${getVersion()}`);
+    const chokidarLazy = requireLazy("chokidar");
+
     fableSplitter(opts).then((info) => {
-        if (findFlag(args, ["-w", "--watch"])) {
-            onCompiled(args, opts, info);
+        if (opts.watch) {
+            onCompiled(opts, info);
             let cachedInfo = info;
             let ready = false;
-            let next: [string, Date]|null = null;
-            let prev: [string, Date]|null = null;
+            let next: [string, Date]|undefined = undefined;
+            let prev: [string, Date]|undefined = undefined;
             const watcher = chokidarLazy()
                 .watch(Array.from(info.compiledPaths), {
                     ignored: /node_modules/,
                     persistent: true,
-                    usePolling: findFlag(args, ["--usePolling"])
+                    usePolling: opts.usePolling
                 })
                 .on("ready", () => {
                     console.log("fable: Watching...");
                     ready = true;
                 })
-                .on("all", (ev, filePath) => {
+                .on("all", (ev: string, filePath: string) => {
                     if (ready && ev === "change") {
                         prev = next;
                         next = [filePath, new Date()];
@@ -251,35 +266,31 @@ function run(entry, args) {
                                     watcher.add(newFiles);
                                 }
                                 cachedInfo = info2;
-                                onCompiled(args, opts, info2);
+                                onCompiled(opts, info2);
                             });
                         }
                     }
                 });
         } else {
-            onCompiled(args, opts, info, true);
+            onCompiled(opts, info, true);
         }
     });
 }
 
-const processArgs = process.argv.slice(2);
-const processCmd = processArgs[0];
-
-switch (processCmd) {
-    case "-h":
-    case "--help":
-        console.log(getHelp());
-        break;
-    case "--version":
-        console.log(getVersion());
-        break;
-    default:
-        let entry: string|null = null;
-        let restArgs = processArgs;
-        if (processCmd && !processCmd.startsWith("-")) {
-            entry = path.resolve(processCmd);
-            restArgs = processArgs.slice(1);
+if (require.main === module) {
+    const processArgs = process.argv.slice(2);
+    switch (processArgs[0]) {
+        case "-h":
+        case "--help":
+            console.log(getHelp());
+            break;
+        case "--version":
+            console.log(getVersion());
+            break;
+        default:
+            const opts = buildOptionsFromCliArgs(processArgs);
+            const cfgFile = findArgValue(processArgs, "-c", "--config");
+            run(opts, cfgFile);
+            break;
         }
-        run(entry, restArgs);
-        break;
-    }
+}

--- a/src/fable-splitter/src/index.ts
+++ b/src/fable-splitter/src/index.ts
@@ -45,6 +45,14 @@ export type FableOptions = {
     // extra?: any,
 };
 
+export type RunOptions = {
+    args: string[],
+    inspect?: boolean,
+    break?: boolean,
+    host?: string,
+    port?: number,
+};
+
 export type FableSplitterOptions = {
     entry: string,
     outDir: string,
@@ -52,10 +60,15 @@ export type FableSplitterOptions = {
     babel?: Babel.TransformOptions,
     fable?: FableOptions,
     port?: number
-    cli?: {},
+    cli?: object,
     allFiles?: boolean,
     externals?: any,
-    postbuild?: () => void,
+    run?: boolean|RunOptions,
+    debug?: boolean,
+    commonjs?: boolean,
+    watch?: boolean,
+    usePolling?: boolean,
+    onCompiled?: () => void
 };
 
 function getResolvePathPlugin(targetDir: string, opts: FableSplitterOptions) {
@@ -462,10 +475,6 @@ export default function fableSplitter(options: FableSplitterOptions, previousInf
             const duration = (elapsed[0] + elapsed[1] / 1e9).toFixed(3);
 
             console.log(`fable: Compilation ${hasError ? "failed" : "succeeded"} at ${dateStr} (${duration} s)`);
-
-            if (!hasError && typeof options.postbuild === "function") {
-                options.postbuild();
-            }
             return info;
         })
         .catch((err) => {

--- a/src/fable-splitter/src/run.ts
+++ b/src/fable-splitter/src/run.ts
@@ -1,16 +1,23 @@
 import { ChildProcess, spawn } from "child_process";
+import { RunOptions } from "./index";
 
 let childCache: ChildProcess|null = null;
 
-export default function runScript(path: string, args: string[], inspect = false): Promise<number> {
+export default function runScript(path: string, opts: RunOptions): Promise<number> {
+    const hostAndPort = opts.host || opts.port ? `=${opts.host ?? "127.0.0.1"}:${opts.port ?? "9229"}` : "";
+    const args = (opts.inspect
+        ? [`--inspect${opts.break ? "-brk" : ""}${hostAndPort}`, path]
+        : [path]).concat(opts.args)
+
     if (childCache != null) {
         childCache.kill();
     }
-    const defaultArgs = inspect ? ['--inspect', path] : [path];
-    const child = spawn("node", defaultArgs.concat(args), {
+    console.log("node " + args.join(" "));
+    const child = spawn("node", args, {
         stdio: "inherit",
     });
     childCache = child;
+
     return new Promise((resolve, reject) => {
         child.on("error", (err) => {
             reject(err);


### PR DESCRIPTION
This PR adds a programatic API for fable-splitter in CLI mode. Incidentally, after making the changes I realized there was **already** a programatic API for fable-splitter that bypassed the cli module. So in order to use the API for the cli (necessary if you want to manage the watch mode, load a config file, run the script after compilation, etc) you have to do something like this:

```js
const fableSplitter = require("fable-splitter/dist/cli").default;
```

Which is not super-nice. But the package is already published (I'm using it in my project to orchestrate different splitter targets from a build script) so let's just merge this and we can think of polishing and documenting the feature later.