### PR TITLE
Add support for named capture groups in Regexes

### DIFF
--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -107,7 +107,7 @@ module Helpers =
             Any)
 
 open Helpers
-
+open Fable.Transforms
 type BuiltinType =
     | BclGuid
     | BclTimeSpan
@@ -2678,10 +2678,7 @@ let regex com (ctx: Context) r t (i: CallInfo) (thisArg: Expr option) (args: Exp
     let isGroup =
         match thisArg with
         | Some (ExprType (EntFullName "System.Text.RegularExpressions.Group")) -> true
-          // access to named `groups` contains a null check
-        | Some (IfThenElse (_, _, ExprType (EntFullName "System.Text.RegularExpressions.Group"), _)) -> true
         | _ -> false
-    let isGroupCollection = i.DeclaringEntityFullName = "System.Text.RegularExpressions.GroupCollection"
 
     match i.CompiledName with
     // TODO: Use RegexConst if no options have been passed?
@@ -2707,30 +2704,26 @@ let regex com (ctx: Context) r t (i: CallInfo) (thisArg: Expr option) (args: Exp
     // Match
     | "get_Groups" -> thisArg.Value |> Some
     // MatchCollection & GroupCollection
-    | "get_Item" when isGroupCollection ->
+    | "get_Item" when i.DeclaringEntityFullName = "System.Text.RegularExpressions.GroupCollection" ->
         // can be group index or group name
         //        `m.Groups.[0]` `m.Groups.["name"]`
         match args |> List.head with
         | Value (StringConstant name, _) ->
             // name
-            (*
-              `groups` might not exist -> check first:
-                `thisArg.Value`.groups?.[`args.Head`]
-              or
-                if `thisArg.Value`.groups === undefined then
-                    undefined
-                else
-                    `thisArg.Value`.groups[`args.Head`]
+            (* `groups` might not exist -> check first:
+                (`m`: `thisArg.Value`; `name`: `args.Head`)
+                  ```ts
+                  m.groups?.[name]
+                  ```
+                or here
+                  ```ts
+                  m.groups && m.groups[name]
+                  ```
             *)
             let groups = propStr "groups" thisArg.Value
             let getItem = getExpr r t groups args.Head
 
-            IfThenElse (
-                isNull groups,
-                Value (Null Any, None),
-                getItem,
-                None
-            )
+            Operation(Logical(LogicalAnd, groups, getItem), t, None)
             |> Some
         | _ ->
             // index

--- a/tests/Main/RegexTests.fs
+++ b/tests/Main/RegexTests.fs
@@ -310,6 +310,52 @@ let tests =
                 let m = r.Match "Number 12345 is positive"
 
                 m.Groups.["nothing"].Success |> equal false
+
+            testCase "doesn't succeed for existing unmatched group" <| fun _ ->
+                let r = Regex "(?<exact>42)|(?<number>\\d+)"
+                let m = r.Match "Number 12345 is positive"
+
+                m.Groups.["exact"].Success |> equal false
+
+
+#if FABLE_COMPILER
+            testList "on not existing group" [
+                // tests to ensure all not existing groups return same value (`undefined`)
+                let isUndefined (x: obj) = Fable.Core.JsInterop.emitJsExpr<bool> x "$0 === undefined"
+                let equalUndefined (x: obj) = isUndefined x |> equal true
+
+                testCase "not existing indexed group" <| fun _ ->
+                    let r = Regex "\\d+"
+                    let m = r.Match "Number 12345 is positive"
+
+                    let g = m.Groups.[42]
+                    g |> equalUndefined
+
+                testCase "not existing named grouped with other named groups" <| fun _ ->
+                    let r = Regex "(?<number>\\d+)"
+                    let m = r.Match "Number 12345 is positive"
+                    // in JS: `m.groups` exists
+
+                    let g = m.Groups.["nothing"]
+                    g |> equalUndefined
+
+                testCase "not existing named grouped without named groups" <| fun _ ->
+                    let r = Regex "\\d+"
+                    let m = r.Match "Number 12345 is positive"
+                    // in JS: no `m.groups`
+
+                    let g = m.Groups.["nothing"]
+                    g |> equalUndefined
+
+                testCase "unmatched existing named group" <| fun _ ->
+                    let r = Regex "(?<exact>42)|(?<number>\\d+)"
+                    let m = r.Match "Number 12345 is positive"
+                    // in JS: `m.groups` exists, `m.groups.["exact"]` is `undefined`
+
+                    let g = m.Groups.["exact"]
+                    g |> equalUndefined
+            ]
+#endif
         ]
 
         testList "Matches" [


### PR DESCRIPTION
implements part of #1820; fixes #2359


Adds support for named capture groups in regexes, like in:
```fsharp
let regex = Regex "(?<number>\\d+)"
let m = regex.Match "alpha 1234 beta"
let v = m.Groups.["number"].Value
assert(v = "1234")
```

Support for named groups was added some time ago in JavaScript. But named groups don't work in too old browser versions. See [Browser Compatibility](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#browser_compatibility) (search for "Named capture groups"):  
firefox >= 78; Chrome >= 64; Edge >= 79; Safari >= 11.1; Node.js >= 10; IE has no support


## Generated JS code

### `m.Groups.["name"]`
In JS: if there's a named group, the match contains a field `groups` with named groups. If there's no named group, that field doesn't exist.  
Access in Fable: `myMatch.group?.myGroup` (or actual implementation `myMatch.groups && myMatch.groups.myGroup`, because optional chaining operator not available yet) -> always one `undefined` check.  
Behaviour for non-existing named group is same as with non-existing indexed group: `undefined` (in JS), `Group` object with `Success = false`

Functions of `Groups` like `Count` or iterating over it: All named matches exist as indexed matches too. In example above: group `number` is index `1` -> Named groups are already accounted for.  
Other functions like `Keys` aren't implemented (see [example (REPL)](https://fable.io/repl/#?code=PYBwpgdgBAygngZwC5gLYDoAqYAeT0BKYA5gK4A2AhgE4CiOI1YCCAlsBAgLABQokUAGKUARuTDoAwsCboAUjF69xSKNSgBeKEWK4oAIgAMACgD8AHgilUIsNQB8AHUcATANQBKfcrCrUmtXQAWUokAGMACwMAOWtbdUMARgAmAGYAFgBWKFYEKBBgNiRWADcwbx5eMI4EYHF0cmBiKFReRlYIJAAzaH1pUk6NAFIAQX0W9ABxamBSEAQpWc6oFYB6VahktuoO7t6ASRRqYbGoYwxp2fmoAB97WDAAR3QkYAAZXKQPKHWoSnJyC1QpFmGcRHAchAXLgPAAaKAQSioMAuKDEGZzKAAAysNjsWJyeQ60JwUESvF+7U6PQMADV-qRmCdxucphj5uh6eRGXk7g9nq8Pshvr8IMBVAg5gVqCgXBSNlS9gYANJgRDMs4XdkLVWIW73GBPF7vT4ijZiiVSmSyoA&html=Q&css=Q))

### In Replace with string (`regex.Replace(input, replacement: string`)

There's a difference in using named capture groups between JS and .NET. In `replacement` in .NET a group is accessed via `${name}`, but in JS it's `$<name>`.  
-> When calling in Fable, `${name}` is replaced with `$<name>` in `RegExp.ts::Replace` (like it's already the case with `$0` -> `$&`).

`$<name>` doesn't get escaped, but instead is kept as is. That means `${name}` and `$<name>` are same and both access the group. (It's just easier to implement (or not implement...)...)