### PR TITLE
Fix TypedArray sort method signature

### DIFF
--- a/src/Fable.Core/Fable.Core.JS.fs
+++ b/src/Fable.Core/Fable.Core.JS.fs
@@ -312,7 +312,7 @@ module JS =
         abstract some: ('T -> int -> TypedArray<'T> -> bool) -> bool
         abstract some: ('T -> int -> bool) -> bool
         abstract some: ('T -> bool) -> bool
-        abstract sort: ?sortFunction:('T -> 'T -> int) -> bool
+        abstract sort: ?sortFunction:('T -> 'T -> int) -> TypedArray<'T>
         abstract subarray: ?``begin``:int * ?``end``:int -> TypedArray<'T>
         abstract values: unit -> obj
 


### PR DESCRIPTION
Found another case where a method type signature is wrong, you can see [here](https://fable.io/repl/#?code=PYBwpgdgBAYghgIwDZgHQGFgCcwFgBQokUAygJ4DOALmALYEEpVQ3VQC8UAUiRsBNSwBXAMZVsFVAEkIVAMwAmAIJYscMhhxwaACgCMABgCUDfKyqoKYKjqEQEwAB5QdAJTAUAlgC8wKtWRQANp6ANwKoQBsoXJRALpGRlAAPgB8UJ4A5hDYePgE5pbYNib4aVAgWJ6yAGbQAEQApEr1BEA&html=Q&css=Q).