### PR TITLE
Re-enable F# AST optimization

### DIFF
--- a/src/Fable.Cli/Entry.fs
+++ b/src/Fable.Cli/Entry.fs
@@ -40,8 +40,8 @@ Arguments:
   --exclude         Skip Fable compilation for files containing the pattern
   --typed-arrays    Compile numeric arrays to JS typed arrays
   --force-pkgs      Force a new copy of package sources into `.fable` folder
+  --optimize        Use optimized AST from F# compiler (experimental)
   --cwd             Working directory
-
 """
 
 type Runner =
@@ -84,6 +84,7 @@ type Runner =
                                            typedArrays = hasFlag "--typed-arrays" args,
                                            ?fileExtension = argValue "--extension" args,
                                            debugMode = Array.contains "DEBUG" defines,
+                                           optimizeFSharpAst = hasFlag "--optimize" args,
                                            verbosity = verbosity)
 
             let cliArgs =

--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -264,11 +264,11 @@ type ProjectParsed(project: Project,
         Log.always(sprintf "F# compilation finished in %ims" ms)
 
         // checkFableCoreVersion checkedProject
-        let optimized = false // TODO: Pass through CompilerOptions
         let implFiles =
-            if not optimized
-            then checkedProject.AssemblyContents.ImplementationFiles
-            else checkedProject.GetOptimizedAssemblyContents().ImplementationFiles
+            if cliArgs.CompilerOptions.OptimizeFSharpAst then
+                checkedProject.GetOptimizedAssemblyContents().ImplementationFiles
+            else
+                checkedProject.AssemblyContents.ImplementationFiles
 
         if List.isEmpty implFiles then
             Log.always "The list of files returned by F# compiler is empty"

--- a/src/Fable.Transforms/Global/Compiler.fs
+++ b/src/Fable.Transforms/Global/Compiler.fs
@@ -11,6 +11,7 @@ type CompilerOptions =
       abstract ClampByteArrays: bool
       abstract Typescript: bool
       abstract DebugMode: bool
+      abstract OptimizeFSharpAst: bool
       abstract Verbosity: Verbosity
       abstract FileExtension: string
 
@@ -19,6 +20,7 @@ type CompilerOptionsHelper =
     static member Make(?typedArrays,
                        ?typescript,
                        ?debugMode,
+                       ?optimizeFSharpAst,
                        ?verbosity,
                        ?fileExtension,
                        ?clampByteArrays) =
@@ -26,6 +28,7 @@ type CompilerOptionsHelper =
               member _.TypedArrays = defaultArg typedArrays false
               member _.Typescript = defaultArg typescript false
               member _.DebugMode = defaultArg debugMode false
+              member _.OptimizeFSharpAst = defaultArg optimizeFSharpAst false
               member _.Verbosity = defaultArg verbosity Verbosity.Normal
               member _.FileExtension = defaultArg fileExtension CompilerOptionsHelper.DefaultFileExtension
               member _.ClampByteArrays = defaultArg clampByteArrays false }


### PR DESCRIPTION
Adds `--optimize` to get optimized implementation files from F# compiler. I enabled the `OptimizedOperator` pattern again behind a compiler flag. I think we don't need the others for the ref args or `for in lists` but please let me know if I'm missing something @ncave.