### PR TITLE
Fix minor issues with the file system watcher tests on Windows

### DIFF
--- a/Fable.sln
+++ b/Fable.sln
@@ -1,9 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30804.86
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Quicktest", "src\quicktest\QuickTest.fsproj", "{661A1972-0D06-46E8-958C-55325E5D520C}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "QuickTest", "src\quicktest\QuickTest.fsproj", "{661A1972-0D06-46E8-958C-55325E5D520C}"
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fable.Transforms", "src\Fable.Transforms\Fable.Transforms.fsproj", "{E55F3DA2-86B7-4E73-9700-EC6490043268}"
 EndProject
@@ -35,6 +35,8 @@ EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "PublishUtils", "src\fable-publish-utils\PublishUtils.fsproj", "{83FF0D5A-9B00-4975-83EF-E399D4466FE4}"
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fable.Tests.React", "tests\React\Fable.Tests.React.fsproj", "{54276AEF-340A-4178-B7C3-CB834D4317BB}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fable.Tests.Integration", "tests\Integration\Fable.Tests.Integration.fsproj", "{7E9173E4-8875-4336-9E76-C87FCC833D50}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -214,6 +216,18 @@ Global
 		{54276AEF-340A-4178-B7C3-CB834D4317BB}.Release|x64.Build.0 = Release|Any CPU
 		{54276AEF-340A-4178-B7C3-CB834D4317BB}.Release|x86.ActiveCfg = Release|Any CPU
 		{54276AEF-340A-4178-B7C3-CB834D4317BB}.Release|x86.Build.0 = Release|Any CPU
+		{7E9173E4-8875-4336-9E76-C87FCC833D50}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7E9173E4-8875-4336-9E76-C87FCC833D50}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7E9173E4-8875-4336-9E76-C87FCC833D50}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7E9173E4-8875-4336-9E76-C87FCC833D50}.Debug|x64.Build.0 = Debug|Any CPU
+		{7E9173E4-8875-4336-9E76-C87FCC833D50}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7E9173E4-8875-4336-9E76-C87FCC833D50}.Debug|x86.Build.0 = Debug|Any CPU
+		{7E9173E4-8875-4336-9E76-C87FCC833D50}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7E9173E4-8875-4336-9E76-C87FCC833D50}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7E9173E4-8875-4336-9E76-C87FCC833D50}.Release|x64.ActiveCfg = Release|Any CPU
+		{7E9173E4-8875-4336-9E76-C87FCC833D50}.Release|x64.Build.0 = Release|Any CPU
+		{7E9173E4-8875-4336-9E76-C87FCC833D50}.Release|x86.ActiveCfg = Release|Any CPU
+		{7E9173E4-8875-4336-9E76-C87FCC833D50}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/build.fsx
+++ b/build.fsx
@@ -342,8 +342,7 @@ let test() =
 
     testReact()
 
-    // Integration tests are failing in CI
-    // testIntegration()
+    testIntegration()
 
     if envVarOrNone "APPVEYOR" |> Option.isSome then
         testJsFast()

--- a/src/Fable.Cli/FileWatchers.fs
+++ b/src/Fable.Cli/FileWatchers.fs
@@ -163,7 +163,7 @@ type PollingFileWatcher (watchedDirectoryPath, ignoredDirectoryNameRegexes) =
 
     interface IDisposable with
         member this.Dispose () =
-            this.EnableRaisingEvents <- false
+            if not disposed then this.EnableRaisingEvents <- false
             disposed <- true
 
 type private WatcherInstance = {

--- a/src/Fable.Cli/FileWatchers.fs
+++ b/src/Fable.Cli/FileWatchers.fs
@@ -254,12 +254,15 @@ type DotnetFileWatcher (globFilters: string list) =
             fileSystemWatcher.Filters.Add(filter)
 
         let watcherChangeHandler (e: FileSystemEventArgs) = onFileChange.Trigger(e.FullPath)
+        let watcherRenameHandler (e: RenamedEventArgs) =
+            onFileChange.Trigger(e.OldFullPath)
+            onFileChange.Trigger(e.FullPath)
         let watcherErrorHandler e = onError.Trigger(e)
 
         fileSystemWatcher.Created.Subscribe(watcherChangeHandler) |> ignore
         fileSystemWatcher.Deleted.Subscribe(watcherChangeHandler) |> ignore
         fileSystemWatcher.Changed.Subscribe(watcherChangeHandler) |> ignore
-        fileSystemWatcher.Renamed.Subscribe(watcherChangeHandler) |> ignore
+        fileSystemWatcher.Renamed.Subscribe(watcherRenameHandler) |> ignore
         fileSystemWatcher.Error.Subscribe(watcherErrorHandler) |> ignore
 
         fileSystemWatcher.IncludeSubdirectories <- true

--- a/tests/Integration/FileWatcherTests.fs
+++ b/tests/Integration/FileWatcherTests.fs
@@ -140,7 +140,7 @@ let tests =
                     tcs.TrySetResult(true) |> ignore
                
                 watcher.OnFileChange.Subscribe(onFileChange) |> ignore
-                watcher.OnError.Subscribe(fun err -> printfn "Error: %A" <| err.GetException()) |> ignore
+                watcher.OnError.Subscribe(fun err -> printfn "Watcher error: %A" <| err.GetException()) |> ignore
                 watcher.EnableRaisingEvents <- true
                
                 let testFilePath = Path.Combine(tempFolder, "testFile")
@@ -163,7 +163,7 @@ let tests =
                     tcs.TrySetResult(true) |> ignore
                
                 watcher.OnFileChange.Subscribe(onFileChange) |> ignore
-                watcher.OnError.Subscribe(fun err -> printfn "Error: %A" <| err.GetException()) |> ignore
+                watcher.OnError.Subscribe(fun err -> printfn "Watcher error: %A" <| err.GetException()) |> ignore
                 watcher.EnableRaisingEvents <- true
                
                 let testDirectoryPath = Path.Combine(tempFolder, "testDirectory")
@@ -189,7 +189,7 @@ let tests =
                     tcs.TrySetResult(true) |> ignore
                
                 watcher.OnFileChange.Subscribe(onFileChange) |> ignore
-                watcher.OnError.Subscribe(fun err -> printfn "Error: %A" <| err.GetException()) |> ignore
+                watcher.OnError.Subscribe(fun err -> printfn "Watcher error: %A" <| err.GetException()) |> ignore
                 watcher.EnableRaisingEvents <- true
                
                 // On Unix the file write time is in 1s increments;
@@ -223,7 +223,7 @@ let tests =
                     tcs.TrySetResult(true) |> ignore
                
                 watcher.OnFileChange.Subscribe(onFileChange) |> ignore
-                watcher.OnError.Subscribe(fun err -> printfn "Error: %A" <| err.GetException()) |> ignore
+                watcher.OnError.Subscribe(fun err -> printfn "Watcher error: %A" <| err.GetException()) |> ignore
                 watcher.EnableRaisingEvents <- true
                
                 File.Delete(testFilePath)
@@ -251,7 +251,7 @@ let tests =
                     then tcs.TrySetResult(true) |> ignore
                
                 watcher.OnFileChange.Subscribe(onFileChange) |> ignore
-                watcher.OnError.Subscribe(fun err -> printfn "Error: %A" <| err.GetException()) |> ignore
+                watcher.OnError.Subscribe(fun err -> printfn "Watcher error: %A" <| err.GetException()) |> ignore
                 watcher.EnableRaisingEvents <- true
                
                 File.Move(srcFile, dstFile)
@@ -295,7 +295,7 @@ let tests =
                     then tcs.TrySetResult(true) |> ignore
                
                 watcher.OnFileChange.Subscribe(onFileChange) |> ignore
-                watcher.OnError.Subscribe(fun err -> printfn "Error: %A" <| err.GetException()) |> ignore
+                watcher.OnError.Subscribe(fun err -> printfn "Watcher error: %A" <| err.GetException()) |> ignore
                 watcher.EnableRaisingEvents <- true
 
                 // On Unix the file write time is in 1s increments;
@@ -345,7 +345,7 @@ let tests =
                     tcs.TrySetResult(true) |> ignore
                
                 watcher.OnFileChange.Subscribe(onFileChange) |> ignore
-                watcher.OnError.Subscribe(fun err -> printfn "Error: %A" <| err.GetException()) |> ignore
+                watcher.OnError.Subscribe(fun err -> printfn "Watcher error: %A" <| err.GetException()) |> ignore
                 watcher.EnableRaisingEvents <- true
 
                 // Disable
@@ -400,7 +400,7 @@ let tests =
                     tcs.TrySetResult(true) |> ignore
                
                 watcher.OnFileChange.Subscribe(onFileChange) |> ignore
-                watcher.OnError.Subscribe(fun err -> printfn "Error: %A" <| err.GetException()) |> ignore
+                watcher.OnError.Subscribe(fun err -> printfn "Watcher error: %A" <| err.GetException()) |> ignore
                 watcher.EnableRaisingEvents <- true
 
                 // Dispose
@@ -464,7 +464,7 @@ let tests =
                     then tcs.TrySetResult(true) |> ignore
                
                 watcher.OnFileChange.Subscribe(onFileChange) |> ignore
-                watcher.OnError.Subscribe(fun err -> printfn "Error: %A" <| err.GetException()) |> ignore
+                watcher.OnError.Subscribe(fun err -> printfn "Watcher error: %A" <| err.GetException()) |> ignore
                 watcher.EnableRaisingEvents <- true
 
                 Directory.Delete(subDirPath, true (*recursive*))
@@ -499,7 +499,7 @@ let tests =
                     then tcs.TrySetResult(true) |> ignore
                
                 watcher.OnFileChange.Subscribe(onFileChange) |> ignore
-                watcher.OnError.Subscribe(fun err -> printfn "Error: %A" <| err.GetException()) |> ignore
+                watcher.OnError.Subscribe(fun err -> printfn "Watcher error: %A" <| err.GetException()) |> ignore
                 watcher.EnableRaisingEvents <- true
 
                 File.WriteAllText(shouldMatchPath1, "")
@@ -553,7 +553,7 @@ let tests =
                         tcs.TrySetResult(true) |> ignore
                
                     let eventSubscription = watcher.OnFileChange.Subscribe(onFileChange)
-                    watcher.OnError.Subscribe(fun err -> printfn "Error: %A" <| err.GetException()) |> ignore
+                    watcher.OnError.Subscribe(fun err -> printfn "Watcher error: %A" <| err.GetException()) |> ignore
                     watcher.EnableRaisingEvents <- true
 
                     File.WriteAllText(file, "")

--- a/tests/Integration/FileWatcherTests.fs
+++ b/tests/Integration/FileWatcherTests.fs
@@ -131,7 +131,7 @@ let tests =
         "New file",
         fun usePolling tempFolder ->
             async {
-                let watcher = createWatcher tempFolder usePolling []
+                use watcher = createWatcher tempFolder usePolling []
                 let tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously)
                 let filesChanged = new HashSet<string>()
                
@@ -154,7 +154,7 @@ let tests =
         "New directory",
         fun usePolling tempFolder ->
             async {
-                let watcher = createWatcher tempFolder usePolling []
+                use watcher = createWatcher tempFolder usePolling []
                 let tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously)
                 let filesChanged = new HashSet<string>()
                
@@ -180,7 +180,7 @@ let tests =
                 let testFilePath = Path.Combine(tempFolder, "testFile")
                 File.WriteAllText(testFilePath, "content")
 
-                let watcher = createWatcher tempFolder usePolling []
+                use watcher = createWatcher tempFolder usePolling []
                 let tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously)
                 let filesChanged = new HashSet<string>()
 
@@ -214,7 +214,7 @@ let tests =
                 let testFilePath = Path.Combine(tempFolder, "testFile")
                 File.WriteAllText(testFilePath, "content")
 
-                let watcher = createWatcher tempFolder usePolling []
+                use watcher = createWatcher tempFolder usePolling []
                 let tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously)
                 let filesChanged = new HashSet<string>()
 
@@ -241,7 +241,7 @@ let tests =
 
                 File.WriteAllText(srcFile, "content")
 
-                let watcher = createWatcher tempFolder usePolling []
+                use watcher = createWatcher tempFolder usePolling []
                 let tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously)
                 let filesChanged = new HashSet<string>()
 
@@ -285,7 +285,7 @@ let tests =
                     dstForRenamedFilePath
                     ]
 
-                let watcher = createWatcher tempFolder usePolling []
+                use watcher = createWatcher tempFolder usePolling []
                 let tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously)
                 let filesChanged = new HashSet<string>()
 
@@ -336,7 +336,7 @@ let tests =
                 File.WriteAllText(deletedFilePath, "content")
                 File.WriteAllText(srcForRenamedFilePath, "content")
 
-                let watcher = createWatcher tempFolder usePolling []
+                use watcher = createWatcher tempFolder usePolling []
                 let tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously)
                 let filesChanged = new HashSet<string>()
                
@@ -391,7 +391,7 @@ let tests =
                 File.WriteAllText(deletedFilePath, "content")
                 File.WriteAllText(srcForRenamedFilePath, "content")
 
-                let watcher = createWatcher tempFolder usePolling []
+                use watcher = createWatcher tempFolder usePolling []
                 let tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously)
                 let filesChanged = new HashSet<string>()
                
@@ -454,7 +454,7 @@ let tests =
                     testFilePath3
                     ]
 
-                let watcher = createWatcher tempFolder usePolling []
+                use watcher = createWatcher tempFolder usePolling []
                 let tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously)
                 let filesChanged = new HashSet<string>()
 
@@ -489,7 +489,7 @@ let tests =
                 let expectedChanges = [ shouldMatchPath1; shouldMatchPath2 ]
                 let ignoredChanges = [ shouldIgnorePath1; shouldIgnorePath2 ]
 
-                let watcher = createWatcher tempFolder usePolling filters
+                use watcher = createWatcher tempFolder usePolling filters
                 let tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously)
                 let filesChanged = new HashSet<string>()
                
@@ -535,7 +535,7 @@ let tests =
 
                 let results = [ new HashSet<string>(); new HashSet<string>(); new HashSet<string>() ]
 
-                let watcher = createWatcherWithoutPath usePolling []
+                use watcher = createWatcherWithoutPath usePolling []
 
                 for i in 0..2 do
                     let dir = subDirs.[i]

--- a/tests/Integration/FileWatcherTests.fs
+++ b/tests/Integration/FileWatcherTests.fs
@@ -308,7 +308,6 @@ let tests =
                 System.Threading.Thread.Sleep(oneSecond)
 
                 File.WriteAllText(newFilePath, "")
-                File.WriteAllText(newFilePath + "2", "")
                 File.WriteAllText(changedFilePath, "changed content")
                 File.Delete(deletedFilePath)
                 File.Move(srcForRenamedFilePath, dstForRenamedFilePath)

--- a/tests/Integration/FileWatcherTests.fs
+++ b/tests/Integration/FileWatcherTests.fs
@@ -23,7 +23,7 @@ let oneSecond = TimeSpan.FromSeconds(1.0)
 
 let usingTempDirectoryAsync f =
     async {
-        let folderName = $"FileWatcherTests-{DateTime.UtcNow:o}-{Guid.NewGuid()}"
+        let folderName = $"""FileWatcherTests-{DateTime.UtcNow.ToString("yyyy-MM-ddTHH_mm_ss_fffffff")}-{Guid.NewGuid()}"""
         let tempFolder = Path.GetFullPath(Path.Combine(Path.GetTempPath(), folderName))
         if Directory.Exists(tempFolder)
         then Directory.Delete(tempFolder, true (*recursive*))


### PR DESCRIPTION
I also added the integration tests project to the solution.

If it was omitted on purpose, I can remove the commit.