### PR TITLE
Fixed fable-library import extensions

### DIFF
--- a/src/fable-library/Async.ts
+++ b/src/fable-library/Async.ts
@@ -1,13 +1,13 @@
-import { OperationCanceledError, Trampoline } from "./AsyncBuilder";
-import { Continuation, Continuations } from "./AsyncBuilder";
-import { CancellationToken } from "./AsyncBuilder";
-import { IAsync } from "./AsyncBuilder";
-import { IAsyncContext } from "./AsyncBuilder";
-import { protectedCont } from "./AsyncBuilder";
-import { protectedBind } from "./AsyncBuilder";
-import { protectedReturn } from "./AsyncBuilder";
-import { choice1Of2, choice2Of2 } from "./Option";
-import { map } from "./Seq";
+import { OperationCanceledError, Trampoline } from "./AsyncBuilder.js";
+import { Continuation, Continuations } from "./AsyncBuilder.js";
+import { CancellationToken } from "./AsyncBuilder.js";
+import { IAsync } from "./AsyncBuilder.js";
+import { IAsyncContext } from "./AsyncBuilder.js";
+import { protectedCont } from "./AsyncBuilder.js";
+import { protectedBind } from "./AsyncBuilder.js";
+import { protectedReturn } from "./AsyncBuilder.js";
+import { choice1Of2, choice2Of2 } from "./Option.js";
+import { map } from "./Seq.js";
 
 // Implemented just for type references
 export class Async<_T> { }

--- a/src/fable-library/AsyncBuilder.ts
+++ b/src/fable-library/AsyncBuilder.ts
@@ -1,4 +1,4 @@
-import { IDisposable } from "./Util";
+import { IDisposable } from "./Util.js";
 
 export type Continuation<T> = (x: T) => void;
 

--- a/src/fable-library/BitConverter.ts
+++ b/src/fable-library/BitConverter.ts
@@ -1,5 +1,5 @@
-import { uint8 } from "./Int32";
-import Long, { fromBits, getHighBits, getHighBitsUnsigned, getLowBits, getLowBitsUnsigned } from "./Long";
+import { uint8 } from "./Int32.js";
+import Long, { fromBits, getHighBits, getHighBitsUnsigned, getLowBits, getLowBitsUnsigned } from "./Long.js";
 
 const littleEndian = true;
 

--- a/src/fable-library/Char.ts
+++ b/src/fable-library/Char.ts
@@ -1,6 +1,6 @@
 // Adapted from: https://github.com/hakatashi/general-category
-import * as Encoding from "./Encoding";
-import packedUnicode from "./Unicode.9.0.0";
+import * as Encoding from "./Encoding.js";
+import packedUnicode from "./Unicode.9.0.0.js";
 
 function decodeVByteToIntegerArray(buffer: Uint8Array) {
   const ret = [];

--- a/src/fable-library/Date.ts
+++ b/src/fable-library/Date.ts
@@ -8,8 +8,8 @@
  * Basically; invariant: date.getTime() always return UTC time.
  */
 
-import { fromValue, Long, ticksToUnixEpochMilliseconds, unixEpochMillisecondsToTicks } from "./Long";
-import { compareDates, DateKind, dateOffset, IDateTime, IDateTimeOffset, padWithZeros } from "./Util";
+import { fromValue, Long, ticksToUnixEpochMilliseconds, unixEpochMillisecondsToTicks } from "./Long.js";
+import { compareDates, DateKind, dateOffset, IDateTime, IDateTimeOffset, padWithZeros } from "./Util.js";
 
 export const offsetRegex = /(?:Z|[+-](\d+):?([0-5]?\d)?)\s*$/;
 
@@ -168,11 +168,11 @@ export function parseRaw(input: string) {
   if (input === null) {
     throw new Error("Value cannot be null when parsing DateTime");
   }
-  
+
   if (input.trim() === "") {
     throw new Error("An empty string is not recognized as a valid DateTime");
   }
-  
+
   let date = new Date(input);
   if (isNaN(date.getTime())) {
     // Try to check strings JS Date cannot parse (see #1045, #1422)

--- a/src/fable-library/DateOffset.ts
+++ b/src/fable-library/DateOffset.ts
@@ -13,9 +13,9 @@
  * Basically; invariant: date.getTime() always return UTC time.
  */
 
-import { create as createDate, dateOffsetToString, daysInMonth, offsetRegex, parseRaw } from "./Date";
-import { fromValue, Long, ticksToUnixEpochMilliseconds, unixEpochMillisecondsToTicks } from "./Long";
-import { compareDates, DateKind, IDateTime, IDateTimeOffset, padWithZeros } from "./Util";
+import { create as createDate, dateOffsetToString, daysInMonth, offsetRegex, parseRaw } from "./Date.js";
+import { fromValue, Long, ticksToUnixEpochMilliseconds, unixEpochMillisecondsToTicks } from "./Long.js";
+import { compareDates, DateKind, IDateTime, IDateTimeOffset, padWithZeros } from "./Util.js";
 
 export default function DateTimeOffset(value: number, offset?: number) {
   const d = new Date(value) as IDateTimeOffset;

--- a/src/fable-library/Decimal.ts
+++ b/src/fable-library/Decimal.ts
@@ -1,4 +1,4 @@
-import Decimal from "./lib/big";
+import Decimal from "./lib/big.js";
 
 export default Decimal;
 export type decimal = Decimal;

--- a/src/fable-library/Encoding.ts
+++ b/src/fable-library/Encoding.ts
@@ -1,4 +1,4 @@
-import { uint8 } from "./Int32";
+import { uint8 } from "./Int32.js";
 
 const littleEndian = true;
 

--- a/src/fable-library/Event.ts
+++ b/src/fable-library/Event.ts
@@ -1,7 +1,7 @@
-import { IObservable, IObserver, Observer, protect } from "./Observable";
-import { Choice, Option, some, tryValueIfChoice1Of2, tryValueIfChoice2Of2, value } from "./Option";
-import { iterate as seqIterate } from "./Seq";
-import { IDisposable } from "./Util";
+import { IObservable, IObserver, Observer, protect } from "./Observable.js";
+import { Choice, Option, some, tryValueIfChoice1Of2, tryValueIfChoice2Of2, value } from "./Option.js";
+import { iterate as seqIterate } from "./Seq.js";
+import { IDisposable } from "./Util.js";
 
 export type Delegate<T> = (x: T) => void;
 export type DotNetDelegate<T> = (sender: any, x: T) => void;

--- a/src/fable-library/Guid.ts
+++ b/src/fable-library/Guid.ts
@@ -1,4 +1,4 @@
-import { trim } from "./String";
+import { trim } from "./String.js";
 
 // RFC 4122 compliant. From https://stackoverflow.com/a/13653180/3922220
 // const guidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;

--- a/src/fable-library/Long.ts
+++ b/src/fable-library/Long.ts
@@ -1,5 +1,5 @@
-import { isValid } from "./Int32";
-import * as LongLib from "./lib/long";
+import { isValid } from "./Int32.js";
+import * as LongLib from "./lib/long.js";
 
 export default LongLib.Long;
 export type Long = LongLib.Long;

--- a/src/fable-library/MailboxProcessor.ts
+++ b/src/fable-library/MailboxProcessor.ts
@@ -1,9 +1,9 @@
-import { defaultCancellationToken } from "./Async";
-import { fromContinuations } from "./Async";
-import { startImmediate } from "./Async";
-import { IAsync } from "./AsyncBuilder";
-import { Continuation, Continuations } from "./AsyncBuilder";
-import { CancellationToken } from "./AsyncBuilder";
+import { defaultCancellationToken } from "./Async.js";
+import { fromContinuations } from "./Async.js";
+import { startImmediate } from "./Async.js";
+import { IAsync } from "./AsyncBuilder.js";
+import { Continuation, Continuations } from "./AsyncBuilder.js";
+import { CancellationToken } from "./AsyncBuilder.js";
 
 class QueueCell<Msg> {
   public value: Msg;

--- a/src/fable-library/Observable.ts
+++ b/src/fable-library/Observable.ts
@@ -1,5 +1,5 @@
-import { Choice, tryValueIfChoice1Of2, tryValueIfChoice2Of2, value } from "./Option";
-import { IDisposable } from "./Util";
+import { Choice, tryValueIfChoice1Of2, tryValueIfChoice2Of2, value } from "./Option.js";
+import { IDisposable } from "./Util.js";
 
 export interface IObserver<T> {
   OnNext: (x: T) => void;

--- a/src/fable-library/Option.ts
+++ b/src/fable-library/Option.ts
@@ -1,4 +1,4 @@
-import { compare, equals, structuralHash } from "./Util";
+import { compare, equals, structuralHash } from "./Util.js";
 
 // Options are erased in runtime by Fable, but we have
 // the `Some` type below to wrap values that would evaluate

--- a/src/fable-library/Reflection.ts
+++ b/src/fable-library/Reflection.ts
@@ -1,6 +1,6 @@
-import { value as getOptionValue } from "./Option";
-import { anonRecord as makeAnonRecord, List } from "./Types";
-import { compareArraysWith, equalArraysWith, isArrayLike, isUnionLike } from "./Util";
+import { value as getOptionValue } from "./Option.js";
+import { anonRecord as makeAnonRecord, List } from "./Types.js";
+import { compareArraysWith, equalArraysWith, isArrayLike, isUnionLike } from "./Util.js";
 
 export type FieldInfo = [string, TypeInfo];
 export type PropertyInfo = FieldInfo;

--- a/src/fable-library/Seq.ts
+++ b/src/fable-library/Seq.ts
@@ -1,7 +1,7 @@
-import Decimal, { makeRangeStepFunction as makeDecimalRangeStepFunction } from "./Decimal";
-import Long, { makeRangeStepFunction as makeLongRangeStepFunction } from "./Long";
-import { Option, some, value } from "./Option";
-import { compare, equals, IComparer, IDisposable } from "./Util";
+import Decimal, { makeRangeStepFunction as makeDecimalRangeStepFunction } from "./Decimal.js";
+import Long, { makeRangeStepFunction as makeLongRangeStepFunction } from "./Long.js";
+import { Option, some, value } from "./Option.js";
+import { compare, equals, IComparer, IDisposable } from "./Util.js";
 
 export interface IEnumerator<T> {
   Current: T | undefined;

--- a/src/fable-library/String.ts
+++ b/src/fable-library/String.ts
@@ -1,7 +1,7 @@
-import { toString as dateToString } from "./Date";
-import Decimal from "./Decimal";
-import Long, * as _Long from "./Long";
-import { escape } from "./RegExp";
+import { toString as dateToString } from "./Date.js";
+import Decimal from "./Decimal.js";
+import Long, * as _Long from "./Long.js";
+import { escape } from "./RegExp.js";
 
 const fsFormatRegExp = /(^|[^%])%([0+\- ]*)(\d+)?(?:\.(\d+))?(\w)/;
 const formatRegExp = /\{(\d+)(,-?\d+)?(?:\:([a-zA-Z])(\d{0,2})|\:(.+?))?\}/g;
@@ -309,7 +309,7 @@ export function format(str: string, ...args: any[]) {
       }
     } else if (rep instanceof Date) {
       rep = dateToString(rep, pattern || format);
-    } 
+    }
     padLength = parseInt((padLength || " ").substring(1), 10);
     if (!isNaN(padLength)) {
       rep = padLeft(String(rep), Math.abs(padLength), " ", padLength < 0);

--- a/src/fable-library/TimeSpan.ts
+++ b/src/fable-library/TimeSpan.ts
@@ -1,6 +1,6 @@
 // tslint:disable:max-line-length
-import Long, { fromNumber, op_Division, op_Multiply, toNumber } from "./Long";
-import { comparePrimitives, padLeftAndRightWithZeros, padWithZeros } from "./Util";
+import Long, { fromNumber, op_Division, op_Multiply, toNumber } from "./Long.js";
+import { comparePrimitives, padLeftAndRightWithZeros, padWithZeros } from "./Util.js";
 
 // TimeSpan in runtime just becomes a number representing milliseconds
 

--- a/src/fable-library/Timer.ts
+++ b/src/fable-library/Timer.ts
@@ -1,5 +1,5 @@
-import Event from "./Event";
-import { IDisposable } from "./Util";
+import Event from "./Event.js";
+import { IDisposable } from "./Util.js";
 
 export class Timer implements IDisposable {
   public Interval: number;

--- a/src/fable-library/Types.ts
+++ b/src/fable-library/Types.ts
@@ -1,5 +1,5 @@
 // tslint:disable: space-before-function-paren
-import { IEquatable, IComparable, combineHashCodes, compare, compareArrays, equalArrays, equals, isComparable, isEquatable, isHashable, isSameType, isStringable, numberHash, structuralHash } from "./Util";
+import { IEquatable, IComparable, combineHashCodes, compare, compareArrays, equalArrays, equals, isComparable, isEquatable, isHashable, isSameType, isStringable, numberHash, structuralHash } from "./Util.js";
 
 export function objectToString(self: any) {
   if (isStringable(self)) {

--- a/src/fable-library/lib/big.js
+++ b/src/fable-library/lib/big.js
@@ -1,6 +1,6 @@
 // https://github.com/MikeMcl/big.js/blob/01b3ce3a6b0ba7b42442ea48ec4ffc88d1669ec4/big.mjs
 /* tslint:disable */
-import { combineHashCodes } from "../Util";
+import { combineHashCodes } from "../Util.js";
 
 // The shared prototype object.
 var P = {

--- a/src/fable-standalone/.gitignore
+++ b/src/fable-standalone/.gitignore
@@ -1,3 +1,4 @@
 # Output
 out*/
 dist/
+perf*.data

--- a/src/fable-standalone/test/bench-compiler/Platform.fs
+++ b/src/fable-standalone/test/bench-compiler/Platform.fs
@@ -1,6 +1,7 @@
 module Fable.Compiler.Platform
 
 type CmdLineOptions = {
+    benchmark: bool
     optimize: bool
     sourceMaps: bool
     typescript: bool

--- a/src/fable-standalone/test/bench-compiler/package.json
+++ b/src/fable-standalone/test/bench-compiler/package.json
@@ -8,9 +8,12 @@
 
     "build-dotnet": "dotnet run -c Release bench-compiler.fsproj out-node",
     "build-dotnet-opt": "dotnet run -c Release bench-compiler.fsproj out-node --optimize-fcs",
-    "postbuild-dotnet": "npm run rollup-bundle",
+    "postbuild-dotnet": "npm run build-dotnet-out && npm run rollup-bundle",
+    "build-dotnet-out": "rm -rf dist && rm -rf out-node && npm run tsc -- --outDir ./out-node",
 
     "build-node": "node dist/bundle.js bench-compiler.fsproj out-node2",
+    "build-node2": "node ./out-node/src/fable-standalone/test/bench-compiler/app.fs.js bench-compiler.fsproj out-node2 --benchmark",
+    "bench-node": "node dist/bundle.js bench-compiler.fsproj out-node2 --benchmark",
 
     "compile-native": "dotnet publish -c Release -r win-x64",
     "native": "cd . && \"bin/Release/netcoreapp2.1/win-x64/native/bench-compiler\"",
@@ -54,7 +57,9 @@
     "webpack": "node ../../../../node_modules/webpack-cli/bin/cli.js",
     "splitter": "node ../../../../node_modules/fable-splitter/dist/cli",
 
-    "profile": "node --prof dist/bundle.js bench-compiler.fsproj out-node2",
+    "perf": "perf record -q -e cpu-clock -F 1000 -g -- node --perf-basic-prof --interpreted-frames-native-stack dist/bundle.js bench-compiler.fsproj out-node2 --benchmark",
+    "perf2": "perf record -q -e cpu-clock -F 1000 -g -- node --perf-basic-prof --interpreted-frames-native-stack ./out-node/src/fable-standalone/test/bench-compiler/app.fs.js bench-compiler.fsproj out-node2 --benchmark",
+    "profile": "node --prof dist/bundle.js bench-compiler.fsproj out-node2 --benchmark",
     "cpu-prof": "node --cpu-prof --cpu-prof-dir=out-prof dist/bundle.js bench-compiler.fsproj out-node2",
     "heap-prof": "node --heap-prof dist/bundle.js bench-compiler.fsproj out-node2",
     "prof-process": "node --prof-process isolate-*.log > profile.log",


### PR DESCRIPTION
- Fixed fable-library import extensions (added `.js` as TypeScript does not add them).
- Updated Fable benchmark compiler test with a --benchmark flag.