### PR TITLE
Optimize list construction

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -84,6 +84,7 @@ let buildLibrary() =
         "--noCache"
         "--exclude Fable.Core"
         "--define FX_NO_BIGINT"
+        "--define FABLE_LIBRARY"
     ]
 
     // // Move js files to build folder
@@ -126,6 +127,7 @@ let buildLibraryTs() =
         "--typescript"
         "--exclude Fable.Core"
         "--define FX_NO_BIGINT"
+        "--define FABLE_LIBRARY"
     ]
     // TODO: cleanDirs [buildDirTs </> "fable-library"]
     // TODO: copy *.ts/*.js from projectDir to buildDir

--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -260,7 +260,8 @@ type ProjectCracked(sourceFiles: File array,
     static member Init(cliArgs: CliArgs) =
         let res =
             CrackerOptions(fableLib = cliArgs.FableLibraryPath,
-                           define = cliArgs.Define,
+                           outDir = cliArgs.OutDir,
+                           define = List.toArray cliArgs.Define,
                            exclude = cliArgs.Exclude,
                            replace = cliArgs.Replace,
                            forcePkgs = cliArgs.NoCache,

--- a/src/Fable.Cli/Util.fs
+++ b/src/Fable.Cli/Util.fs
@@ -20,7 +20,7 @@ type CliArgs =
       RootDir: string
       OutDir: string option
       FableLibraryPath: string option
-      Define: string[]
+      Define: string list
       NoCache: bool
       WatchMode: bool
       Exclude: string option
@@ -188,7 +188,7 @@ module Imports =
 
     let getRelativePath (path: string) (pathTo: string) =
         let relPath = Path.GetRelativePath(path, pathTo).Replace('\\', '/')
-        if relPath.StartsWith('.') then relPath else "./" + relPath
+        if isRelativePath relPath then relPath else "./" + relPath
 
     let getTargetRelPath importPath targetDir projDir outDir =
         let relPath = getRelativePath projDir importPath |> trimPath
@@ -197,10 +197,14 @@ module Imports =
         let relPath = if relPath.EndsWith(".fs.js") then relPath.Replace(".fs.js", ".js") else relPath
         relPath
 
-    let getImportPath sourcePath targetPath projDir outDir importPath =
+    let getImportPath sourcePath targetPath projDir outDir (importPath: string) =
         match outDir with
         | None -> importPath
         | Some outDir ->
+            let importPath =
+                if importPath.StartsWith("${outDir}") then
+                    Path.Combine(outDir, importPath.Replace("${outDir}", "").TrimStart('/'))
+                else importPath
             let sourceDir = Path.GetDirectoryName(sourcePath)
             let targetDir = Path.GetDirectoryName(targetPath)
             let importPath =

--- a/src/Fable.Core/Fable.Core.Types.fs
+++ b/src/Fable.Core/Fable.Core.Types.fs
@@ -76,6 +76,13 @@ type StringEnumAttribute(caseRules: CaseRules) =
     inherit Attribute()
     new () = StringEnumAttribute(CaseRules.LowerFirst)
 
+/// Used to spread the last argument. Mainly intended for `React.createElement` binding, not for general use.
+[<AttributeUsage(AttributeTargets.Parameter)>]
+type ParamSeqAttribute() =
+    inherit Attribute()
+
+type ParamListAttribute = ParamSeqAttribute
+
 /// Experimental: Currently only intended for some specific libraries
 [<AttributeUsage(AttributeTargets.Parameter)>]
 type InjectAttribute() =

--- a/src/Fable.Transforms/Global/Compiler.fs
+++ b/src/Fable.Transforms/Global/Compiler.fs
@@ -10,6 +10,7 @@ type CompilerOptions =
       abstract TypedArrays: bool
       abstract ClampByteArrays: bool
       abstract Typescript: bool
+      abstract Define: string list
       abstract DebugMode: bool
       abstract OptimizeFSharpAst: bool
       abstract Verbosity: Verbosity
@@ -19,7 +20,7 @@ type CompilerOptionsHelper =
     static member DefaultFileExtension = ".fs.js"
     static member Make(?typedArrays,
                        ?typescript,
-                       ?debugMode,
+                       ?define,
                        ?optimizeFSharpAst,
                        ?verbosity,
                        ?fileExtension,
@@ -27,7 +28,8 @@ type CompilerOptionsHelper =
         { new CompilerOptions with
               member _.Typescript = defaultArg typescript false
               member _.TypedArrays = defaultArg typedArrays true
-              member _.DebugMode = defaultArg debugMode false
+              member _.Define = defaultArg define []
+              member this.DebugMode = this.Define |> List.contains "DEBUG"
               member _.OptimizeFSharpAst = defaultArg optimizeFSharpAst false
               member _.Verbosity = defaultArg verbosity Verbosity.Normal
               member _.FileExtension = defaultArg fileExtension CompilerOptionsHelper.DefaultFileExtension

--- a/src/fable-compiler-js/src/Platform.fs
+++ b/src/fable-compiler-js/src/Platform.fs
@@ -73,7 +73,7 @@ let normalizeFullPath (path: string) =
 
 let getRelativePath (path: string) (pathTo: string) =
     let relPath = JS.path.relative(path, pathTo).Replace('\\', '/')
-    if relPath.StartsWith('.') then relPath else "./" + relPath
+    if relPath.StartsWith("./") || relPath.StartsWith("../") then relPath else "./" + relPath
 
 let getHomePath () =
     JS.os.homedir()

--- a/src/fable-library/List.fs
+++ b/src/fable-library/List.fs
@@ -6,6 +6,13 @@ module List
 open System.Collections.Generic
 open Fable.Core
 
+[<Import("List", "${outDir}/Types.js"); EmitConstructor>]
+let private newList ([<ParamList>] args: obj list): 'a list = jsNative
+
+let empty<'a> : 'a list = newList []
+let singleton (x: 'a): 'a list = newList [x; empty]
+let cons (x: 'a) (xs: 'a list): 'a list = newList [x; xs]
+
 let head = function
     | x::_ -> x
     | _ -> failwith "List was empty"
@@ -170,14 +177,15 @@ let iterateIndexed f xs =
 let iterateIndexed2 f xs ys =
     foldIndexed2 (fun i () x y -> f i x y) () xs ys
 
-let ofArray (xs: IList<'T>) =
-    // Array.foldBack (fun x acc -> x::acc) xs []
-    let mutable res = []
+let ofArrayWithTail (xs: IList<'T>) (tail: 'T list) =
+    let mutable res = tail
     for i = xs.Count - 1 downto 0 do
         res <- xs.[i]::res
     res
 
-let empty<'a> : 'a list = []
+let ofArray (xs: IList<'T>) =
+    // Array.foldBack (fun x acc -> x::acc) xs []
+    ofArrayWithTail xs []
 
 let isEmpty = function
     | [] -> true

--- a/src/fable-standalone/src/Main.fs
+++ b/src/fable-standalone/src/Main.fs
@@ -259,8 +259,11 @@ let init () =
                                     ?typedArrays, ?typescript) =
             let res = parseResults :?> ParseResults
             let project = res.GetProject()
-            let isDebug = parseResults.OtherFSharpOptions |> Array.exists (fun x -> x = "--define:DEBUG" || x = "-d:DEBUG")
-            let options = Fable.CompilerOptionsHelper.Make(debugMode=isDebug, ?typedArrays=typedArrays, ?typescript=typescript)
+            let define = parseResults.OtherFSharpOptions |> Array.choose (fun x ->
+                if x.StartsWith("--define:") || x.StartsWith("-d:")
+                then x.[(x.IndexOf(':') + 1)..] |> Some
+                else None) |> Array.toList
+            let options = Fable.CompilerOptionsHelper.Make(define=define, ?typedArrays=typedArrays, ?typescript=typescript)
             let com = CompilerImpl(fileName, project, options, fableLibrary)
             let ast =
                 FSharp2Fable.Compiler.transformFile com


### PR DESCRIPTION
This was intended to optimize the list constructors for better JS minification, but it also contains some other quality-of-life improvements:

- Put .fable folder in `outDir` when selected
- Enable `${outDir}` macro as with fable-splitter
- Other minor fixes