### PR TITLE
[WIP] SpreadElement without parenthesis 

### DIFF
--- a/src/Fable.AST/Babel.fs
+++ b/src/Fable.AST/Babel.fs
@@ -195,6 +195,7 @@ module PrinterExtensions =
             | :? CallExpression
             | :? ThisExpression
             | :? Super
+            | :? SpreadElement
             | :? ArrayExpression -> expr.Print(printer)
             | :? ObjectExpression ->
                 match objExpr with

--- a/tests/Main/JsInteropTests.fs
+++ b/tests/Main/JsInteropTests.fs
@@ -375,7 +375,7 @@ let tests =
         style.FontSize(true) |> equal "foo"
         style.FontSize(false) |> equal "bar"
 
-    testCase "Emit wors with ParamArray" <| fun () ->
+    testCase "Emit works with ParamArray" <| fun () ->
         let style = createEmpty<TextStyle>
         style.Sum(1.5, 2, 3, 4) |> equal 10.5
 
@@ -442,6 +442,13 @@ let tests =
     testCase "Stringifying an F# type in JS works" <| fun () ->
         let addFooString (x: obj) = importMember "./js/1foo.js"
         { Float = 7. } |> addFooString |> equal "35x foo"
+
+    testCase "JsFunc.Invoke call with param array is spreaded in JS" <| fun () ->
+      let fn : Fable.Core.JsInterop.JsFunc = !!(fun (arg:int) -> arg+1) // actual implementation is not important
+      let arg = [|box 1|] // invoke wants an obj array
+      fn.Invoke(arg)  // fable compiler will spread this argument
+      |> unbox 
+      |> equal 2
 #endif
 
     testCase "Pattern matching with StringEnum works" <| fun () ->


### PR DESCRIPTION
Hi,

I've splitted this merge request into two commits.
1. The oldest commit contains a new added test case which will fail when executed without the fix in the latest commit
2. The latest commit contains a (hopefully) fix for the fable compiler which will generate no parenthesis around SpreadElement Expressions

**The Problem**
Calls to JsFunc.Invoke (and maybe others) with a non-inlined obj array syntax are translated to `(...array)` calls which produces invalid Js Code due to the parenthesis.

**What is an inlined-array syntax:** `.Invoke([|...|])`
_If this is not the right term for this construct, please let me know_

I've stumbled across this problem when I was using the JsInterop Module for some TypeProvider work and noticed, that the conversion for JsFunc.Invoke calls are transformed differently when used with different syntax.

[Here is a simple repo example from the Fable Repl to see the problem in the compiled code](https://fable.io/repl/#?code=PTAEHUCcEsBcFNQGMD2ATRLKgDYoIZqj6gDO+AtgA46IBmkKFZ0GARvpALABQKV8AHagAYvja0AdAGEs8SQClSASUEJGVXvyGjxU2ZHi9eIUAHcsAa1K9asUAlKxwcABYBBSJHwBPUAAoASlAAXlBeUEjceHtHewAuXQl5A3klVXV+RVIRAFdBJFDQaGosWHccHFAAIlImeABaCnRc2mqo8J4O01hXRGhBADcUS0QkfErQAHMY0mQsQyRYHD9Yb0FSHHwEIlgUB3gnf2r8aoAaarZqwIiouMlVYdH-AG0AH1A2FAAPGtOAbk+PxqV1AbwAujceCYwGgUIdQFRGGhckh+pV4FMJqAAFZzVAYAIwKauWAAfihdgOThcvU8kB8AAVDNJDNt4EQgkVbpEqXFQIkxMkZHJshl4BpsnkCkUSlQyhUqrV6k0Wm0edF7L8wu8gb8TtVAV99aCIRqen1ikMRmMJlUZrA5gNUF54EsVg51pt2bt9nF-P5JEHvoEoR17o8bf4Q7wgA&html=Q&css=Q
) 

The test case I've written is a minimum reproduction example. I've noticed that more complex scenarios are not yielding the same results as my fable repl example and actually failed. My guess is, that the repl example is different by design and any attempt to  mimic this with actual f# functions will fail.

In addition, my current take is that even translating the JsFunc.Invoke call into a JS Spread Op isn't the final answer and it should probably be consistent with any call using the inline syntax `.Invoke([|....|])`. If you agree and someone can point me to the right direction  I'm happy to help (This is my first day navigating this awesome repo and I haven't visited every corner ;)) 


I hope this will help.
Greetings

Dominik
