### PR TITLE
Reduce the memory usage when creating char ranges

### DIFF
--- a/src/fable-library/Seq.ts
+++ b/src/fable-library/Seq.ts
@@ -619,7 +619,9 @@ export function pairwise<T>(xs: Iterable<T>): IterableIterator<[T, T]> {
 }
 
 export function rangeChar(first: string, last: string) {
-  return delay(() => unfold((x) => x <= last ? [x, String.fromCharCode(x.charCodeAt(0) + 1)] : undefined, first));
+  const firstNum = first.charCodeAt(0);
+  const lastNum = last.charCodeAt(0);
+  return delay(() => unfold((x) => x <= lastNum ? [String.fromCharCode(x), x + 1] : undefined, firstNum));
 }
 
 export function rangeLong(first: Long, step: Long, last: Long, unsigned: boolean): IterableIterator<Long> {


### PR DESCRIPTION
Fixes #2318.

@alfonsogarciacaro ~Is it ok to use `rangeNumber` here or should I use `unfold` and `delay` as it was before?~