### PR TITLE
[WIP] Add DateTime meridiem formatting option

### DIFF
--- a/tests/Main/DateTimeOffsetTests.fs
+++ b/tests/Main/DateTimeOffsetTests.fs
@@ -26,6 +26,10 @@ let tests =
         DateTimeOffset(2017, 9, 5, 0, 0, 0, TimeSpan.Zero).ToString("yyyyMM")
         |> equal "201709"
 
+    testCase "DateTime.ToString with meridiem" <| fun () ->
+        DateTimeOffset(2017, 9, 5, 0, 0, 0, TimeSpan.Zero).ToString("tt")
+        |> equal "AM"
+
     // TODO
     // testCase "TimeSpan.ToString with format works" <| fun () ->
     //     TimeSpan.FromMinutes(234.).ToString("hh\:mm\:ss")

--- a/tests/Main/DateTimeTests.fs
+++ b/tests/Main/DateTimeTests.fs
@@ -36,6 +36,10 @@ let tests =
         System.Text.RegularExpressions.Regex.Replace(str, "0{3,}", "000")
         |> equal "2014-09-11T16:37:02.000Z"
 
+    testCase "DateTime.ToString with meridiem" <| fun () ->
+        DateTime(2014, 9, 11, 16, 37, 11, 345).ToString("tt")
+        |> equal "PM"
+
     // TODO
     // Next test is disabled because it's depends on the time zone of the machine
     //A fix could be to use a regex or detect the time zone


### PR DESCRIPTION
PR to add `DateTime.ToString("tt")` formatting option.

This is currently not working, but I'm not quite sure why. I can run the function in a repl and it works as expected so it's something upstream of `dateToStringWithCustomFormat`.

```javascript
> dateToStringWithCustomFormat(new Date(), 'tt', false);
'AM'
```