### PR TITLE
Changes in AST for plugins

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -81,7 +81,6 @@ let buildLibrary() =
     runFableWithArgs projectDir [
         "--outDir " + buildDir
         "--fableLib " + buildDir
-        "--noCache"
         "--exclude Fable.Core"
         "--define FX_NO_BIGINT"
         "--define FABLE_LIBRARY"
@@ -123,7 +122,6 @@ let buildLibraryTs() =
     runFableWithArgs projectDir [
         "--outDir " + buildDirTs
         "--fableLib " + buildDirTs
-        "--noCache"
         "--typescript"
         "--exclude Fable.Core"
         "--define FX_NO_BIGINT"
@@ -143,7 +141,7 @@ let quicktest () =
     if pathExists quicktestJsPath |> not then
         writeFile quicktestJsPath "console.log('Getting ready, hold tight')"
 
-    run "dotnet watch -p src/Fable.Cli run -- watch --cwd ../quicktest --exclude Fable.Core --noCache --runScript"
+    run "dotnet watch -p src/Fable.Cli run -- watch --cwd ../quicktest --exclude Fable.Core --forcePkgs --runScript"
 
 let buildStandalone(minify: bool) =
     printfn "Building standalone%s..." (if minify then "" else " (no minification)")
@@ -163,7 +161,6 @@ let buildStandalone(minify: bool) =
     // build standalone bundle
     runFableWithArgs projectDir [
         "--outDir " + buildDir + "/bundle"
-        "--noCache"
         "--define FX_NO_CORHOST_SIGNER"
         "--define FX_NO_LINKEDRESOURCES"
         "--define FX_NO_PDB_READER"
@@ -178,7 +175,6 @@ let buildStandalone(minify: bool) =
     // build standalone worker
     runFableWithArgs (projectDir + "/Worker") [
         "--outDir " + buildDir + "/worker"
-        "--noCache"
     ]
 
     // make standalone bundle dist
@@ -232,7 +228,6 @@ let buildCompilerJs(minify: bool) =
 
     runFableWithArgs projectDir [
         "--outDir " + buildDir
-        "--noCache"
         "--exclude Fable.Core"
     ]
 
@@ -279,6 +274,7 @@ let test() =
     if not (pathExists libraryDir) then
         buildLibrary()
 
+    cleanDirs [buildDir]
     runFableWithArgs projectDir [
         "--outDir " + buildDir
         "--noCache"

--- a/build.fsx
+++ b/build.fsx
@@ -184,8 +184,12 @@ let buildStandalone(minify: bool) =
         run (sprintf "npx terser %s/bundle.js -o %s/bundle.min.js --mangle --compress" buildDir distDir)
 
     // make standalone worker dist
-    run (sprintf "npx rollup %s/worker/Worker.js -o %s/worker.js --format esm" buildDir buildDir)
-    run (sprintf "npx webpack --entry ./%s/worker.js --output ./%s/worker.min.js --config ./%s/../worker.config.js" buildDir distDir projectDir)
+    // TODO: Temporarily disable minification as it's failing in Appveyor for some reason
+    if envVarOrNone "APPVEYOR" |> Option.isSome then
+        run (sprintf "npx rollup %s/worker/Worker.js -o %s/worker.min.js --format esm" buildDir distDir)
+    else
+        run (sprintf "npx rollup %s/worker/Worker.js -o %s/worker.js --format esm" buildDir buildDir)
+        run (sprintf "npx webpack --entry ./%s/worker.js --output ./%s/worker.min.js --config ./%s/../worker.config.js" buildDir distDir projectDir)
 
     // print bundle size
     fileSizeInBytes (distDir </> "bundle.min.js") / 1000 |> printfn "Bundle size: %iKB"

--- a/src/Fable.AST/Fable.fs
+++ b/src/Fable.AST/Fable.fs
@@ -209,12 +209,20 @@ type ValueKind =
         | NewAnonymousRecord (_, fieldNames, genArgs) -> AnonymousRecordType(fieldNames, genArgs)
         | NewUnion (_, _, ent, genArgs) -> DeclaredType(ent, genArgs)
 
+type CallMemberInfo =
+    { CurriedParameterGroups: Parameter list list
+      IsInstance: bool
+      FullName: string
+      CompiledName: string
+      DeclaringEntity: EntityRef option }
+
 type CallInfo =
     { ThisArg: Expr option
       Args: Expr list
       /// Argument types as defined in the method signature, this may be slightly different to types of actual argument expressions.
       /// E.g.: signature accepts 'a->'b->'c (2-arity) but we pass int->int->int->int (3-arity)
       SignatureArgTypes: Type list
+      CallMemberInfo: CallMemberInfo option
       HasSpread: bool
       IsJsConstructor: bool }
 

--- a/src/Fable.AST/Fable.fs
+++ b/src/Fable.AST/Fable.fs
@@ -276,7 +276,7 @@ type Expr =
     | ObjectExpr of MemberDecl list * Type * baseCall: Expr option
 
     // Type cast and tests
-    | TypeCast of Expr * Type
+    | TypeCast of Expr * Type * tag: string option
     | Test of Expr * TestKind * range: SourceLocation option
 
     // Operations
@@ -312,7 +312,7 @@ type Expr =
         | IdentExpr id -> id.Type
         | Call(_,_,t,_)
         | CurriedApply(_,_,t,_)
-        | TypeCast (_, t)
+        | TypeCast (_, t,_)
         | Import (_, t, _)
         | Curry (_, _, t, _)
         | ObjectExpr (_, t, _)
@@ -340,7 +340,7 @@ type Expr =
         | DecisionTreeSuccess _ -> None
         | Lambda (_, e, _)
         | Delegate (_, e, _)
-        | TypeCast (e, _) -> e.Range
+        | TypeCast (e, _, _) -> e.Range
         | IdentExpr id -> id.Range
         | Call(_,_,_,r)
         | CurriedApply(_,_,_,r)

--- a/src/Fable.AST/Plugins.fs
+++ b/src/Fable.AST/Plugins.fs
@@ -3,9 +3,30 @@ namespace Fable
 open Fable.AST
 open Fable.AST.Fable
 
+[<RequireQualifiedAccess>]
+type Verbosity =
+    | Normal
+    | Verbose
+    | Silent
+
+type CompilerOptions =
+      abstract TypedArrays: bool
+      abstract ClampByteArrays: bool
+      abstract Typescript: bool
+      abstract Define: string list
+      abstract DebugMode: bool
+      abstract OptimizeFSharpAst: bool
+      abstract Verbosity: Verbosity
+      abstract FileExtension: string
+
 type PluginHelper =
+    abstract LibraryDir: string
+    abstract CurrentFile: string
+    abstract Options: CompilerOptions
     abstract LogWarning: string * ?range: SourceLocation -> unit
     abstract LogError: string * ?range: SourceLocation -> unit
+    abstract GetRootModule: fileName: string -> string
+    abstract GetEntity: EntityRef -> Entity
 
 [<AbstractClass>]
 type PluginAttribute() =

--- a/src/Fable.Cli/Entry.fs
+++ b/src/Fable.Cli/Entry.fs
@@ -130,7 +130,7 @@ type Runner =
               RootDir = rootDir
               OutDir = argValue "--outDir" args |> Option.map makeAbsolute
               WatchMode = watch
-              NoCache = flagEnabled "--noCache" args || flagEnabled "--forcePkgs" args
+              ForcePkgs = flagEnabled "--forcePkgs" args
               Exclude = argValue "--exclude" args
               Replace =
                 argValues "--replace" args
@@ -138,7 +138,6 @@ type Runner =
                     let v = v.Split(':')
                     v.[0], Path.normalizeFullPath v.[1])
                 |> Map
-              Define = define
               RunProcess = runProc
               CompilerOptions = compilerOptions }
 

--- a/src/Fable.Cli/Entry.fs
+++ b/src/Fable.Cli/Entry.fs
@@ -57,7 +57,7 @@ Arguments:
   --runScript       Runs the generated script for last file with node
                     (Requires "esm" npm package)
 
-  --noCache         Ignore cached files during compilation
+  --forcePkgs       Force a new copy of package sources into `.fable` folder
   --exclude         Don't merge sources of referenced projects with specified pattern
                     (Intended for plugin development)
 

--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -247,9 +247,6 @@ type ProjectCracked(sourceFiles: File array,
     member _.Packages = crackerResponse.Packages
     member _.SourceFiles = sourceFiles
 
-    /// Indicates if the .fable dir has been created or reset because of new compiler version
-    member _.FableLibReset = crackerResponse.FableLibReset
-
     member _.MakeCompiler(currentFile, project) =
         let fableLibDir = Path.getRelativePath currentFile crackerResponse.FableLibDir
         CompilerImpl(currentFile, project, fableCompilerOptions, fableLibDir)
@@ -261,10 +258,10 @@ type ProjectCracked(sourceFiles: File array,
         let res =
             CrackerOptions(fableLib = cliArgs.FableLibraryPath,
                            outDir = cliArgs.OutDir,
-                           define = List.toArray cliArgs.Define,
+                           define = List.toArray cliArgs.CompilerOptions.Define,
                            exclude = cliArgs.Exclude,
                            replace = cliArgs.Replace,
-                           forcePkgs = cliArgs.NoCache,
+                           forcePkgs = cliArgs.ForcePkgs,
                            projFile = cliArgs.ProjectFile,
                            optimize = cliArgs.CompilerOptions.OptimizeFSharpAst)
             |> getFullProjectOpts
@@ -384,7 +381,7 @@ let rec startCompilation (changes: Set<string>) (state: State) = async {
                 cracked.SourceFiles
                 |> Array.map (fun f -> f.NormalizedFullPath)
                 |> fun files ->
-                    if cracked.FableLibReset || state.CliArgs.NoCache then files
+                    if not state.CliArgs.CompilerOptions.DebugMode then files
                     else
                         // Skip files that have a more recent JS version
                         files |> Array.skipWhile (fun file ->

--- a/src/Fable.Cli/ProjectCracker.fs
+++ b/src/Fable.Cli/ProjectCracker.fs
@@ -35,7 +35,6 @@ type CrackerOptions(fableLib, outDir, define, exclude, replace, forcePkgs, projF
 
 type CrackerResponse =
     { FableLibDir: string
-      FableLibReset: bool
       Packages: FablePackage list
       ProjectOptions: FSharpProjectOptions }
 
@@ -433,7 +432,7 @@ let createFableDir (opts: CrackerOptions) =
         IO.File.WriteAllText(compilerInfo, Literals.VERSION)
         IO.File.WriteAllText(IO.Path.Combine(fableDir, ".gitignore"), "**/*")
 
-    isEmptyOrOutdated, fableDir
+    fableDir
 
 let copyDirIfDoesNotExist (source: string) (target: string) =
     if isDirectoryEmpty target then
@@ -448,7 +447,7 @@ let copyDirIfDoesNotExist (source: string) (target: string) =
             IO.File.Copy(newPath, newPath.Replace(source, target), true)
 
 let copyFableLibraryAndPackageSources (opts: CrackerOptions) (pkgs: FablePackage list) =
-    let fableLibReset, fableLibDir = createFableDir opts
+    let fableLibDir = createFableDir opts
 
     let fableLibraryPath =
         match opts.FableLib with
@@ -483,7 +482,7 @@ let copyFableLibraryAndPackageSources (opts: CrackerOptions) (pkgs: FablePackage
             copyDirIfDoesNotExist sourceDir targetDir
             { pkg with FsprojPath = IO.Path.Combine(targetDir, IO.Path.GetFileName(pkg.FsprojPath)) })
 
-    fableLibReset, fableLibraryPath, pkgRefs
+    fableLibraryPath, pkgRefs
 
 // See #1455: F# compiler generates *.AssemblyInfo.fs in obj folder, but we don't need it
 let removeFilesInObjFolder sourceFiles =
@@ -496,7 +495,7 @@ let getFullProjectOpts (opts: CrackerOptions) =
 
     let projRefs, mainProj = retryGetCrackedProjects opts
 
-    let fableLibReset, fableLibDir, pkgRefs =
+    let fableLibDir, pkgRefs =
         copyFableLibraryAndPackageSources opts mainProj.PackageReferences
 
     let pkgRefs =
@@ -542,5 +541,4 @@ let getFullProjectOpts (opts: CrackerOptions) =
 
     { ProjectOptions = projOpts
       Packages = pkgRefs
-      FableLibReset = fableLibReset
       FableLibDir = fableLibDir }

--- a/src/Fable.Cli/Util.fs
+++ b/src/Fable.Cli/Util.fs
@@ -20,8 +20,7 @@ type CliArgs =
       RootDir: string
       OutDir: string option
       FableLibraryPath: string option
-      Define: string list
-      NoCache: bool
+      ForcePkgs: bool
       WatchMode: bool
       Exclude: string option
       Replace: Map<string, string>

--- a/src/Fable.Transforms/FSharp2Fable.fs
+++ b/src/Fable.Transforms/FSharp2Fable.fs
@@ -29,6 +29,7 @@ let private transformBaseConsCall com ctx r (baseEnt: FSharpEntity) (baseCons: F
           { ThisArg = None
             Args = args
             SignatureArgTypes = getArgTypes com baseCons
+            CallMemberInfo = None
             HasSpread = false
             IsJsConstructor = false }
         makeCall r Fable.Unit callInfo baseRef

--- a/src/Fable.Transforms/FSharp2Fable.fs
+++ b/src/Fable.Transforms/FSharp2Fable.fs
@@ -446,8 +446,8 @@ let private transformExpr (com: IFableCompiler) (ctx: Context) fsExpr =
         | Some(_, Some fullName) ->
             match fullName with
             | Types.ienumerableGeneric | Types.ienumerable -> return Replacements.toSeq t inpExpr
-            | _ -> return Fable.TypeCast(inpExpr, t)
-        | _ -> return Fable.TypeCast(inpExpr, t)
+            | _ -> return Fable.TypeCast(inpExpr, t, None)
+        | _ -> return Fable.TypeCast(inpExpr, t, None)
 
     // TypeLambda is a local generic lambda
     // e.g, member x.Test() = let typeLambda x = x in typeLambda 1, typeLambda "A"

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -1492,7 +1492,7 @@ module Util =
 
     let rec transformAsExpr (com: IBabelCompiler) ctx (expr: Fable.Expr): Expression =
         match expr with
-        | Fable.TypeCast(e,t) -> transformCast com ctx t e
+        | Fable.TypeCast(e,t,_) -> transformCast com ctx t e
 
         | Fable.Curry(e, arity, _, r) -> transformCurry com ctx r e arity
 
@@ -1565,7 +1565,7 @@ module Util =
     let rec transformAsStatements (com: IBabelCompiler) ctx returnStrategy
                                     (expr: Fable.Expr): Statement array =
         match expr with
-        | Fable.TypeCast(e, t) ->
+        | Fable.TypeCast(e, t, _) ->
             [|transformCast com ctx t e |> resolveExpr t returnStrategy|]
 
         | Fable.Curry(e, arity, t, r) ->

--- a/src/Fable.Transforms/FableTransforms.fs
+++ b/src/Fable.Transforms/FableTransforms.fs
@@ -6,7 +6,7 @@ open Fable.AST.Fable
 let visit f e =
     match e with
     | IdentExpr _ -> e
-    | TypeCast(e, t) -> TypeCast(f e, t)
+    | TypeCast(e, t, tag) -> TypeCast(f e, t, tag)
     | Import(info, t, r) ->
         Import({ info with Selector = f info.Selector
                            Path = f info.Path }, t, r)
@@ -95,7 +95,7 @@ let rec visitFromOutsideIn (f: Expr->Expr option) e =
 
 let getSubExpressions = function
     | IdentExpr _ -> []
-    | TypeCast(e,_) -> [e]
+    | TypeCast(e,_,_) -> [e]
     | Import(info,_,_) -> [info.Selector; info.Path]
     | Value(kind,_) ->
         match kind with

--- a/src/Fable.Transforms/FableTransforms.fs
+++ b/src/Fable.Transforms/FableTransforms.fs
@@ -264,7 +264,7 @@ module private Transforms =
             (not com.Options.DebugMode) || ident.IsCompilerGenerated
         match e with
         // Don't try to optimize bindings with multiple ident-value pairs as they can reference each other
-        | Let([ident, value], letBody) when (not ident.IsMutable) && ident.IsCompilerGenerated ->
+        | Let([ident, value], letBody) when (not ident.IsMutable) && isErasingCandidate ident ->
             let canEraseBinding =
                 match value with
                 | NestedLambda(_, lambdaBody, _) ->

--- a/src/Fable.Transforms/FableTransforms.fs
+++ b/src/Fable.Transforms/FableTransforms.fs
@@ -197,9 +197,8 @@ let countReferences limit identName body =
     count
 
 let canInlineArg identName value body =
-    match value with
-    | Lambda _ | Delegate _ -> countReferences 1 identName body <= 1
-    | value -> canHaveSideEffects value |> not
+    not(canHaveSideEffects value)
+    && countReferences 1 identName body <= 1
 
 module private Transforms =
     let (|LambdaOrDelegate|_|) = function

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -294,7 +294,7 @@ module AST =
         | _ -> uncurryLambdaInner None [] arity expr
 
     let (|MaybeCasted|) = function
-        | TypeCast(e,_) -> e
+        | TypeCast(e,_,_) -> e
         | e -> e
 
     /// Try to uncurry lambdas at compile time in dynamic assignments
@@ -306,7 +306,7 @@ module AST =
     // TODO: Improve this, see https://github.com/fable-compiler/Fable/issues/1659#issuecomment-445071965
     let rec canHaveSideEffects = function
         | Import _ -> false
-        | TypeCast(e,_) -> canHaveSideEffects e
+        | TypeCast(e,_,_) -> canHaveSideEffects e
         | Value(value,_) ->
             match value with
             | ThisValue _ | BaseValue _ -> true

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -302,10 +302,10 @@ module AST =
         | MaybeCasted(LambdaUncurriedAtCompileTime None lambda) -> lambda
         | e -> e
 
-    // Functions return yes because we don't want to duplicate them in the code
     // TODO: Improve this, see https://github.com/fable-compiler/Fable/issues/1659#issuecomment-445071965
     let rec canHaveSideEffects = function
         | Import _ -> false
+        | Lambda _ | Delegate _ -> false
         | TypeCast(e,_,_) -> canHaveSideEffects e
         | Value(value,_) ->
             match value with

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -427,6 +427,7 @@ module AST =
         { ThisArg = thisArg
           Args = args
           SignatureArgTypes = argTypes
+          CallMemberInfo = None
           HasSpread = false
           IsJsConstructor = false }
 
@@ -435,6 +436,7 @@ module AST =
             { ThisArg = None
               Args = args
               SignatureArgTypes = []
+              CallMemberInfo = None
               HasSpread = false
               IsJsConstructor = false }
         let emitInfo =


### PR DESCRIPTION
These adds some changes in the AST to help plugins:

- Add `tag: string option` to `TypeCast` expression. This is in case we want to recycle the element later to add "metadata" to an expression.
- Include information from the called member in `Call` expression.
- Add more methods to the PluginHelper from the Compiler object. Particularly, `GetEntity` so we can retrieve entities in the plugins from the entity references in the AST.

Also, remove `--noCache` option. Cache will be used automatically only in debug mode.

Appveyor fails when bundling (actually minifying) the fable-standalone worker with this error. Not sure why as I haven't touched that part. Locally I can run the full build (including the tests with fable-compiler-js) without issue.

```
build\fable-standalone\worker\Worker.js → build\fable-standalone\worker.js...
created build\fable-standalone\worker.js in 2.1s
> npx webpack --entry ./build/fable-standalone/worker.js --output ./src/fable-standalone/dist/worker.min.js --config ./src/fable-standalone/src/../worker.config.js
Insufficient number of arguments or no entry found.
Alternatively, run 'webpack(-cli) --help' for usage info.
Hash: 94fb36a0bc99303aa725
Version: webpack 4.44.1
Time: 63ms
Built at: 10/21/2020 4:38:32 PM
ERROR in Entry module not found: Error: Can't resolve 'build\fable-standalone\worker.js' in 'C:\projects\fable'
npm ERR! code 2
npm ERR! path C:\projects\fable
```