### PR TITLE
Make Fable AST independent of FCS

### DIFF
--- a/src/Fable.Core/Fable.Core.JsInterop.fs
+++ b/src/Fable.Core/Fable.Core.JsInterop.fs
@@ -34,8 +34,13 @@ let (==>) (key: string) (v: obj): string*obj = jsNative
 let createNew (o: obj) (args: obj): obj = jsNative
 
 /// Destructure a tuple of arguments and applies to literal JS code as with EmitAttribute.
-/// E.g. `emitJs "$0 + $1" (arg1, arg2)` in JS becomes `arg1 + arg2`
-let emitJs (jsCode: string) (args: obj): 'T = jsNative
+/// E.g. `emitJsExpr (arg1, arg2) "$0 + $1"` in JS becomes `arg1 + arg2`
+let emitJsExpr (args: obj) (jsCode: string): 'T = jsNative
+
+/// Same as emitJsExpr but intended for JS code that must appear in a statement position
+/// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements
+/// E.g. `emitJsExpr aValue "while($0 < 5) doSomething()"`
+let emitJsStatement (args: obj) (jsCode: string): 'T = jsNative
 
 /// Create a literal JS object from a collection of key-value tuples.
 /// E.g. `createObj [ "a" ==> 5 ]` in JS becomes `{ a: 5 }`

--- a/src/Fable.Core/Fable.Core.Types.fs
+++ b/src/Fable.Core/Fable.Core.Types.fs
@@ -49,11 +49,14 @@ type ImportAllAttribute(from: string) =
 
 /// Function calls will be replaced by inlined JS code.
 /// More info: http://fable.io/docs/interacting.html#emit-attribute
-type EmitAttribute(macro: string) =
+type EmitAttribute(macro: string, ?isStatement: bool) =
     inherit Attribute()
 
 /// Same as `Emit("$0.methodName($1...)")`
 type EmitMethodAttribute(methodName: string) =
+    inherit Attribute()
+
+type TestAttribute(r: System.Text.RegularExpressions.Regex) =
     inherit Attribute()
 
 /// Same as `Emit("new $0($1...)")`
@@ -74,13 +77,6 @@ type EmitPropertyAttribute(propertyName: string) =
 type StringEnumAttribute() =
     inherit Attribute()
     new (caseRules: CaseRules) = StringEnumAttribute()
-
-/// Used to spread the last argument. Mainly intended for `React.createElement` binding, not for general use.
-[<AttributeUsage(AttributeTargets.Parameter)>]
-type ParamSeqAttribute() =
-    inherit Attribute()
-
-type ParamListAttribute = ParamSeqAttribute
 
 /// Experimental: Currently only intended for some specific libraries
 [<AttributeUsage(AttributeTargets.Parameter)>]

--- a/src/Fable.Core/Fable.Core.Types.fs
+++ b/src/Fable.Core/Fable.Core.Types.fs
@@ -52,10 +52,6 @@ type ImportAllAttribute(from: string) =
 type EmitAttribute(macro: string) =
     inherit Attribute()
 
-/// The declaration value will be replaced with the JS code.
-type EmitDeclarationAttribute(macro: string) =
-    inherit Attribute()
-
 /// Same as `Emit("$0.methodName($1...)")`
 type EmitMethodAttribute(methodName: string) =
     inherit Attribute()

--- a/src/Fable.Transforms/AST/AST.Fable.fs
+++ b/src/Fable.Transforms/AST/AST.Fable.fs
@@ -2,12 +2,11 @@ namespace rec Fable.AST.Fable
 
 open Fable
 open Fable.AST
-open FSharp.Compiler.SourceCodeServices
 open System
 
-type FunctionTypeKind =
-    | LambdaType of Type
-    | DelegateType of Type list
+type DeclaredType =
+    abstract Definition: Entity
+    abstract GenericArgs: Type list
 
 type Type =
     | MetaType
@@ -18,14 +17,15 @@ type Type =
     | String
     | Regex
     | Number of NumberKind
-    | Enum of FSharpEntity
+    | Enum of Entity
     | Option of genericArg: Type
     | Tuple of genericArgs: Type list
     | Array of genericArg: Type
     | List of genericArg: Type
-    | FunctionType of FunctionTypeKind * returnType: Type
+    | LambdaType of Type * returnType: Type
+    | DelegateType of Type list * returnType: Type
     | GenericParam of name: string
-    | DeclaredType of FSharpEntity * genericArgs: Type list
+    | DeclaredType of Entity * genericArgs: Type list
     | AnonymousRecordType of fieldNames: string [] * genericArgs: Type list
 
     member this.Generics =
@@ -33,142 +33,113 @@ type Type =
         | Option gen
         | Array gen
         | List gen -> [ gen ]
-        | FunctionType (LambdaType argType, returnType) -> [ argType; returnType ]
-        | FunctionType (DelegateType argTypes, returnType) -> argTypes @ [ returnType ]
+        | LambdaType(argType, returnType) -> [ argType; returnType ]
+        | DelegateType(argTypes, returnType) -> argTypes @ [ returnType ]
         | Tuple gen -> gen
         | DeclaredType (_, gen) -> gen
+        | AnonymousRecordType (_, gen) -> gen
         | _ -> []
 
-    member this.ReplaceGenerics(newGen: Type list) =
-        match this with
-        | Option _ -> Option newGen.Head
-        | Array _ -> Array newGen.Head
-        | List _ -> List newGen.Head
-        | FunctionType (LambdaType _, _) ->
-            let argTypes, returnType = List.splitLast newGen
-            FunctionType(LambdaType argTypes.Head, returnType)
-        | FunctionType (DelegateType _, _) ->
-            let argTypes, returnType = List.splitLast newGen
-            FunctionType(DelegateType argTypes, returnType)
-        | Tuple _ -> Tuple newGen
-        | DeclaredType (ent, _) -> DeclaredType(ent, newGen)
-        | t -> t
+type Attribute =
+    abstract FullName: string
+    abstract ConstructorArguments: obj list
 
-type MemberInfo(name, ?declaringEntity, ?hasSpread, ?isValue, ?range) =
-    member _.Name: string = name
-    member _.IsValue = defaultArg isValue false
-    member _.HasSpread = defaultArg hasSpread false
-    member _.DeclaringEntity: FSharpEntity option = declaringEntity
-    member _.Range: SourceLocation option = range
+type Field =
+    abstract Name: string
+    abstract FieldType: Type
+    abstract IsMutable: bool
+    abstract IsStatic: bool
+    abstract LiteralValue: obj option
 
-type ModuleMemberInfo(name, ?declaringEntity, ?hasSpread, ?isValue, ?isPublic,
-                      ?isInstance, ?isMutable, ?isEntryPoint, ?range) =
-    inherit MemberInfo(name, ?declaringEntity=declaringEntity, ?hasSpread=hasSpread, ?isValue=isValue, ?range=range)
+type UnionCase =
+    abstract Name: string
+    abstract CompiledName: string option
+    abstract UnionCaseFields: Field list
 
-    member _.IsPublic = defaultArg isPublic false
-    member _.IsInstance = defaultArg isInstance false
-    member _.IsMutable = defaultArg isMutable false
-    member _.IsEntryPoint = defaultArg isEntryPoint false
+type GenericParam =
+    abstract Name: string
 
-type AttachedMemberInfo(name, declaringEntity, ?hasSpread, ?isValue,
-                        ?isGetter, ?isSetter, ?isEnumerator, ?range) =
-    inherit MemberInfo(name, ?declaringEntity=declaringEntity, ?hasSpread=hasSpread, ?isValue=isValue, ?range=range)
+type Parameter =
+    abstract Name: string option
+    abstract Type: Type
 
-    member _.IsGetter = defaultArg isGetter false
-    member _.IsSetter = defaultArg isSetter false
-    member _.IsEnumerator = defaultArg isEnumerator false
+type MemberFunctionOrValue =
+    abstract DisplayName: string
+    abstract CompiledName: string
+    abstract FullName: string
+    abstract CurriedParameterGroups: Parameter list list
+    abstract ReturnParameter: Parameter
+    abstract IsExplicitInterfaceImplementation: bool
+    abstract ApparentEnclosingEntity: Entity
 
-    member this.IsMethod =
-        not this.IsValue && not this.IsGetter && not this.IsSetter && not this.IsEnumerator
+type Entity =
+    abstract DisplayName: string
+    abstract FullName: string
+    abstract SourcePath: string
+    abstract AssemblyPath: string option
+    abstract Attributes: Attribute seq
+    abstract BaseDeclaration: DeclaredType option
+    abstract AllInterfaces: DeclaredType seq
+    abstract GenericParameters: GenericParam list
+    abstract MembersFunctionsAndValues: MemberFunctionOrValue seq
+    abstract FSharpFields: Field list
+    abstract UnionCases: UnionCase list
+    abstract IsPublic: bool
+    abstract IsFSharpUnion: bool
+    abstract IsFSharpRecord: bool
+    abstract IsValueType: bool
+    abstract IsFSharpExceptionDeclaration: bool
+    abstract IsInterface: bool
 
-type ConstructorInfo(entity, entityName, ?isEntityPublic, ?isUnion, ?range) =
-    member _.Entity: FSharpEntity = entity
-    member _.EntityName: string = entityName
-    member _.IsEntityPublic = defaultArg isEntityPublic false
-    member _.IsUnion = defaultArg isUnion false
-    member _.Range: SourceLocation option = range
+type MemberDeclInfo =
+    abstract Attributes: Attribute seq
+    abstract HasSpread: bool
+    abstract IsPublic: bool
+    abstract IsInstance: bool
+    abstract IsValue: bool
+    abstract IsMutable: bool
+    abstract IsGetter: bool
+    abstract IsSetter: bool
+    abstract IsEnumerator: bool
+    abstract IsMangled: bool
 
-type ClassImplicitConstructorInfo(entity, constructorName, entityName,
-                                  arguments, body, baseCall, ?hasSpread,
-                                  ?isConstructorPublic, ?isEntityPublic, ?range) =
-    inherit ConstructorInfo(entity, entityName, ?isEntityPublic=isEntityPublic, ?range=range)
-
-    member _.ConstructorName: string = constructorName
-    member _.Arguments: Ident list = arguments
-    member _.Body: Expr = body
-    member _.BaseCall: Expr option = baseCall
-    member _.IsConstructorPublic = defaultArg isConstructorPublic false
-    member _.HasSpread = defaultArg hasSpread false
-
-    member _.WithBodyAndBaseCall(body, baseCall) =
-        ClassImplicitConstructorInfo(entity, constructorName, entityName, arguments,
-            body, baseCall, ?hasSpread=hasSpread, ?isConstructorPublic=isConstructorPublic,
-            ?isEntityPublic=isEntityPublic, ?range=range)
-
-type UsedNames = Set<string>
+type MemberDecl = {
+    Ident: Ident
+    Args: Ident list
+    Body: Expr
+    UsedNames: Set<string>
+    Info: MemberDeclInfo
+}
 
 type Declaration =
-    | ActionDeclaration of Expr * UsedNames
-    /// Note: Non-attached type members become module members
-    | ModuleMemberDeclaration of args: Ident list * body: Expr * ModuleMemberInfo * UsedNames
-    /// Interface and abstract class implementations
-    | AttachedMemberDeclaration of args: Ident list * body: Expr * AttachedMemberInfo * declaringEntity: FSharpEntity * UsedNames
-    /// For unions, records and structs
-    | CompilerGeneratedConstructorDeclaration of ConstructorInfo
-    | ClassImplicitConstructorDeclaration of ClassImplicitConstructorInfo * UsedNames
-
+    | ActionDeclaration of Expr * usedNames: Set<string>
+    | MemberDeclaration of MemberDecl
+    | ClassDeclaration of Entity * Ident * constructor: MemberDecl option * baseCall: Expr option * attachedMembers: MemberDecl list
     member this.UsedNames =
         match this with
-        | ActionDeclaration(_,u)
-        | ModuleMemberDeclaration(_,_,_,u)
-        | AttachedMemberDeclaration(_,_,_,_,u)
-        | ClassImplicitConstructorDeclaration(_,u) -> u
-        | CompilerGeneratedConstructorDeclaration _ -> Set.empty
+        | ActionDeclaration(_, usedNames) -> usedNames
+        | MemberDeclaration m -> m.UsedNames
+        | ClassDeclaration(_,_,cons,_,attachedMembers) ->
+            let usedNames = match cons with Some c -> c.UsedNames | None -> Set.empty
+            (usedNames, attachedMembers) ||> List.fold (fun acc m -> Set.union acc m.UsedNames)
 
 type File(sourcePath, decls, ?usedRootNames, ?inlineDependencies) =
     member __.SourcePath: string = sourcePath
     member __.Declarations: Declaration list = decls
-    member __.UseNamesInRootScope: UsedNames = defaultArg usedRootNames Set.empty
+    member __.UsedNamesInRootScope: Set<string> = defaultArg usedRootNames Set.empty
     member __.InlineDependencies: Set<string> = defaultArg inlineDependencies Set.empty
-
-type IdentKind =
-    | UserDeclared
-    | CompilerGenerated
-    | ThisArgIdent
 
 type Ident =
     { Name: string
       Type: Type
-      Kind: IdentKind
       IsMutable: bool
+      IsThisArgument: bool
+      IsCompilerGenerated: bool
       Range: SourceLocation option }
-    member x.IsCompilerGenerated =
-        match x.Kind with
-        | CompilerGenerated -> true
-        | _ -> false
-
-    member x.IsThisArgIdent =
-        match x.Kind with
-        | ThisArgIdent -> true
-        | _ -> false
-
     member x.DisplayName =
         x.Range
         |> Option.bind (fun r -> r.identifierName)
         |> Option.defaultValue x.Name
-
-type ImportKind =
-    | Internal
-    | Library
-    | CustomImport
-
-type NewArrayKind =
-    | ArrayValues of Expr list
-    | ArrayAlloc of Expr
-
-type NewRecordKind =
-    | DeclaredRecord of FSharpEntity
-    | AnonymousRecord of fieldNames: string []
 
 type ValueKind =
     // The AST from F# compiler is a bit inconsistent with ThisValue and BaseValue.
@@ -184,13 +155,15 @@ type ValueKind =
     | StringConstant of string
     | NumberConstant of float * NumberKind
     | RegexConstant of source: string * flags: RegexFlag list
-    | EnumConstant of Expr * FSharpEntity
+    | EnumConstant of Expr * Entity
     | NewOption of value: Expr option * Type
-    | NewArray of NewArrayKind * Type
+    | NewArray of Expr list * Type
+    | NewArrayAlloc of Expr * Type
     | NewList of headAndTail: (Expr * Expr) option * Type
     | NewTuple of Expr list
-    | NewRecord of Expr list * NewRecordKind * genArgs: Type list
-    | NewUnion of Expr list * FSharpUnionCase * FSharpEntity * genArgs: Type list
+    | NewRecord of Expr list * Entity * genArgs: Type list
+    | NewAnonymousRecord of Expr list * fieldNames: string [] * genArgs: Type list
+    | NewUnion of Expr list * tag: int * Entity * genArgs: Type list
     member this.Type =
         match this with
         | ThisValue t
@@ -206,21 +179,12 @@ type ValueKind =
         | EnumConstant (_, ent) -> Enum ent
         | NewOption (_, t) -> Option t
         | NewArray (_, t) -> Array t
+        | NewArrayAlloc (_, t) -> Array t
         | NewList (_, t) -> List t
         | NewTuple exprs -> exprs |> List.map (fun e -> e.Type) |> Tuple
-        | NewRecord (_, kind, genArgs) ->
-            match kind with
-            | DeclaredRecord ent -> DeclaredType(ent, genArgs)
-            | AnonymousRecord fieldNames -> AnonymousRecordType(fieldNames, genArgs)
+        | NewRecord (_, ent, genArgs) -> DeclaredType(ent, genArgs)
+        | NewAnonymousRecord (_, fieldNames, genArgs) -> AnonymousRecordType(fieldNames, genArgs)
         | NewUnion (_, _, ent, genArgs) -> DeclaredType(ent, genArgs)
-
-type LoopKind =
-    | While of guard: Expr * body: Expr
-    | For of ident: Ident * start: Expr * limit: Expr * body: Expr * isUp: bool
-
-type FunctionKind =
-    | Lambda of arg: Ident
-    | Delegate of args: Ident list
 
 type CallInfo =
     { ThisArg: Expr option
@@ -229,8 +193,6 @@ type CallInfo =
       /// E.g.: signature accepts 'a->'b->'c (2-arity) but we pass int->int->int->int (3-arity)
       SignatureArgTypes: Type list
       HasSpread: bool
-      AutoUncurrying: bool
-      /// Must apply `new` keyword when converted to JS
       IsJsConstructor: bool }
 
 type ReplaceCallInfo =
@@ -244,61 +206,74 @@ type ReplaceCallInfo =
       DeclaringEntityFullName: string
       GenericArgs: (string * Type) list }
 
+type EmitInfo =
+    { Macro: string
+      Args: Expr list
+      IsJsStatement: bool }
+
 type OperationKind =
-    | Call of callee: Expr * info: CallInfo
-    | CurriedApply of applied: Expr * args: Expr list
-    | Emit of macro: string * args: CallInfo option
-    | UnaryOperation of UnaryOperator * Expr
-    | BinaryOperation of BinaryOperator * left: Expr * right: Expr
-    | LogicalOperation of LogicalOperator * left: Expr * right: Expr
+    | Unary of UnaryOperator * Expr
+    | Binary of BinaryOperator * left: Expr * right: Expr
+    | Logical of LogicalOperator * left: Expr * right: Expr
+
+type KeyKind =
+    | FieldKey of Field
+    | ExprKey of Expr
 
 type GetKind =
-    | ExprGet of Expr
-    | TupleGet of int
-    | FieldGet of string * isFieldMutable: bool * fieldType: Type
-    | UnionField of FSharpField * FSharpUnionCase * fieldType: Type
+    | ByKey of KeyKind
+    | TupleIndex of int
+    | UnionField of index: int * fieldType: Type
     | UnionTag
     | ListHead
     | ListTail
     | OptionValue
 
-type SetKind =
-    | VarSet
-    | ExprSet of Expr
-    | FieldSet of string * Type
-
 type TestKind =
     | TypeTest of Type
-    | ErasedUnionTest of Type
     | OptionTest of isSome: bool
     | ListTest of isCons: bool
-    | UnionCaseTest of FSharpUnionCase * FSharpEntity
+    | UnionCaseTest of tag: int
 
 type Expr =
+    // Values and Idents
     | Value of ValueKind * SourceLocation option
     | IdentExpr of Ident
+
+    // Closures
+    /// Lambdas are curried, they always have a single argument (which can be unit)
+    | Lambda of arg: Ident * body: Expr * name: string option
+    /// Delegates are uncurried functions, can have none or multiple arguments
+    | Delegate of args: Ident list * body: Expr * name: string option
+    | ObjectExpr of MemberDecl list * Type * baseCall: Expr option
+
+    // Type cast and tests
     | TypeCast of Expr * Type
-    | Curry of Expr * arity: int * Type * SourceLocation option
-    | Import of selector: Expr * path: Expr * ImportKind * Type * SourceLocation option
-
-    | Function of FunctionKind * body: Expr * name: string option
-    | ObjectExpr of (Ident list * Expr * AttachedMemberInfo) list * Type * baseCall: Expr option
-
     | Test of Expr * TestKind * range: SourceLocation option
+
+    // Operations
+    | Call of callee: Expr * info: CallInfo * typ: Type * range: SourceLocation option
+    | CurriedApply of applied: Expr * args: Expr list * typ: Type * range: SourceLocation option
+    | Curry of Expr * arity: int * Type * SourceLocation option
     | Operation of OperationKind * typ: Type * range: SourceLocation option
-    | Get of Expr * GetKind * typ: Type * range: SourceLocation option
 
-    | Debugger of range: SourceLocation option
-    | Throw of Expr * typ: Type * range: SourceLocation option
+    // JS related: imports and statements
+    | Import of selector: Expr * path: Expr * Type * SourceLocation option
+    | Emit of EmitInfo * typ: Type * range: SourceLocation option
 
+    // Pattern matching
     | DecisionTree of Expr * targets: (Ident list * Expr) list
     | DecisionTreeSuccess of targetIndex: int * boundValues: Expr list * Type
 
-    | Sequential of Expr list
+    // Getters, setters and bindings
     | Let of bindings: (Ident * Expr) list * body: Expr
-    | Set of Expr * SetKind * value: Expr * range: SourceLocation option
-    // TODO: Check if we actually need range for loops
-    | Loop of LoopKind * range: SourceLocation option
+    | Get of Expr * GetKind * typ: Type * range: SourceLocation option
+    | Set of Expr * key: KeyKind option * value: Expr * range: SourceLocation option
+
+    // Flow control
+    | Sequential of Expr list
+    | WhileLoop of guard: Expr * body: Expr * range: SourceLocation option
+    | ForLoop of ident: Ident * start: Expr * limit: Expr * body: Expr * isUp: bool * range: SourceLocation option
     | TryCatch of body: Expr * catch: (Ident * Expr) option * finalizer: Expr option * range: SourceLocation option
     | IfThenElse of guardExpr: Expr * thenExpr: Expr * elseExpr: Expr * range: SourceLocation option
 
@@ -307,26 +282,26 @@ type Expr =
         | Test _ -> Boolean
         | Value (kind, _) -> kind.Type
         | IdentExpr id -> id.Type
+        | Call(_,_,t,_)
+        | CurriedApply(_,_,t,_)
         | TypeCast (_, t)
-        | Import (_, _, _, t, _)
+        | Import (_, _, t, _)
         | Curry (_, _, t, _)
         | ObjectExpr (_, t, _)
         | Operation (_, t, _)
         | Get (_, _, t, _)
-        | Throw (_, t, _)
+        | Emit (_,t,_)
         | DecisionTreeSuccess (_, _, t) -> t
-        | Debugger _
         | Set _
-        | Loop _ -> Unit
-        | Sequential exprs -> (List.last exprs).Type
+        | WhileLoop _
+        | ForLoop _-> Unit
+        | Sequential exprs -> List.tryLast exprs |> Option.map (fun e -> e.Type) |> Option.defaultValue Unit
         | Let (_, expr)
         | TryCatch (expr, _, _, _)
         | IfThenElse (_, expr, _, _)
         | DecisionTree (expr, _) -> expr.Type
-        | Function (kind, body, _) ->
-            match kind with
-            | Lambda arg -> FunctionType(LambdaType arg.Type, body.Type)
-            | Delegate args -> FunctionType(DelegateType(args |> List.map (fun a -> a.Type)), body.Type)
+        | Lambda(arg, body, _) -> LambdaType(arg.Type, body.Type)
+        | Delegate(args, body, _) -> DelegateType(args |> List.map (fun a -> a.Type), body.Type)
 
     member this.Range: SourceLocation option =
         match this with
@@ -335,20 +310,21 @@ type Expr =
         | Let _
         | DecisionTree _
         | DecisionTreeSuccess _ -> None
-
-        | Function (_, e, _)
+        | Lambda (_, e, _)
+        | Delegate (_, e, _)
         | TypeCast (e, _) -> e.Range
         | IdentExpr id -> id.Range
-
-        | Import(_,_,_,_,r)
+        | Call(_,_,_,r)
+        | CurriedApply(_,_,_,r)
+        | Emit (_,_,r)
+        | Import(_,_,_,r)
         | Curry(_,_,_,r)
         | Value (_, r)
         | IfThenElse (_, _, _, r)
         | TryCatch (_, _, _, r)
-        | Debugger r
         | Test (_, _, r)
         | Operation (_, _, r)
         | Get (_, _, _, r)
-        | Throw (_, _, r)
         | Set (_, _, _, r)
-        | Loop (_, r) -> r
+        | ForLoop (_,_,_,_,_,r)
+        | WhileLoop (_,_,r) -> r

--- a/src/Fable.Transforms/FableTransforms.fs
+++ b/src/Fable.Transforms/FableTransforms.fs
@@ -7,9 +7,9 @@ open FSharp.Compiler.SourceCodeServices
 // TODO: Use trampoline here?
 let visit f e =
     match e with
-    | IdentExpr _ | Debugger _ -> e
+    | IdentExpr _ -> e
     | TypeCast(e, t) -> TypeCast(f e, t)
-    | Import(e1, e2, kind, t, r) -> Import(f e1, f e2, kind, t, r)
+    | Import(e1, e2, t, r) -> Import(f e1, f e2, t, r)
     | Value(kind, r) ->
         match kind with
         | ThisValue _ | BaseValue _
@@ -19,49 +19,46 @@ let visit f e =
         | EnumConstant(exp, ent) -> EnumConstant(f exp, ent) |> makeValue r
         | NewOption(e, t) -> NewOption(Option.map f e, t) |> makeValue r
         | NewTuple exprs -> NewTuple(List.map f exprs) |> makeValue r
-        | NewArray(kind, t) ->
-            match kind with
-            | ArrayValues exprs -> NewArray(ArrayValues(List.map f exprs), t) |> makeValue r
-            | ArrayAlloc e -> NewArray(ArrayAlloc(f e), t) |> makeValue r
+        | NewArray(exprs, t) -> NewArray(List.map f exprs, t) |> makeValue r
+        | NewArrayAlloc(e, t) -> NewArrayAlloc(f e, t) |> makeValue r
         | NewList(ht, t) ->
             let ht = ht |> Option.map (fun (h,t) -> f h, f t)
             NewList(ht, t) |> makeValue r
         | NewRecord(exprs, ent, genArgs) ->
             NewRecord(List.map f exprs, ent, genArgs) |> makeValue r
+        | NewAnonymousRecord(exprs, ent, genArgs) ->
+            NewAnonymousRecord(List.map f exprs, ent, genArgs) |> makeValue r
         | NewUnion(exprs, uci, ent, genArgs) ->
             NewUnion(List.map f exprs, uci, ent, genArgs) |> makeValue r
     | Test(e, kind, r) -> Test(f e, kind, r)
     | Curry(e, arity, t, r) -> Curry(f e, arity, t, r)
-    | Function(kind, body, name) -> Function(kind, f body, name)
+    | Lambda(arg, body, name) -> Lambda(arg, f body, name)
+    | Delegate(args, body, name) -> Delegate(args, f body, name)
     | ObjectExpr(members, t, baseCall) ->
         let baseCall = Option.map f baseCall
-        let members = members |> List.map (fun (args, v, info) -> args, f v, info)
+        let members = members |> List.map (fun m -> { m with Body = f m.Body })
         ObjectExpr(members, t, baseCall)
+    | CurriedApply(callee, args, t, r) ->
+        CurriedApply(f callee, List.map f args, t, r)
+    | Call(callee, info, t, r) ->
+        let info = { info with ThisArg = Option.map f info.ThisArg
+                               Args = List.map f info.Args }
+        Call(f callee, info, t, r)
+    | Emit(info, t, r) ->
+        Emit({ info with Args = List.map f info.Args }, t, r)
     | Operation(kind, t, r) ->
         match kind with
-        | CurriedApply(callee, args) ->
-            Operation(CurriedApply(f callee, List.map f args), t, r)
-        | Call(callee, info) ->
-            let info = { info with ThisArg = Option.map f info.ThisArg
-                                   Args = List.map f info.Args }
-            Operation(Call(f callee, info), t, r)
-        | Emit(macro, info) ->
-            let info = info |> Option.map (fun info ->
-                { info with ThisArg = Option.map f info.ThisArg
-                            Args = List.map f info.Args })
-            Operation(Emit(macro, info), t, r)
-        | UnaryOperation(operator, operand) ->
-            Operation(UnaryOperation(operator, f operand), t, r)
-        | BinaryOperation(op, left, right) ->
-            Operation(BinaryOperation(op, f left, f right), t, r)
-        | LogicalOperation(op, left, right) ->
-            Operation(LogicalOperation(op, f left, f right), t, r)
+        | Unary(operator, operand) ->
+            Operation(Unary(operator, f operand), t, r)
+        | Binary(op, left, right) ->
+            Operation(Binary(op, f left, f right), t, r)
+        | Logical(op, left, right) ->
+            Operation(Logical(op, f left, f right), t, r)
     | Get(e, kind, t, r) ->
         match kind with
-        | ListHead | ListTail | OptionValue | TupleGet _ | UnionTag
-        | UnionField _ | FieldGet _ -> Get(f e, kind, t, r)
-        | ExprGet e2 -> Get(f e, ExprGet (f e2), t, r)
-    | Throw(e, typ, r) -> Throw(f e, typ, r)
+        | ListHead | ListTail | OptionValue | TupleIndex _ | UnionTag
+        | UnionField _ | ByKey(FieldKey _) -> Get(f e, kind, t, r)
+        | ByKey(ExprKey e2) -> Get(f e, ByKey(ExprKey(f e2)), t, r)
     | Sequential exprs -> Sequential(List.map f exprs)
     | Let(bs, body) ->
         let bs = bs |> List.map (fun (i,e) -> i, f e)
@@ -70,13 +67,11 @@ let visit f e =
         IfThenElse(f cond, f thenExpr, f elseExpr, r)
     | Set(e, kind, v, r) ->
         match kind with
-        | VarSet | FieldSet _ ->
-            Set(f e, kind, f v, r)
-        | ExprSet e2 -> Set(f e, ExprSet (f e2), f v, r)
-    | Loop (kind, r) ->
-        match kind with
-        | While(e1, e2) -> Loop(While(f e1, f e2), r)
-        | For(i, e1, e2, e3, up) -> Loop(For(i, f e1, f e2, f e3, up), r)
+        | Some(ExprKey e2) ->
+            Set(f e, Some(ExprKey(f e2)), f v, r)
+        | Some(FieldKey _) | None -> Set(f e, kind, f v, r)
+    | WhileLoop(e1, e2, r) -> WhileLoop(f e1, f e2, r)
+    | ForLoop(i, e1, e2, e3, up, r) -> ForLoop(i, f e1, f e2, f e3, up, r)
     | TryCatch(body, catch, finalizer, r) ->
         TryCatch(f body,
                  Option.map (fun (i, e) -> i, f e) catch,
@@ -96,9 +91,9 @@ let rec visitFromOutsideIn (f: Expr->Expr option) e =
     | None -> visit (visitFromOutsideIn f) e
 
 let getSubExpressions = function
-    | IdentExpr _ | Debugger _ -> []
+    | IdentExpr _ -> []
     | TypeCast(e,_) -> [e]
-    | Import(e1,e2,_,_,_) -> [e1;e2]
+    | Import(e1,e2,_,_) -> [e1;e2]
     | Value(kind,_) ->
         match kind with
         | ThisValue _ | BaseValue _
@@ -108,47 +103,42 @@ let getSubExpressions = function
         | EnumConstant(e, _) -> [e]
         | NewOption(e, _) -> Option.toList e
         | NewTuple exprs -> exprs
-        | NewArray(kind, _) ->
-            match kind with
-            | ArrayValues exprs -> exprs
-            | ArrayAlloc e -> [e]
+        | NewArray(exprs, _) -> exprs
+        | NewArrayAlloc(e, _) -> [e]
         | NewList(ht, _) ->
             match ht with Some(h,t) -> [h;t] | None -> []
         | NewRecord(exprs, _, _) -> exprs
+        | NewAnonymousRecord(exprs, _, _) -> exprs
         | NewUnion(exprs, _, _, _) -> exprs
     | Test(e, _, _) -> [e]
     | Curry(e, _, _, _) -> [e]
-    | Function(_, body, _) -> [body]
+    | Lambda(_, body, _) -> [body]
+    | Delegate(_, body, _) -> [body]
     | ObjectExpr(members, _, baseCall) ->
-        let members = members |> List.collect (fun (_,v,_) -> [v])
+        let members = members |> List.map (fun m -> m.Body)
         match baseCall with Some b -> b::members | None -> members
+    | CurriedApply(callee, args, _, _) -> callee::args
+    | Call(e1, info, _, _) -> e1 :: (Option.toList info.ThisArg) @ info.Args
+    | Emit(info, _, _) -> info.Args
     | Operation(kind, _, _) ->
         match kind with
-        | CurriedApply(callee, args) -> callee::args
-        | Call(e1, info) ->
-            e1 :: (Option.toList info.ThisArg) @ info.Args
-        | Emit(_, info) ->
-            match info with Some info -> (Option.toList info.ThisArg) @ info.Args | None -> []
-        | UnaryOperation(_, operand) -> [operand]
-        | BinaryOperation(_, left, right) -> [left; right]
-        | LogicalOperation(_, left, right) -> [left; right]
+        | Unary(_, operand) -> [operand]
+        | Binary(_, left, right) -> [left; right]
+        | Logical(_, left, right) -> [left; right]
     | Get(e, kind, _, _) ->
         match kind with
-        | ListHead | ListTail | OptionValue | TupleGet _ | UnionTag
-        | UnionField _ | FieldGet _ -> [e]
-        | ExprGet e2 -> [e; e2]
-    | Throw(e, _, _) -> [e]
+        | ListHead | ListTail | OptionValue | TupleIndex _ | UnionTag
+        | UnionField _ | ByKey(FieldKey _) -> [e]
+        | ByKey(ExprKey e2) -> [e; e2]
     | Sequential exprs -> exprs
     | Let(bs, body) -> (List.map snd bs) @ [body]
     | IfThenElse(cond, thenExpr, elseExpr, _) -> [cond; thenExpr; elseExpr]
     | Set(e, kind, v, _) ->
         match kind with
-        | VarSet | FieldSet _ -> [e; v]
-        | ExprSet e2 -> [e; e2; v]
-    | Loop (kind, _) ->
-        match kind with
-        | While(e1, e2) -> [e1; e2]
-        | For(_, e1, e2, e3, _) -> [e1; e2; e3]
+        | Some(ExprKey e2) -> [e; e2; v]
+        | Some(FieldKey _) | None -> [e; v]
+    | WhileLoop(e1, e2, _) -> [e1; e2]
+    | ForLoop(_, e1, e2, e3, _, _) -> [e1; e2; e3]
     | TryCatch(body, catch, finalizer, _) ->
         match catch with
         | Some(_,c) -> body::c::(Option.toList finalizer)
@@ -200,21 +190,23 @@ let countReferences limit identName body =
 
 let canInlineArg identName value body =
     match value with
-    | Function _ -> countReferences 1 identName body <= 1
+    | Lambda _ | Delegate _ -> countReferences 1 identName body <= 1
     | value -> canHaveSideEffects value |> not
 
 module private Transforms =
     let (|LambdaOrDelegate|_|) = function
-        | Function(Lambda arg, body, name) -> Some([arg], body, name)
-        | Function(Delegate args, body, name) -> Some(args, body, name)
+        | Lambda(arg, body, name) -> Some([arg], body, name)
+        | Delegate(args, body, name) -> Some(args, body, name)
         | _ -> None
+
+    let (|FieldType|) (fi: Field) = fi.FieldType
 
     let lambdaBetaReduction (com: ICompiler) e =
         // Sometimes the F# compiler creates a lot of binding closures, as with printfn
         let (|NestedLetsAndLambdas|_|) expr =
             let rec inner accBindings accArgs body name =
                 match body with
-                | Function(Lambda arg, body, None) ->
+                | Lambda(arg, body, None) ->
                     inner accBindings (arg::accArgs) body name
                 | Let(bindings, body) ->
                     inner (accBindings @ bindings) accArgs body name
@@ -224,7 +216,7 @@ module private Transforms =
             match expr with
             | Let(bindings, body) ->
                 inner bindings [] body None
-            | Function(Lambda arg, body, name) ->
+            | Lambda(arg, body, name) ->
                 inner [] [arg] body name
             | _ -> None
         let applyArgs (args: Ident list) argExprs body =
@@ -239,7 +231,7 @@ module private Transforms =
             | bindings -> Let(List.rev bindings, replaceValues replacements body)
         match e with
         // TODO: Other binary operations and numeric types, also recursive?
-        | Operation(BinaryOperation(AST.BinaryPlus, Value(StringConstant str1, r1), Value(StringConstant str2, r2)),_,_) ->
+        | Operation(Binary(AST.BinaryPlus, Value(StringConstant str1, r1), Value(StringConstant str2, r2)),_,_) ->
             Value(StringConstant(str1 + str2), addRanges [r1; r2])
         | NestedApply(NestedLetsAndLambdas(lambdaArgs, body, _) as lambda, argExprs,_,_) ->
             if List.sameLength lambdaArgs argExprs then
@@ -247,13 +239,13 @@ module private Transforms =
             else
                 // Partial apply
                 match List.length argExprs, lambda with
-                | 1, Function(Lambda arg, body, _) ->
+                | 1, Lambda(arg, body, _) ->
                     applyArgs [arg] argExprs body
-                | 2, Function(Lambda arg1, Function(Lambda arg2, body,_),_) ->
+                | 2, Lambda(arg1, Lambda(arg2, body,_),_) ->
                     applyArgs [arg1; arg2] argExprs body
-                | 3, Function(Lambda arg1, Function(Lambda arg2, Function(Lambda arg3, body,_),_),_) ->
+                | 3, Lambda(arg1, Lambda(arg2, Lambda(arg3, body,_),_),_) ->
                     applyArgs [arg1; arg2; arg3] argExprs body
-                | 4, Function(Lambda arg1, Function(Lambda arg2, Function(Lambda arg3, Function(Lambda arg4, body,_),_),_),_) ->
+                | 4, Lambda(arg1, Lambda(arg2, Lambda(arg3, Lambda(arg4, body,_),_),_),_) ->
                     applyArgs [arg1; arg2; arg3; arg4] argExprs body
                 | _ -> e
         | e -> e
@@ -261,7 +253,7 @@ module private Transforms =
     /// Tuples created when pattern matching multiple elements can usually be erased
     /// after the binding and lambda beta reduction
     let tupleBetaReduction (_: ICompiler) = function
-        | Get(Value(NewTuple exprs, _), TupleGet index, _, _) -> List.item index exprs
+        | Get(Value(NewTuple exprs, _), TupleIndex index, _, _) -> List.item index exprs
         | e -> e
 
     let bindingBetaReduction (com: ICompiler) e =
@@ -284,7 +276,8 @@ module private Transforms =
                 let value =
                     match value with
                     // Ident becomes the name of the function (mainly used for tail call optimizations)
-                    | Function(args, funBody, _) -> Function(args, funBody, Some ident.Name)
+                    | Lambda(arg, funBody, _) -> Lambda(arg, funBody, Some ident.Name)
+                    | Delegate(args, funBody, _) -> Delegate(args, funBody, Some ident.Name)
                     | value -> value
                 replaceValues (Map [ident.Name, value]) letBody
             else e
@@ -293,12 +286,12 @@ module private Transforms =
     /// Returns arity of lambda (or lambda option) types
     let getLambdaTypeArity t =
         let rec getLambdaTypeArity acc = function
-            | FunctionType(LambdaType _, returnType) ->
+            | LambdaType(_, returnType) ->
                 getLambdaTypeArity (acc + 1) returnType
             | _ -> acc
         match t with
-        | FunctionType(LambdaType _, returnType)
-        | Option(FunctionType(LambdaType _, returnType)) ->
+        | LambdaType(_, returnType)
+        | Option(LambdaType(_, returnType)) ->
             getLambdaTypeArity 1 returnType
         | _ -> 0
 
@@ -321,7 +314,7 @@ module private Transforms =
         then body
         else curryIdentsInBody replacements body
 
-    let uncurryExpr arity expr =
+    let uncurryExpr com arity expr =
         let matches arity arity2 =
             match arity with
             // TODO: check cases where arity <> arity2
@@ -338,7 +331,7 @@ module private Transforms =
             when matches arity arity2 -> Value(NewOption(Some(innerExpr),r1),r2)
         | _ ->
             match arity with
-            | Some arity -> Replacements.uncurryExprAtRuntime arity expr
+            | Some arity -> Replacements.uncurryExprAtRuntime com arity expr
             | None -> expr
 
     // For function arguments check if the arity of their own function arguments is expected or not
@@ -369,7 +362,7 @@ module private Transforms =
                             NewTuple [makeIntConst expectedArity; makeIntConst actualArity] |> makeValue None
                         | None -> makeIntConst 0)
                     |> makeArray Any
-                Replacements.Helper.CoreCall("Util", "mapCurriedArgs", expectedType, [expr; mappings])
+                Replacements.Helper.LibCall(com, "Util", "mapCurriedArgs", expectedType, [expr; mappings])
         | _ -> expr
 
     let uncurryArgs com autoUncurrying argTypes args =
@@ -383,14 +376,14 @@ module private Transforms =
                 | _, [] -> List.rev acc
             mapArgsInner f [] argTypes args
         match argTypes with
-        | _ when autoUncurrying -> List.map (uncurryExpr None) args
+        | _ when autoUncurrying -> List.map (uncurryExpr com None) args
         | [] -> args // Do nothing
         | argTypes ->
             (argTypes, args) ||> mapArgs (fun expectedType arg ->
                 let arg = checkSubArguments com expectedType arg
                 let arity = getLambdaTypeArity expectedType
                 if arity > 1
-                then uncurryExpr (Some arity) arg
+                then uncurryExpr com (Some arity) arg
                 else arg)
 
     let uncurryInnerFunctions (_: ICompiler) e =
@@ -400,13 +393,13 @@ module private Transforms =
         | Let([ident, NestedLambdaWithSameArity(args, fnBody, _)], letBody) when List.isMultiple args ->
             let fnBody = curryIdentInBody ident.Name args fnBody
             let letBody = curryIdentInBody ident.Name args letBody
-            Let([ident, Function(Delegate args, fnBody, None)], letBody)
+            Let([ident, Delegate(args, fnBody, None)], letBody)
         // Anonymous lambda immediately applied
-        | Operation(CurriedApply((NestedLambdaWithSameArity(args, fnBody, Some name)), argExprs), t, r)
+        | CurriedApply(NestedLambdaWithSameArity(args, fnBody, Some name), argExprs, t, r)
                         when List.isMultiple args && List.sameLength args argExprs ->
             let fnBody = curryIdentInBody name args fnBody
-            let info = makeSimpleCallInfo None argExprs (args |> List.map (fun a -> a.Type))
-            Function(Delegate args, fnBody, Some name)
+            let info = makeCallInfo None argExprs (args |> List.map (fun a -> a.Type))
+            Delegate(args, fnBody, Some name)
             |> makeCall r t info
         | e -> e
 
@@ -427,73 +420,73 @@ module private Transforms =
             else Let(identsAndValues, curryIdentsInBody replacements body)
         | e -> e
 
+    let uncurryMemberArgs (m: MemberDecl) =
+        if m.Info.IsValue then m
+        else { m with Body = uncurryIdentsAndReplaceInBody m.Args m.Body }
+
     let uncurryReceivedArgs (_: ICompiler) e =
         match e with
-        | Function(Lambda arg, body, name) ->
+        | Lambda(arg, body, name) ->
             let body = uncurryIdentsAndReplaceInBody [arg] body
-            Function(Lambda arg, body, name)
-        | Function(Delegate args, body, name) ->
+            Lambda(arg, body, name)
+        | Delegate(args, body, name) ->
             let body = uncurryIdentsAndReplaceInBody args body
-            Function(Delegate args, body, name)
+            Delegate(args, body, name)
         // Uncurry also values received from getters
-        | Get(_, (FieldGet(_,_,fieldType) | UnionField(_,_,fieldType)), t, r) ->
+        | Get(_, (ByKey(FieldKey(FieldType fieldType)) | UnionField(_,fieldType)), t, r) ->
             let arity = getLambdaTypeArity fieldType
             if arity > 1
             then Curry(e, arity, t, r)
             else e
         | ObjectExpr(members, t, baseCall) ->
-            let members =
-                members |> List.map (fun (args, body, info) ->
-                    let body = if info.IsMethod then uncurryIdentsAndReplaceInBody args body
-                               else body
-                    args, body, info)
-            ObjectExpr(members, t, baseCall)
+            ObjectExpr(List.map uncurryMemberArgs members, t, baseCall)
         | e -> e
 
     let uncurrySendingArgs (com: ICompiler) e =
-        let uncurryConsArgs args (fields: seq<FSharpField>) =
+        let uncurryConsArgs args (fields: seq<Field>) =
             let argTypes =
                 fields
-                |> Seq.map (fun fi -> FSharp2Fable.TypeHelpers.makeType com Map.empty fi.FieldType)
+                |> Seq.map (fun fi -> fi.FieldType)
                 |> Seq.toList
             uncurryArgs com false argTypes args
         match e with
-        | Operation(Call(callee, info), t, r) ->
-            let args = uncurryArgs com info.AutoUncurrying info.SignatureArgTypes info.Args
+        | Call(callee, info, t, r) ->
+            let args = uncurryArgs com false info.SignatureArgTypes info.Args
             let info = { info with Args = args }
-            Operation(Call(callee, info), t, r)
-        | Operation(CurriedApply(callee, args), t, r) ->
+            Call(callee, info, t, r)
+        | CurriedApply(callee, args, t, r) ->
             match callee.Type with
             | NestedLambdaType(argTypes, _) ->
-                Operation(CurriedApply(callee, uncurryArgs com false argTypes args), t, r)
+                CurriedApply(callee, uncurryArgs com false argTypes args, t, r)
             | _ -> e
-        | Operation(Emit(macro, Some info), t, r) ->
-            let args = uncurryArgs com info.AutoUncurrying info.SignatureArgTypes info.Args
-            let info = { info with Args = args }
-            Operation(Emit(macro, Some info), t, r)
+        | Emit(info, t, r) ->
+            Emit({ info with Args = uncurryArgs com true [] info.Args }, t, r)
         // Uncurry also values in setters or new record/union/tuple
-        | Value(NewRecord(args, kind, genArgs), r) ->
-            let args =
-                match kind with
-                | DeclaredRecord ent -> uncurryConsArgs args ent.FSharpFields
-                | AnonymousRecord _ -> uncurryArgs com true [] args
-            Value(NewRecord(args, kind, genArgs), r)
-        | Value(NewUnion(args, uci, ent, genArgs), r) ->
+        | Value(NewRecord(args, ent, genArgs), r) ->
+            let args = uncurryConsArgs args ent.FSharpFields
+            Value(NewRecord(args, ent, genArgs), r)
+        | Value(NewAnonymousRecord(args, fieldNames, genArgs), r) ->
+            let args = uncurryArgs com true [] args
+            Value(NewAnonymousRecord(args, fieldNames, genArgs), r)
+        | Value(NewUnion(args, tag, ent, genArgs), r) ->
+            let uci = ent.UnionCases.[tag]
             let args = uncurryConsArgs args uci.UnionCaseFields
-            Value(NewUnion(args, uci, ent, genArgs), r)
-        | Set(e, FieldSet(fieldName, fieldType), value, r) ->
-            let value = uncurryArgs com false [fieldType] [value]
-            Set(e, FieldSet(fieldName, fieldType), List.head value, r)
+            Value(NewUnion(args, tag, ent, genArgs), r)
+        | Set(e, Some(FieldKey fi), value, r) ->
+            let value = uncurryArgs com false [fi.FieldType] [value]
+            Set(e, Some(FieldKey fi), List.head value, r)
         | e -> e
 
     let rec uncurryApplications (com: ICompiler) e =
         let uncurryApply r t applied args uncurriedArity =
             let argsLen = List.length args
             if uncurriedArity = argsLen then
-                let info = { makeSimpleCallInfo None args [] with AutoUncurrying = true }
+                // This is already uncurried we don't need the signature arg types anymore,
+                // just make a normal call
+                let info = makeCallInfo None args []
                 makeCall r t info applied |> Some
             else
-                Replacements.partialApplyAtRuntime t (uncurriedArity - argsLen) applied args |> Some
+                Replacements.partialApplyAtRuntime com t (uncurriedArity - argsLen) applied args |> Some
         match e with
         | NestedApply(applied, args, t, r) ->
             let applied = visitFromOutsideIn (uncurryApplications com) applied
@@ -503,7 +496,7 @@ module private Transforms =
                 uncurryApply r t applied args uncurriedArity
             | Get(Curry(applied, uncurriedArity,_,_), OptionValue, t2, r2) ->
                 uncurryApply r t (Get(applied, OptionValue, t2, r2)) args uncurriedArity
-            | _ -> Operation(CurriedApply(applied, args), t, r) |> Some
+            | _ -> CurriedApply(applied, args, t, r) |> Some
         | _ -> None
 
 open Transforms
@@ -527,36 +520,38 @@ let optimizations =
 let transformExpr (com: ICompiler) e =
     List.fold (fun e f -> f com e) e optimizations
 
+let transformMemberBody com (m: MemberDecl) =
+    { m with Body = transformExpr com m.Body }
+
 let transformDeclaration (com: ICompiler) = function
     | ActionDeclaration(expr, usedNames) ->
         ActionDeclaration(transformExpr com expr, usedNames)
-    | ModuleMemberDeclaration(args, body, info, usedNames) ->
-        let body =
-            if info.IsValue then body
-            else uncurryIdentsAndReplaceInBody args body
-        ModuleMemberDeclaration(args, transformExpr com body, info, usedNames)
-    | AttachedMemberDeclaration(args, body, info, e, usedNames) ->
-        let body =
-            if info.IsMethod then uncurryIdentsAndReplaceInBody args body
-            else body
-        AttachedMemberDeclaration(args, transformExpr com body, info, e, usedNames)
-    | ClassImplicitConstructorDeclaration(info, usedNames) ->
-        let baseCall, body =
-            match info.BaseCall with
-            | Some baseCall ->
+
+    | MemberDeclaration m ->
+        uncurryMemberArgs m |> transformMemberBody com |> MemberDeclaration
+
+    | ClassDeclaration(ent, ident, cons, baseCall, attachedMembers) ->
+        let attachedMembers =
+            attachedMembers
+            |> List.map (uncurryMemberArgs >> transformMemberBody com)
+
+        let cons, baseCall =
+            match cons, baseCall with
+            | None, _ -> cons, baseCall
+            | Some cons, None ->
+                uncurryMemberArgs cons |> transformMemberBody com |> Some, None
+            | Some cons, Some baseCall ->
                 // In order to uncurry correctly the baseCall arguments,
                 // we need to include it in the constructor body
-                Sequential [baseCall; info.Body]
-                |> uncurryIdentsAndReplaceInBody info.Arguments
+                Sequential [baseCall; cons.Body]
+                |> uncurryIdentsAndReplaceInBody cons.Args
                 |> transformExpr com
                 |> function
-                    | Sequential [baseCall; body] -> Some baseCall, body
-                    | body -> None, body // Unexpected, raise error?
-            | None ->
-                None, uncurryIdentsAndReplaceInBody info.Arguments info.Body |> transformExpr com
-        ClassImplicitConstructorDeclaration(info.WithBodyAndBaseCall(body, baseCall), usedNames)
-    | CompilerGeneratedConstructorDeclaration _ as d -> d
+                    | Sequential [baseCall; body] -> Some { cons with Body = body }, Some baseCall
+                    | body -> Some { cons with Body = body }, None // Unexpected, raise error?
+
+        ClassDeclaration(ent, ident, cons, baseCall, attachedMembers)
 
 let transformFile (com: ICompiler) (file: File) =
     let newDecls = List.map (transformDeclaration com) file.Declarations
-    File(file.SourcePath, newDecls, usedRootNames=file.UseNamesInRootScope, inlineDependencies=file.InlineDependencies)
+    File(file.SourcePath, newDecls, usedRootNames=file.UsedNamesInRootScope, inlineDependencies=file.InlineDependencies)

--- a/src/Fable.Transforms/Global/Compiler.fs
+++ b/src/Fable.Transforms/Global/Compiler.fs
@@ -37,7 +37,6 @@ type ICompiler =
     abstract LibraryDir: string
     abstract CurrentFile: string
     abstract Options: CompilerOptions
-    abstract GetUniqueVar: ?name: string -> string
     abstract GetRootModule: string -> string
     abstract GetOrAddInlineExpr: string * (unit->InlineExpr) -> InlineExpr
     abstract AddLog: msg:string * severity: Severity * ?range:SourceLocation

--- a/src/Fable.Transforms/Global/Prelude.fs
+++ b/src/Fable.Transforms/Global/Prelude.fs
@@ -6,8 +6,9 @@ type Position =
     static member Empty = { line = 1; column = 0 }
 
 type SourceLocation =
-    { start: Position;
-      ``end``: Position;
+    { start: Position
+      ``end``: Position
+      /// We added the display name here because it seemed to be used by Babel source map generation
       identifierName: string option }
     static member (+)(r1, r2) =
         { start = r1.start
@@ -31,6 +32,11 @@ module Tuple3 =
     let item1 (x,_,_) = x
     let item2 (_,y,_) = y
     let item3 (_,_,z) = z
+
+[<RequireQualifiedAccess>]
+module Seq =
+    let mapToList (f: 'a -> 'b) (xs: 'a seq) =
+        ([], xs) ||> Seq.fold (fun li x -> (f x)::li) |> List.rev
 
 [<RequireQualifiedAccess>]
 module Array =

--- a/src/Fable.Transforms/Global/Prelude.fs
+++ b/src/Fable.Transforms/Global/Prelude.fs
@@ -78,6 +78,10 @@ module List =
         xs.[xs.Length - 1 ] <- f xs.[xs.Length - 1 ]
         List.ofArray xs
 
+    let collecti (f: int -> 'a -> 'b list) (xs: 'a list) =
+        let mutable i = -1
+        xs |> List.collect (fun x -> i <- i + 1; f i x)
+
     let mapToArray (f: 'a -> 'b) (xs: 'a list) =
         let ar: 'b[] = List.length xs |> Array.zeroCreate
         xs |> List.iteri (fun i x -> ar.[i] <- f x)
@@ -128,20 +132,19 @@ module Naming =
     let umdModules =
         set ["commonjs"; "amd"; "umd"]
 
-    // Dollar sign is reserved by Fable as a special character
-    // to encode other characters, unique var names and as a separator
     let isIdentChar index (c: char) =
         let code = int c
-        c = '_'
+        c = '_' || c = '$'
         || (65 <= code && code <= 90)   // a-z
         || (97 <= code && code <= 122)  // A-Z
         // Digits are not allowed in first position, see #1397
         || (index > 0 && 48 <= code && code <= 57) // 0-9
 
     let hasIdentForbiddenChars (ident: string) =
-        let mutable i = 0
-        while i < ident.Length && (isIdentChar i ident.[i]) do i <- i + 1
-        i < ident.Length
+        let mutable found = false
+        for i = 0 to ident.Length - 1 do
+            found <- found || not(isIdentChar i ident.[i])
+        found
 
     let sanitizeIdentForbiddenChars (ident: string) =
         if hasIdentForbiddenChars ident then
@@ -153,10 +156,6 @@ module Naming =
                     else yield "$" + System.String.Format("{0:X}", int c).PadLeft(4, '0')
                 })
         else ident
-
-    /// Does not guarantee unique names, only used to clean function constructor names
-    let unsafeReplaceIdentForbiddenChars (replacement: char) (ident: string): string =
-        ident.ToCharArray() |> Array.mapi (fun i c -> if isIdentChar i c then c else replacement) |> System.String
 
     let removeGetSetPrefix (s: string) =
         if s.StartsWith("get_") || s.StartsWith("set_") then
@@ -192,58 +191,221 @@ module Naming =
 
     let jsKeywords =
         System.Collections.Generic.HashSet [
-            // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Keywords
-            "abstract"; "await"; "boolean"; "break"; "byte"; "case"; "catch"; "char"; "class"; "const"; "continue"; "debugger"; "default"; "delete"; "do"; "double";
-            "else"; "enum"; "export"; "extends"; "false"; "final"; "finally"; "float"; "for"; "function"; "goto"; "if"; "implements"; "import"; "in"; "instanceof"; "int"; "interface";
-            "let"; "long"; "native"; "new"; "null"; "package"; "private"; "protected"; "public"; "return"; "self"; "short"; "static"; "super"; "switch"; "synchronized";
-            "this"; "throw"; "throws"; "transient"; "true"; "try"; "typeof"; "undefined"; "var"; "void"; "volatile"; "while"; "with"; "yield";
-            // Standard built-in objects (https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects)
-            "Object"; "Function"; "Boolean"; "Symbol"; "Map"; "Set"; "NaN"; "Number"; "Math"; "Date"; "String"; "RegExp"; "JSON"; "Promise";
-            "Array"; "Int8Array"; "Uint8Array"; "Uint8ClampedArray"; "Int16Array"; "Uint16Array"; "Int32Array"; "Uint32Array"; "Float32Array"; "Float64Array";
-            // DOM interfaces (https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model)
-            "Attr"; "CharacterData"; "Comment"; "CustomEvent"; "Document"; "DocumentFragment"; "DocumentType"; "DOMError"; "DOMException"; "DOMImplementation";
-            "DOMString"; "DOMTimeStamp"; "DOMSettableTokenList"; "DOMStringList"; "DOMTokenList"; "Element"; "Event"; "EventTarget"; "Error"; "HTMLCollection"; "MutationObserver";
-            "MutationRecord"; "Node"; "NodeFilter"; "NodeIterator"; "NodeList"; "ProcessingInstruction"; "Range"; "Text"; "TreeWalker"; "URL"; "Window"; "Worker"; "XMLDocument";
-            // Other JS global and special objects/functions
-            // See #258, #1358
-            // See https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
-            // See https://twitter.com/FableCompiler/status/930725972629913600
-            "arguments"; "fetch"; "eval"; "window"; "console"; "global"; "document"
+            // Keywords: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Keywords
+            "break"
+            "case"
+            "catch"
+            "class"
+            "const"
+            "continue"
+            "debugger"
+            "default"
+            "delete"
+            "do"
+            "else"
+            "export"
+            "extends"
+            "finally"
+            "for"
+            "function"
+            "if"
+            "import"
+            "in"
+            "instanceof"
+            "new"
+            "return"
+            "super"
+            "switch"
+            "this"
+            "throw"
+            "try"
+            "typeof"
+            "var"
+            "void"
+            "while"
+            "with"
+            "yield"
+
+            "enum"
+
+            "implements"
+            "interface"
+            "let"
+            "package"
+            "private"
+            "protected"
+            "public"
+            "static"
+
+            "await"
+
+            "null"
+            "true"
+            "false"
+            "arguments"
+            "get"
+            "set"
+
+            // Standard built-in objects: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects
+            "Infinity"
+            "NaN"
+            "undefined"
+            "globalThis"
+
+            "eval"
+            "uneval"
+            "isFinite"
+            "isNaN"
+            "parseFloat"
+            "parseInt"
+            "decodeURI"
+            "decodeURIComponent"
+            "encodeURI"
+            "encodeURIComponent"
+
+            "Object"
+            "Function"
+            "Boolean"
+            "Symbol"
+
+            "Error"
+            "AggregateError"
+            "EvalError"
+            "InternalError"
+            "RangeError"
+            "ReferenceError"
+            "SyntaxError"
+            "TypeError"
+            "URIError"
+
+            "Number"
+            "BigInt"
+            "Math"
+            "Date"
+
+            "String"
+            "RegExp"
+
+            "Array"
+            "Int8Array"
+            "Uint8Array"
+            "Uint8ClampedArray"
+            "Int16Array"
+            "Uint16Array"
+            "Int32Array"
+            "Uint32Array"
+            "Float32Array"
+            "Float64Array"
+            "BigInt64Array"
+            "BigUint64Array"
+
+            "Map"
+            "Set"
+            "WeakMap"
+            "WeakSet"
+
+            "ArrayBuffer"
+            "SharedArrayBuffer"
+            "Atomics"
+            "DataView"
+            "JSON"
+
+            "Promise"
+            "Generator"
+            "GeneratorFunction"
+            "AsyncFunction"
+
+            "Reflect"
+            "Proxy"
+
+            "Intl"
+            "WebAssembly"
+
+            // DOM interfaces (omitting SVG): https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model
+            "Attr"
+            "CDATASection"
+            "CharacterData"
+            "ChildNode"
+            "Comment"
+            "CustomEvent"
+            "Document"
+            "DocumentFragment"
+            "DocumentType"
+            "DOMError"
+            "DOMException"
+            "DOMImplementation"
+            "DOMString"
+            "DOMTimeStamp"
+            "DOMStringList"
+            "DOMTokenList"
+            "Element"
+            "Event"
+            "EventTarget"
+            "HTMLCollection"
+            "MutationObserver"
+            "MutationRecord"
+            "NamedNodeMap"
+            "Node"
+            "NodeFilter"
+            "NodeIterator"
+            "NodeList"
+            "NonDocumentTypeChildNode"
+            "ParentNode"
+            "ProcessingInstruction"
+            "Selection"
+            "Range"
+            "Text"
+            "TextDecoder"
+            "TextEncoder"
+            "TimeRanges"
+            "TreeWalker"
+            "URL"
+            "Window"
+            "Worker"
+            "XMLDocument"
+
+            // Other JS global and special objects/functions. See #258, #1358
+            "console"
+            "window"
+            "document"
+            "global"
+            "fetch"
         ]
 
-    // A dollar sign is used to prefix chars encoded in hexadecimal
-    // so use two as separator to prevent conflicts
-    // (see also `getUniqueName` and `buildName` below)
-    let preventConflicts conflicts name =
-        let rec check n =
-            let name = if n > 0 then name + "$$" + (string n) else name
-            if not (conflicts name) then name else check (n+1)
-        check 0
+    let preventConflicts conflicts originalName =
+        let rec check originalName n =
+            let name = if n > 0 then originalName + "_" + (string n) else originalName
+            if not (conflicts name) then name else check originalName (n+1)
+        check originalName 0
 
+    // TODO: Move this to FSharp2Fable.Util
     type MemberPart =
         | InstanceMemberPart of string * overloadSuffix: string
         | StaticMemberPart of string * overloadSuffix: string
         | NoMemberPart
+        member this.Replace(f: string -> string) =
+            match this with
+            | InstanceMemberPart(s, o) -> InstanceMemberPart(f s, o)
+            | StaticMemberPart(s, o) -> StaticMemberPart(f s, o)
+            | NoMemberPart -> this
 
-    let getUniqueName baseName (index: int) =
-        "$" + baseName + "$$" + string index
+        member this.OverloadSuffix =
+            match this with
+            | InstanceMemberPart(_,o)
+            | StaticMemberPart(_,o) -> o
+            | NoMemberPart -> ""
 
-    let appendSuffix baseName suffix =
-        if suffix = ""
-        then baseName
-        else baseName + "$" + suffix
-
-    let reflectionSuffix = "reflection"
+    let reflectionSuffix = "$reflection"
 
     let private printPart sanitize separator part overloadSuffix =
         (if part = "" then "" else separator + (sanitize part)) +
-            (if overloadSuffix = "" then "" else "$$" + overloadSuffix)
+            (if overloadSuffix = "" then "" else "_" + overloadSuffix)
 
     let private buildName sanitize name part =
         (sanitize name) +
             (match part with
-                | InstanceMemberPart(s, i) -> printPart sanitize "$$" s i
-                | StaticMemberPart(s, i)   -> printPart sanitize "$$$" s i
+                | InstanceMemberPart(s, i) -> printPart sanitize "__" s i
+                | StaticMemberPart(s, i) -> printPart sanitize "_" s i
                 | NoMemberPart -> "")
 
     let buildNameWithoutSanitation name part =

--- a/src/Fable.Transforms/Inject.fs
+++ b/src/Fable.Transforms/Inject.fs
@@ -27,17 +27,17 @@ let (|GeneratedInterface|_|) com ctx r t =
     match t with
     | Fable.DeclaredType(typDef,[t]) ->
         // TODO: Unify with Replacements.injectArg?
-        match typDef.TryFullName with
-        | Some Types.typeResolver ->
+        match typDef.FullName with
+        | Types.typeResolver ->
             let fn = Fable.Value(Fable.TypeInfo t, r) |> makeDelegate []
             Replacements.Helpers.objExpr ["ResolveType", fn] |> Some
-        | Some Types.comparer ->
+        | Types.comparer ->
             Replacements.makeComparer com t |> Some
-        | Some Types.equalityComparer ->
+        | Types.equalityComparer ->
             Replacements.makeEqualityComparer com t |> Some
-        | Some Types.adder ->
+        | Types.adder ->
             Replacements.makeGenericAdder com ctx t |> Some
-        | Some Types.averager ->
+        | Types.averager ->
             Replacements.makeGenericAverager com ctx t |> Some
         | _ -> None
     | _ -> None
@@ -47,7 +47,7 @@ let injectArg com ctx r (genArgs: (string * Fable.Type) list) (par: FSharpParame
     let typ =
         // The type of the parameter must be an option
         if parType.HasTypeDefinition && parType.TypeDefinition.TryFullName = Some Types.option
-        then makeType com (Map genArgs) parType.GenericArguments.[0] |> Some
+        then makeType (Map genArgs) parType.GenericArguments.[0] |> Some
         else None
     match typ with
     | Some(GeneratedInterface com ctx r e) -> e

--- a/src/Fable.Transforms/State.fs
+++ b/src/Fable.Transforms/State.fs
@@ -48,7 +48,6 @@ type Log =
 /// Type with utilities for compiling F# files to JS
 /// Not thread-safe, an instance must be created per file
 type Compiler(currentFile, project: Project, options, fableLibraryDir: string) =
-    let mutable id = 0
     let logs = ResizeArray<Log>()
     let fableLibraryDir = fableLibraryDir.TrimEnd('/')
     member __.GetLogs() =
@@ -94,7 +93,3 @@ type Compiler(currentFile, project: Project, options, fableLibraryDir: string) =
               Range = range
               FileName = fileName }
             |> logs.Add
-        // TODO: If name includes `$$2` at the end, remove it
-        member __.GetUniqueVar(name) =
-            id <- id + 1
-            Naming.getUniqueName (defaultArg name "var") id

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -21,7 +21,6 @@ module Atts =
     let [<Literal>] emitProperty = "Fable.Core.EmitPropertyAttribute" // typeof<Fable.Core.EmitAttribute>.FullName
     let [<Literal>] erase = "Fable.Core.EraseAttribute" // typeof<Fable.Core.EraseAttribute>.FullName
     let [<Literal>] stringEnum = "Fable.Core.StringEnumAttribute" // typeof<Fable.Core.StringEnumAttribute>.FullName
-    let [<Literal>] paramList = "Fable.Core.ParamListAttribute" // typeof<Fable.Core.ParamListAttribute>.FullName
     let [<Literal>] inject = "Fable.Core.InjectAttribute" // typeof<Fable.Core.InjectAttribute>.FullName
 
 [<RequireQualifiedAccess>]
@@ -194,6 +193,10 @@ module Log =
     let addError (com: ICompiler) inlinePath range error =
         addLog com inlinePath range error Severity.Error
 
+    let addWarningAndReturnNull (com: ICompiler) inlinePath range error =
+        addLog com inlinePath range error Severity.Warning
+        AST.Fable.Value(AST.Fable.Null AST.Fable.Any, None)
+
     let addErrorAndReturnNull (com: ICompiler) inlinePath range error =
         addLog com inlinePath range error Severity.Error
         AST.Fable.Value(AST.Fable.Null AST.Fable.Any, None)
@@ -220,22 +223,22 @@ module AST =
 
     let (|NestedLambdaType|_|) t =
         let rec nestedLambda acc = function
-            | FunctionType(LambdaType arg, returnType) ->
+            | LambdaType(arg, returnType) ->
                 nestedLambda (arg::acc) returnType
             | returnType -> Some(List.rev acc, returnType)
         match t with
-        | FunctionType(LambdaType arg, returnType) -> nestedLambda [arg] returnType
+        | LambdaType(arg, returnType) -> nestedLambda [arg] returnType
         | _ -> None
 
     /// Only matches lambda immediately nested within each other
     let rec nestedLambda checkArity expr =
         let rec inner accArgs body name =
             match body with
-            | Function(Lambda arg, body, None) ->
+            | Lambda(arg, body, None) ->
                 inner (arg::accArgs) body name
             | _ -> List.rev accArgs, body, name
         match expr with
-        | Function(Lambda arg, body, name) ->
+        | Lambda(arg, body, name) ->
             let args, body, name = inner [arg] body name
             if checkArity then
                 match expr.Type with
@@ -256,26 +259,26 @@ module AST =
     let (|NestedApply|_|) expr =
         let rec nestedApply r t accArgs applied =
             match applied with
-            | Operation(CurriedApply(applied, args), _, _) ->
+            | CurriedApply(applied, args, _, _) ->
                 nestedApply r t (args@accArgs) applied
             | _ -> Some(applied, accArgs, t, r)
         match expr with
-        | Operation(CurriedApply(applied, args), t, r) ->
+        | CurriedApply(applied, args, t, r) ->
             nestedApply r t args applied
         | _ -> None
 
     let (|LambdaUncurriedAtCompileTime|_|) arity expr =
         let rec uncurryLambdaInner name accArgs remainingArity expr =
             if remainingArity = Some 0
-            then Function(Delegate(List.rev accArgs), expr, name) |> Some
+            then Delegate(List.rev accArgs, expr, name) |> Some
             else
                 match expr, remainingArity with
-                | Function(Lambda arg, body, name2), _ ->
+                | Lambda(arg, body, name2), _ ->
                     let remainingArity = remainingArity |> Option.map (fun x -> x - 1)
                     uncurryLambdaInner (Option.orElse name2 name) (arg::accArgs) remainingArity body
                 // If there's no arity expectation we can return the flattened part
                 | _, None when List.isEmpty accArgs |> not ->
-                    Function(Delegate(List.rev accArgs), expr, name) |> Some
+                    Delegate(List.rev accArgs, expr, name) |> Some
                 // We cannot flatten lambda to the expected arity
                 | _, _ -> None
         match expr with
@@ -306,10 +309,10 @@ module AST =
         | Get(e,kind,_,_) ->
             match kind with
             // OptionValue has a runtime check
-            | ListHead | ListTail | TupleGet _
+            | ListHead | ListTail | TupleIndex _
             | UnionTag | UnionField _ -> canHaveSideEffects e
-            | FieldGet(_,isFieldMutable,_) ->
-                if isFieldMutable then true
+            | ByKey(FieldKey fi) ->
+                if fi.IsMutable then true
                 else canHaveSideEffects e
             | _ -> true
         | _ -> true
@@ -320,39 +323,48 @@ module AST =
         | Any | Unit | GenericParam _ | Option _ -> true
         | _ -> false
 
-    /// ATTENTION: Make sure the ident name is unique
-    let makeIdent name =
-        { Name = name
-          Type = Any
-          Kind = CompilerGenerated
-          IsMutable = false
-          Range = None }
+    let makeFieldKey name isMutable typ =
+        FieldKey({ new Field with
+                    member _.Name = name
+                    member _.IsMutable = isMutable
+                    member _.IsStatic = false
+                    member _.FieldType = typ
+                    member _.LiteralValue = None })
 
     /// ATTENTION: Make sure the ident name is unique
     let makeTypedIdent typ name =
         { Name = name
           Type = typ
-          Kind = CompilerGenerated
+          IsCompilerGenerated = true
+          IsThisArgument = false
           IsMutable = false
           Range = None }
+
+    /// ATTENTION: Make sure the ident name is unique
+    let makeIdent name =
+        makeTypedIdent Any name
 
     /// ATTENTION: Make sure the ident name is unique
     let makeIdentExpr name =
         makeIdent name |> IdentExpr
 
-    let makeLoop range loopKind = Loop (loopKind, range)
+    let makeWhileLoop range guardExpr bodyExpr =
+        WhileLoop (guardExpr, bodyExpr, range)
+
+    let makeForLoop range isUp ident start limit body =
+        ForLoop (ident, start, limit, body, isUp, range)
 
     let makeBinOp range typ left right op =
-        Operation(BinaryOperation(op, left, right), typ, range)
+        Operation(Binary(op, left, right), typ, range)
 
     let makeUnOp range typ arg op =
-        Operation(UnaryOperation(op, arg), typ, range)
+        Operation(Unary(op, arg), typ, range)
 
     let makeLogOp range left right op =
-        Operation(LogicalOperation(op, left, right), Boolean, range)
+        Operation(Logical(op, left, right), Boolean, range)
 
     let makeEqOp range left right op =
-        Operation(BinaryOperation(op, left, right), Boolean, range)
+        Operation(Binary(op, left, right), Boolean, range)
 
     let makeNull () =
         Value(Null Any, None)
@@ -361,37 +373,52 @@ module AST =
         Value(value, r)
 
     let makeArray elementType arrExprs =
-        NewArray(ArrayValues arrExprs, elementType) |> makeValue None
+        NewArray(arrExprs, elementType) |> makeValue None
 
     let makeDelegate args body =
-        Function(Delegate args, body, None)
+        Delegate(args, body, None)
 
     let makeLambda (args: Ident list) (body: Expr) =
         (args, body) ||> List.foldBack (fun arg body ->
-            Function(Lambda arg, body, None))
+            Lambda(arg, body, None))
 
     let makeBoolConst (x: bool) = BoolConstant x |> makeValue None
     let makeStrConst (x: string) = StringConstant x |> makeValue None
     let makeIntConst (x: int) = NumberConstant (float x, Int32) |> makeValue None
     let makeFloatConst (x: float) = NumberConstant (x, Float64) |> makeValue None
 
-    let makeCoreRef t memberName moduleName =
-        Import(makeStrConst memberName, makeStrConst moduleName, Library, t, None)
+    let getLibPath (com: ICompiler) moduleName =
+        let ext = if com.Options.typescript then "" else Naming.targetFileExtension
+        com.LibraryDir + "/" + moduleName + ext
+
+    let makeLibRef (com: ICompiler) t memberName moduleName =
+        Import(makeStrConst memberName, makeStrConst (getLibPath com moduleName), t, None)
 
     let makeCustomImport t (selector: string) (path: string) =
-        Import(selector.Trim() |> makeStrConst, path.Trim() |> makeStrConst, CustomImport, t, None)
+        Import(selector.Trim() |> makeStrConst, path.Trim() |> makeStrConst, t, None)
 
     let makeInternalImport (com: ICompiler) t (selector: string) (path: string) =
         let path = Path.getRelativeFileOrDirPath false com.CurrentFile false path
-        Import(makeStrConst selector, makeStrConst path, Internal, t, None)
+        Import(makeStrConst selector, makeStrConst path, t, None)
 
-    let makeSimpleCallInfo thisArg args argTypes =
+    let makeCallInfo thisArg args argTypes =
         { ThisArg = thisArg
           Args = args
           SignatureArgTypes = argTypes
           HasSpread = false
-          AutoUncurrying = false
           IsJsConstructor = false }
+
+    let emitJsExpr r t args macro =
+        Emit({ Macro = macro; Args = args; IsJsStatement = false }, t, r)
+
+    let emitJsStatement r args macro =
+        Emit({ Macro = macro; Args = args; IsJsStatement = true }, Unit, r)
+
+    let makeThrow range errorExpr =
+        emitJsStatement range [errorExpr] "throw $0"
+
+    let makeDebugger range =
+        emitJsStatement range [] "debugger"
 
     let destructureTupleArgs = function
         | [MaybeCasted(Value(UnitConstant,_))] -> []
@@ -399,10 +426,10 @@ module AST =
         | args -> args
 
     let makeCall r t argInfo calleeExpr =
-        Operation(Call(calleeExpr, argInfo), t, r)
+        Call(calleeExpr, argInfo, t, r)
 
     let getExpr r t left memb =
-        Get(left, ExprGet memb, t, r)
+        Get(left, ByKey(ExprKey memb), t, r)
 
     let get r t left membName =
         makeStrConst membName |> getExpr r t left
@@ -451,10 +478,8 @@ module AST =
 
     /// When strict is false doesn't take generic params into account (e.g. when solving SRTP)
     let rec typeEquals strict typ1 typ2 =
-        let entEquals (ent1: FSharp.Compiler.SourceCodeServices.FSharpEntity) gen1 (ent2: FSharp.Compiler.SourceCodeServices.FSharpEntity) gen2 =
-            match ent1.TryFullName, ent2.TryFullName with
-            | Some n1, Some n2 when n1 = n2 -> listEquals (typeEquals strict) gen1 gen2
-            | _ -> false
+        let entEquals (ent1: Entity) gen1 (ent2: Entity) gen2 =
+            ent1.FullName = ent2.FullName && listEquals (typeEquals strict) gen1 gen2
         match typ1, typ2 with
         | Any, Any
         | Unit, Unit
@@ -468,24 +493,21 @@ module AST =
         | Array t1, Array t2
         | List t1, List t2 -> typeEquals strict t1 t2
         | Tuple ts1, Tuple ts2 -> listEquals (typeEquals strict) ts1 ts2
-        | FunctionType(LambdaType a1, t1), FunctionType(LambdaType a2, t2) ->
+        | LambdaType(a1, t1), LambdaType(a2, t2) ->
             typeEquals strict a1 a2 && typeEquals strict t1 t2
-        | FunctionType(DelegateType as1, t1), FunctionType(DelegateType as2, t2) ->
+        | DelegateType(as1, t1), DelegateType(as2, t2) ->
             listEquals (typeEquals strict) as1 as2 && typeEquals strict t1 t2
         | DeclaredType(ent1, gen1), DeclaredType(ent2, gen2) ->
-            match ent1.TryFullName, ent2.TryFullName with
-            | Some n1, Some n2 when n1 = n2 -> listEquals (typeEquals strict) gen1 gen2
-            | _ -> false
+            ent1.FullName = ent2.FullName && listEquals (typeEquals strict) gen1 gen2
         | GenericParam _, _ | _, GenericParam _ when not strict -> true
         | GenericParam name1, GenericParam name2 -> name1 = name2
         | _ -> false
 
     let rec getTypeFullName prettify t =
-        let getEntityFullName (ent: FSharp.Compiler.SourceCodeServices.FSharpEntity) gen =
-            match ent.TryFullName with
-            | None -> Naming.unknown
-            | Some fullname when List.isEmpty gen -> fullname
-            | Some fullname ->
+        let getEntityFullName (ent: Entity) gen =
+            let fullname = ent.FullName
+            if List.isEmpty gen then fullname
+            else
                 let gen = (List.map (getTypeFullName prettify) gen |> String.concat ",")
                 let fullname =
                     if prettify then
@@ -516,13 +538,13 @@ module AST =
             | UInt32  -> Types.uint32
             | Float32 -> Types.float32
             | Float64 -> Types.float64
-        | FunctionType(LambdaType argType, returnType) ->
+        | LambdaType(argType, returnType) ->
             let argType = getTypeFullName prettify argType
             let returnType = getTypeFullName prettify returnType
             if prettify
             then argType + " -> " + returnType
             else "Microsoft.FSharp.Core.FSharpFunc`2[" + argType + "," + returnType + "]"
-        | FunctionType(DelegateType argTypes, returnType) ->
+        | DelegateType(argTypes, returnType) ->
             sprintf "System.Func`%i[%s,%s]"
                 (List.length argTypes + 1)
                 (List.map (getTypeFullName prettify) argTypes |> String.concat ",")

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -9,17 +9,16 @@ module Atts =
     let [<Literal>] entryPoint = "Microsoft.FSharp.Core.EntryPointAttribute" // typeof<Microsoft.FSharp.Core.EntryPointAttribute>.FullName
     let [<Literal>] sealed_ = "Microsoft.FSharp.Core.SealedAttribute" // typeof<Microsoft.FSharp.Core.SealedAttribute>.FullName
     let [<Literal>] mangle = "Fable.Core.MangleAttribute" // typeof<Fable.Core.MangleAttribute>.FullName
-    let [<Literal>] import = "Fable.Core.ImportAttribute" // typeof<Fable.Core.ImportAttribute>.FullName
+    let [<Literal>] import = "Fable.Core.Import"
     let [<Literal>] importAll = "Fable.Core.ImportAllAttribute" // typeof<Fable.Core.ImportAllAttribute>.FullName
     let [<Literal>] importDefault = "Fable.Core.ImportDefaultAttribute" // typeof<Fable.Core.ImportDefaultAttribute>.FullName
     let [<Literal>] importMember = "Fable.Core.ImportMemberAttribute" // typeof<Fable.Core.ImportMemberAttribute>.FullName
     let [<Literal>] global_ = "Fable.Core.GlobalAttribute" // typeof<Fable.Core.GlobalAttribute>.FullName
-    let [<Literal>] emit            = "Fable.Core.EmitAttribute" // typeof<Fable.Core.EmitAttribute>.FullName
-    let [<Literal>] emitMethod      = "Fable.Core.EmitMethodAttribute" // typeof<Fable.Core.EmitAttribute>.FullName
+    let [<Literal>] emit = "Fable.Core.Emit"
+    let [<Literal>] emitMethod = "Fable.Core.EmitMethodAttribute" // typeof<Fable.Core.EmitAttribute>.FullName
     let [<Literal>] emitConstructor = "Fable.Core.EmitConstructorAttribute" // typeof<Fable.Core.EmitAttribute>.FullName
-    let [<Literal>] emitIndexer     = "Fable.Core.EmitIndexerAttribute" // typeof<Fable.Core.EmitAttribute>.FullName
-    let [<Literal>] emitProperty    = "Fable.Core.EmitPropertyAttribute" // typeof<Fable.Core.EmitAttribute>.FullName
-    let [<Literal>] emitDeclaration = "Fable.Core.EmitDeclarationAttribute" // typeof<Fable.Core.EmitDeclarationAttribute>.FullName
+    let [<Literal>] emitIndexer = "Fable.Core.EmitIndexerAttribute" // typeof<Fable.Core.EmitAttribute>.FullName
+    let [<Literal>] emitProperty = "Fable.Core.EmitPropertyAttribute" // typeof<Fable.Core.EmitAttribute>.FullName
     let [<Literal>] erase = "Fable.Core.EraseAttribute" // typeof<Fable.Core.EraseAttribute>.FullName
     let [<Literal>] stringEnum = "Fable.Core.StringEnumAttribute" // typeof<Fable.Core.StringEnumAttribute>.FullName
     let [<Literal>] paramList = "Fable.Core.ParamListAttribute" // typeof<Fable.Core.ParamListAttribute>.FullName
@@ -321,33 +320,25 @@ module AST =
         | Any | Unit | GenericParam _ | Option _ -> true
         | _ -> false
 
-    /// ATTENTION: Make sure the ident name will be unique within the file
-    let makeIdentNonMangled name =
+    /// ATTENTION: Make sure the ident name is unique
+    let makeIdent name =
         { Name = name
           Type = Any
           Kind = CompilerGenerated
           IsMutable = false
           Range = None }
 
-    /// Mangles ident name to prevent conflicts in the file
-    let makeIdentUnique (com: ICompiler) name =
-        com.GetUniqueVar(name) |> makeIdentNonMangled
-
-    /// ATTENTION: Make sure the ident name will be unique within the file
-    let makeTypedIdentNonMangled typ name =
+    /// ATTENTION: Make sure the ident name is unique
+    let makeTypedIdent typ name =
         { Name = name
           Type = typ
           Kind = CompilerGenerated
           IsMutable = false
           Range = None }
 
-    /// Mangles ident name to prevent conflicts in the file
-    let makeTypedIdentUnique (com: ICompiler) typ name =
-        com.GetUniqueVar(name) |> makeTypedIdentNonMangled typ
-
-    /// ATTENTION: Make sure the ident name will be unique within the file
-    let makeIdentExprNonMangled name =
-        makeIdentNonMangled name |> IdentExpr
+    /// ATTENTION: Make sure the ident name is unique
+    let makeIdentExpr name =
+        makeIdent name |> IdentExpr
 
     let makeLoop range loopKind = Loop (loopKind, range)
 

--- a/src/quicktest/QuickTest.fs
+++ b/src/quicktest/QuickTest.fs
@@ -58,3 +58,34 @@ let testCaseAsync msg f =
 // to Fable.Tests project. For example:
 // testCase "Addition works" <| fun () ->
 //     2 + 2 |> equal 4
+
+let rec test x f =
+    match x with
+    | [] -> f x
+    | h::t -> test t (f << id)
+
+// base can be used in a constructor
+// Can call a virtual member with default implementation in
+// this can be used in a function in a constructor
+
+
+[<AbstractClass>]
+type A() =
+    abstract Value: int
+    default _.Value = 5
+
+type B() =
+    inherit A()
+    let y = base.Value
+    override _.Value = y + 3
+
+
+type C() =
+    member _.Value = 4
+
+type D() =
+    inherit C()
+    member _.Value = base.Value + 8
+
+B().Value |> printfn "%i"
+D().Value |> printfn "%i"


### PR DESCRIPTION
This was supposed to fix #2087 but then I started another AST cleanup, tried to make Fable.AST independent of FCS and then everything become red 😮 Finally the project builds again but I need to fix the tests. It's gonna be difficult to make a proper review because the PR is too big and the reasons behind many of the changes are only in my head atm, but if you have a moment @ncave please do have a look to see if this makes sense to you.

Next steps I think this could unblock:

- Run formatter on the files Fable.Transform. Most of the lines have been touched anyways.
- Compile to class types
- Don't use inheritance for equality/comparison as discussed here: https://github.com/fable-compiler/Fable/pull/2124#issuecomment-663030527
- Move Fable.AST to a separate project, which should be available to plugins
- Move Replacements out of Fable.Transforms, and make them look more like "regular" plugins. Hopefully this should help make the compiler more modular and easier to maintain/contribute 
