### PR TITLE
TypeScript-related updates

### DIFF
--- a/src/Fable.AST/Babel.fs
+++ b/src/Fable.AST/Babel.fs
@@ -104,8 +104,12 @@ module PrinterExtensions =
             printer.Print("class", ?loc=loc)
             printer.PrintOptional(" ", id)
             printer.PrintOptional(typeParameters)
-            printer.PrintOptional(" extends ", superClass)
-            printer.PrintOptional(superTypeParameters)
+            match superClass with
+            | Some (:? Identifier as id) when id.TypeAnnotation.IsSome ->
+                printer.Print(" extends ");
+                printer.Print(id.TypeAnnotation.Value.TypeAnnotation)
+            | _ -> printer.PrintOptional(" extends ", superClass)
+            // printer.PrintOptional(superTypeParameters)
             match implements with
             | Some implements when not (Array.isEmpty implements) ->
                 printer.Print(" implements ")

--- a/src/Fable.Cli/Util.fs
+++ b/src/Fable.Cli/Util.fs
@@ -200,7 +200,7 @@ module Imports =
 
     let getImportPath sourcePath targetPath projDir outDir (importPath: string) =
         match outDir with
-        | None -> importPath
+        | None -> importPath.Replace("${outDir}", ".")
         | Some outDir ->
             let importPath =
                 if importPath.StartsWith("${outDir}") then

--- a/src/Fable.Core/Fable.Core.JS.fs
+++ b/src/Fable.Core/Fable.Core.JS.fs
@@ -172,7 +172,7 @@ module JS =
         abstract get: key: 'K -> 'V
         abstract has: key: 'K -> bool
         abstract keys: unit -> seq<'K>
-        abstract set: key: 'K * ?value: 'V -> Map<'K, 'V>
+        abstract set: key: 'K * value: 'V -> Map<'K, 'V>
         abstract values: unit -> seq<'V>
 
     and [<AllowNullLiteral>] MapConstructor =
@@ -183,7 +183,7 @@ module JS =
         abstract delete: key: 'K -> bool
         abstract get: key: 'K -> 'V
         abstract has: key: 'K -> bool
-        abstract set: key: 'K * ?value: 'V -> WeakMap<'K, 'V>
+        abstract set: key: 'K * value: 'V -> WeakMap<'K, 'V>
 
     and [<AllowNullLiteral>] WeakMapConstructor =
         [<Emit("new $0($1...)")>] abstract Create: ?iterable: seq<'K * 'V> -> WeakMap<'K, 'V>

--- a/src/Fable.Transforms/ReplacementsInject.fs
+++ b/src/Fable.Transforms/ReplacementsInject.fs
@@ -14,6 +14,7 @@ let fableReplacementsModules =
       "average", (Types.averager, 0)
     ]
     "Array", Map [
+      "append", (Types.arrayCons, 0)
       "mapIndexed", (Types.arrayCons, 1)
       "map", (Types.arrayCons, 1)
       "mapIndexed2", (Types.arrayCons, 2)
@@ -35,6 +36,10 @@ let fableReplacementsModules =
       "replicate", (Types.arrayCons, 0)
       "scan", (Types.arrayCons, 1)
       "scanBack", (Types.arrayCons, 1)
+      "skip", (Types.arrayCons, 0)
+      "skipWhile", (Types.arrayCons, 0)
+      "take", (Types.arrayCons, 0)
+      "takeWhile", (Types.arrayCons, 0)
       "partition", (Types.arrayCons, 0)
       "choose", (Types.arrayCons, 1)
       "sortInPlaceBy", (Types.comparer, 1)
@@ -51,6 +56,7 @@ let fableReplacementsModules =
       "min", (Types.comparer, 0)
       "average", ("Fable.Core.IGenericAverager`1", 0)
       "averageBy", ("Fable.Core.IGenericAverager`1", 1)
+      "transpose", (Types.arrayCons, 0)
     ]
     "List", Map [
       "contains", (Types.equalityComparer, 0)
@@ -73,7 +79,7 @@ let fableReplacementsModules =
       "countBy", (Types.equalityComparer, 1)
     ]
     "Set", Map [
-      "FSharpSet$$Map$$7597B8F7", (Types.comparer, 1)
+      "FSharpSet__Map", (Types.comparer, 1)
       "singleton", (Types.comparer, 0)
       "unionMany", (Types.comparer, 0)
       "empty", (Types.comparer, 0)
@@ -91,12 +97,9 @@ let fableReplacementsModules =
       "isProperSupersetOf", (Types.comparer, 0)
     ]
     "Map", Map [
-      "ofList", (Types.comparer, 0)
-      "ofSeq", (Types.comparer, 0)
-      "ofArray", (Types.comparer, 0)
-      "empty", (Types.comparer, 0)
       "createMutable", (Types.equalityComparer, 0)
       "groupBy", (Types.equalityComparer, 1)
       "countBy", (Types.equalityComparer, 1)
     ]
   ]
+

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -364,6 +364,9 @@ module AST =
     let makeIdentExpr name =
         makeIdent name |> IdentExpr
 
+    let makeTypedIdentExpr typ name =
+        makeTypedIdent typ name |> IdentExpr
+
     let makeWhileLoop range guardExpr bodyExpr =
         WhileLoop (guardExpr, bodyExpr, range)
 

--- a/src/fable-library/Global.fs
+++ b/src/fable-library/Global.fs
@@ -8,3 +8,6 @@ type IGenericAverager<'T> =
     abstract GetZero: unit -> 'T
     abstract Add: 'T * 'T -> 'T
     abstract DivideByInt: 'T * int -> 'T
+
+type Symbol_wellknown =
+    abstract ``Symbol.toStringTag``: string

--- a/src/fable-library/MutableSet.fs
+++ b/src/fable-library/MutableSet.fs
@@ -3,20 +3,6 @@ namespace Fable.Collections
 
 open System.Collections.Generic
 
-/// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
-type IMutableSet<'T> =
-    inherit IEnumerable<'T>
-    abstract size: int
-    abstract add: 'T -> IMutableSet<'T>
-    /// Convenience method (not in JS Set prototype) to check if the element has actually been added
-    abstract add_: 'T -> bool
-    abstract clear: unit -> unit
-    abstract delete: 'T -> bool
-    abstract has: 'T -> bool
-    abstract keys: unit -> 'T seq
-    abstract values: unit -> 'T seq
-    abstract entries: unit -> ('T * 'T) seq
-
 [<Sealed>]
 [<CompiledName("HashSet")>]
 type MutableSet<'T when 'T: equality>(items: 'T seq, comparer: IEqualityComparer<'T>) as this =
@@ -27,6 +13,9 @@ type MutableSet<'T when 'T: equality>(items: 'T seq, comparer: IEqualityComparer
 
     // new () = MutableSet (Seq.empty, EqualityComparer.Default)
     // new (comparer) = MutableSet (Seq.empty, comparer)
+
+    interface Fable.Core.Symbol_wellknown with
+        member _.``Symbol.toStringTag`` = "HashSet"
 
     member private this.TryFindIndex(k) =
         let h = comparer.GetHashCode(k)
@@ -127,13 +116,13 @@ type MutableSet<'T when 'T: equality>(items: 'T seq, comparer: IEqualityComparer
                 this.Add x |> ignore
 #endif
 
-    interface IMutableSet<'T> with
+    interface Fable.Core.JS.Set<'T> with
         member this.size = this.Count
-        member this.add(k) = this.Add(k) |> ignore; this :> IMutableSet<'T>
-        member this.add_(k) = this.Add(k)
+        member this.add(k) = this.Add(k) |> ignore; this :> Fable.Core.JS.Set<'T>
         member this.clear() = this.Clear()
         member this.delete(k) = this.Remove(k)
         member this.has(k) = this.Contains(k)
         member this.keys() = this |> Seq.map id
         member this.values() = this |> Seq.map id
         member this.entries() = this |> Seq.map (fun v -> (v, v))
+        member this.forEach (f, ?thisArg) = this |> Seq.iter (fun x -> f x x this)

--- a/src/fable-library/Types.ts
+++ b/src/fable-library/Types.ts
@@ -1,4 +1,4 @@
-import { IComparable, combineHashCodes, compare, compareArrays, equalArrays, equals, sameConstructor, numberHash, structuralHash } from "./Util.js";
+import { IComparable, IEquatable, combineHashCodes, compare, compareArrays, equalArrays, equals, sameConstructor, numberHash, structuralHash } from "./Util.js";
 
 export function seqToString<T>(self: Iterable<T>): string {
   let count = 0;
@@ -52,7 +52,7 @@ function compareList<T>(self: List<T>, other: List<T>): number {
   }
 }
 
-export class List<T> implements IComparable<List<T>>, Iterable<T> {
+export class List<T> implements IEquatable<List<T>>, IComparable<List<T>>, Iterable<T> {
   public head: T;
   public tail?: List<T>;
 
@@ -81,7 +81,7 @@ export class List<T> implements IComparable<List<T>>, Iterable<T> {
   public CompareTo(other: List<T>): number { return compareList(this, other); }
 }
 
-export abstract class Union implements IComparable<Union> {
+export abstract class Union implements IEquatable<Union>, IComparable<Union> {
   public tag!: number;
   public fields!: any[];
   abstract cases(): string[];
@@ -92,7 +92,7 @@ export abstract class Union implements IComparable<Union> {
 
   public toJSON() {
     return this.fields.length === 0 ? this.name : [this.name].concat(this.fields);
-  };
+  }
 
   public toString() {
     return this.ToString();
@@ -198,7 +198,7 @@ function recordCompareTo<T>(self: T, other: T) {
   }
 }
 
-export abstract class Record implements IComparable<Record> {
+export abstract class Record implements IEquatable<Record>, IComparable<Record> {
   toJSON() { return recordToJSON(this); }
   toString() { return this.ToString(); }
   ToString() { return recordToString(this); }
@@ -241,7 +241,8 @@ export function isException(x: any) {
   return x instanceof Exception || x instanceof Error;
 }
 
-export abstract class FSharpException extends Exception implements IComparable<FSharpException> {
+export abstract class FSharpException extends Exception
+  implements IEquatable<FSharpException>, IComparable<FSharpException> {
   toJSON() { return recordToJSON(this); }
   toString() { return this.ToString(); }
   ToString() { return recordToString(this); }

--- a/src/fable-library/Util.ts
+++ b/src/fable-library/Util.ts
@@ -47,30 +47,6 @@ export interface ICollection<T> {
   Remove(item: T): boolean;
 }
 
-// export interface IMutableMap<K, V> {
-//   readonly size: number;
-//   clear(): void;
-//   delete(key: K): boolean;
-//   get(key: K): V | undefined;
-//   has(key: K): boolean;
-//   set(key: K, value: V): this;
-//   keys(): IterableIterator<K>;
-//   values(): IterableIterator<V>;
-//   entries(): IterableIterator<[K, V]>;
-// }
-
-// export interface IMutableSet<T> {
-//   readonly size: number;
-//   add(value: T): this;
-//   add_(value: T): boolean;
-//   clear(): void;
-//   delete(value: T): boolean;
-//   has(value: T): boolean;
-//   keys(): IterableIterator<T>;
-//   values(): IterableIterator<T>;
-//   entries(): IterableIterator<[T, T]>;
-// }
-
 export function isIterable<T>(x: T | Iterable<T>): x is Iterable<T> {
   return x != null && typeof x === "object" && Symbol.iterator in x;
 }

--- a/src/tools/InjectProcessor/InjectProcessor.fs
+++ b/src/tools/InjectProcessor/InjectProcessor.fs
@@ -91,14 +91,14 @@ module Fable.Transforms.ReplacementsInject
 let fableReplacementsModules =
   Map [
     "Seq", Map [
-      "maxBy", [(Types.comparer, 1)]
-      "max", [(Types.comparer, 0)]
-      "minBy", [(Types.comparer, 1)]
-      "min", [(Types.comparer, 0)]
-      "sumBy", [(Types.adder, 1)]
-      "sum", [(Types.adder, 0)]
-      "averageBy", [(Types.averager, 1)]
-      "average", [(Types.averager, 0)]
+      "maxBy", (Types.comparer, 1)
+      "max", (Types.comparer, 0)
+      "minBy", (Types.comparer, 1)
+      "min", (Types.comparer, 0)
+      "sumBy", (Types.adder, 1)
+      "sum", (Types.adder, 0)
+      "averageBy", (Types.averager, 1)
+      "average", (Types.averager, 0)
     ]"""
             for file in proj.AssemblyContents.ImplementationFiles do
                 let fileName = System.IO.Path.GetFileNameWithoutExtension(file.FileName)
@@ -114,7 +114,7 @@ let fableReplacementsModules =
                                     | None -> "\"" + typeArgName + "\""
                                 sprintf "(%s, %i)" typeArgName genArgIndex)
                             |> String.concat "; "
-                            |> sprintf "      \"%s\", [%s]" membName)
+                            |> sprintf "      \"%s\", %s" membName)
                         |> Seq.toArray
                     if moduleInjects.Length > 0 then
                         yield sprintf "    \"%s\", Map [" fileName


### PR DESCRIPTION
Various TypeScript-related improvements:
- Fixed `Map` and `WeakMap` interface in `Fable.Core`.
- Use `Option` instead of `Nullable` nodes in `FSharpMap` and `FSharpSet` (more idiomatic, little or no change in JS).
- `FSharpMap`, `FSharpSet`, `Dictionary` and `HashSet` now implement ES6 `Map` and `Set` interfaces directly.
- Changed sequence type from `Iterable` to `IterableIterator` for better integration with `Map` and `Set` interfaces.
- Constructor functions now retain the actual `baseExpr` type.
- Fixed `extends` printing for generic types.
- Fixed naming for compiler generated idents.
- Fixed paths with `${outDir}` in them.
- Fixed and regenerated Replacement injects.
- Changed array creation to only use injected constructors.
- Added Reflection info generic types.
- Minor `Types` cleanup.