### PR TITLE
Fixed List type

### DIFF
--- a/src/fable-library/List.fs
+++ b/src/fable-library/List.fs
@@ -433,7 +433,7 @@ let splitAt i xs =
 
 let outOfRange() = failwith "Index out of range"
 
-let slice (lower: int option) (upper: int option) (xs: 'T list) =
+let getSlice (lower: int option) (upper: int option) (xs: 'T list) =
     let lower = defaultArg lower 0
     let hasUpper = Option.isSome upper
     if lower < 0 then outOfRange()
@@ -503,7 +503,7 @@ let windowed (windowSize: int) (source: 'T list): 'T list list =
         failwith "windowSize must be positive"
     let mutable res = []
     for i = length source downto windowSize do
-        res <- (slice (Some(i-windowSize)) (Some(i-1)) source) :: res
+        res <- (getSlice (Some(i-windowSize)) (Some(i-1)) source) :: res
     res
 
 let splitInto (chunks: int) (source: 'T list): 'T list list =

--- a/tests/Main/ListTests.fs
+++ b/tests/Main/ListTests.fs
@@ -42,12 +42,25 @@ module List =
 
 let tests =
   testList "Lists" [
-    // TODO: Empty lists may be represented as null, make sure they don't conflict with None
     testCase "Some [] works" <| fun () ->
         let xs: int list option = Some []
         let ys: int list option = None
         Option.isSome xs |> equal true
         Option.isNone ys |> equal true
+
+    testCase "List equality works" <| fun () ->
+        let xs = [1;2;3]
+        let ys = [1;2;3]
+        let zs = [1;4;3]
+        xs = ys |> equal true
+        xs = zs |> equal false
+
+    testCase "List comparison works" <| fun () ->
+        let xs = [1;2;3]
+        let ys = [1;2;3]
+        let zs = [1;4;3]
+        xs < ys |> equal false
+        xs < zs |> equal true
 
     testCase "Pattern matching with lists works" <| fun () ->
         match [] with [] -> true | _ -> false
@@ -302,9 +315,9 @@ let tests =
             |> List.sum |> equal 9
 
     testCase "List.rev works" <| fun () ->
-            let xs = [1; 2]
+            let xs = [1; 2; 3]
             let ys = xs |> List.rev
-            equal 2 ys.Head
+            equal 3 ys.Head
 
     testCase "List.scan works" <| fun () ->
             let xs = [1; 2; 3; 4]


### PR DESCRIPTION
@alfonsogarciacaro 
- I fixed the List type with `real tail` (as opposed to `copy tail`), it works now. You can merge it in the `optimized-list` branch.
- Unfortunately there is no perf improvement vs the `copy-tail` version (still about 17% slower than the original), so the bottle-neck must be somewhere else. But it should in theory help with the memory usage.
- There is still room for improvement, like making the `Head/Tail/Length/IsEmpty/Item` iterative instead of recursive, and other optimization attempts that can continue in #2124.