### PR TITLE
Several fixes and optimizations

### DIFF
--- a/src/Fable.Cli/Entry.fs
+++ b/src/Fable.Cli/Entry.fs
@@ -45,7 +45,7 @@ Arguments:
 """
 
 type Runner =
-  static member Run(args: string list, rootDir: string, ?fsprojPath, ?watch) =
+  static member Run(args: string list, rootDir: string, ?fsprojPath, ?watch, ?testInfo) =
     let watch = defaultArg watch false
 
     fsprojPath
@@ -106,7 +106,8 @@ type Runner =
             { CliArgs = cliArgs
               ProjectCrackedAndParsed = None
               Watcher = watcher
-              WatchDependencies = Map.empty }
+              WatchDependencies = Map.empty
+              TestInfo = testInfo }
             |> startCompilation Set.empty
             |> Async.RunSynchronously
             |> function
@@ -162,6 +163,7 @@ let main argv =
         match commands with
         | ["clean"; dir] -> clean args dir
         | ["clean"] -> clean args rootDir
+        | ["test"; path] -> Runner.Run(args, rootDir, fsprojPath=path, testInfo=TestInfo())
         | ["watch"; path] -> Runner.Run(args, rootDir, fsprojPath=path, watch=true)
         | ["watch"] -> Runner.Run(args, rootDir, watch=true)
         | [path] -> Runner.Run(args, rootDir, fsprojPath=path)

--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -282,7 +282,8 @@ type ProjectParsed(project: Project,
         ProjectParsed(proj, checker)
 
 type TestInfo private (current, iterations, times: int64 list) =
-    new (?iterations) = TestInfo(0, defaultArg iterations 10, [])
+    new (?iterations) = TestInfo(0, defaultArg iterations 50, [])
+    member _.LogFileName = "fable-perf-log.txt"
     member _.CurrentIteration: int = current
     member _.TotalIterations: int = iterations
     member _.AverageMilliseconds =
@@ -405,7 +406,7 @@ let rec startCompilation (changes: Set<string>) (state: State) = async {
                         info.AverageMilliseconds
                         info.MedianMilliseconds
             Log.always(log)
-            let perfLog = IO.Path.Combine(state.CliArgs.RootDir, "fable-perf-log.txt")
+            let perfLog = IO.Path.Combine(state.CliArgs.RootDir, info.LogFileName)
             File.AppendAllText(perfLog, log + "\n")
             return Ok()
 }

--- a/src/Fable.Transforms/AST/AST.Babel.fs
+++ b/src/Fable.Transforms/AST/AST.Babel.fs
@@ -174,9 +174,9 @@ module PrinterExtensions =
             | :? Identifier
             | :? MemberExpression
             | :? CallExpression
-            // | :? NewExpression // Safe?
             | :? ThisExpression
-            | :? Super -> expr.Print(printer)
+            | :? Super
+            | :? ArrayExpression -> expr.Print(printer)
             | :? ObjectExpression ->
                 match objExpr with
                 | Some true -> printer.WithParens(expr)

--- a/src/Fable.Transforms/AST/AST.Babel.fs
+++ b/src/Fable.Transforms/AST/AST.Babel.fs
@@ -229,8 +229,11 @@ type EmitExpression(value, args, ?loc) =
                     let segment = value.Substring(segmentStart, segmentLength)
                     let subSegments = System.Text.RegularExpressions.Regex.Split(segment, @"\r?\n")
                     for i = 1 to subSegments.Length do
-                        // Remove whitespace in front of the subsegment as indent will be automatically applied
-                        let subSegment = subSegments.[i - 1].TrimStart()
+                        let subSegment =
+                            // Remove whitespace in front of new lines,
+                            // indent will be automatically applied
+                            if printer.Column = 0 then subSegments.[i - 1].TrimStart()
+                            else subSegments.[i - 1]
                         if subSegment.Length > 0 then
                             printer.Print(subSegment)
                             if i < subSegments.Length then

--- a/src/Fable.Transforms/AST/AST.Babel.fs
+++ b/src/Fable.Transforms/AST/AST.Babel.fs
@@ -230,9 +230,11 @@ type EmitExpression(value, args, ?loc) =
                     let subSegments = System.Text.RegularExpressions.Regex.Split(segment, @"\r?\n")
                     for i = 1 to subSegments.Length do
                         // Remove whitespace in front of the subsegment as indent will be automatically applied
-                        printer.Print(replace @"^\s*" (fun _ -> "") subSegments.[i - 1])
-                        if i < subSegments.Length then
-                            printer.PrintNewLine()
+                        let subSegment = subSegments.[i - 1].TrimStart()
+                        if subSegment.Length > 0 then
+                            printer.Print(subSegment)
+                            if i < subSegments.Length then
+                                printer.PrintNewLine()
 
             // Macro transformations
             // https://fable.io/docs/communicate/js-from-fable.html#Emit-when-F-is-not-enough

--- a/src/Fable.Transforms/AST/AST.Babel.fs
+++ b/src/Fable.Transforms/AST/AST.Babel.fs
@@ -229,7 +229,8 @@ type EmitExpression(value, args, ?loc) =
                     let segment = value.Substring(segmentStart, segmentLength)
                     let subSegments = System.Text.RegularExpressions.Regex.Split(segment, @"\r?\n")
                     for i = 1 to subSegments.Length do
-                        printer.Print(subSegments.[i - 1])
+                        // Remove whitespace in front of the subsegment as indent will be automatically applied
+                        printer.Print(replace @"^\s*" (fun _ -> "") subSegments.[i - 1])
                         if i < subSegments.Length then
                             printer.PrintNewLine()
 

--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -611,18 +611,6 @@ module Patterns =
             Some(baseCall, genArgs1 @ genArgs2, baseArgs)
         | _ -> None
 
-    let (|CapturedBaseConsCall|_|) com (ctx: Context) transformBaseCall = function
-        | Sequential(ConstructorCall(call, genArgs, args) as expr1, expr2)
-        // This pattern occurs in constructors that define a this value: `type C() as this`
-        // We're discarding the bound `this` value, it "shouldn't" be used in the base constructor arguments
-        | Sequential(Let(_, (ConstructorCall(call, genArgs, args) as expr1)), expr2) ->
-            match call.DeclaringEntity, ctx.CaptureBaseConsCall with
-            | Some baseEnt, Some(expectedBaseEnt, capture) when baseEnt = expectedBaseEnt ->
-                transformBaseCall com ctx (makeRangeFrom expr1) baseEnt call genArgs args |> capture
-                Some expr2
-            | _ -> None
-        | _ -> None
-
     let (|OptimizedOperator|_|) = function
         // work-around for optimized string operator (Operators.string)
         | Let((var, Call(None, memb, _, membArgTypes, membArgs)),

--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -595,16 +595,6 @@ module Patterns =
             Some (callee, eventName)
         | _ -> None
 
-    let (|CallCreateEvent|_|) = function
-        | Call(Some(CreateEvent(callee, eventName)), memb, typArgs, methTypArgs, args) ->
-            Some (callee, eventName, memb, typArgs, methTypArgs, args)
-        | _ -> None
-
-    let (|BindCreateEvent|_|) = function
-        | Let((var, CreateEvent(value, eventName)), body) ->
-            Some (var, value, eventName, body)
-        | _ -> None
-
     let (|ConstructorCall|_|) = function
         | NewObject(baseCall, genArgs, baseArgs) -> Some(baseCall, genArgs, baseArgs)
         | Call(None, baseCall, genArgs1, genArgs2, baseArgs) when baseCall.IsConstructor ->

--- a/src/Fable.Transforms/FSharp2Fable.fs
+++ b/src/Fable.Transforms/FSharp2Fable.fs
@@ -438,11 +438,10 @@ let private transformExpr (com: IFableCompiler) (ctx: Context) fsExpr =
         let! body = transformExpr com ctx body
         return Fable.Let([ident, value], body)
 
-    // TODO: Detect if it's ResizeArray and compile as FastIntegerForLoop?
-    | ForOf (PutArgInScope com ctx (newContext, ident), value, body) ->
-        let! value = transformExpr com ctx value
-        let! body = transformExpr com newContext body
-        return Replacements.iterate com (makeRangeFrom fsExpr) ident body value
+    // | ForOf (PutArgInScope com ctx (newContext, ident), value, body) ->
+    //     let! value = transformExpr com ctx value
+    //     let! body = transformExpr com newContext body
+    //     return Replacements.iterate com (makeRangeFrom fsExpr) ident body value
 
     // Flow control
     | BasicPatterns.FastIntegerForLoop(start, limit, body, isUp) ->

--- a/src/Fable.Transforms/FSharp2Fable.fs
+++ b/src/Fable.Transforms/FSharp2Fable.fs
@@ -252,11 +252,10 @@ let private transformObjExpr (com: IFableCompiler) (ctx: Context) (objType: FSha
             // but check the baseCall.DeclaringEntity name just in case
             | BasicPatterns.Call(None,baseCall,genArgs1,genArgs2,baseArgs) ->
                 match baseCall.DeclaringEntity with
-                | Some baseType when baseType.TryFullName <> Some Types.object ->
-                    let typ = makeType ctx.GenericArgs baseCallExpr.Type
-                    let! baseArgs = transformExprList com ctx baseArgs
-                    let genArgs = genArgs1 @ genArgs2 |> Seq.map (makeType ctx.GenericArgs)
-                    return makeCallFrom com ctx None typ genArgs None baseArgs baseCall |> Some
+                | Some baseEnt when baseEnt.TryFullName <> Some Types.object ->
+                    let r = makeRangeFrom baseCallExpr
+                    let genArgs = genArgs1 @ genArgs2
+                    return transformBaseConsCall com ctx r baseEnt baseCall genArgs baseArgs |> Some
                 | _ -> return None
             | _ -> return None
         }

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -955,7 +955,9 @@ module Util =
             members |> List.collect (fun memb ->
                 let info = memb.Info
                 let prop, computed = memberFromName memb.Name
-                if info.IsValue then
+                // Optimization: if body doesn't have side effects, avoid getter in object literal
+                // which bails out optimizations in V8. See
+                if info.IsValue || (info.IsGetter && not(canHaveSideEffects memb.Body)) then
                     [ObjectProperty(prop, com.TransformAsExpr(ctx, memb.Body), computed_=computed) :> ObjectMember]
                 elif info.IsGetter then
                     [makeObjMethod ObjectGetter prop computed false memb.Args memb.Body]

--- a/src/fable-library/BigInt.fs
+++ b/src/fable-library/BigInt.fs
@@ -2,15 +2,19 @@ module BigInt.Exports
 
 type bigint = BigInt.BigInteger
 
-let tryParse str =
+let tryParse str res =
     try
-        let res = bigint.Parse str
-        true, res
+        res := bigint.Parse str
+        true
     with _ ->
-        false, bigint.Zero
+        false
+
+let divRem x y (remainder: _ ref) =
+    let quotient, remainder' = bigint.DivRem(x, y)
+    remainder := remainder'
+    quotient
 
 let parse = bigint.Parse
-let divRem = bigint.DivRem
 let greatestCommonDivisor = bigint.GreatestCommonDivisor
 let pow = bigint.Pow
 let abs = bigint.Abs

--- a/src/fable-library/Boolean.ts
+++ b/src/fable-library/Boolean.ts
@@ -1,18 +1,21 @@
-export function tryParse(str: string): [boolean, boolean] {
+import { FSharpRef } from "./Types"
+
+export function tryParse(str: string, defValue: FSharpRef<boolean>): boolean {
   if (str.match(/^\s*true\s*$/i)) {
-    return [true, true]
+    defValue.contents = true;
+    return true;
   } else if (str.match(/^\s*false\s*$/i)) {
-    return [true, false]
-  } else {
-    return [false, false]
+    defValue.contents = false;
+    return true;
   }
+  return false;
 }
 
 export function parse(str: string): boolean {
-  const [ok, value] = tryParse(str)
+  const defValue = new FSharpRef(false);
 
-  if (ok) {
-    return value
+  if (tryParse(str, defValue)) {
+    return defValue.contents;
   } else {
     throw new Error(`String '${str}' was not recognized as a valid Boolean.`)
   }

--- a/src/fable-library/Date.ts
+++ b/src/fable-library/Date.ts
@@ -9,6 +9,7 @@
  */
 
 import { fromValue, Long, ticksToUnixEpochMilliseconds, unixEpochMillisecondsToTicks } from "./Long.js";
+import { FSharpRef } from "./Types.js";
 import { compareDates, DateKind, dateOffset, IDateTime, IDateTimeOffset, padWithZeros } from "./Util.js";
 
 export const offsetRegex = /(?:Z|[+-](\d+):?([0-5]?\d)?)\s*$/;
@@ -233,11 +234,12 @@ export function parse(str: string, detectUTC = false): IDateTime {
   return DateTime(date.getTime(), kind);
 }
 
-export function tryParse(v: string, _refValue?: any): [boolean, IDateTime] {
+export function tryParse(v: string, defValue: FSharpRef<IDateTime>): boolean {
   try {
-    return [true, parse(v)];
+    defValue.contents = parse(v);
+    return true;
   } catch (_err) {
-    return [false, minValue()];
+    return false;
   }
 }
 

--- a/src/fable-library/DateOffset.ts
+++ b/src/fable-library/DateOffset.ts
@@ -15,6 +15,7 @@
 
 import { create as createDate, dateOffsetToString, daysInMonth, offsetRegex, parseRaw } from "./Date.js";
 import { fromValue, Long, ticksToUnixEpochMilliseconds, unixEpochMillisecondsToTicks } from "./Long.js";
+import { FSharpRef } from "./Types.js";
 import { compareDates, DateKind, IDateTime, IDateTimeOffset, padWithZeros } from "./Util.js";
 
 export default function DateTimeOffset(value: number, offset?: number) {
@@ -66,11 +67,12 @@ export function parse(str: string): IDateTimeOffset {
   return DateTimeOffset(date.getTime(), offset);
 }
 
-export function tryParse(v: string, _refValue?: any): [boolean, IDateTimeOffset] {
+export function tryParse(v: string, defValue: FSharpRef<IDateTimeOffset>): boolean {
   try {
-    return [true, parse(v)];
+    defValue.contents = parse(v);
+    return true;
   } catch (_err) {
-    return [false, minValue()];
+    return false;
   }
 }
 

--- a/src/fable-library/Decimal.ts
+++ b/src/fable-library/Decimal.ts
@@ -1,4 +1,5 @@
 import Decimal from "./lib/big.js";
+import { FSharpRef } from "./Types.js";
 
 export default Decimal;
 export type decimal = Decimal;
@@ -82,18 +83,19 @@ export function toString(x: Decimal) {
   return x.toString();
 }
 
-export function tryParse(str: string): [boolean, Decimal] {
+export function tryParse(str: string, defValue: FSharpRef<Decimal>): boolean {
   try {
-    return [true, new Decimal(str.trim())];
+    defValue.contents = new Decimal(str.trim());
+    return true;
   } catch {
-    return [false, get_Zero];
+    return false;
   }
 }
 
 export function parse(str: string): Decimal {
-  const [ok, value] = tryParse(str);
-  if (ok) {
-    return value;
+  const defValue = new FSharpRef(get_Zero);
+  if (tryParse(str, defValue)) {
+    return defValue.contents;
   } else {
     throw new Error("Input string was not in a correct format.");
   }

--- a/src/fable-library/Double.ts
+++ b/src/fable-library/Double.ts
@@ -1,18 +1,21 @@
-export function tryParse(str: string): [boolean, number] {
+import { FSharpRef } from "./Types";
+
+export function tryParse(str: string, defValue: FSharpRef<number>): boolean {
   // TODO: test if value is valid and in range
   if (str != null && /\S/.test(str)) {
     const v = +str.replace("_", "");
     if (!Number.isNaN(v)) {
-      return [true, v];
+      defValue.contents = v;
+      return true;
     }
   }
-  return [false, 0];
+  return false;
 }
 
 export function parse(str: string): number {
-  const [ok, value] = tryParse(str);
-  if (ok) {
-    return value;
+  const defValue = new FSharpRef(0);
+  if (tryParse(str, defValue)) {
+    return defValue.contents;
   } else {
     throw new Error("Input string was not in a correct format.");
   }

--- a/src/fable-library/Guid.ts
+++ b/src/fable-library/Guid.ts
@@ -1,4 +1,5 @@
 import { trim } from "./String.js";
+import { FSharpRef } from "./Types.js";
 
 // RFC 4122 compliant. From https://stackoverflow.com/a/13653180/3922220
 // const guidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
@@ -31,7 +32,7 @@ export function toString(str: string, format?: string, _provider?: any) {
 }
 
 /** Validates UUID as specified in RFC4122 (versions 1-5). */
-export function validateGuid(str: string, doNotThrow?: boolean): string | [boolean, string] {
+export function parse(str: string): string {
   function hyphenateGuid(str: string) {
     return str.replace(guidRegexNoHyphen, "$1-$2-$3-$4-$5");
   }
@@ -39,24 +40,25 @@ export function validateGuid(str: string, doNotThrow?: boolean): string | [boole
   const wsTrimAndLowered = str.trim().toLowerCase();
 
   if (guidRegex.test(wsTrimAndLowered)) {
-    const containersTrimmed = trim(wsTrimAndLowered, "{", "}", "(", ")");
-
-    return doNotThrow ? [true, containersTrimmed] : containersTrimmed;
+    return trim(wsTrimAndLowered, "{", "}", "(", ")");
   }
   else if (guidRegexNoHyphen.test(wsTrimAndLowered)) {
-    const hyphenatedGuid = hyphenateGuid(wsTrimAndLowered);
-
-    return doNotThrow ? [true, hyphenatedGuid] : hyphenatedGuid;
+    return hyphenateGuid(wsTrimAndLowered);
   }
   else if (guidRegexHex.test(wsTrimAndLowered)) {
-    const hyphenatedGuid = hyphenateGuid(wsTrimAndLowered.replace(/[\{\},]|0x/g, ''));
-
-    return doNotThrow ? [true, hyphenatedGuid] : hyphenatedGuid;
-  } else if (doNotThrow) {
-    return [false, "00000000-0000-0000-0000-000000000000"];
+    return hyphenateGuid(wsTrimAndLowered.replace(/[\{\},]|0x/g, ''));
   }
   else {
     throw new Error("Guid should contain 32 digits with 4 dashes: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx");
+  }
+}
+
+export function tryParse(str: string, defValue: FSharpRef<string>): boolean {
+  try {
+    defValue.contents = parse(str);
+    return true;
+  } catch {
+    return false;
   }
 }
 

--- a/src/fable-library/Int32.ts
+++ b/src/fable-library/Int32.ts
@@ -1,3 +1,5 @@
+import { FSharpRef } from "./Types";
+
 export type int8 = number;
 export type uint8 = number;
 export type int16 = number;
@@ -110,14 +112,13 @@ export function parse(str: string, style: number, unsigned: boolean, bitsize: nu
   throw new Error("Input string was not in a correct format.");
 }
 
-export function tryParse(str: string, style: number, unsigned: boolean, bitsize: number): [boolean, number] {
+export function tryParse(str: string, style: number, unsigned: boolean, bitsize: number, defValue: FSharpRef<number>): boolean {
   try {
-    const v = parse(str, style, unsigned, bitsize);
-    return [true, v];
+    defValue.contents = parse(str, style, unsigned, bitsize);
+    return true;
   } catch {
-    // supress error
+    return false;
   }
-  return [false, 0];
 }
 
 export function op_UnaryNegation_Int8(x: number) {

--- a/src/fable-library/Long.ts
+++ b/src/fable-library/Long.ts
@@ -1,5 +1,6 @@
 import { isValid } from "./Int32.js";
 import * as LongLib from "./lib/long.js";
+import { FSharpRef } from "./Types.js";
 
 export default LongLib.Long;
 export type Long = LongLib.Long;
@@ -109,14 +110,13 @@ export function parse(str: string, style: number, unsigned: boolean, _bitsize: n
   throw new Error("Input string was not in a correct format.");
 }
 
-export function tryParse(str: string, style: number, unsigned: boolean, bitsize: number) {
+export function tryParse(str: string, style: number, unsigned: boolean, bitsize: number, defValue: FSharpRef<Long>) {
   try {
-    const v = parse(str, style, unsigned, bitsize);
-    return [true, v];
+    defValue.contents = parse(str, style, unsigned, bitsize);
+    return true;
   } catch {
-    // supress error
+    return false;
   }
-  return [false, LongLib.ZERO];
 }
 
 export function unixEpochMillisecondsToTicks(ms: number, offset: number) {

--- a/src/fable-library/Map.fs
+++ b/src/fable-library/Map.fs
@@ -413,10 +413,13 @@ type Map<[<EqualityConditionalOn>]'Key,[<EqualityConditionalOn;ComparisonConditi
     member __.Item
         with get(k : 'Key) =
             MapTree.find comparer k tree
-    member __.TryGetValue(k: 'Key, defValue: 'Value) =
+
+    [<OverloadSuffix("")>]
+    member __.TryGetValue(k: 'Key, defValue: 'Value ref) =
         match MapTree.tryFind comparer k tree with
-        | Some v -> true, v
-        | None -> false, defValue
+        | Some v -> defValue := v; true
+        | None -> false
+
     member __.TryPick(f) = MapTree.tryPick f tree
     member __.Exists(f) = MapTree.exists f tree
     member __.Filter(f): Map<'Key,'Value> =

--- a/src/fable-library/Reflection.ts
+++ b/src/fable-library/Reflection.ts
@@ -1,5 +1,5 @@
 import { value as getOptionValue } from "./Option.js";
-import { anonRecord as makeAnonRecord, List } from "./Types.js";
+import { anonRecord as makeAnonRecord, FSharpRef, List } from "./Types.js";
 import { compareArraysWith, equalArraysWith, isArrayLike, isUnionLike } from "./Util.js";
 
 export type FieldInfo = [string, TypeInfo];
@@ -239,14 +239,13 @@ export function parseEnum(t: TypeInfo, str: string): number {
   return getEnumCase(t, isNaN(value) ? str : value)[1];
 }
 
-export function tryParseEnum(t: TypeInfo, str: string): [boolean, number] {
+export function tryParseEnum(t: TypeInfo, str: string, defValue: FSharpRef<number>): boolean {
   try {
-    const v = parseEnum(t, str);
-    return [true, v];
+    defValue.contents = parseEnum(t, str);
+    return true;
   } catch {
-    // supress error
+    return false;
   }
-  return [false, NaN];
 }
 
 export function getEnumName(t: TypeInfo, v: number): string {

--- a/src/fable-library/TimeSpan.ts
+++ b/src/fable-library/TimeSpan.ts
@@ -1,5 +1,6 @@
 // tslint:disable:max-line-length
 import Long, { fromNumber, op_Division, op_Multiply, toNumber } from "./Long.js";
+import { FSharpRef } from "./Types.js";
 import { comparePrimitives, padLeftAndRightWithZeros, padWithZeros } from "./Util.js";
 
 // TimeSpan in runtime just becomes a number representing milliseconds
@@ -172,10 +173,11 @@ export function parse(str: string) {
   throw new Error(`String '${str}' was not recognized as a valid TimeSpan.`);
 }
 
-export function tryParse(v: string, _refValue?: any): [boolean, number] {
+export function tryParse(v: string, defValue: FSharpRef<number>): boolean {
   try {
-    return [true, parse(v)];
-  } catch (_err) {
-    return [false, 0];
+    defValue.contents = parse(v);
+    return true;
+  } catch {
+    return false;
   }
 }

--- a/src/fable-library/Types.ts
+++ b/src/fable-library/Types.ts
@@ -282,9 +282,25 @@ export function anonRecord(o: any) {
 }
 
 export class FSharpRef<T> {
-  public contents: T;
-  constructor(contents: T | null) {
-    this.contents = contents as T;
+  private getter: () => T;
+  private setter: (v: T) => void;
+
+  get contents() {
+    return this.getter();
+  }
+
+  set contents(v) {
+    this.setter(v)
+  }
+
+  constructor(contentsOrGetter: T | (() => T), setter?: (v: T) => void) {
+    if (typeof setter === "function") {
+      this.getter = contentsOrGetter as () => T;
+      this.setter = setter
+    } else {
+      this.getter = () => contentsOrGetter as T;
+      this.setter = (v) => { contentsOrGetter = v };
+    }
   }
 }
 

--- a/src/fable-library/Util.ts
+++ b/src/fable-library/Util.ts
@@ -1,17 +1,5 @@
 // tslint:disable:ban-types
 
-// Object.assign flattens getters and setters
-// See https://stackoverflow.com/questions/37054596/js-es5-how-to-assign-objects-with-setters-and-getters
-export function extend(target: any, ...sources: any[]) {
-  for (const source of sources) {
-    for (const key of Object.keys(source)) {
-      const descr = Object.getOwnPropertyDescriptor(source, key);
-      if (descr) { Object.defineProperty(target, key, descr); }
-    }
-  }
-  return target;
-}
-
 // Don't change, this corresponds to DateTime.Kind enum values in .NET
 export const enum DateKind {
   Unspecified = 0,

--- a/src/fable-library/Util.ts
+++ b/src/fable-library/Util.ts
@@ -1,5 +1,7 @@
 // tslint:disable:ban-types
 
+import { FSharpRef } from "./Types";
+
 // Don't change, this corresponds to DateTime.Kind enum values in .NET
 export const enum DateKind {
   Unspecified = 0,
@@ -153,8 +155,12 @@ export function containsValue<K, V>(v: V, map: Map<K, V>) {
   return false;
 }
 
-export function tryGetValue<K, V>(map: Map<K, V>, key: K, defaultValue: V | null): [boolean, V] {
-  return map.has(key) ? [true, map.get(key) as V] : [false, defaultValue as V];
+export function tryGetValue<K, V>(map: Map<K, V>, key: K, defaultValue: FSharpRef<V>): boolean {
+  if (map.has(key)) {
+    defaultValue.contents = map.get(key) as V;
+    return true;
+  }
+  return false;
 }
 
 export function addToSet<T>(v: T, set: Set<T>) {

--- a/src/quicktest/QuickTest.fs
+++ b/src/quicktest/QuickTest.fs
@@ -53,7 +53,28 @@ let testCaseAsync msg f =
                     printfn "%s" ex.StackTrace
         } |> Async.StartImmediate)
 
+let measureTime (f: unit -> unit) =
+    emitJsStatement f
+        """const startTime = process.hrtime();
+            $0();
+            const elapsed = process.hrtime(startTime);
+            console.log("Ms:", elapsed[0] * 1e3 + elapsed[1] / 1e6);"""
+
 // Write here your unit test, you can later move it
 // to Fable.Tests project. For example:
 // testCase "Addition works" <| fun () ->
 //     2 + 2 |> equal 4
+
+type MyGetter =
+    abstract MyNumber: int
+
+measureTime <| (fun () ->
+    let myGetter = { new MyGetter with
+                        member _.MyNumber = 1 + 1 }
+
+    let mutable x = 0
+    for i = 0 to 1000000000 do
+        x <- myGetter.MyNumber
+
+    printfn "x = %i" x
+)

--- a/src/quicktest/QuickTest.fs
+++ b/src/quicktest/QuickTest.fs
@@ -53,12 +53,14 @@ let testCaseAsync msg f =
                     printfn "%s" ex.StackTrace
         } |> Async.StartImmediate)
 
-let measureTime (f: unit -> unit) =
-    emitJsStatement f
-        """const startTime = process.hrtime();
-            $0();
-            const elapsed = process.hrtime(startTime);
-            console.log("Ms:", elapsed[0] * 1e3 + elapsed[1] / 1e6);"""
+let measureTime (f: unit -> unit) = emitJsStatement f """
+    //js
+    const startTime = process.hrtime();
+    $0();
+    const elapsed = process.hrtime(startTime);
+    console.log("Ms:", elapsed[0] * 1e3 + elapsed[1] / 1e6);
+    //!js
+"""
 
 // Write here your unit test, you can later move it
 // to Fable.Tests project. For example:
@@ -66,15 +68,17 @@ let measureTime (f: unit -> unit) =
 //     2 + 2 |> equal 4
 
 type MyGetter =
+    abstract Foo: int
     abstract MyNumber: int
 
 measureTime <| (fun () ->
     let myGetter = { new MyGetter with
-                        member _.MyNumber = 1 + 1 }
+                        member _.Foo = 1
+                        member this.MyNumber = this.Foo + 1 }
 
     let mutable x = 0
     for i = 0 to 1000000000 do
-        x <- myGetter.MyNumber
+        x <- x + myGetter.MyNumber
 
     printfn "x = %i" x
 )

--- a/tests/Main/MiscTests.fs
+++ b/tests/Main/MiscTests.fs
@@ -241,6 +241,11 @@ module Extensions =
     type NestedModule.AnotherClass with
         member x.Value2 = x.Value * 4
 
+    [<AbstractClass>]
+    type ObjectExprBase (x: int ref) as this =
+        do x := this.dup x.contents
+        abstract member dup: int -> int
+
 open Extensions
 
 
@@ -631,6 +636,12 @@ let tests =
                 member __.Bite() = 25
             }
         o.Taste(4., 6.) |> equal 28
+
+    testCase "Members are accessible in abstract class constructor inherited by object expr" <| fun () -> // See #2139
+        let x = ref 5
+        let obj = { new ObjectExprBase(x) with
+                        override _.dup x = x * x }
+        equal 25 x.contents
 
     testCase "Composition with recursive `this` works" <| fun () ->
         let mutable x = 0

--- a/tests/Main/RegexTests.fs
+++ b/tests/Main/RegexTests.fs
@@ -106,6 +106,12 @@ let tests =
         for g in m.Groups do count := !count + g.Value.Length
         equal 17 !count
 
+    testCase "Match.Groups iteration works II" <| fun () -> // See #2167
+        let m = Regex.Match("foo bar baz", @"(\w+) \w+ (\w+)")
+        let li = [for g in m.Groups -> g.Value]
+        let x = li |> List.skip 1 |> List.reduce (+)
+        equal "foobaz" x
+
     testCase "Match.Groups.Count works" <| fun _ ->
         let str = "For more information, see Chapter 3.4.5.1"
         let m = Regex.Match(str, "Chapter \d+(\.\d)*")


### PR DESCRIPTION
- Fix #2139 
- Fix #2167 
- Optimize getters in JS objects literals, [discussion](https://github.com/fable-compiler/Fable/pull/2165#issuecomment-695835444)
- Measure compilation time (F# and Fable part)
- Improve JS output: emitted JS code and don't bind `this` when it's not needed
- Improve Fable compilation time by reducing the calls to FCS `BasicPatterns`

@ncave About the last point, I did some profiling and (if I interpreted the results right) the `FSharp2Fable` step is still the one taking longest because calls to `BasicPatterns` are expensive so I tried to reduce them. For this I removed some active patterns we had built on top of `BasicPatterns`. The main changes are:

- I removed `ByrefArgToTuple` so now we have to pass a reference to replacements like `TryParse`
- I commented out the patterns to detect optimized operators. I think they are not needed because the optimization is disabled currently in nagareyama, but we can activate them again behind a compiler flag if needed.

In a simple test, when compiling FCS these changes make the Fable part run close to 20% faster in my machine (26 vs 32s).