### PR TITLE
[WIP] Optimize List runtime representation with a stack

### DIFF
--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -1211,7 +1211,7 @@ module Util =
             let op = if nonEmpty then BinaryUnequal else BinaryEqual
             upcast BinaryExpression(op, com.TransformAsExpr(ctx, expr), NullLiteral(), ?loc=range)
         | Fable.ListTest nonEmpty ->
-            let expr = get range (com.TransformAsExpr(ctx, expr)) "empty"
+            let expr = get range (com.TransformAsExpr(ctx, expr)) "isEmpty"
             if nonEmpty then upcast UnaryExpression(UnaryNot, expr, ?loc=range)
             else expr
         | Fable.UnionCaseTest(uci, ent) ->

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -813,7 +813,7 @@ module Util =
             match headAndTail with
             | None -> coreLibConstructorCall com ctx "Types" "List" [||]
             | Some(TransformExpr com ctx head, TransformExpr com ctx tail) ->
-                coreLibCall com ctx None "Types" "newList" [|head; tail|]
+                callFunction r (get None tail "add") [head]
         | Fable.NewOption (value, t) ->
             match value with
             | Some (TransformExpr com ctx e) ->

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -1733,6 +1733,8 @@ let resizeArrays (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (this
         Helper.CoreCall("Seq", "filter", t, [arg; ar], ?loc=r) |> toArray com t |> Some
     | "AddRange", Some ar, [arg] ->
         Helper.CoreCall("Array", "addRangeInPlace", t, [arg; ar], ?loc=r) |> Some
+    | "GetRange", Some ar, [idx; cnt] ->
+        Helper.CoreCall("Array", "getSubArray", t, [ar; idx; cnt], ?loc=r) |> Some
     | "Contains", Some (MaybeCasted(ar)), [arg] ->
         match ar.Type with
         | Array _ ->

--- a/src/fable-library/Types.ts
+++ b/src/fable-library/Types.ts
@@ -56,7 +56,7 @@ function compareList<T>(self: List<T>, other: List<T>) {
     }
     const idxDiff = self.idx - other.idx;
     for (let i = self.idx; i >= 0; i--) {
-      let otherIdx = i - idxDiff;
+      const otherIdx = i - idxDiff;
       if (otherIdx < 0) { return 1; }
       const selfItem = self.vals[i];
       const otherItem = other.vals[otherIdx];
@@ -73,7 +73,6 @@ export function newList<T>(head: T, tail: List<T>): List<T> {
   const vals = tail.vals.length === tail.idx + 1 ? tail.vals : tail.vals.slice(0, tail.idx + 1);
   vals.push(head);
   const li = new List(vals);
-  li._tail = tail;
   return li;
 }
 
@@ -92,7 +91,7 @@ export class List<T> implements IEquatable<List<T>>, IComparable<List<T>>, Itera
     this.idx = idx ?? this.vals.length - 1;
   }
 
-  public get empty() {
+  public get isEmpty() {
     return this.idx < 0;
   }
 
@@ -101,9 +100,7 @@ export class List<T> implements IEquatable<List<T>>, IComparable<List<T>>, Itera
   }
 
   public get tail(): List<T> | undefined {
-    return !this.empty
-      ? this._tail ?? (this._tail = new List(this.vals, this.idx - 1))
-      : undefined;
+    return this.idx >= 0 ? new List(this.vals, this.idx - 1) : undefined;
   }
 
   public get length() {

--- a/tests/Main/ResizeArrayTests.fs
+++ b/tests/Main/ResizeArrayTests.fs
@@ -131,6 +131,13 @@ let tests =
         li.AddRange [1;2;3]
         equal 3 li.Count
 
+    testCase "ResizeArray.GetRange works" <| fun () ->
+        let li = ResizeArray<_>()
+        li.AddRange [1;2;3]
+        let sub = li.GetRange(1, 2)
+        sub.Count |> equal 2
+        sub.Contains(1) |> equal false
+
     testCase "ResizeArray.Contains works" <| fun () ->
         let li = ResizeArray<_>()
         li.Add("ab")


### PR DESCRIPTION
Note this PR is for `master` not `nagareyama` (codename for Fable 3) so if this gets merged it will be published for Fable 2.

While random-thinking (is that an actual expression?) this weekend, it came to my mind that in Fable we're using a specific type for lists instead of a simple union, but this type is not particularly optimized. I tried to find how we could improve that by taking the following into consideration:

- Lists are widely used in F# as it's the default collection (at least the one with terser syntax).
- Most of the time users just want an immutable collection and they don't need an actual linked list.
- The FSharp.Core List module is usually used to work on lists (vs using a recursive function to fold the list)
- Most users are aware (hopefully) that adding elements to the beginning of the list is faster than adding them to the end.

So I decided to implement an internal stack to store the items, while the List object itself become a simple pointer to a position in that stack. In most cases a single List pointer should be enough, but additional ones will be created on-the-fly when traversing the list manually. When adding items to the beginning of the list, if the affected list points to the top of the stack we just reuse it, otherwise we create a new stack. This could require extra memory in some cases (e.g. if we have a big list, then go to the last element to the list and grow another list from there) but hopefully it shouldn't happen very often.

I'm using a reverted JS array for the stack (though it makes it a bit harder for debugging) because `Array.push` should be much faster than inserting at the beginning.

Later I will add some unsafe helpers (that access directly the internal stack) to the List module to optimize the most used functions (fold, map, append) and try to make some benchmarks.

@ncave As you're the performance expert :wink: could you please have a look and let me know if this makes any sense to you?