### PR TITLE
Improvements to CLI

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -76,7 +76,7 @@ let buildLibrary() =
 
     runFableWithArgs projectDir [
         "--outDir " + buildDir
-        "--fable-library " + buildDir
+        "--fableLib " + buildDir
         "--exclude Fable.Core"
         "--define FX_NO_BIGINT"
     ]
@@ -116,7 +116,7 @@ let buildLibraryTs() =
 
     runFableWithArgs projectDir [
         "--outDir " + buildDirTs
-        "--fable-library " + buildDirTs
+        "--fableLib " + buildDirTs
         "--typescript"
         "--exclude Fable.Core"
         "--define FX_NO_BIGINT"
@@ -136,7 +136,7 @@ let quicktest () =
         writeFile quicktestJsPath "console.log('Getting ready, hold tight')"
 
     concurrently [|
-        "dotnet watch -p src/Fable.Cli run -- watch --cwd ../quicktest --exclude Fable.Core --force-pkgs"
+        "dotnet watch -p src/Fable.Cli run -- watch --cwd ../quicktest --exclude Fable.Core --forcePkgs"
         "npx nodemon " + quicktestJsPath
     |]
 
@@ -156,9 +156,9 @@ let buildStandalone() =
     // build standalone bundle
     runFableWithArgs projectDir [
         "--outDir " + buildDir + "/bundle"
-        "--fable-library " + libraryDir
-        "--force-pkgs"
-        "--typed-arrays"
+        "--fableLib " + libraryDir
+        "--forcePkgs"
+        "--typedArrays"
         "--define FX_NO_CORHOST_SIGNER"
         "--define FX_NO_LINKEDRESOURCES"
         "--define FX_NO_PDB_READER"
@@ -173,8 +173,8 @@ let buildStandalone() =
     // build standalone worker
     runFableWithArgs (projectDir + "/Worker") [
         "--outDir " + buildDir + "/worker"
-        "--fable-library " + libraryDir
-        "--force-pkgs"
+        "--fableLib " + libraryDir
+        "--forcePkgs"
     ]
 
     // make standalone bundle dist
@@ -227,8 +227,8 @@ let buildCompilerJs() =
 
     runFableWithArgs projectDir [
         "--outDir " + buildDir
-        "--fable-library " + libraryDir
-        "--force-pkgs"
+        "--fableLib " + libraryDir
+        "--forcePkgs"
         "--exclude Fable.Core"
     ]
 
@@ -275,8 +275,8 @@ let test() =
 
     runFableWithArgs projectDir [
         "--outDir " + buildDir
-        "--fable-library " + libraryDir
-        "--force-pkgs"
+        "--fableLib " + libraryDir
+        "--forcePkgs"
         "--exclude Fable.Core"
     ]
 

--- a/src/Fable.Cli/Entry.fs
+++ b/src/Fable.Cli/Entry.fs
@@ -33,15 +33,17 @@ Commands:
   clean             Clean generated JS files
 
 Arguments:
+  --cwd             Working directory
   --outDir          Redirect compilation output files to a directory
   --define          Defines a symbol for use in conditional compilation
+  --run             The command after the argument will be executed after compilation
+  --runWatch        Like run, but will execute after each watch compilation
+  --typedArrays     Compile numeric arrays to JS typed arrays
+  --forcePkgs       Force a new copy of package sources into `.fable` folder
   --extension       Extension for generated JS files (default .fs.js)
   --verbose         Print more info during compilation
   --exclude         Skip Fable compilation for files containing the pattern
-  --typed-arrays    Compile numeric arrays to JS typed arrays
-  --force-pkgs      Force a new copy of package sources into `.fable` folder
   --optimize        Use optimized AST from F# compiler (experimental)
-  --cwd             Working directory
 """
 
 type Runner =
@@ -84,7 +86,7 @@ type Runner =
 
             let compilerOptions =
                 CompilerOptionsHelper.Make(typescript = hasFlag "--typescript" args,
-                                           typedArrays = hasFlag "--typed-arrays" args,
+                                       typedArrays = hasFlag "--typedArrays" args,
                                            ?fileExtension = argValue "--extension" args,
                                            debugMode = Array.contains "DEBUG" defines,
                                            optimizeFSharpAst = hasFlag "--optimize" args,
@@ -92,10 +94,10 @@ type Runner =
 
             let cliArgs =
                 { ProjectFile = projFile
-                  FableLibraryPath = argValue "--fable-library" args
+                  FableLibraryPath = argValue "--fableLib" args
                   RootDir = rootDir
                   OutDir = argValue "--outDir" args
-                  ForcePackages = hasFlag "--force-pkgs" args
+                  ForcePackages = hasFlag "--forcePkgs" args
                   Exclude = argValue "--exclude" args
                   Define = defines
                   RunArgs = runArgs
@@ -162,7 +164,7 @@ let main argv =
         |> List.splitWhile (fun a -> not(a.StartsWith("--run")))
         |> function
             | argv, flag::exeFile::runArgs ->
-                argv, Some(RunArgs(exeFile, runArgs, watch=(flag = "--run-watch")))
+                argv, Some(RunArgs(exeFile, runArgs, watch=(flag = "--runWatch")))
             | argv, _ -> argv, None
 
     let rootDir =

--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -191,7 +191,7 @@ module private Util =
             let writer = new FileWriter(com.CurrentFile, outPath, projDir, cliArgs.OutDir)
             do! BabelPrinter.run writer map babel
 
-            Log.always("Compiled " + Path.getRelativePath cliArgs.RootDir com.CurrentFile)
+            Log.always("Compiled " + File.getRelativePathFromCwd com.CurrentFile)
 
             return Ok {| File = com.CurrentFile
                          Logs = com.Logs
@@ -243,7 +243,7 @@ type ProjectCracked(sourceFiles: File array,
             }
 
         Log.verbose(lazy
-            let proj = Path.getRelativePath msg.RootDir msg.ProjectFile
+            let proj = File.getRelativePathFromCwd msg.ProjectFile
             let opts = projectOptions.OtherOptions |> String.concat "\n   "
             sprintf "F# PROJECT: %s\n   %s" proj opts)
 
@@ -264,7 +264,7 @@ type ProjectParsed(project: Project,
                 Log.always("Initializing F# compiler...")
                 InteractiveChecker.Create(config.ProjectOptions)
 
-        Log.always("Compiling " + Path.getRelativePath cliArgs.RootDir config.ProjectFile + "...")
+        Log.always("Compiling " + File.getRelativePathFromCwd config.ProjectFile + "...")
 
         let checkedProject, ms = measureTime <| fun () ->
             let fileDic = config.SourceFiles |> Seq.map (fun f -> f.NormalizedFullPath, f) |> dict
@@ -433,7 +433,7 @@ let rec startCompilation (changes: Set<string>) (state: State) = async {
             state.ErroredFiles
             |> Set.filter (fun file -> not(Array.contains file filesToCompile))
 
-        Log.always("Watching " + Path.getRelativePath state.CliArgs.RootDir watcher.Directory)
+        Log.always("Watching " + File.getRelativePathFromCwd watcher.Directory)
         let! changes = watcher.AwaitChanges()
         return!
             { state with ProjectCrackedAndParsed = Some(cracked, parsed)

--- a/src/Fable.Cli/ProjectCracker.fs
+++ b/src/Fable.Cli/ProjectCracker.fs
@@ -250,7 +250,7 @@ let fullCrack (opts: Options): CrackedFsproj =
     Process.runSync projDir "dotnet" ["restore"; projName]
     |> ignore
 
-    Log.always("Parsing " + Path.getRelativePath opts.rootDir projFile + "...")
+    Log.always("Parsing " + File.getRelativePathFromCwd projFile + "...")
     let projOpts, projRefs, _msbuildProps =
         ProjectCoreCracker.GetProjectOptionsFromProjectFile projFile
 

--- a/src/Fable.Cli/ProjectCracker.fs
+++ b/src/Fable.Cli/ProjectCracker.fs
@@ -245,9 +245,9 @@ let fullCrack (opts: Options): CrackedFsproj =
     let dllRefs = Dictionary(StringComparer.OrdinalIgnoreCase)
 
     // Try restoring project
-    Process.runCmd Log.always
-        (IO.Path.GetDirectoryName projFile)
-        "dotnet" ["restore"; IO.Path.GetFileName projFile]
+    let projDir = IO.Path.GetDirectoryName projFile
+    let projName = IO.Path.GetFileName projFile
+    Process.runSync projDir "dotnet" ["restore"; projName]
     |> ignore
 
     Log.always("Parsing " + Path.getRelativePath opts.rootDir projFile + "...")
@@ -367,9 +367,25 @@ let isDirectoryEmpty dir =
 
 let createFableDir rootDir =
     let fableDir = IO.Path.Combine(rootDir, Naming.fableHiddenDir)
-    if isDirectoryEmpty fableDir then
+    let compilerInfo = IO.Path.Combine(fableDir, "compiler_info.txt")
+
+    let isEmptyOrOutdated =
+        if isDirectoryEmpty fableDir then true
+        else
+            let isOutdated =
+                try
+                    let version = IO.File.ReadAllText(compilerInfo)
+                    version <> Literals.VERSION
+                with _ -> true
+            if isOutdated then
+                IO.Directory.Delete(fableDir, true)
+            isOutdated
+
+    if isEmptyOrOutdated then
         IO.Directory.CreateDirectory(fableDir) |> ignore
+        IO.File.WriteAllText(compilerInfo, Literals.VERSION)
         IO.File.WriteAllText(IO.Path.Combine(fableDir, ".gitignore"), "**/*")
+
     fableDir
 
 let copyDirIfDoesNotExist (opts: Options) (source: string) (target: string) =

--- a/src/Fable.Cli/Util.fs
+++ b/src/Fable.Cli/Util.fs
@@ -7,6 +7,11 @@ module Literals =
     let [<Literal>] VERSION = "3.0.0-nagareyama-alpha-003"
     let [<Literal>] CORE_VERSION = "2.1.0"
 
+type RunArgs(exeFile: string, args: string list, ?watch: bool) =
+    member _.ExeFile = exeFile
+    member _.Args = args
+    member _.IsWatch = defaultArg watch false
+
 type CliArgs =
     { ProjectFile: string
       RootDir: string
@@ -15,6 +20,7 @@ type CliArgs =
       Define: string[]
       ForcePackages: bool
       Exclude: string option
+      RunArgs: RunArgs option
       CompilerOptions: Fable.CompilerOptions }
 
 type private TypeInThisAssembly = class end
@@ -36,7 +42,7 @@ module Log =
             && not(String.IsNullOrEmpty(msg)) then
 //            lock writerLock <| fun () ->
                 Console.Out.WriteLine(msg)
-                Console.Out.Flush()
+                // Console.Out.Flush()
 
     let verbose (msg: Lazy<string>) =
         if verbosity = Fable.Verbosity.Verbose then
@@ -45,41 +51,21 @@ module Log =
 [<RequireQualifiedAccess>]
 module Process =
     open System.Diagnostics
+    open System.Runtime.InteropServices
 
-    type Options(?envVars, ?redirectOutput) =
-        member val EnvVars = defaultArg envVars Map.empty<string,string>
-        member val RedirectOuput = defaultArg redirectOutput false
-
-    let isWindows =
-        #if NETFX
-        true
-        #else
-        System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform
-            (System.Runtime.InteropServices.OSPlatform.Windows)
-        #endif
-
-    let start workingDir fileName args (opts: Options) =
-        let fileName, args =
-            if isWindows
-            then "cmd", ("/C \"" + fileName + "\" " + args)
-            else fileName, args
-        let p = new Process()
-        p.StartInfo.FileName <- fileName
-        p.StartInfo.Arguments <- args
-        p.StartInfo.WorkingDirectory <- workingDir
-        p.StartInfo.RedirectStandardOutput <- opts.RedirectOuput
-        #if NETFX
-        p.StartInfo.UseShellExecute <- false
-        #endif
-        opts.EnvVars |> Map.iter (fun k v ->
-            p.StartInfo.Environment.[k] <- v)
-        p.Start() |> ignore
-        p
+    let isWindows() =
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
 
     // Adapted from https://github.com/enricosada/dotnet-proj-info/blob/1e6d0521f7f333df7eff3148465f7df6191e0201/src/dotnet-proj/Program.fs#L155
-    let private runProcess (workingDir: string) (exePath: string) (args: string) =
-        let logOut = System.Collections.Concurrent.ConcurrentQueue<string>()
-        let logErr = System.Collections.Concurrent.ConcurrentQueue<string>()
+    let private startProcess workingDir exePath args =
+        let args = String.concat " " args
+        let exePath, args =
+            if isWindows() then "cmd", ("/C \"" + exePath + "\" " + args)
+            else exePath, args
+
+        Log.always(
+            let workingDir = Fable.Path.getRelativeFileOrDirPath true (Directory.GetCurrentDirectory()) true workingDir
+            workingDir + "> " + exePath + " " + args)
 
         let psi = ProcessStartInfo()
         psi.FileName <- exePath
@@ -90,38 +76,28 @@ module Process =
         psi.CreateNoWindow <- true
         psi.UseShellExecute <- false
 
-        use p = new Process()
-        p.StartInfo <- psi
+        let p = Process.Start(psi)
+        p.OutputDataReceived.Add(fun ea -> Log.always(ea.Data))
+        p.ErrorDataReceived.Add(fun ea -> Log.always(ea.Data))
+        p.BeginOutputReadLine()
+        p.BeginErrorReadLine()
+        p
 
-        p.OutputDataReceived.Add(fun ea -> logOut.Enqueue (ea.Data))
-        p.ErrorDataReceived.Add(fun ea -> logErr.Enqueue (ea.Data))
+    let fireAndForget (workingDir: string) (exePath: string) (args: string list) =
+        try
+            startProcess workingDir exePath args |> ignore
+        with ex ->
+            Log.always("Cannot run: " + ex.Message)
 
-        let exitCode =
-            try
-                p.Start() |> ignore
-                p.BeginOutputReadLine()
-                p.BeginErrorReadLine()
-                p.WaitForExit()
-                p.ExitCode
-            with ex ->
-                logErr.Enqueue ("Cannot run: " + ex.Message)
-                -1
-
-        exitCode, logOut.ToArray(), logErr.ToArray()
-
-    // Adapted from https://github.com/enricosada/dotnet-proj-info/blob/1e6d0521f7f333df7eff3148465f7df6191e0201/src/dotnet-proj/Program.fs#L155
-    let runCmd log workingDir exePath args =
-        log (workingDir + "> " + exePath + " " + (args |> String.concat " "))
-
-        let exitCode, logOut, logErr =
-            String.concat " " args
-            |> runProcess workingDir exePath
-
-        Array.append logOut logErr
-        |> String.concat "\n"
-        |> log
-
-        exitCode
+    let runSync (workingDir: string) (exePath: string) (args: string list) =
+        try
+            let p = startProcess workingDir exePath args
+            p.WaitForExit()
+            p.ExitCode
+        with ex ->
+            Log.always("Cannot run: " + ex.Message)
+            Log.always(ex.StackTrace)
+            -1
 
 [<RequireQualifiedAccess>]
 module Async =

--- a/src/Fable.Transforms/AST/AST.Babel.fs
+++ b/src/Fable.Transforms/AST/AST.Babel.fs
@@ -763,7 +763,7 @@ type ObjectProperty(key, value, ?computed_) = // ?shorthand_,
             else
                 printer.Print(key)
             printer.Print(": ")
-            value.Print(printer)
+            printer.SequenceExpressionWithParens(value)
 
 type ObjectMethodKind = ObjectGetter | ObjectSetter | ObjectMeth
 


### PR DESCRIPTION
- Add `--run` argument to run a command after Fable compilation (`--run-watch` will run it after every watch compilation)
- Add `--define DEBUG` automatically in watch mode
- `clean` command also cleans hidden `.fable` folders now
- Add compiler version to `.fable` and reset it when it changes
- Skip Fable compilation of files that have a more recent JS version