### PR TITLE
+ Overload for StringBuilder.Append(StringBuilder)

### DIFF
--- a/src/fable-library/System.Text.fs
+++ b/src/fable-library/System.Text.fs
@@ -8,6 +8,7 @@ type StringBuilder(value: string, capacity: int) =
     new () = StringBuilder("", 16)
     member x.Append(s: string) = buf.Add(s); x
     member x.Append(c: char) = buf.Add(string c); x
+    member x.Append(s: StringBuilder) = buf.Add(s.ToString()); x
     member x.AppendFormat(fmt: string, o: obj) = buf.Add(System.String.Format(fmt, o)); x
     member x.AppendLine() = buf.Add(System.Environment.NewLine); x
     member x.AppendLine(s: string) = buf.Add(s); buf.Add(System.Environment.NewLine); x


### PR DESCRIPTION
This will add the missing overload for StringBuilder