### PR TITLE
Remove glob dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "private": true,
   "scripts": {
     "tsc": "tsc",
+    "mocha": "mocha",
+    "rollup": "rollup",
+    "terser": "terser",
     "tslint": "tslint",
     "build": "dotnet fsi build.fsx",
     "publish": "dotnet fsi build.fsx publish",

--- a/src/fable-compiler-js/RELEASE_NOTES.md
+++ b/src/fable-compiler-js/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### 3.0.1
+
+* Reduced package dependencies
+
 ### 3.0.0
 
 * Nagareyama official release

--- a/src/fable-compiler-js/package.json
+++ b/src/fable-compiler-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fable-compiler-js",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "main": "index.js",
   "bin": {
     "fable": "index.js"
@@ -23,7 +23,6 @@
   "homepage": "https://github.com/fable-compiler/Fable#readme",
   "dependencies": {
     "fable-metadata": "^2.0.0",
-    "fable-standalone": "^3.0.0-nagareyama-rc-008",
-    "glob": "^7.1.6"
+    "fable-standalone": "^3.0.0"
   }
 }

--- a/src/fable-compiler-js/src/Platform.fs
+++ b/src/fable-compiler-js/src/Platform.fs
@@ -34,8 +34,8 @@ module JS =
         abstract resolve: string -> string
         abstract relative: string * string -> string
 
-    type IGlob =
-        abstract sync: pattern: string * ?options: obj -> array<string>
+    // type IGlob =
+    //     abstract sync: pattern: string * ?options: obj -> array<string>
 
     type IUtil =
         abstract getDirFiles: dir: string -> string[]
@@ -48,7 +48,7 @@ module JS =
     let os: IOperSystem = importAll "os"
     let proc: IProcess = importAll "process"
     let path: IPath = importAll "path"
-    let glob: IGlob = importAll "glob"
+    // let glob: IGlob = importAll "glob"
     let util: IUtil = importAll "./util.js"
 
 let readAllBytes (filePath: string) = JS.fs.readFileSync(filePath)
@@ -88,8 +88,14 @@ let getDirFiles (path: string) (extension: string) =
     |> Array.sort
 
 let getGlobFiles (path: string) =
-    if path.Contains("*") || path.Contains("?")
-    then JS.glob.sync(path)
+    if path.Contains("*") || path.Contains("?") then
+        // JS.glob.sync(path) // commented to remove dependency
+        // replaced with fixed globbing pattern (*.fs)
+        let dirPath =
+            let normPath = path.Replace('\\', '/')
+            let i = normPath.LastIndexOf('/')
+            if i < 0 then "" else normPath.Substring(0, i)
+        getDirFiles dirPath ".fs"
     else [| path |]
 
 module Path =

--- a/src/fable-standalone/test/bench-compiler/Platform.fs
+++ b/src/fable-standalone/test/bench-compiler/Platform.fs
@@ -87,8 +87,8 @@ module JS =
         abstract resolve: string -> string
         abstract relative: string * string -> string
 
-    type IGlob =
-        abstract sync: pattern: string * ?options: obj -> array<string>
+    // type IGlob =
+    //     abstract sync: pattern: string * ?options: obj -> array<string>
 
     type IUtil =
         abstract getDirFiles: dir: string -> string[]
@@ -150,10 +150,10 @@ let getGlobFiles (path: string) =
     if path.Contains("*") || path.Contains("?") then
         // JS.glob.sync(path) // commented to remove dependency
         // replaced with fixed globbing pattern (*.fs)
-        let normPath = path.Replace('\\', '/')
-        let i = normPath.LastIndexOf('/')
-        // let pattern = normPath.Substring(i + 1) // ignored
-        let dirPath = if i < 0 then "" else normPath.Substring(0, i)
+        let dirPath =
+            let normPath = path.Replace('\\', '/')
+            let i = normPath.LastIndexOf('/')
+            if i < 0 then "" else normPath.Substring(0, i)
         getDirFiles dirPath ".fs"
     else [| path |]
 


### PR DESCRIPTION
- Removed `glob` dependency to get to *zero [third-party] package dependency* for `fable-compiler-js`.
- Replaced `npx` with `npm run` in `build.fsx`.