### PR TITLE
New helpers and fixes in replacements

### DIFF
--- a/src/Fable.Core/Fable.Core.JsInterop.fs
+++ b/src/Fable.Core/Fable.Core.JsInterop.fs
@@ -33,6 +33,10 @@ let (==>) (key: string) (v: obj): string*obj = jsNative
 /// E.g. `createNew myCons (arg1, arg2)` in JS becomes `new myCons(arg1, arg2)`
 let createNew (o: obj) (args: obj): obj = jsNative
 
+/// Destructure a tuple of arguments and applies to literal JS code as with EmitAttribute.
+/// E.g. `emitJs "$0 + $1" (arg1, arg2)` in JS becomes `arg1 + arg2`
+let emitJs (jsCode: string) (args: obj): 'T = jsNative
+
 /// Create a literal JS object from a collection of key-value tuples.
 /// E.g. `createObj [ "a" ==> 5 ]` in JS becomes `{ a: 5 }`
 let createObj (fields: #seq<string*obj>): obj = jsNative

--- a/src/Fable.Core/Fable.Core.Types.fs
+++ b/src/Fable.Core/Fable.Core.Types.fs
@@ -20,6 +20,7 @@ type MangleAttribute() =
 /// More info: http://fable.io/docs/interacting.html#Erase-attribute
 type EraseAttribute() =
     inherit Attribute()
+    new (caseRules: CaseRules) = EraseAttribute()
 
 /// The module, type, function... is globally accessible in JS.
 /// More info: http://fable.io/docs/interacting.html#Import-attribute

--- a/src/Fable.Transforms/AST/AST.Fable.fs
+++ b/src/Fable.Transforms/AST/AST.Fable.fs
@@ -25,7 +25,6 @@ type Type =
     | List of genericArg: Type
     | FunctionType of FunctionTypeKind * returnType: Type
     | GenericParam of name: string
-    | ErasedUnion of genericArgs: Type list
     | DeclaredType of FSharpEntity * genericArgs: Type list
     | AnonymousRecordType of fieldNames: string [] * genericArgs: Type list
 
@@ -37,7 +36,6 @@ type Type =
         | FunctionType (LambdaType argType, returnType) -> [ argType; returnType ]
         | FunctionType (DelegateType argTypes, returnType) -> argTypes @ [ returnType ]
         | Tuple gen -> gen
-        | ErasedUnion gen -> gen
         | DeclaredType (_, gen) -> gen
         | _ -> []
 
@@ -53,7 +51,6 @@ type Type =
             let argTypes, returnType = List.splitLast newGen
             FunctionType(DelegateType argTypes, returnType)
         | Tuple _ -> Tuple newGen
-        | ErasedUnion _ -> ErasedUnion newGen
         | DeclaredType (ent, _) -> DeclaredType(ent, newGen)
         | t -> t
 
@@ -187,7 +184,6 @@ type ValueKind =
     | NewTuple of Expr list
     | NewRecord of Expr list * NewRecordKind * genArgs: Type list
     | NewUnion of Expr list * FSharpUnionCase * FSharpEntity * genArgs: Type list
-    | NewErasedUnion of Expr list * genericArgs: Type list
     member this.Type =
         match this with
         | TypeInfo _ -> MetaType
@@ -208,7 +204,6 @@ type ValueKind =
             | DeclaredRecord ent -> DeclaredType(ent, genArgs)
             | AnonymousRecord fieldNames -> AnonymousRecordType(fieldNames, genArgs)
         | NewUnion (_, _, ent, genArgs) -> DeclaredType(ent, genArgs)
-        | NewErasedUnion (_, genArgs) -> ErasedUnion genArgs
 
 type LoopKind =
     | While of guard: Expr * body: Expr

--- a/src/Fable.Transforms/FableTransforms.fs
+++ b/src/Fable.Transforms/FableTransforms.fs
@@ -27,8 +27,6 @@ let visit f e =
             NewList(ht, t) |> makeValue r
         | NewRecord(exprs, ent, genArgs) ->
             NewRecord(List.map f exprs, ent, genArgs) |> makeValue r
-        | NewErasedUnion(exprs, genArgs) ->
-            NewErasedUnion(List.map f exprs, genArgs) |> makeValue r
         | NewUnion(exprs, uci, ent, genArgs) ->
             NewUnion(List.map f exprs, uci, ent, genArgs) |> makeValue r
     | Test(e, kind, r) -> Test(f e, kind, r)
@@ -121,7 +119,6 @@ let getSubExpressions = function
         | NewList(ht, _) ->
             match ht with Some(h,t) -> [h;t] | None -> []
         | NewRecord(exprs, _, _) -> exprs
-        | NewErasedUnion(exprs, _) -> exprs
         | NewUnion(exprs, _, _, _) -> exprs
     | Test(e, _, _) -> [e]
     | Curry(e, _, _, _) -> [e]

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -1919,12 +1919,13 @@ let optionModule (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (_: E
     match i.CompiledName, args with
     | "None", _ -> NewOption(None, t) |> makeValue r |> Some
     | "GetValue", [c] -> Get(c, OptionValue, t, r) |> Some
-    | ("OfObj" | "OfNullable"), [c] -> TypeCast(c, t) |> Some
-    | ("ToObj" | "ToNullable" | "Flatten"), [c] ->
-        Helper.CoreCall("Option", "tryValue", t, args, ?loc=r) |> Some
+    | ("OfObj" | "OfNullable"), _ ->
+        Helper.CoreCall("Option", "ofNullable", t, args, ?loc=r) |> Some
+    | ("ToObj" | "ToNullable"), _ ->
+        Helper.CoreCall("Option", "toNullable", t, args, ?loc=r) |> Some
     | "IsSome", [c] -> Test(c, OptionTest true, r) |> Some
     | "IsNone", [c] -> Test(c, OptionTest false, r) |> Some
-    | ("Filter" | "Map" | "Map2" | "Map3" | "Bind" as meth), args ->
+    | ("Filter" | "Flatten" | "Map" | "Map2" | "Map3" | "Bind" as meth), args ->
         Helper.CoreCall("Option", Naming.lowerFirst meth, t, args, i.SignatureArgTypes, ?loc=r) |> Some
     | "ToArray", [arg] ->
         toArray r t arg |> Some

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -717,7 +717,7 @@ let isCompatibleWithJsComparison = function
     | GenericParam _ -> false
     | AnonymousRecordType _ -> false
     | Any | Unit | Boolean | Number _ | String | Char | Regex
-    | Enum _ | ErasedUnion _ | FunctionType _ -> true
+    | Enum _ | FunctionType _ -> true
 
 // Overview of hash rules:
 // * `hash`, `Unchecked.hash` first check if GetHashCode is implemented and then default to structural hash.

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -476,7 +476,6 @@ module AST =
         | Option t1, Option t2
         | Array t1, Array t2
         | List t1, List t2 -> typeEquals strict t1 t2
-        | ErasedUnion ts1, ErasedUnion ts2
         | Tuple ts1, Tuple ts2 -> listEquals (typeEquals strict) ts1 ts2
         | FunctionType(LambdaType a1, t1), FunctionType(LambdaType a2, t2) ->
             typeEquals strict a1 a2 && typeEquals strict t1 t2
@@ -515,8 +514,7 @@ module AST =
         | Boolean -> Types.bool
         | Char    -> Types.char
         | String  -> Types.string
-        // TODO: Type info forErasedUnion?
-        | ErasedUnion _ | Any -> Types.object
+        | Any -> Types.object
         | Number kind ->
             match kind with
             | Int8    -> Types.int8

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -403,6 +403,7 @@ module AST =
           IsJsConstructor = false }
 
     let destructureTupleArgs = function
+        | [MaybeCasted(Value(UnitConstant,_))] -> []
         | [MaybeCasted(Value(NewTuple(args),_))] -> args
         | args -> args
 

--- a/src/fable-library/Option.ts
+++ b/src/fable-library/Option.ts
@@ -7,8 +7,11 @@ import { compare, equals, structuralHash } from "./Util";
 
 // 1- `None` is always `undefined` in runtime, a non-strict null check
 //    (`x == null`) is enough to check the case of an option.
-// 2- To get the value of an option the `getValue` helper
+// 2- To get the value of an option the `value` helper
 //    below must **always** be used.
+
+// Note: We use non-strict null check for backwards compatibility with
+// code that use F# options to represent values that could be null in JS
 
 export type Option<T> = T | Some<T> | undefined;
 
@@ -66,8 +69,19 @@ export function value<T>(x: Option<T>) {
   }
 }
 
-export function tryValue<T>(x: Option<T>) {
-  return x instanceof Some ? x.value : x;
+export function ofNullable<T>(x: T|null): Option<T> {
+  // This will fail with unit probably, an alternative would be:
+  // return x === null ? undefined : (x === undefined ? new Some(x) : x);
+  return x == null ? undefined : x;
+}
+
+export function toNullable<T>(x: Option<T>): T|null {
+  return x == null ? null : value(x);
+}
+
+
+export function flatten<T>(x: Option<Option<T>>) {
+  return x == null ? undefined : value(x);
 }
 
 export function toArray<T>(opt: Option<T>): T[] {

--- a/src/fable-library/Util.ts
+++ b/src/fable-library/Util.ts
@@ -502,9 +502,26 @@ function changeCase(str: string, caseRule: number) {
   }
 }
 
-// TODO: For better performance, once we update the packages using keyValueList,
-// this will only accept arrays with first element being the key name (without case rule)
-export function createObj(fields: Iterable<any>, caseRule = CaseRules.None, isDebug = false) {
+export function createObj(fields: Iterable<[string, any]>) {
+  const obj: any = {};
+  for (let kv of fields) {
+    obj[kv[0]] = kv[1];
+  }
+  return obj;
+}
+
+export function createObjDebug(fields: Iterable<[string, any]>) {
+  const obj: any = {};
+  for (let kv of fields) {
+    if (kv[0] in obj) {
+      console.error(new Error(`Property ${kv[0]} is duplicated`));
+    }
+    obj[kv[0]] = kv[1];
+  }
+  return obj;
+}
+
+export function keyValueList(fields: Iterable<any>, caseRule = CaseRules.None, isDebug = false) {
   const obj: { [k: string]: any } = {};
   const definedCaseRule = caseRule;
 

--- a/src/fable-splitter/src/cli.ts
+++ b/src/fable-splitter/src/cli.ts
@@ -149,6 +149,16 @@ function concatSafe<T>(ar: T[]|undefined, item: T): T[] {
     }
 }
 
+function isDirectory(path: string) {
+    try {
+        var stat = fs.lstatSync(path);
+        return stat.isDirectory();
+    } catch (e) {
+        // lstatSync throws an error if path doesn't exist
+        return false;
+    }
+}
+
 /** Reads config from first match in filePaths argument */
 function tryReadConfig(...filePaths: string[]): FableSplitterOptions|undefined {
     for (let filePath of filePaths) {
@@ -161,6 +171,7 @@ function tryReadConfig(...filePaths: string[]): FableSplitterOptions|undefined {
 }
 
 function forceReadConfig(filePath: string): FableSplitterOptions {
+    filePath = isDirectory(filePath) ? path.join(filePath, "splitter.config.js") : filePath;
     const cfg = tryReadConfig(filePath);
     if (cfg == null) {
         throw new Error("Cannot read config file: " + filePath);

--- a/tests/Main/JsInteropTests.fs
+++ b/tests/Main/JsInteropTests.fs
@@ -307,6 +307,14 @@ let tests =
         style.Bar |> equal "foo"
         style.Add(3,5) |> equal 8
 
+    testCase "emitJs works" <| fun () ->
+        let x = 4
+        let y = 8
+        let z1: int = emitJs "$0 * Math.pow(2, $1)" (x, y)
+        let z2: int = emitJs "$0 << $1" (x, y)
+        equal z1 z2
+        equal 1024 z1
+
     testCase "Assigning null with emit works" <| fun () ->
         let x = createEmpty<obj>
         x.["prop"] <- "prop value"

--- a/tests/Main/OptionTests.fs
+++ b/tests/Main/OptionTests.fs
@@ -278,5 +278,48 @@ let tests =
 
     testCase "Some (box null) |> Option.isSome evals to true" <| fun () -> // See #1948
         Some (box null) |> Option.isSome |> equal true
-        Some (null) |> Option.isSome |> equal true        
+        Some (null) |> Option.isSome |> equal true
+
+#if FABLE_COMPILER
+    testCase "None and unit compile to JS undefined" <| fun () ->
+        let isActualJsNull (x: obj) = emitJs "$0 === null" x
+        let isActualJsUndefined (x: obj) = emitJs "$0 === void 0" x
+
+        let x: int option = None
+        let y = ()
+        isActualJsNull x |> equal false
+        isActualJsUndefined x |> equal true
+        isActualJsNull y |> equal false
+        isActualJsUndefined y |> equal true
+
+    testCase "Option.toObj/toNullable converts to null" <| fun () ->
+        let isActualJsNull (x: obj) = emitJs "$0 === null" x
+        let isActualJsUndefined (x: obj) = emitJs "$0 === void 0" x
+
+        let x: string option = None
+        let x2: int option = None
+        let y = Option.toObj x
+        let z = Option.toNullable x2
+        isActualJsNull y |> equal true
+        isActualJsUndefined y |> equal false
+        isActualJsNull z |> equal true
+        isActualJsUndefined z |> equal false
+
+    testCase "Option.ofObj/ofNullable converts to undefined" <| fun () ->
+        let isActualJsNull (x: obj) = emitJs "$0 === null" x
+        let isActualJsUndefined (x: obj) = emitJs "$0 === void 0" x
+
+        let x: string = null
+        let x2: Nullable<int> = Nullable()
+        let y = Option.ofObj x
+        let z = Option.ofNullable x2
+        isActualJsNull x |> equal true
+        isActualJsUndefined x |> equal false
+        isActualJsNull x2 |> equal true
+        isActualJsUndefined x2 |> equal false
+        isActualJsNull y |> equal false
+        isActualJsUndefined y |> equal true
+        isActualJsNull z |> equal false
+        isActualJsUndefined z |> equal true
+#endif
   ]

--- a/tests/Main/OptionTests.fs
+++ b/tests/Main/OptionTests.fs
@@ -1,5 +1,7 @@
 module Fable.Tests.Option
 
+open System
+open Fable.Core.JsInterop
 open Util.Testing
 
 type Tree =


### PR DESCRIPTION
- `emitJs`: Like `Emit` attribute but used in expressions
- Fix Option/null interaction with Option.toObj/toNullable/ofOb/ofNullable. See #2081 
- Optimize `createObj` as it doesn't need as many checks as `keyValueList`. In debug mode, it will check if a field is set more than once.
- Remove `ErasedUnion` from Fable AST and enable cases without fields which will behave as in `StringEnum`.