### PR TITLE
Add back base Union/Record classes

### DIFF
--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -325,6 +325,7 @@ let excludeFilesAndSignatures (exclude: string option) (files: string[]) =
         | None -> filesToCompile
 
 let rec startCompilation (changes: Set<string>) (state: State) = async {
+    // TODO: Use Result here to fail more gracefully if FCS crashes
     let cracked, parsed, filesToCompile =
         match state.ProjectCrackedAndParsed with
         | Some(cracked, parsed) ->

--- a/src/Fable.Transforms/AST/AST.Babel.fs
+++ b/src/Fable.Transforms/AST/AST.Babel.fs
@@ -210,8 +210,11 @@ type Node =
     abstract Print: Printer -> unit
 
 /// Since the left-hand side of an assignment may be any expression in general, an expression can also be a pattern.
-type Expression = inherit Node
-type Pattern = inherit Node
+type Expression =
+    inherit Node
+type Pattern =
+    inherit Node
+    abstract Name: string
 type PatternExpression =
     inherit Pattern
     inherit Expression
@@ -324,6 +327,7 @@ type Identifier(name, ?optional, ?typeAnnotation, ?loc) =
     member _.Optional: bool option = optional
     member _.TypeAnnotation: TypeAnnotation option = typeAnnotation
     interface PatternExpression with
+        member _.Name = name
         member _.Print(printer) =
             printer.Print(name, ?loc=loc)
             if optional = Some true then
@@ -817,6 +821,10 @@ type MemberExpression(object, property, ?computed_, ?loc) =
     member _.Property: Expression = property
     member _.Computed: bool = computed
     interface PatternExpression with
+        member _.Name =
+            match property with
+            | :? Identifier as i -> i.Name
+            | _ -> ""
         member _.Print(printer) =
             printer.AddLocation(loc)
             match object with
@@ -1028,6 +1036,7 @@ type RestElement(argument, ?typeAnnotation, ?loc) =
     member _.Argument: Pattern = argument
     member _.TypeAnnotation: TypeAnnotation option = typeAnnotation
     interface Pattern with
+        member _.Name = argument.Name
         member _.Print(printer) =
             printer.Print("...", ?loc=loc)
             argument.Print(printer)

--- a/src/fable-library/Option.ts
+++ b/src/fable-library/Option.ts
@@ -1,3 +1,4 @@
+import { Union } from "./Types.js";
 import { compare, equals, structuralHash } from "./Util.js";
 
 // Options are erased in runtime by Fable, but we have
@@ -129,34 +130,52 @@ export function tryOp<T, U>(op: (x: T) => U, arg: T): Option<U> {
 
 // CHOICE
 
-export class Choice<_T1, _T2> {
-  public fields: any[];
-  constructor(public tag: number, ...fields: any[]) { this.fields = fields; }
+export class Choice<_T1, _T2> extends Union {
+  constructor(tag: number, ...fields: any[]) {
+    super();
+    this.tag = tag | 0;
+    this.fields = fields;
+  }
   public cases() { return ["Choice1Of2", "Choice2Of2"]; }
 }
-export class Choice3<_T1, _T2, _T3> {
-  public fields: any[];
-  constructor(public tag: number, ...fields: any[]) { this.fields = fields; }
+export class Choice3<_T1, _T2, _T3> extends Union {
+  constructor(tag: number, ...fields: any[]) {
+    super();
+    this.tag = tag | 0;
+    this.fields = fields;
+  }
   public cases() { return ["Choice1Of3", "Choice2Of3", "Choice3Of3"]; }
 }
-export class Choice4<_T1, _T2, _T3, _T4> {
-  public fields: any[];
-  constructor(public tag: number, ...fields: any[]) { this.fields = fields; }
+export class Choice4<_T1, _T2, _T3, _T4> extends Union {
+  constructor(tag: number, ...fields: any[]) {
+    super();
+    this.tag = tag | 0;
+    this.fields = fields;
+  }
   public cases() { return ["Choice1Of4", "Choice2Of4", "Choice3Of4", "Choice4Of4"]; }
 }
-export class Choice5<_T1, _T2, _T3, _T4, _T5> {
-  public fields: any[];
-  constructor(public tag: number, ...fields: any[]) { this.fields = fields; }
+export class Choice5<_T1, _T2, _T3, _T4, _T5> extends Union {
+  constructor(tag: number, ...fields: any[]) {
+    super();
+    this.tag = tag | 0;
+    this.fields = fields;
+  }
   public cases() { return ["Choice1Of5", "Choice2Of5", "Choice3Of5", "Choice4Of5", "Choice5Of5"]; }
 }
-export class Choice6<_T1, _T2, _T3, _T4, _T5, _T6> {
-  public fields: any[];
-  constructor(public tag: number, ...fields: any[]) { this.fields = fields; }
+export class Choice6<_T1, _T2, _T3, _T4, _T5, _T6> extends Union {
+  constructor(tag: number, ...fields: any[]) {
+    super();
+    this.tag = tag | 0;
+    this.fields = fields;
+  }
   public cases() { return ["Choice1Of6", "Choice2Of6", "Choice3Of6", "Choice4Of6", "Choice5Of6", "Choice6Of6"]; }
 }
-export class Choice7<_T1, _T2, _T3, _T4, _T5, _T6, _T7> {
-  public fields: any[];
-  constructor(public tag: number, ...fields: any[]) { this.fields = fields; }
+export class Choice7<_T1, _T2, _T3, _T4, _T5, _T6, _T7> extends Union {
+  constructor(tag: number, ...fields: any[]) {
+    super();
+    this.tag = tag | 0;
+    this.fields = fields;
+  }
   public cases() { return ["Choice1Of7", "Choice2Of7", "Choice3Of7", "Choice4Of7", "Choice5Of7", "Choice6Of7", "Choice7Of7"]; }
 }
 
@@ -178,9 +197,12 @@ export function tryValueIfChoice2Of2<T1, T2>(x: Choice<T1, T2>): Option<T2> {
 
 // RESULT
 
-export class Result<_T, _U> {
-  public fields: any[];
-  constructor(public tag: number, ...fields: any[]) { this.fields = fields; }
+export class Result<_T, _U> extends Union {
+  constructor(tag: number, ...fields: any[]) {
+    super();
+    this.tag = tag | 0;
+    this.fields = fields;
+  }
   public cases() { return ["Ok", "Error"]; }
 }
 

--- a/src/fable-library/Reflection.ts
+++ b/src/fable-library/Reflection.ts
@@ -1,5 +1,5 @@
-import { FSharpRef } from "./Types.js";
-import { compareArraysWith, equalArraysWith, isUnionLike } from "./Util.js";
+import { FSharpRef, Record, Union } from "./Types.js";
+import { compareArraysWith, equalArraysWith } from "./Util.js";
 
 export type FieldInfo = [string, TypeInfo];
 export type PropertyInfo = FieldInfo;
@@ -297,11 +297,11 @@ export function getFunctionElements(t: TypeInfo): [TypeInfo, TypeInfo] {
 }
 
 export function isUnion(t: any): boolean {
-  return t instanceof TypeInfo ? t.cases != null : isUnionLike(t);
+  return t instanceof TypeInfo ? t.cases != null : t instanceof Union;
 }
 
 export function isRecord(t: any): boolean {
-  return t instanceof TypeInfo ? t.fields != null : typeof t === "object" && !isUnionLike(t); // TODO: better test
+  return t instanceof TypeInfo ? t.fields != null : t instanceof Record;
 }
 
 export function isTuple(t: TypeInfo): boolean {
@@ -397,7 +397,7 @@ export function getValue(propertyInfo: PropertyInfo, v: any): any {
 // Fable.Core.Reflection
 
 function assertUnion(x: any) {
-  if (!isUnionLike(x)) {
+  if (!(x instanceof Union)) {
     throw new Error(`Value is not an F# union type`);
   }
 }

--- a/src/fable-library/String.ts
+++ b/src/fable-library/String.ts
@@ -2,13 +2,9 @@ import { toString as dateToString } from "./Date.js";
 import Decimal from "./Decimal.js";
 import Long, * as _Long from "./Long.js";
 import { escape } from "./RegExp.js";
-import { isIterable, isUnionLike } from "./Util.js";
+import { toString } from "./Types.js";
 
 type Numeric = number | Long | Decimal;
-
-export interface IStringable {
-  ToString(): string;
-}
 
 const fsFormatRegExp = /(^|[^%])%([0+\- ]*)(\d+)?(?:\.(\d+))?(\w)/;
 const formatRegExp = /\{(\d+)(,-?\d+)?(?:\:([a-zA-Z])(\d{0,2})|\:(.+?))?\}/g;
@@ -325,80 +321,6 @@ export function format(str: string, ...args: any[]) {
     }
     return rep;
   });
-}
-
-export function isStringable<T>(x: T | IStringable): x is IStringable {
-  return x != null && typeof (x as IStringable).ToString === "function";
-}
-
-function unionToStringPrivate(self: any): string {
-  const name = self.cases()[self.tag];
-  if (self.fields.length === 0) {
-    return name;
-  } else {
-    let fields = "";
-    let withParens = true;
-    if (self.fields.length === 1) {
-      const field = toString(self.fields[0]);
-      withParens = field.indexOf(" ") >= 0;
-      fields = field;
-    }
-    else {
-      fields = self.fields.map((x: any) => toString(x)).join(", ");
-    }
-    return name + (withParens ? " (" : " ") + fields + (withParens ? ")" : "");
-  }
-}
-
-export function unionToString(self: any) {
-  return isStringable(self) ? self.ToString() : unionToStringPrivate(self);
-}
-
-function recordToStringPrivate(self: any, callStack=0): string {
-  return callStack > 10
-    ? Object.getPrototypeOf(self).constructor.name
-    : "{ " + Object.entries(self).map(([k, v]) => k + " = " + toString(v, callStack)).join("\n  ") + " }";
-}
-
-export function recordToString(self: any): string {
-  return isStringable(self) ? self.ToString() : recordToStringPrivate(self);
-}
-
-export function objectToString(self: any): string {
-  return isStringable(self) ? self.ToString() : Object.getPrototypeOf(self).constructor.name;
-}
-
-export function seqToString<T>(self: Iterable<T>): string {
-  let count = 0;
-  let str = "[";
-  for (let x of self) {
-    if (count === 0) {
-      str += toString(x);
-    } else if (count === 100) {
-      str += "; ...";
-      break;
-    } else {
-      str += "; " + toString(x);
-    }
-    count++;
-  }
-  return str + "]";
-}
-
-export function toString(x: any, callStack=-1): string {
-  if (x == null || typeof x !== "object") {
-    return String(x);
-  } else if (isStringable(x)) {
-    return x.ToString();
-  } else if (isIterable(x)) {
-    return seqToString(x);
-  } else if (isUnionLike(x)) {
-    return unionToStringPrivate(x);
-  } else {
-    // TODO: Defaulting to recordToString until we have a way
-    // to tell records apart from other objects in runtime
-    return recordToStringPrivate(x, callStack + 1);
-  }
 }
 
 export function endsWith(str: string, search: string) {


### PR DESCRIPTION
When trying to compile Fable.SimpleJson with Nagareyama we realized the code that relied on Unions and Record inheriting some behavior (like `toJSON` implementations) could easily break so I've tried to apply @chrisvanderpennen solution (see #2160) to bring back the base classes for unions and records ...although it seems @Zaid-Ajaj already managed to fix Fable.SimpleJson so maybe this is already outdate 😅 

https://github.com/Zaid-Ajaj/Fable.SimpleJson/pull/54

In microbenchmarks initializing derived classes takes longer, but I couldn't see an appreciable difference when running the benchmark (see #2186) between this branch and current `nagareyama`.