### PR TITLE
Add Guid.ToString formats

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+
+# All files
+[*]
+indent_style = space
+
+# TS files
+[*.ts]
+indent_size = 2

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -2710,10 +2710,10 @@ let asyncs com (ctx: Context) r t (i: CallInfo) (_: Expr option) (args: Expr lis
 let guids (com: ICompiler) (ctx: Context) (r: SourceLocation option) t (i: CallInfo) (thisArg: Expr option) (args: Expr list) =
     let parseGuid (literalGuid: string) =
         try
-            System.Guid.Parse(literalGuid) |> string |> makeStrConst |> Some
+            System.Guid.Parse(literalGuid) |> string |> makeStrConst
         with e ->
-            e.Message |> addError com ctx.InlinePath r
-            None
+            e.Message |> addErrorAndReturnNull com ctx.InlinePath r
+        |> Some
 
     match i.CompiledName with
     | "NewGuid"     -> Helper.CoreCall("Guid", "newGuid", t, []) |> Some

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -391,6 +391,7 @@ let toString com (ctx: Context) r (args: Expr list) =
     | head::tail ->
         match head.Type with
         | Char | String -> head
+        | Builtin BclGuid when tail.IsEmpty -> head
         | Builtin (BclGuid|BclTimeSpan|BclInt64|BclUInt64 as t) ->
             Helper.CoreCall(coreModFor t, "toString", String, args)
         | Number Int16 -> Helper.CoreCall("Util", "int16ToString", String, args)
@@ -2712,8 +2713,7 @@ let guids (com: ICompiler) (ctx: Context) (r: SourceLocation option) t (i: CallI
     | "Parse"       -> Helper.CoreCall("Guid", "validateGuid", t, args, i.SignatureArgTypes) |> Some
     | "TryParse"    -> Helper.CoreCall("Guid", "validateGuid", t, [args.Head; makeBoolConst true], [args.Head.Type; Boolean]) |> Some
     | "ToByteArray" -> Helper.CoreCall("Guid", "guidToArray", t, [thisArg.Value], [thisArg.Value.Type]) |> Some
-    | "ToString" when (args.Length = 0) ->
-        Helper.CoreCall("Guid", "toString", t, args, i.SignatureArgTypes, ?thisArg=thisArg, ?loc=r) |> Some
+    | "ToString" when (args.Length = 0) -> thisArg.Value |> Some
     | "ToString" when (args.Length = 1) ->
         match args.Head with
         | Value (StringConstant "N", _)

--- a/src/fable-library/Guid.ts
+++ b/src/fable-library/Guid.ts
@@ -1,0 +1,141 @@
+import { trim } from "./String";
+
+// RFC 4122 compliant. From https://stackoverflow.com/a/13653180/3922220
+// const guidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+// Relax GUID parsing, see #1637
+const guidRegex = /^[\(\{]{0,2}[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}[\)\}]{0,2}$/;
+const guidRegexNoHyphen = /^([0-9a-f]{8})([0-9a-f]{4})([0-9a-f]{4})([0-9a-f]{4})([0-9a-f]{12})$/;
+const guidRegexHex = /^\{0x[0-9a-f]{8},(0x[0-9a-f]{4},){2}\{(0x[0-9a-f]{2},){7}0x[0-9a-f]{2}\}\}$/;
+const guidHexCaptures = /^([0-9a-f]{8})-(([0-9a-f]{4})-)(([0-9a-f]{4})-)([0-9a-f]{2})([0-9a-f]{2})-([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/;
+
+export function toString(str: string, format?: string, _provider?: any) {
+  if (format && format?.length > 0) {
+    switch (format) {
+      case "N":
+        return str.replace(/-/g, '');
+      case "D":
+        return str;
+      case "B":
+        return "{" + str + "}";
+      case "P":
+        return "(" + str + ")";
+      case "X":
+        return str.replace(guidHexCaptures, "{0x$1,0x$3,0x$5,{0x$6,0x$7,0x$8,0x$9,0x$10,0x$11,0x$12,0x$13}}");
+      default:
+        throw new Error("Unrecognized Guid print format");
+    }
+  }
+  else {
+    return str;
+  }
+}
+
+/** Validates UUID as specified in RFC4122 (versions 1-5). */
+export function validateGuid(str: string, doNotThrow?: boolean): string | [boolean, string] {
+  function hyphenateGuid(str: string) {
+    return str.replace(guidRegexNoHyphen, "$1-$2-$3-$4-$5");
+  }
+
+  const wsTrimAndLowered = str.trim().toLowerCase();
+
+  if (guidRegex.test(wsTrimAndLowered)) {
+    const containersTrimmed = trim(wsTrimAndLowered, "{", "}", "(", ")");
+
+    return doNotThrow ? [true, containersTrimmed] : containersTrimmed;
+  }
+  else if (guidRegexNoHyphen.test(wsTrimAndLowered)) {
+    const hyphenatedGuid = hyphenateGuid(wsTrimAndLowered);
+
+    return doNotThrow ? [true, hyphenatedGuid] : hyphenatedGuid;
+  }
+  else if (guidRegexHex.test(wsTrimAndLowered)) {
+    const hyphenatedGuid = hyphenateGuid(wsTrimAndLowered.replace(/[\{\},]|0x/g, ''));
+
+    return doNotThrow ? [true, hyphenatedGuid] : hyphenatedGuid;
+  } else if (doNotThrow) {
+    return [false, "00000000-0000-0000-0000-000000000000"];
+  }
+  else {
+    throw new Error("Guid should contain 32 digits with 4 dashes: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx");
+  }
+}
+
+// From https://gist.github.com/LeverOne/1308368
+export function newGuid() {
+  let b = "";
+  for (let a = 0; a++ < 36;) {
+    b += a * 51 & 52
+      ? (a ^ 15 ? 8 ^ Math.random() * (a ^ 20 ? 16 : 4) : 4).toString(16)
+      : "-";
+  }
+  return b;
+}
+
+// Maps for number <-> hex string conversion
+let _convertMapsInitialized = false;
+let _byteToHex: string[];
+let _hexToByte: { [k: string]: number };
+
+function initConvertMaps() {
+  _byteToHex = new Array(256);
+  _hexToByte = {};
+  for (let i = 0; i < 256; i++) {
+    _byteToHex[i] = (i + 0x100).toString(16).substr(1);
+    _hexToByte[_byteToHex[i]] = i;
+  }
+  _convertMapsInitialized = true;
+}
+
+/** Parse a UUID into it's component bytes */
+// Adapted from https://github.com/zefferus/uuid-parse
+export function guidToArray(s: string) {
+  if (!_convertMapsInitialized) {
+    initConvertMaps();
+  }
+  let i = 0;
+  const buf = new Uint8Array(16);
+  s.toLowerCase().replace(/[0-9a-f]{2}/g, ((oct: number) => {
+    switch (i) {
+      // .NET saves first three byte groups with different endianness
+      // See https://stackoverflow.com/a/16722909/3922220
+      case 0: case 1: case 2: case 3:
+        buf[3 - i++] = _hexToByte[oct];
+        break;
+      case 4: case 5:
+        buf[9 - i++] = _hexToByte[oct];
+        break;
+      case 6: case 7:
+        buf[13 - i++] = _hexToByte[oct];
+        break;
+      case 8: case 9: case 10: case 11:
+      case 12: case 13: case 14: case 15:
+        buf[i++] = _hexToByte[oct];
+        break;
+    }
+  }) as any);
+  // Zero out remaining bytes if string was short
+  while (i < 16) {
+    buf[i++] = 0;
+  }
+  return buf;
+}
+
+/** Convert UUID byte array into a string */
+export function arrayToGuid(buf: ArrayLike<number>) {
+  if (buf.length !== 16) {
+    throw new Error("Byte array for GUID must be exactly 16 bytes long");
+  }
+  if (!_convertMapsInitialized) {
+    initConvertMaps();
+  }
+  const guid =
+    _byteToHex[buf[3]] + _byteToHex[buf[2]] +
+    _byteToHex[buf[1]] + _byteToHex[buf[0]] + "-" +
+    _byteToHex[buf[5]] + _byteToHex[buf[4]] + "-" +
+    _byteToHex[buf[7]] + _byteToHex[buf[6]] + "-" +
+    _byteToHex[buf[8]] + _byteToHex[buf[9]] + "-" +
+    _byteToHex[buf[10]] + _byteToHex[buf[11]] +
+    _byteToHex[buf[12]] + _byteToHex[buf[13]] +
+    _byteToHex[buf[14]] + _byteToHex[buf[15]];
+  return guid;
+}

--- a/src/fable-library/String.ts
+++ b/src/fable-library/String.ts
@@ -5,10 +5,6 @@ import { escape } from "./RegExp";
 
 const fsFormatRegExp = /(^|[^%])%([0+\- ]*)(\d+)?(?:\.(\d+))?(\w)/;
 const formatRegExp = /\{(\d+)(,-?\d+)?(?:\:([a-zA-Z])(\d{0,2})|\:(.+?))?\}/g;
-// RFC 4122 compliant. From https://stackoverflow.com/a/13653180/3922220
-// const guidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
-// Relax GUID parsing, see #1637
-const guidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
 type Numeric = number | Long | Decimal;
 
@@ -313,7 +309,7 @@ export function format(str: string, ...args: any[]) {
       }
     } else if (rep instanceof Date) {
       rep = dateToString(rep, pattern || format);
-    }
+    } 
     padLength = parseInt((padLength || " ").substring(1), 10);
     if (!isNaN(padLength)) {
       rep = padLeft(String(rep), Math.abs(padLength), " ", padLength < 0);
@@ -371,97 +367,6 @@ export function joinWithIndices(delimiter: string, xs: string[], startIndex: num
     throw new Error("Index and count must refer to a location within the buffer.");
   }
   return xs.slice(startIndex, endIndexPlusOne).join(delimiter);
-}
-
-/** Validates UUID as specified in RFC4122 (versions 1-5). Trims braces. */
-export function validateGuid(str: string, doNotThrow?: boolean): string | [boolean, string] {
-  const trimmedAndLowered = trim(str, "{", "}").toLowerCase();
-  if (guidRegex.test(trimmedAndLowered)) {
-    return doNotThrow ? [true, trimmedAndLowered] : trimmedAndLowered;
-  } else if (doNotThrow) {
-    return [false, "00000000-0000-0000-0000-000000000000"];
-  }
-  throw new Error("Guid should contain 32 digits with 4 dashes: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx");
-}
-
-// From https://gist.github.com/LeverOne/1308368
-export function newGuid() {
-  let b = "";
-  for (let a = 0; a++ < 36;) {
-    b += a * 51 & 52
-      ? (a ^ 15 ? 8 ^ Math.random() * (a ^ 20 ? 16 : 4) : 4).toString(16)
-      : "-";
-  }
-  return b;
-}
-
-// Maps for number <-> hex string conversion
-let _convertMapsInitialized = false;
-let _byteToHex: string[];
-let _hexToByte: { [k: string]: number };
-
-function initConvertMaps() {
-  _byteToHex = new Array(256);
-  _hexToByte = {};
-  for (let i = 0; i < 256; i++) {
-    _byteToHex[i] = (i + 0x100).toString(16).substr(1);
-    _hexToByte[_byteToHex[i]] = i;
-  }
-  _convertMapsInitialized = true;
-}
-
-/** Parse a UUID into it's component bytes */
-// Adapted from https://github.com/zefferus/uuid-parse
-export function guidToArray(s: string) {
-  if (!_convertMapsInitialized) {
-    initConvertMaps();
-  }
-  let i = 0;
-  const buf = new Uint8Array(16);
-  s.toLowerCase().replace(/[0-9a-f]{2}/g, ((oct: number) => {
-    switch (i) {
-      // .NET saves first three byte groups with different endianness
-      // See https://stackoverflow.com/a/16722909/3922220
-      case 0: case 1: case 2: case 3:
-        buf[3 - i++] = _hexToByte[oct];
-        break;
-      case 4: case 5:
-        buf[9 - i++] = _hexToByte[oct];
-        break;
-      case 6: case 7:
-        buf[13 - i++] = _hexToByte[oct];
-        break;
-      case 8: case 9: case 10: case 11:
-      case 12: case 13: case 14: case 15:
-        buf[i++] = _hexToByte[oct];
-        break;
-    }
-  }) as any);
-  // Zero out remaining bytes if string was short
-  while (i < 16) {
-    buf[i++] = 0;
-  }
-  return buf;
-}
-
-/** Convert UUID byte array into a string */
-export function arrayToGuid(buf: ArrayLike<number>) {
-  if (buf.length !== 16) {
-    throw new Error("Byte array for GUID must be exactly 16 bytes long");
-  }
-  if (!_convertMapsInitialized) {
-    initConvertMaps();
-  }
-  const guid =
-    _byteToHex[buf[3]] + _byteToHex[buf[2]] +
-    _byteToHex[buf[1]] + _byteToHex[buf[0]] + "-" +
-    _byteToHex[buf[5]] + _byteToHex[buf[4]] + "-" +
-    _byteToHex[buf[7]] + _byteToHex[buf[6]] + "-" +
-    _byteToHex[buf[8]] + _byteToHex[buf[9]] + "-" +
-    _byteToHex[buf[10]] + _byteToHex[buf[11]] +
-    _byteToHex[buf[12]] + _byteToHex[buf[13]] +
-    _byteToHex[buf[14]] + _byteToHex[buf[15]];
-  return guid;
 }
 
 function notSupported(name: string): never {

--- a/tests/Main/ConvertTests.fs
+++ b/tests/Main/ConvertTests.fs
@@ -1089,18 +1089,29 @@ let tests =
         Convert.FromBase64String("AgQGCAoMDhASFA==")
         |> equal [| 2uy; 4uy; 6uy; 8uy; 10uy; 12uy; 14uy; 16uy; 18uy; 20uy |]
 
-    testCase "Guid.Parse works" <| fun () ->
+    // id is prefixed for guid creation as we check at compile time (if able) to create a string const
+    testCase "Guid.Parse works from literals" <| fun () ->
         let guids = [
             Guid.Parse("96258006-c4ba-4a7f-80c4-de7f2b2898c5")
+            Guid.Parse(id "96258006-c4ba-4a7f-80c4-de7f2b2898c5")
             Guid.Parse("96258006c4ba4a7f80c4de7f2b2898c5")
+            Guid.Parse(id "96258006c4ba4a7f80c4de7f2b2898c5")
             Guid.Parse("{96258006-c4ba-4a7f-80c4-de7f2b2898c5}")
+            Guid.Parse(id "{96258006-c4ba-4a7f-80c4-de7f2b2898c5}")
             Guid.Parse("(96258006-c4ba-4a7f-80c4-de7f2b2898c5)")
+            Guid.Parse(id "(96258006-c4ba-4a7f-80c4-de7f2b2898c5)")
             Guid.Parse("{0x96258006,0xc4ba,0x4a7f,{0x80,0xc4,0xde,0x7f,0x2b,0x28,0x98,0xc5}}")
+            Guid.Parse(id "{0x96258006,0xc4ba,0x4a7f,{0x80,0xc4,0xde,0x7f,0x2b,0x28,0x98,0xc5}}")
             Guid("96258006-c4ba-4a7f-80c4-de7f2b2898c5")
+            Guid(id "96258006-c4ba-4a7f-80c4-de7f2b2898c5")
             Guid("96258006c4ba4a7f80c4de7f2b2898c5")
+            Guid(id "96258006c4ba4a7f80c4de7f2b2898c5")
             Guid("{96258006-c4ba-4a7f-80c4-de7f2b2898c5}")
+            Guid(id "{96258006-c4ba-4a7f-80c4-de7f2b2898c5}")
             Guid("(96258006-c4ba-4a7f-80c4-de7f2b2898c5)")
+            Guid(id "(96258006-c4ba-4a7f-80c4-de7f2b2898c5)")
             Guid("{0x96258006,0xc4ba,0x4a7f,{0x80,0xc4,0xde,0x7f,0x2b,0x28,0x98,0xc5}}")
+            Guid(id "{0x96258006,0xc4ba,0x4a7f,{0x80,0xc4,0xde,0x7f,0x2b,0x28,0x98,0xc5}}")
         ]
         
         guids
@@ -1109,7 +1120,7 @@ let tests =
     testCase "Guid.Parse fails if string is not well formed" <| fun () ->
         let success =
             try
-                let g1 = Guid.Parse("foo")
+                let g1 = Guid.Parse(id "foo")
                 true
             with _ -> false
         equal false success
@@ -1117,18 +1128,28 @@ let tests =
     testCase "Guid.TryParse works" <| fun () ->
         let successGuids = [
             Guid.TryParse("96258006-c4ba-4a7f-80c4-de7f2b2898c5")
+            Guid.TryParse(id "96258006-c4ba-4a7f-80c4-de7f2b2898c5")
             Guid.TryParse("96258006c4ba4a7f80c4de7f2b2898c5")
+            Guid.TryParse(id "96258006c4ba4a7f80c4de7f2b2898c5")
             Guid.TryParse("{96258006-c4ba-4a7f-80c4-de7f2b2898c5}")
+            Guid.TryParse(id "{96258006-c4ba-4a7f-80c4-de7f2b2898c5}")
             Guid.TryParse("(96258006-c4ba-4a7f-80c4-de7f2b2898c5)")
+            Guid.TryParse(id "(96258006-c4ba-4a7f-80c4-de7f2b2898c5)")
             Guid.TryParse("{0x96258006,0xc4ba,0x4a7f,{0x80,0xc4,0xde,0x7f,0x2b,0x28,0x98,0xc5}}")
+            Guid.TryParse(id "{0x96258006,0xc4ba,0x4a7f,{0x80,0xc4,0xde,0x7f,0x2b,0x28,0x98,0xc5}}")
         ]
         
         let failGuids = [
             Guid.TryParse("96258006-c4ba-4a7f-80c4")
+            Guid.TryParse(id "96258006-c4ba-4a7f-80c4")
             Guid.TryParse("96258007f80c4de7f2b2898c5")
+            Guid.TryParse(id "96258007f80c4de7f2b2898c5")
             Guid.TryParse("{96258006-c4ba-4a7f-80c4}")
+            Guid.TryParse(id "{96258006-c4ba-4a7f-80c4}")
             Guid.TryParse("(96258006-c4ba-80c4-de7f2b2898c5)")
+            Guid.TryParse(id "(96258006-c4ba-80c4-de7f2b2898c5)")
             Guid.TryParse("{0x96258006,0xc4ba,{0x80,0xc4,0xde,0x7f,0x28,0x98,0xc5}}")
+            Guid.TryParse(id "{0x96258006,0xc4ba,{0x80,0xc4,0xde,0x7f,0x28,0x98,0xc5}}")
         ]
 
         successGuids
@@ -1150,7 +1171,10 @@ let tests =
 
     testCase "Convert Guid to byte[] works" <| fun () ->
         let g = Guid.Parse("96258006-c4ba-4a7f-80c4-de7f2b2898c5")
+        let g2 = Guid.Parse(id "96258006-c4ba-4a7f-80c4-de7f2b2898c5")
+
         g.ToByteArray() |> equal [|6uy; 128uy; 37uy; 150uy; 186uy; 196uy; 127uy; 74uy; 128uy; 196uy; 222uy; 127uy; 43uy; 40uy; 152uy; 197uy|]
+        g2.ToByteArray() |> equal [|6uy; 128uy; 37uy; 150uy; 186uy; 196uy; 127uy; 74uy; 128uy; 196uy; 222uy; 127uy; 43uy; 40uy; 152uy; 197uy|]
 
     testCase "Convert byte[] to Guid works" <| fun () ->
         let g = Guid [|6uy; 128uy; 37uy; 150uy; 186uy; 196uy; 127uy; 74uy; 128uy; 196uy; 222uy; 127uy; 43uy; 40uy; 152uy; 197uy|]
@@ -1158,20 +1182,18 @@ let tests =
 
     testCase "Guid.ToString works with formats" <| fun () ->
         let g = Guid.Parse("96258006-c4ba-4a7f-80c4-de7f2b2898c5")
+        let g2 = Guid.Parse(id "96258006-c4ba-4a7f-80c4-de7f2b2898c5")
 
-        let gStr = g.ToString()
-        let nStr = g.ToString("N")
-        let dStr = g.ToString("D")
-        let bStr = g.ToString("B")
-        let pStr = g.ToString("P")
-        let xStr = g.ToString("X")
+        let testGuid (g: Guid) =
+            g.ToString()|> equal "96258006-c4ba-4a7f-80c4-de7f2b2898c5"
+            g.ToString("N") |> equal "96258006c4ba4a7f80c4de7f2b2898c5"
+            g.ToString("D") |> equal "96258006-c4ba-4a7f-80c4-de7f2b2898c5"
+            g.ToString("B") |> equal "{96258006-c4ba-4a7f-80c4-de7f2b2898c5}"
+            g.ToString("P") |> equal "(96258006-c4ba-4a7f-80c4-de7f2b2898c5)"
+            g.ToString("X") |> equal "{0x96258006,0xc4ba,0x4a7f,{0x80,0xc4,0xde,0x7f,0x2b,0x28,0x98,0xc5}}"
 
-        equal "96258006-c4ba-4a7f-80c4-de7f2b2898c5" gStr
-        equal "96258006c4ba4a7f80c4de7f2b2898c5" nStr
-        equal "96258006-c4ba-4a7f-80c4-de7f2b2898c5" dStr
-        equal "{96258006-c4ba-4a7f-80c4-de7f2b2898c5}" bStr
-        equal "(96258006-c4ba-4a7f-80c4-de7f2b2898c5)" pStr
-        equal "{0x96258006,0xc4ba,0x4a7f,{0x80,0xc4,0xde,0x7f,0x2b,0x28,0x98,0xc5}}" xStr
+        testGuid g
+        testGuid g2
 
     //-------------------------------------
     // System.Text.Encoding

--- a/tests/Main/ConvertTests.fs
+++ b/tests/Main/ConvertTests.fs
@@ -1185,7 +1185,7 @@ let tests =
         let g2 = Guid.Parse(id "96258006-c4ba-4a7f-80c4-de7f2b2898c5")
 
         let testGuid (g: Guid) =
-            g.ToString()|> equal "96258006-c4ba-4a7f-80c4-de7f2b2898c5"
+            g.ToString() |> equal "96258006-c4ba-4a7f-80c4-de7f2b2898c5"
             g.ToString("N") |> equal "96258006c4ba4a7f80c4de7f2b2898c5"
             g.ToString("D") |> equal "96258006-c4ba-4a7f-80c4-de7f2b2898c5"
             g.ToString("B") |> equal "{96258006-c4ba-4a7f-80c4-de7f2b2898c5}"

--- a/tests/Main/ConvertTests.fs
+++ b/tests/Main/ConvertTests.fs
@@ -1090,16 +1090,21 @@ let tests =
         |> equal [| 2uy; 4uy; 6uy; 8uy; 10uy; 12uy; 14uy; 16uy; 18uy; 20uy |]
 
     testCase "Guid.Parse works" <| fun () ->
-        let g1 = Guid.Parse("96258006-c4ba-4a7f-80c4-de7f2b2898c5")
-        let g2 = Guid("{96258006-c4ba-4a7f-80c4-de7f2b2898c5}")
-        g1.ToString().Trim('{','}').ToLower() |> equal "96258006-c4ba-4a7f-80c4-de7f2b2898c5"
-        g2.ToString().Trim('{','}').ToLower() |> equal "96258006-c4ba-4a7f-80c4-de7f2b2898c5"
-
-    testCase "Guid.Parse works relaxed" <| fun () ->
-        let g1 = Guid.Parse("773788c2-ae1c-2ce4-e053-6c04a8c05e57")
-        let g2 = Guid("{00000000-0000-0000-0000-000000000000}")
-        g1.ToString().Trim('{','}').ToLower() |> equal "773788c2-ae1c-2ce4-e053-6c04a8c05e57"
-        g2.ToString().Trim('{','}').ToLower() |> equal "00000000-0000-0000-0000-000000000000"
+        let guids = [
+            Guid.Parse("96258006-c4ba-4a7f-80c4-de7f2b2898c5")
+            Guid.Parse("96258006c4ba4a7f80c4de7f2b2898c5")
+            Guid.Parse("{96258006-c4ba-4a7f-80c4-de7f2b2898c5}")
+            Guid.Parse("(96258006-c4ba-4a7f-80c4-de7f2b2898c5)")
+            Guid.Parse("{0x96258006,0xc4ba,0x4a7f,{0x80,0xc4,0xde,0x7f,0x2b,0x28,0x98,0xc5}}")
+            Guid("96258006-c4ba-4a7f-80c4-de7f2b2898c5")
+            Guid("96258006c4ba4a7f80c4de7f2b2898c5")
+            Guid("{96258006-c4ba-4a7f-80c4-de7f2b2898c5}")
+            Guid("(96258006-c4ba-4a7f-80c4-de7f2b2898c5)")
+            Guid("{0x96258006,0xc4ba,0x4a7f,{0x80,0xc4,0xde,0x7f,0x2b,0x28,0x98,0xc5}}")
+        ]
+        
+        guids
+        |> List.iter (fun g -> g.ToString() |> equal "96258006-c4ba-4a7f-80c4-de7f2b2898c5")
 
     testCase "Guid.Parse fails if string is not well formed" <| fun () ->
         let success =
@@ -1110,10 +1115,27 @@ let tests =
         equal false success
 
     testCase "Guid.TryParse works" <| fun () ->
-        let success1, _ = Guid.TryParse("96258006-c4ba-4a7f-80c4-de7f2b2898c5")
-        let success2, _ = Guid.TryParse("96258006-c4ba-4a7f-80c4")
-        equal true success1
-        equal false success2
+        let successGuids = [
+            Guid.TryParse("96258006-c4ba-4a7f-80c4-de7f2b2898c5")
+            Guid.TryParse("96258006c4ba4a7f80c4de7f2b2898c5")
+            Guid.TryParse("{96258006-c4ba-4a7f-80c4-de7f2b2898c5}")
+            Guid.TryParse("(96258006-c4ba-4a7f-80c4-de7f2b2898c5)")
+            Guid.TryParse("{0x96258006,0xc4ba,0x4a7f,{0x80,0xc4,0xde,0x7f,0x2b,0x28,0x98,0xc5}}")
+        ]
+        
+        let failGuids = [
+            Guid.TryParse("96258006-c4ba-4a7f-80c4")
+            Guid.TryParse("96258007f80c4de7f2b2898c5")
+            Guid.TryParse("{96258006-c4ba-4a7f-80c4}")
+            Guid.TryParse("(96258006-c4ba-80c4-de7f2b2898c5)")
+            Guid.TryParse("{0x96258006,0xc4ba,{0x80,0xc4,0xde,0x7f,0x28,0x98,0xc5}}")
+        ]
+
+        successGuids
+        |> List.iter (fst >> (equal true))
+
+        failGuids
+        |> List.iter (fst >> (equal false))
 
     testCase "Parsed guids with different case are considered the same" <| fun () -> // See #1718
         let aGuid = Guid.NewGuid()
@@ -1133,6 +1155,23 @@ let tests =
     testCase "Convert byte[] to Guid works" <| fun () ->
         let g = Guid [|6uy; 128uy; 37uy; 150uy; 186uy; 196uy; 127uy; 74uy; 128uy; 196uy; 222uy; 127uy; 43uy; 40uy; 152uy; 197uy|]
         g.ToString() |> equal("96258006-c4ba-4a7f-80c4-de7f2b2898c5")
+
+    testCase "Guid.ToString works with formats" <| fun () ->
+        let g = Guid.Parse("96258006-c4ba-4a7f-80c4-de7f2b2898c5")
+
+        let gStr = g.ToString()
+        let nStr = g.ToString("N")
+        let dStr = g.ToString("D")
+        let bStr = g.ToString("B")
+        let pStr = g.ToString("P")
+        let xStr = g.ToString("X")
+
+        equal "96258006-c4ba-4a7f-80c4-de7f2b2898c5" gStr
+        equal "96258006c4ba4a7f80c4de7f2b2898c5" nStr
+        equal "96258006-c4ba-4a7f-80c4-de7f2b2898c5" dStr
+        equal "{96258006-c4ba-4a7f-80c4-de7f2b2898c5}" bStr
+        equal "(96258006-c4ba-4a7f-80c4-de7f2b2898c5)" pStr
+        equal "{0x96258006,0xc4ba,0x4a7f,{0x80,0xc4,0xde,0x7f,0x2b,0x28,0x98,0xc5}}" xStr
 
     //-------------------------------------
     // System.Text.Encoding

--- a/tests/Main/ConvertTests.fs
+++ b/tests/Main/ConvertTests.fs
@@ -1090,7 +1090,7 @@ let tests =
         |> equal [| 2uy; 4uy; 6uy; 8uy; 10uy; 12uy; 14uy; 16uy; 18uy; 20uy |]
 
     // id is prefixed for guid creation as we check at compile time (if able) to create a string const
-    testCase "Guid.Parse works from literals" <| fun () ->
+    testCase "Guid.Parse works" <| fun () ->
         let guids = [
             Guid.Parse("96258006-c4ba-4a7f-80c4-de7f2b2898c5")
             Guid.Parse(id "96258006-c4ba-4a7f-80c4-de7f2b2898c5")


### PR DESCRIPTION
Adds `System.Guid.ToString` with format overloads to Fable, and expands parsing to better follow .NET behavior.

Specifier | Format of return value
-- | --
N | 32 digits: `00000000000000000000000000000000`
D | 32 digits separated by hyphens: `00000000-0000-0000-0000-000000000000`
B | 32 digits separated by hyphens, enclosed in braces: `{00000000-0000-0000-0000-000000000000}`
P | 32 digits separated by hyphens, enclosed in parentheses: `(00000000-0000-0000-0000-000000000000)`
X | Four hexadecimal values enclosed in braces, where the fourth value is a subset of eight hexadecimal values that is also enclosed in braces: `{0x00000000,0x0000,0x0000,{0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00}}`

Resolves #2055
Enhances #1637