### PR TITLE
Omit module prefix on module imports

### DIFF
--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -2069,7 +2069,7 @@ module Util =
             let moduleName = Path.GetFileNameWithoutExtension(path)
             match selector with
             | "*" | "default" -> moduleName
-            | _ -> moduleName + "_" + selector
+            | _ -> selector
             |> getUniqueNameInRootScope ctx
             |> Some
 


### PR DESCRIPTION
As per @alfonsogarciacaro's comment [here](https://github.com/fable-compiler/Fable/issues/2221#issuecomment-716322713)