### PR TITLE
Fixed #2355

### DIFF
--- a/src/fable-library/lib/big.js
+++ b/src/fable-library/lib/big.js
@@ -226,7 +226,7 @@ function round(x, dp, rm, more) {
       more = xc[i] > 5 || xc[i] == 5 &&
         (more || i < 0 || xc[i + 1] !== UNDEFINED || xc[i - 1] & 1);
     } else if (rm === 3) {
-      more = more || !!xc[0];
+      more = more || !!xc[i];
     } else {
       more = false;
       if (rm !== 0) throw Error(INVALID_RM);

--- a/src/fable-standalone/.gitignore
+++ b/src/fable-standalone/.gitignore
@@ -2,3 +2,4 @@
 out*/
 dist/
 perf*.data
+perf*.svg

--- a/src/fable-standalone/test/bench-compiler/package.json
+++ b/src/fable-standalone/test/bench-compiler/package.json
@@ -55,15 +55,16 @@
     "webpack": "node ../../../../node_modules/webpack-cli/bin/cli.js",
     "splitter": "node ../../../../node_modules/fable-splitter/dist/cli",
 
-    "perf": "perf record -q -e cpu-clock -F 1000 -g -- node --perf-basic-prof --interpreted-frames-native-stack dist/bundle.js bench-compiler.fsproj out-node2 --benchmark",
-    "perf2": "perf record -q -e cpu-clock -F 1000 -g -- node --perf-basic-prof --interpreted-frames-native-stack ./out-node/app.js bench-compiler.fsproj out-node2 --benchmark",
+    "perf": "perf record -q -e cpu-clock -F 99 -g -- node --perf-basic-prof --interpreted-frames-native-stack dist/bundle.js bench-compiler.fsproj out-node2 --benchmark",
+    "perf2": "perf record -q -e cpu-clock -F 99 -g -- node --perf-basic-prof --interpreted-frames-native-stack ./out-node/app.js bench-compiler.fsproj out-node2 --benchmark",
     "perf-report": "perf report -n --stdio -g srcline -s dso,sym,srcline --inline > perf-report.log",
     "profile": "node --prof dist/bundle.js bench-compiler.fsproj out-node2 --benchmark",
     "cpu-prof": "node --cpu-prof --cpu-prof-dir=out-prof dist/bundle.js bench-compiler.fsproj out-node2 --benchmark",
     "heap-prof": "node --heap-prof dist/bundle.js bench-compiler.fsproj out-node2 --benchmark",
     "prof-process": "node --prof-process isolate-*.log > profile.log",
     "prof-preprocess": "node --prof-process --preprocess isolate-*.log > profile.v8log.json",
-    "flamegraph": "speedscope profile.v8log.json",
+    "speedscope": "speedscope profile.v8log.json",
+    "flamegraph": "perf script | ../../../../../FlameGraph/stackcollapse-perf.pl | ../../../../../FlameGraph/flamegraph.pl > perf.svg",
     "trace": "node --trace-deopt ./out-node/app.js bench-compiler.fsproj out-node2 > deopt.log"
   }
 }

--- a/tests/Main/ArithmeticTests.fs
+++ b/tests/Main/ArithmeticTests.fs
@@ -200,10 +200,16 @@ let tests =
         abs -4M |> equal 4M
 
     testCase "Decimal round works" <| fun () ->
-        round -12.5M |> equal -12.M
-        round 1.5M |> equal 2.M
-        round 1.535M |> equal 2.M
-        round 1.525M |> equal 2.M
+        round 11.0M |> equal 11.M
+        round 11.1M |> equal 11.M
+        round 11.25M |> equal 11.M
+        round 11.50M |> equal 12.M
+        round 11.75M |> equal 12.M
+        round -11.0M |> equal -11.M
+        round -11.1M |> equal -11.M
+        round -11.25M |> equal -11.M
+        round -11.50M |> equal -12.M
+        round -11.75M |> equal -12.M
         Math.Round 1.425M |> equal 1.M
         Math.Round -1.425M |> equal -1.M
         Math.Round 1.546M |> equal 2.M
@@ -218,12 +224,24 @@ let tests =
         round -3.5M |> equal -4.M
 
     testCase "Decimal round with digits works" <| fun () ->
+        Math.Round(1.426M, 3) |> equal 1.426M
         Math.Round(1.426M, 2) |> equal 1.43M
         Math.Round(1.426M, 1) |> equal 1.4M
+        Math.Round(-1.426M, 3) |> equal -1.426M
         Math.Round(-1.426M, 2) |> equal -1.43M
         Math.Round(-1.426M, 1) |> equal -1.4M
 
     testCase "Decimal truncate works" <| fun () ->
+        truncate 11.0M |> equal 11.M
+        truncate 11.1M |> equal 11.M
+        truncate 11.25M |> equal 11.M
+        truncate 11.50M |> equal 11.M
+        truncate 11.75M |> equal 11.M
+        truncate -11.0M |> equal -11.M
+        truncate -11.1M |> equal -11.M
+        truncate -11.25M |> equal -11.M
+        truncate -11.50M |> equal -11.M
+        truncate -11.75M |> equal -11.M
         Math.Truncate -12.5M |> equal -12.M
         Math.Truncate 1.425M |> equal 1.M
         Math.Truncate -1.425M |> equal -1.M
@@ -231,14 +249,32 @@ let tests =
         Math.Truncate -1.546M |> equal -1.M
 
     testCase "Decimal ceil works" <| fun () ->
+        ceil 11.0M |> equal 11.M
+        ceil 11.1M |> equal 12.M
         ceil 11.25M |> equal 12.M
+        ceil 11.50M |> equal 12.M
+        ceil 11.75M |> equal 12.M
+        ceil -11.0M |> equal -11.M
+        ceil -11.1M |> equal -11.M
         ceil -11.25M |> equal -11.M
+        ceil -11.50M |> equal -11.M
+        ceil -11.75M |> equal -11.M
         Math.Ceiling 11.25M |> equal 12.M
+        Math.Ceiling -11.25M |> equal -11.M
 
     testCase "Decimal floor works" <| fun () ->
+        floor 11.0M |> equal 11.M
+        floor 11.1M |> equal 11.M
+        floor 11.25M |> equal 11.M
+        floor 11.50M |> equal 11.M
         floor 11.75M |> equal 11.M
+        floor -11.0M |> equal -11.M
+        floor -11.1M |> equal -12.M
+        floor -11.25M |> equal -12.M
+        floor -11.50M |> equal -12.M
         floor -11.75M |> equal -12.M
         Math.Floor 11.25M |> equal 11.M
+        Math.Floor -11.25M |> equal -12.M
 
     testCase "Decimal pown works" <| fun () ->
         pown 2.2M 3 |> equal 10.648M


### PR DESCRIPTION
- Fixed #2355

The "fix" is somewhat of a quick hack without spending much time, but it seems to work.

@alfonsogarciacaro This is a minimal fix without updating `big.js`, for an updated version see #2360.
Ideally in the future we should switch to a F# decimal implementation, either based on `System.Decimal`, or [BigDecimal](https://gist.github.com/JcBernack/0b4eef59ca97ee931a2f45542b9ff06d).