### PR TITLE
Units of Measure Overload Resolution

### DIFF
--- a/tests/Main/CustomOperatorsTests.fs
+++ b/tests/Main/CustomOperatorsTests.fs
@@ -67,6 +67,28 @@ let operatorsAsFunctions = [
         x |> equal false
 ]
 
+type [<Measure>] px
+type [<Measure>] em
+
+type D1 = D1
+type D2 = D2
+type D3 = D3
+
+type ToLength = ToLength with
+    static member (&.) (ToLength, x: int<px>) = fun D1 _ _ -> String.Join("", string x, "px")
+    static member (&.) (ToLength, x: int<em>) = fun D1 D2 _ -> String.Join("", string x, "em")
+
+let inline toLen x : string = (Unchecked.defaultof<ToLength> &. x) D1 D2 D3
+
+let operatorsForOverloads = [
+    testCase "first overload" <| fun () ->
+        toLen 1<px>
+        |> equal "1px"
+    testCase "second overload" <| fun () ->
+        toLen 1<em>
+        |> equal "1em"
+]
+
 let tests =
   testList "Miscellaneous"
-    (typeOperators @ moduleOperators @ operatorsAsFunctions)
+    (typeOperators @ moduleOperators @ operatorsAsFunctions @ operatorsForOverloads)


### PR DESCRIPTION
This adds the test case to show how overload resolution doesn't function quite the same when doing some hacky stuff to make units of measure overloads work.

Here you can see Expecto runs the overload cases correctly (BTW there are a couple tests failing):

![image](https://user-images.githubusercontent.com/11186595/96970812-d93c5280-14d9-11eb-86ad-39565ffdaff6.png)

However when running via Mocha:

![image](https://user-images.githubusercontent.com/11186595/96970874-f07b4000-14d9-11eb-84e6-3b637f39e3c7.png)


