### PR TITLE
Allow direct console output preserving colors. Fixes #2267.

### DIFF
--- a/src/Fable.Cli/Util.fs
+++ b/src/Fable.Cli/Util.fs
@@ -103,18 +103,11 @@ module Process =
         //     psi.EnvironmentVariables.[envVar.Key] <- envVar.Value
         psi.FileName <- exePath
         psi.WorkingDirectory <- workingDir
-        psi.RedirectStandardOutput <- true
-        psi.RedirectStandardError <- true
         psi.Arguments <- args
-        psi.CreateNoWindow <- true
+        psi.CreateNoWindow <- false
         psi.UseShellExecute <- false
 
-        let p = Process.Start(psi)
-        p.OutputDataReceived.Add(fun ea -> Log.always(ea.Data))
-        p.ErrorDataReceived.Add(fun ea -> Log.always(ea.Data))
-        p.BeginOutputReadLine()
-        p.BeginErrorReadLine()
-        p
+        Process.Start(psi)
 
     let kill(p: Process) =
         p.Refresh()


### PR DESCRIPTION
I guess redirecting stdout discards color sequences. Since we are only echoing the output to console anyway, there seems no need to redirect. We can just let the process write to console directly, which fixes the colors.

There may be some potential issue with `Fable.Verbosity.Silent` but that appears to be unused for now. If that is used in the future then either: 1) expect user to also set whatever appropriate silence flag on the child process, or 2) we can conditionally, only if Silent is enabled, wire up the redirection events and discard the output.

Fixes #2267.