### PR TITLE
Fix fable watcher for certain directory structures

### DIFF
--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -186,8 +186,11 @@ module private Util =
     }
 
     let getCommonBaseDir (files: string list) =
+        let dirNameWithTrailingSep (file: string) = sprintf "%s%c" (IO.Path.GetDirectoryName file) IO.Path.DirectorySeparatorChar
+        // it's important to include a trailing separator, otherwise things like ["a/b"; "a/b.c"] won't get handled right
+        // https://github.com/fable-compiler/Fable/issues/2332
         files
-        |> List.map (IO.Path.GetDirectoryName)
+        |> List.map dirNameWithTrailingSep
         |> List.distinct
         |> List.sortBy (fun f -> f.Length)
         |> function
@@ -197,7 +200,7 @@ module private Util =
                 let rec getCommonDir (dir: string) =
                     if restDirs |> List.forall (fun d -> d.StartsWith(dir)) then dir
                     else
-                        match IO.Path.GetDirectoryName(dir) with
+                        match dirNameWithTrailingSep (IO.Path.TrimEndingDirectorySeparator dir) with
                         | null -> failwith "No common base dir"
                         | dir -> getCommonDir dir
                 getCommonDir dir

--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -204,6 +204,7 @@ module private Util =
                         | null -> failwith "No common base dir"
                         | dir -> getCommonDir dir
                 getCommonDir dir
+                |> IO.Path.TrimEndingDirectorySeparator
 
 open Util
 open FileWatcher


### PR DESCRIPTION
Fixes [#2332](https://github.com/fable-compiler/Fable/issues/2332) by appending a path separator when performing substring checks, and then removing it after the fact