### PR TITLE
Refactor Babel AST to union/records

### DIFF
--- a/src/Fable.Transforms/BabelPrinter.fs
+++ b/src/Fable.Transforms/BabelPrinter.fs
@@ -679,7 +679,7 @@ module PrinterExtensions =
 
         member printer.Print(node: Super) = printer.Print("super", ?loc = node.Loc)
 
-        member printer.Print(node: ThisExpression) = printer.Print("node", ?loc = node.Loc)
+        member printer.Print(node: ThisExpression) = printer.Print("this", ?loc = node.Loc)
 
         /// A fat arrow function expression, e.g., let foo = (bar) => { /* body */ }.
         member printer.Print(node: ArrowFunctionExpression) =

--- a/src/Fable.Transforms/BabelPrinter.fs
+++ b/src/Fable.Transforms/BabelPrinter.fs
@@ -101,7 +101,7 @@ let run writer map (program: Program): Async<unit> =
 
         let imports, restDecls =
             program.Body |> Array.splitWhile (function
-                | :? ImportDeclaration -> true
+                | ImportDeclaration(_) -> true
                 | _ -> false)
 
         for decl in imports do

--- a/src/Fable.Transforms/BabelPrinter.fs
+++ b/src/Fable.Transforms/BabelPrinter.fs
@@ -200,7 +200,6 @@ module PrinterExtensions =
                 | ImportMemberSpecifier(local, imported) -> p.PrintImportMemberSpecific(local, imported)
                 | ImportDefaultSpecifier(local) -> printer.Print(local)
                 | ImportNamespaceSpecifier(local) -> printer.PrintImportNamespaceSpecifier(local)
-                | _ -> failwith "not implemented"
             ), (fun p -> p.Print(", ")))
         member printer.PrintCommaSeparatedArray(nodes: ExportSpecifier array) =
             printer.PrintArray(nodes, (fun p x -> p.Print(x)), (fun p -> p.Print(", ")))
@@ -928,7 +927,6 @@ module PrinterExtensions =
             | Choice1Of2 x -> printer.Print(x)
             | Choice2Of2 x -> printer.Print(x)
 
-
         member printer.Print(node: TypeAnnotationInfo) =
             match node with
             | StringTypeAnnotation -> printer.Print("string")
@@ -941,10 +939,13 @@ module PrinterExtensions =
                 printer.Print("[")
                 printer.PrintCommaSeparatedArray(types)
                 printer.Print("]")
-            | UnionTypeAnnotation(an) -> printer.Print(an)
+            | UnionTypeAnnotation(types) ->
+                printer.PrintArray(types, (fun p x -> p.Print(x)), (fun p -> p.Print(" | ")))
             | FunctionTypeAnnotation(an) -> printer.Print(an)
-            | NullableTypeAnnotation(an) -> printer.Print(an)
-            | GenericTypeAnnotation(an) -> printer.Print(an)
+            | NullableTypeAnnotation(typeAnnotation) -> printer.Print(typeAnnotation)
+            | GenericTypeAnnotation(id, typeParameters) ->
+                printer.Print(id)
+                printer.PrintOptional(typeParameters)
             | ObjectTypeAnnotation(an) -> printer.Print(an)
 
         member printer.Print(node: TypeAnnotation) =
@@ -966,9 +967,6 @@ module PrinterExtensions =
             printer.PrintCommaSeparatedArray(node.Params)
             printer.Print(">")
 
-        member printer.Print(node: UnionTypeAnnotation) =
-            printer.PrintArray(node.Types, (fun p x -> p.Print(x)), (fun p -> p.Print(" | ")))
-
         member printer.Print(node: FunctionTypeParam) =
             printer.Print(node.Name)
             if node.Optional = Some true then
@@ -985,13 +983,6 @@ module PrinterExtensions =
                 printer.Print(node.Rest.Value)
             printer.Print(") => ")
             printer.Print(node.ReturnType)
-
-        member printer.Print(node: NullableTypeAnnotation) =
-            printer.Print(node.TypeAnnotation)
-
-        member printer.Print(node: GenericTypeAnnotation) =
-            printer.Print(node.Id)
-            printer.PrintOptional(node.TypeParameters)
 
         member printer.Print(node: ObjectTypeProperty) =
             if node.Static then

--- a/src/Fable.Transforms/BabelPrinter.fs
+++ b/src/Fable.Transforms/BabelPrinter.fs
@@ -397,7 +397,7 @@ module PrinterExtensions =
 
         member printer.Print(pattern: Pattern) =
             match pattern with
-            | IdentifierPattern(p) -> printer.Print(p)
+            | Pattern.Identifier(p) -> printer.Print(p)
             | RestElement(name, argument, typeAnnotation, loc) ->
                 printer.Print("...", ?loc=loc)
                 printer.Print(argument)

--- a/src/Fable.Transforms/BabelPrinter.fs
+++ b/src/Fable.Transforms/BabelPrinter.fs
@@ -355,7 +355,7 @@ module PrinterExtensions =
             | ImportSpecifier(_)
             | Node.ObjectTypeIndexer(_)
             | Node.VariableDeclarator(_)
-            | ObjectTypeCallProperty(_)
+            | Node.ObjectTypeCallProperty(_)
             | ObjectTypeInternalSlot(_) -> failwith "Not implemented"
 
         member printer.Print(expr: Expression) =
@@ -440,7 +440,12 @@ module PrinterExtensions =
         member printer.Print(md: ModuleDeclaration) =
             match md with
             | ImportDeclaration(d) -> printer.Print(d)
-            | ExportNamedReferences(d) -> printer.Print(d)
+            | ExportNamedReferences(specifiers, source) ->
+                printer.Print("export ")
+                printer.Print("{ ")
+                printer.PrintCommaSeparatedArray(specifiers)
+                printer.Print(" }")
+                printer.PrintOptional(source, " from ")
             | ExportNamedDeclaration(declaration) ->
                 printer.Print("export ")
                 printer.Print(declaration)
@@ -919,13 +924,6 @@ module PrinterExtensions =
                 printer.Print(" as ")
                 printer.Print(node.Exported)
 
-        member printer.Print(node: ExportNamedReferences) =
-            printer.Print("export ")
-            printer.Print("{ ")
-            printer.PrintCommaSeparatedArray(node.Specifiers)
-            printer.Print(" }")
-            printer.PrintOptional(node.Source, " from ")
-
         member printer.Print(node: TypeAnnotationInfo) =
             match node with
             | StringTypeAnnotation -> printer.Print("string")
@@ -1007,7 +1005,7 @@ module PrinterExtensions =
             printer.PushIndentation()
             printer.PrintArray(node.Properties, (fun p x -> p.Print(x)), (fun p -> p.PrintStatementSeparator()))
             printer.PrintArray(node.Indexers, (fun p x -> p.Print(x |> Node.ObjectTypeIndexer)), (fun p -> p.PrintStatementSeparator()))
-            printer.PrintArray(node.CallProperties, (fun p x -> p.Print(x |> ObjectTypeCallProperty)), (fun p -> p.PrintStatementSeparator()))
+            printer.PrintArray(node.CallProperties, (fun p x -> p.Print(x |> Node.ObjectTypeCallProperty)), (fun p -> p.PrintStatementSeparator()))
             printer.PrintArray(node.InternalSlots, (fun p x -> p.Print(x |> ObjectTypeInternalSlot)), (fun p -> p.PrintStatementSeparator()))
             printer.PrintNewLine()
             printer.PopIndentation()

--- a/src/Fable.Transforms/BabelPrinter.fs
+++ b/src/Fable.Transforms/BabelPrinter.fs
@@ -163,7 +163,7 @@ module PrinterExtensions =
         member printer.PrintOptional(node: Expression option, ?before: string) =
             printer.PrintOptional(node |> Option.map Expression, ?before=before)
         member printer.PrintOptional(node: TypeParameterDeclaration option, ?before: string) =
-            printer.PrintOptional(node |> Option.map TypeParameterDeclaration, ?before=before)
+            printer.PrintOptional(node |> Option.map Node.TypeParameterDeclaration, ?before=before)
         member printer.PrintOptional(node: TypeAnnotation option, ?before: string) =
             printer.PrintOptional(node |> Option.map Node.TypeAnnotation, ?before=before)
         member printer.PrintOptional(node: Identifier option, ?before: string) =
@@ -173,7 +173,7 @@ module PrinterExtensions =
         member printer.PrintOptional(node: StringLiteral option, ?before: string) =
             printer.PrintOptional(node |> Option.map Literal.StringLiteral, ?before=before)
         member printer.PrintOptional(node: TypeParameterInstantiation option, ?before: string) =
-            printer.PrintOptional(node |> Option.map TypeParameterInstantiation, ?before=before)
+            printer.PrintOptional(node |> Option.map Node.TypeParameterInstantiation, ?before=before)
         member printer.PrintOptional(node: Statement option, ?before: string) =
             printer.PrintOptional(node |> Option.map Statement, ?before=before)
         member printer.PrintOptional(node: Declaration option, ?before: string) =
@@ -183,7 +183,7 @@ module PrinterExtensions =
         member printer.PrintOptional(node: CatchClause option, ?before: string) =
             printer.PrintOptional(node |> Option.map Node.CatchClause, ?before=before)
         member printer.PrintOptional(node: BlockStatement option, ?before: string) =
-            printer.PrintOptional(node, ?before=before)
+            printer.PrintOptional(node |> Option.map Statement.BlockStatement, ?before=before)
 
         member printer.PrintArray(nodes: 'a array, printNode: Printer -> 'a -> unit, printSeparator: Printer -> unit) =
             for i = 0 to nodes.Length - 1 do
@@ -222,7 +222,7 @@ module PrinterExtensions =
                 implements: ClassImplements array option, body: ClassBody, loc) =
             printer.Print("class", ?loc=loc)
             printer.PrintOptional(id, " ")
-            printer.PrintOptional(typeParameters |> Option.map TypeParameterDeclaration)
+            printer.PrintOptional(typeParameters)
             match superClass with
             | Some (Expression.Identifier(Identifier(typeAnnotation=Some(typeAnnotation)))) ->
                 printer.Print(" extends ")
@@ -348,8 +348,8 @@ module PrinterExtensions =
             | FunctionTypeParam(n) -> printer.Print(n)
             | ObjectTypeProperty(n) -> printer.Print(n)
             | Node.TypeAnnotationInfo(n) -> printer.Print(n)
-            | TypeParameterDeclaration(n) -> printer.Print(n)
-            | TypeParameterInstantiation(n) -> printer.Print(n)
+            | Node.TypeParameterDeclaration(n) -> printer.Print(n)
+            | Node.TypeParameterInstantiation(n) -> printer.Print(n)
             | Node.Program(_)
             | Directive(_)
             | ImportSpecifier(_)
@@ -962,14 +962,14 @@ module PrinterExtensions =
             // printer.PrintOptional(bound)
             // printer.PrintOptional(``default``)
 
-        member printer.Print(node: TypeParameterDeclaration) =
+        member printer.Print((TypeParameterDeclaration ``params``): TypeParameterDeclaration) =
             printer.Print("<")
-            printer.PrintCommaSeparatedArray(node.Params)
+            printer.PrintCommaSeparatedArray(``params``)
             printer.Print(">")
 
-        member printer.Print(node: TypeParameterInstantiation) =
+        member printer.Print((TypeParameterInstantiation ``params``) : TypeParameterInstantiation) =
             printer.Print("<")
-            printer.PrintCommaSeparatedArray(node.Params)
+            printer.PrintCommaSeparatedArray(``params``)
             printer.Print(">")
 
         member printer.Print(node: FunctionTypeParam) =

--- a/src/Fable.Transforms/BabelPrinter.fs
+++ b/src/Fable.Transforms/BabelPrinter.fs
@@ -345,7 +345,7 @@ module PrinterExtensions =
             | ExportSpecifier(n) -> printer.Print(n)
             | Node.InterfaceExtends(n) -> printer.Print(n)
             | ModuleDeclaration(n) -> printer.Print(n)
-            | FunctionTypeParam(n) -> printer.Print(n)
+            | Node.FunctionTypeParam(n) -> printer.Print(n)
             | ObjectTypeProperty(n) -> printer.Print(n)
             | Node.TypeAnnotationInfo(n) -> printer.Print(n)
             | Node.TypeParameterDeclaration(n) -> printer.Print(n)
@@ -353,7 +353,7 @@ module PrinterExtensions =
             | Node.Program(_)
             | Directive(_)
             | ImportSpecifier(_)
-            | ObjectTypeIndexer(_)
+            | Node.ObjectTypeIndexer(_)
             | Node.VariableDeclarator(_)
             | ObjectTypeCallProperty(_)
             | ObjectTypeInternalSlot(_) -> failwith "Not implemented"
@@ -380,7 +380,7 @@ module PrinterExtensions =
             | UnaryExpression(n) -> printer.Print(n)
             | UpdateExpression(n) -> printer.Print(n)
             | ObjectExpression(properties, loc) -> printer.PrintObjectExpression(properties, loc)
-            | BinaryExpression(n) -> printer.Print(n)
+            | BinaryExpression(left, right, operator, loc) ->  printer.PrintOperation(left, operator, right, loc)
             | MemberExpression(name, object, property, computed, loc) -> printer.PrintMemberExpression(name, object, property, computed, loc)
             | LogicalExpression(left, operator, right, loc) -> printer.PrintOperation(left, operator, right, loc)
             | SequenceExpression(expressions, loc) ->
@@ -802,9 +802,6 @@ module PrinterExtensions =
 
 // Binary Operations
 
-        member printer.Print(node: BinaryExpression) =
-            printer.PrintOperation(node.Left, node.Operator, node.Right, node.Loc)
-
         member printer.Print(node: RestElement) =
             printer.Print("...", ?loc=node.Loc)
             printer.Print(node.Argument)
@@ -970,11 +967,12 @@ module PrinterExtensions =
             printer.Print(">")
 
         member printer.Print(node: FunctionTypeParam) =
-            printer.Print(node.Name)
-            if node.Optional = Some true then
+            let (FunctionTypeParam(name, typeAnnotation, optional)) = node
+            printer.Print(name)
+            if optional = Some true then
                 printer.Print("?")
             printer.Print(": ")
-            printer.Print(node.TypeAnnotation)
+            printer.Print(typeAnnotation)
 
         member printer.Print(node: FunctionTypeAnnotation) =
             printer.PrintOptional(node.TypeParameters)
@@ -1008,7 +1006,7 @@ module PrinterExtensions =
             printer.PrintNewLine()
             printer.PushIndentation()
             printer.PrintArray(node.Properties, (fun p x -> p.Print(x)), (fun p -> p.PrintStatementSeparator()))
-            printer.PrintArray(node.Indexers, (fun p x -> p.Print(x |> ObjectTypeIndexer)), (fun p -> p.PrintStatementSeparator()))
+            printer.PrintArray(node.Indexers, (fun p x -> p.Print(x |> Node.ObjectTypeIndexer)), (fun p -> p.PrintStatementSeparator()))
             printer.PrintArray(node.CallProperties, (fun p x -> p.Print(x |> ObjectTypeCallProperty)), (fun p -> p.PrintStatementSeparator()))
             printer.PrintArray(node.InternalSlots, (fun p x -> p.Print(x |> ObjectTypeInternalSlot)), (fun p -> p.PrintStatementSeparator()))
             printer.PrintNewLine()

--- a/src/Fable.Transforms/BabelPrinter.fs
+++ b/src/Fable.Transforms/BabelPrinter.fs
@@ -20,6 +20,17 @@ type Writer =
     abstract MakeImportPath: string -> string
     abstract Write: string -> Async<unit>
 
+type Printer =
+    abstract Line: int
+    abstract Column: int
+    abstract PushIndentation: unit -> unit
+    abstract PopIndentation: unit -> unit
+    abstract Print: string * ?loc: SourceLocation -> unit
+    abstract PrintNewLine: unit -> unit
+    abstract AddLocation: SourceLocation option -> unit
+    abstract EscapeJsStringLiteral: string -> string
+    abstract MakeImportPath: string -> string
+
 type PrinterImpl(writer: Writer, map: SourceMapGenerator) =
     // TODO: We can make this configurable later
     let indentSpaces = "    "
@@ -44,17 +55,17 @@ type PrinterImpl(writer: Writer, map: SourceMapGenerator) =
             builder.Clear() |> ignore
         }
 
-    member _.PrintNewLine() =
-        builder.AppendLine() |> ignore
-        line <- line + 1
-        column <- 0
-
     interface IDisposable with
         member _.Dispose() = writer.Dispose()
 
     interface Printer with
         member _.Line = line
         member _.Column = column
+
+        member _.PrintNewLine() =
+            builder.AppendLine() |> ignore
+            line <- line + 1
+            column <- 0
 
         member _.PushIndentation() =
             indent <- indent + 1
@@ -65,7 +76,7 @@ type PrinterImpl(writer: Writer, map: SourceMapGenerator) =
         member _.AddLocation(loc) =
             addLoc loc
 
-        member _.Print(str, loc) =
+        member _.Print(str: string, ?loc) =
             addLoc loc
 
             if column = 0 then
@@ -76,19 +87,1006 @@ type PrinterImpl(writer: Writer, map: SourceMapGenerator) =
             builder.Append(str) |> ignore
             column <- column + str.Length
 
-        member this.PrintNewLine() =
-            this.PrintNewLine()
-
         member this.EscapeJsStringLiteral(str) =
             writer.EscapeJsStringLiteral(str)
 
         member this.MakeImportPath(path) =
             writer.MakeImportPath(path)
 
-let run writer map (program: Program): Async<unit> =
 
+module PrinterExtensions =
+    type Printer with
+        member printer.PrintBlock(nodes: 'a array, printNode: Printer -> 'a -> unit, printSeparator: Printer -> unit, ?skipNewLineAtEnd) =
+            let skipNewLineAtEnd = defaultArg skipNewLineAtEnd false
+            printer.Print("{")
+            printer.PrintNewLine()
+            printer.PushIndentation()
+            for node in nodes do
+                printNode printer node
+                printSeparator printer
+            printer.PopIndentation()
+            printer.Print("}")
+            if not skipNewLineAtEnd then
+                printer.PrintNewLine()
+
+        member printer.PrintStatementSeparator() =
+            if printer.Column > 0 then
+                printer.Print(";")
+                printer.PrintNewLine()
+
+        member _.IsProductiveStatement(s: Statement) =
+            let rec hasNoSideEffects (e: Expression) =
+                match e with
+                | Undefined(_)
+                | Literal(NullLiteral(_))
+                | Literal(StringLiteral(_))
+                | Literal(BooleanLiteral(_))
+                | Literal(NumericLiteral(_)) -> true
+                // Constructors of classes deriving from System.Object add an empty object at the end
+                | ObjectExpression(expr) -> expr.Properties.Length = 0
+                | UnaryExpression(expr) when expr.Operator = "void" -> hasNoSideEffects expr.Argument
+                // Some identifiers may be stranded as the result of imports
+                // intended only for side effects, see #2228
+                | Identifier(_) -> true
+                | _ -> false
+
+            match s with
+            | ExpressionStatement(stmt) -> hasNoSideEffects stmt.Expression |> not
+            | _ -> true
+
+        member printer.PrintProductiveStatement(s: Statement, ?printSeparator) =
+            if printer.IsProductiveStatement(s) then
+                printer.Print(s)
+                printSeparator |> Option.iter (fun f -> f printer)
+
+        member printer.PrintProductiveStatements(statements: Statement[]) =
+            for s in statements do
+                printer.PrintProductiveStatement(s, (fun p -> p.PrintStatementSeparator()))
+
+        member printer.PrintBlock(nodes: Statement array, ?skipNewLineAtEnd) =
+            printer.PrintBlock(nodes,
+                               (fun p s -> p.PrintProductiveStatement(s)),
+                               (fun p -> p.PrintStatementSeparator()),
+                               ?skipNewLineAtEnd=skipNewLineAtEnd)
+
+        member printer.PrintOptional(node: Node option, ?before: string) =
+            match node with
+            | None -> ()
+            | Some node ->
+                match before with
+                | Some before ->
+                    printer.Print(before)
+                | _ -> ()
+                printer.Print(node)
+
+        member printer.PrintOptional(node: Expression option, ?before: string) =
+            printer.PrintOptional(node |> Option.map Expression, ?before=before)
+        member printer.PrintOptional(node: TypeParameterDeclaration option, ?before: string) =
+            printer.PrintOptional(node |> Option.map TypeParameterDeclaration, ?before=before)
+        member printer.PrintOptional(node: TypeAnnotation option, ?before: string) =
+            printer.PrintOptional(node |> Option.map TypeAnnotation, ?before=before)
+        member printer.PrintOptional(node: Identifier option, ?before: string) =
+            printer.PrintOptional(node |> Option.map Identifier, ?before=before)
+        member printer.PrintOptional(node: Literal option, ?before: string) =
+            printer.PrintOptional(node |> Option.map Literal, ?before=before)
+        member printer.PrintOptional(node: StringLiteral option, ?before: string) =
+            printer.PrintOptional(node |> Option.map StringLiteral, ?before=before)
+        member printer.PrintOptional(node: TypeParameterInstantiation option, ?before: string) =
+            printer.PrintOptional(node |> Option.map TypeParameterInstantiation, ?before=before)
+        member printer.PrintOptional(node: Statement option, ?before: string) =
+            printer.PrintOptional(node |> Option.map Statement, ?before=before)
+        member printer.PrintOptional(node: Declaration option, ?before: string) =
+            printer.PrintOptional(node |> Option.map Declaration, ?before=before)
+        member printer.PrintOptional(node: VariableDeclaration option, ?before: string) =
+            printer.PrintOptional(node |> Option.map VariableDeclaration, ?before=before)
+        member printer.PrintOptional(node: CatchClause option, ?before: string) =
+            printer.PrintOptional(node |> Option.map CatchClause, ?before=before)
+        member printer.PrintOptional(node: BlockStatement option, ?before: string) =
+            printer.PrintOptional(node |> Option.map BlockStatement, ?before=before)
+
+        member printer.PrintArray(nodes: 'a array, printNode: Printer -> 'a -> unit, printSeparator: Printer -> unit) =
+            for i = 0 to nodes.Length - 1 do
+                printNode printer nodes.[i]
+                if i < nodes.Length - 1 then
+                    printSeparator printer
+
+        member printer.PrintCommaSeparatedArray(nodes: Node array) =
+            printer.PrintArray(nodes, (fun p x -> p.Print(x)), (fun p -> p.Print(", ")))
+        member printer.PrintCommaSeparatedArray(nodes: Pattern array) =
+            printer.PrintArray(nodes, (fun p x -> p.Print(x)), (fun p -> p.Print(", ")))
+        member printer.PrintCommaSeparatedArray(nodes: ImportDefaultSpecifier array) =
+            printer.PrintArray(nodes, (fun p x -> p.Print(x)), (fun p -> p.Print(", ")))
+        member printer.PrintCommaSeparatedArray(nodes: ImportNamespaceSpecifier array) =
+            printer.PrintArray(nodes, (fun p x -> p.Print(x)), (fun p -> p.Print(", ")))
+        member printer.PrintCommaSeparatedArray(nodes: ImportMemberSpecifier array) =
+            printer.PrintArray(nodes, (fun p x -> p.Print(x)), (fun p -> p.Print(", ")))
+        member printer.PrintCommaSeparatedArray(nodes: ExportSpecifier array) =
+            printer.PrintArray(nodes, (fun p x -> p.Print(x)), (fun p -> p.Print(", ")))
+        member printer.PrintCommaSeparatedArray(nodes: FunctionTypeParam array) =
+            printer.PrintArray(nodes, (fun p x -> p.Print(x)), (fun p -> p.Print(", ")))
+        member printer.PrintCommaSeparatedArray(nodes: TypeAnnotationInfo array) =
+            printer.PrintArray(nodes, (fun p x -> p.Print(x)), (fun p -> p.Print(", ")))
+        member printer.PrintCommaSeparatedArray(nodes: TypeParameter array) =
+            printer.PrintArray(nodes, (fun p x -> p.Print(x)), (fun p -> p.Print(", ")))
+
+        member printer.PrintCommaSeparatedArray(nodes: Expression array) =
+            printer.PrintArray(nodes, (fun p x -> p.SequenceExpressionWithParens(x)), (fun p -> p.Print(", ")))
+
+
+        // TODO: (super) type parameters, implements
+        member printer.PrintClass(id: Identifier option, superClass: Expression option,
+                superTypeParameters: TypeParameterInstantiation option,
+                typeParameters: TypeParameterDeclaration option,
+                implements: ClassImplements array option, body: ClassBody, loc) =
+            printer.Print("class", ?loc=loc)
+            printer.PrintOptional(id, " ")
+            printer.PrintOptional(typeParameters |> Option.map TypeParameterDeclaration)
+            match superClass with
+            | Some (Identifier(id)) when id.TypeAnnotation.IsSome ->
+                printer.Print(" extends ");
+                printer.Print(id.TypeAnnotation.Value.TypeAnnotation)
+            | _ -> printer.PrintOptional(superClass, " extends ")
+            // printer.PrintOptional(superTypeParameters)
+            match implements with
+            | Some implements when not (Array.isEmpty implements) ->
+                printer.Print(" implements ")
+                printer.PrintArray(implements, (fun p x -> p.Print(x)), (fun p -> p.Print(", ")))
+            | _ -> ()
+            printer.Print(" ")
+            printer.Print(body)
+
+        member printer.PrintFunction(id: Identifier option, parameters: Pattern array, body: BlockStatement,
+                typeParameters: TypeParameterDeclaration option, returnType: TypeAnnotation option, loc, ?isDeclaration, ?isArrow) =
+            let areEqualPassedAndAppliedArgs (passedArgs: Pattern[]) (appliedAgs: Expression[]) =
+                Array.zip passedArgs appliedAgs
+                |> Array.forall (function
+                    | RestElement(p), Identifier(a) -> p.Name = a.Name
+                    | _ -> false)
+
+            let isDeclaration = defaultArg isDeclaration false
+            let isArrow = defaultArg isArrow false
+
+            printer.AddLocation(loc)
+
+            // Check if we can remove the function
+            let skipExpr =
+                match body.Body with
+                | [| ReturnStatement(r) |] when not isDeclaration ->
+                    match r.Argument with
+                    | CallExpression(c) when parameters.Length = c.Arguments.Length ->
+                        // To be sure we're not running side effects when deleting the function,
+                        // check the callee is an identifier (accept non-computed member expressions too?)
+                        match c.Callee with
+                        | Identifier(id) when areEqualPassedAndAppliedArgs parameters c.Arguments ->
+                            Some c.Callee
+                        | _ -> None
+                    | _ -> None
+                | _ -> None
+
+            match skipExpr with
+            | Some e -> printer.Print(e)
+            | None ->
+                if isArrow then
+                    // Remove parens if we only have one argument? (and no annotation)
+                    printer.PrintOptional(typeParameters)
+                    printer.Print("(")
+                    printer.PrintCommaSeparatedArray(parameters)
+                    printer.Print(")")
+                    printer.PrintOptional(returnType)
+                    printer.Print(" => ")
+                    match body.Body with
+                    | [| ReturnStatement(r) |] ->
+                        match r.Argument with
+                        | ObjectExpression(e) -> printer.WithParens(e |> ObjectExpression)
+                        | MemberExpression(e) ->
+                            match e.Object with
+                            | ObjectExpression(o) -> printer.Print(e, objectWithParens=true)
+                            | _ -> printer.Print(e)
+                        | _ -> printer.ComplexExpressionWithParens(r.Argument)
+                    | _ -> printer.PrintBlock(body.Body, skipNewLineAtEnd=true)
+                else
+                    printer.Print("function ")
+                    printer.PrintOptional(id)
+                    printer.PrintOptional(typeParameters)
+                    printer.Print("(")
+                    printer.PrintCommaSeparatedArray(parameters)
+                    printer.Print(")")
+                    printer.PrintOptional(returnType)
+                    printer.Print(" ")
+                    printer.PrintBlock(body.Body, skipNewLineAtEnd=true)
+
+        member printer.WithParens(expr: Expression) =
+            printer.Print("(")
+            printer.Print(expr)
+            printer.Print(")")
+
+        member printer.SequenceExpressionWithParens(expr: Expression) =
+            match expr with
+            | SequenceExpression(_) -> printer.WithParens(expr)
+            | _ -> printer.Print(expr)
+
+        /// Surround with parens anything that can potentially conflict with operator precedence
+        member printer.ComplexExpressionWithParens(expr: Expression) =
+            match expr with
+            | Undefined(_)
+            | Literal(NullLiteral(_))
+            | Literal(StringLiteral(_))
+            | Literal(BooleanLiteral(_))
+            | Literal(NumericLiteral(_))
+            | Identifier(_)
+            | MemberExpression(_)
+            | CallExpression(_)
+            | ThisExpression(_)
+            | Super(_)
+            | SpreadElement(_)
+            | ArrayExpression(_)
+            | ObjectExpression(_) -> printer.Print(expr)
+            | _ -> printer.WithParens(expr)
+
+        member printer.PrintOperation(left, operator, right, loc) =
+            printer.AddLocation(loc)
+            printer.ComplexExpressionWithParens(left)
+            printer.Print(" " + operator + " ")
+            printer.ComplexExpressionWithParens(right)
+
+        member printer.Print(node: Node) =
+            match node with
+            | Pattern(n) -> printer.Print(n)
+            | Statement(n) -> printer.Print(n)
+            | ClassBody(n) -> printer.Print(n)
+            | Expression(n) -> printer.Print(n)
+            | SwitchCase(n) -> printer.Print(n)
+            | CatchClause(n) -> printer.Print(n)
+            | ObjectMember(n) -> printer.Print(n)
+            | TypeParameter(n) -> printer.Print(n)
+            | TypeAnnotation(n) -> printer.Print(n)
+            | ExportSpecifier(n) -> printer.Print(n)
+            | InterfaceExtends(n) -> printer.Print(n)
+            | ModuleDeclaration(n) -> printer.Print(n)
+            | FunctionTypeParam(n) -> printer.Print(n)
+            | ObjectTypeProperty(n) -> printer.Print(n)
+            | Node.TypeAnnotationInfo(n) -> printer.Print(n)
+            | TypeParameterDeclaration(n) -> printer.Print(n)
+            | TypeParameterInstantiation(n) -> printer.Print(n)
+            | Program(_)
+            | Directive(_)
+            | ImportSpecifier(_)
+            | ObjectTypeIndexer(_)
+            | VariableDeclarator(_)
+            | ObjectTypeCallProperty(_)
+            | ObjectTypeInternalSlot(_) -> failwith "Not implemented"
+
+        member printer.Print(expr: Expression) =
+            match expr with
+            | Super(n) -> printer.Print(n)
+            | Literal(n) -> printer.Print(n)
+            | Undefined(n) -> printer.Print(n)
+            | Identifier(n) -> printer.Print(n)
+            | NewExpression(n) -> printer.Print(n)
+            | SpreadElement(n) -> printer.Print(n)
+            | ThisExpression(n) -> printer.Print(n)
+            | CallExpression(n) -> printer.Print(n)
+            | EmitExpression(n) -> printer.Print(n)
+            | ArrayExpression(n) -> printer.Print(n)
+            | ClassExpression(n) -> printer.Print(n)
+            | ClassImplements(n) -> printer.Print(n)
+            | UnaryExpression(n) -> printer.Print(n)
+            | UpdateExpression(n) -> printer.Print(n)
+            | ObjectExpression(n) -> printer.Print(n)
+            | BinaryExpression(n) -> printer.Print(n)
+            | MemberExpression(n) -> printer.Print(n)
+            | LogicalExpression(n) -> printer.Print(n)
+            | SequenceExpression(n) -> printer.Print(n)
+            | FunctionExpression(n) -> printer.Print(n)
+            | AssignmentExpression(n) -> printer.Print(n)
+            | ConditionalExpression(n) -> printer.Print(n)
+            | ArrowFunctionExpression(n) -> printer.Print(n)
+
+        member printer.Print(pattern: Pattern) =
+            match pattern with
+            | IdentifierPattern(p) -> printer.Print(p)
+            | RestElement(e) -> printer.Print(e)
+
+        member printer.Print(literal: Literal) =
+            match literal with
+            | RegExp(l) -> printer.Print(l)
+            | NullLiteral(l) -> printer.Print(l)
+            | StringLiteral(l) -> printer.Print(l)
+            | BooleanLiteral(l) -> printer.Print(l)
+            | NumericLiteral(l) -> printer.Print(l)
+            | DirectiveLiteral(l) -> failwith "not implemented"
+
+        member printer.Print(stmt: Statement) =
+            match stmt with
+            | Declaration(s) -> printer.Print(s)
+            | IfStatement(s) -> printer.Print(s)
+            | TryStatement(s) -> printer.Print(s)
+            | ForStatement(s) -> printer.Print(s)
+            | BreakStatement(s) -> printer.Print("break", ?loc = s.Loc)
+            | WhileStatement(s) -> printer.Print(s)
+            | ThrowStatement(s) -> printer.Print(s)
+            | BlockStatement(s) -> printer.Print(s)
+            | ReturnStatement(s) -> printer.Print(s)
+            | SwitchStatement(s) -> printer.Print(s)
+            | LabeledStatement(s) -> printer.Print(s)
+            | DebuggerStatement(s) -> printer.Print(s)
+            | ContinueStatement(s) -> printer.Print(s)
+            | ExpressionStatement(s) -> printer.Print(s)
+
+        member printer.Print(decl: Declaration) =
+            match decl with
+            | ClassDeclaration(d) -> printer.Print(d)
+            | VariableDeclaration(d) -> printer.Print(d)
+            | FunctionDeclaration(d) -> printer.Print(d)
+            | InterfaceDeclaration(d) -> printer.Print(d)
+
+        member printer.Print(md: ModuleDeclaration) =
+            match md with
+            | ImportDeclaration(d) -> printer.Print(d)
+            | ExportNamedReferences(d) -> printer.Print(d)
+            | ExportNamedDeclaration(d) -> printer.Print(d)
+            | ExportAllDeclaration(d) -> printer.Print(d)
+            | PrivateModuleDeclaration(d) -> printer.Print(d)
+            | ExportDefaultDeclaration(d) -> printer.Print(d)
+
+        member printer.Print(emit: EmitExpression) =
+            printer.AddLocation(emit.Loc)
+
+            let inline replace pattern (f: System.Text.RegularExpressions.Match -> string) input =
+                System.Text.RegularExpressions.Regex.Replace(input, pattern, f)
+
+            let printSegment (printer: Printer) (value: string) segmentStart segmentEnd =
+                let segmentLength = segmentEnd - segmentStart
+                if segmentLength > 0 then
+                    let segment = value.Substring(segmentStart, segmentLength)
+                    let subSegments = System.Text.RegularExpressions.Regex.Split(segment, @"\r?\n")
+                    for i = 1 to subSegments.Length do
+                        let subSegment =
+                            // Remove whitespace in front of new lines,
+                            // indent will be automatically applied
+                            if printer.Column = 0 then subSegments.[i - 1].TrimStart()
+                            else subSegments.[i - 1]
+                        if subSegment.Length > 0 then
+                            printer.Print(subSegment)
+                            if i < subSegments.Length then
+                                printer.PrintNewLine()
+
+            // Macro transformations
+            // https://fable.io/docs/communicate/js-from-fable.html#Emit-when-F-is-not-enough
+            let value =
+                emit.Value
+                |> replace @"\$(\d+)\.\.\." (fun m ->
+                    let rep = ResizeArray()
+                    let i = int m.Groups.[1].Value
+                    for j = i to emit.Args.Length - 1 do
+                        rep.Add("$" + string j)
+                    String.concat ", " rep)
+
+                |> replace @"\{\{\s*\$(\d+)\s*\?(.*?)\:(.*?)\}\}" (fun m ->
+                    let i = int m.Groups.[1].Value
+                    match emit.Args.[i] with
+                    | Literal(BooleanLiteral(b)) when b.Value -> m.Groups.[2].Value
+                    | _ -> m.Groups.[3].Value)
+
+                |> replace @"\{\{([^\}]*\$(\d+).*?)\}\}" (fun m ->
+                    let i = int m.Groups.[2].Value
+                    match Array.tryItem i emit.Args with
+                    | Some _ -> m.Groups.[1].Value
+                    | None -> "")
+
+                // This is to emit string literals as JS, I think it's no really
+                // used and it shouldn't be necessary with the new emitJsExpr
+    //            |> replace @"\$(\d+)!" (fun m ->
+    //                let i = int m.Groups.[1].Value
+    //                match Array.tryItem i args with
+    //                | Some(:? StringLiteral as s) -> s.Value
+    //                | _ -> "")
+
+            let matches = System.Text.RegularExpressions.Regex.Matches(value, @"\$\d+")
+            if matches.Count > 0 then
+                for i = 0 to matches.Count - 1 do
+                    let m = matches.[i]
+
+                    let segmentStart =
+                        if i > 0 then matches.[i-1].Index + matches.[i-1].Length
+                        else 0
+
+                    printSegment printer value segmentStart m.Index
+
+                    let argIndex = int m.Value.[1..]
+                    match Array.tryItem argIndex emit.Args with
+                    | Some e -> printer.ComplexExpressionWithParens(e)
+                    | None -> printer.Print("undefined")
+
+                let lastMatch = matches.[matches.Count - 1]
+                printSegment printer value (lastMatch.Index + lastMatch.Length) value.Length
+            else
+                printSegment printer value 0 value.Length
+
+        member printer.Print(identifier: Identifier) =
+            printer.Print(identifier.Name, ?loc=identifier.Loc)
+            if identifier.Optional = Some true then
+                printer.Print("?")
+            printer.PrintOptional(identifier.TypeAnnotation)
+
+        member printer.Print(re: RegExpLiteral) =
+            printer.Print("/", ?loc=re.Loc)
+            printer.Print(re.Pattern)
+            printer.Print("/")
+            printer.Print(re.Flags)
+
+        member printer.Print(undef: Undefined) =
+            printer.Print("undefined", ?loc=undef.Loc)
+
+        member printer.Print(nl: NullLiteral) =
+            printer.Print("null", ?loc=nl.Loc)
+
+        member printer.Print(node: StringLiteral)=
+            printer.Print("\"", ?loc=node.Loc)
+            printer.Print(printer.EscapeJsStringLiteral(node.Value))
+            printer.Print("\"")
+
+        member printer.Print(node: BooleanLiteral) =
+            printer.Print((if node.Value then "true" else "false"), ?loc=node.Loc)
+
+        member printer.Print(node: NumericLiteral) =
+            let value =
+                match node.Value.ToString(System.Globalization.CultureInfo.InvariantCulture) with
+                | "∞" -> "Infinity"
+                | "-∞" -> "-Infinity"
+                | value -> value
+            printer.Print(value, ?loc=node.Loc)
+
+        member printer.Print(node: BlockStatement) =
+            printer.PrintBlock(node.Body)
+
+        member printer.Print(node:ExpressionStatement) =
+            printer.Print(node.Expression)
+
+        member printer.Print(node: DebuggerStatement) = printer.Print("debugger", ?loc = node.Loc)
+
+        member printer.Print(node: LabeledStatement) =
+            printer.Print(node.Label)
+            printer.Print(":")
+            printer.PrintNewLine()
+            // Don't push indent
+            printer.Print(node.Body)
+
+        member printer.Print(node: ContinueStatement) =
+            printer.Print("continue", ?loc=node.Loc)
+            printer.PrintOptional(node.Label, " ")
+
+// type WithStatement
+
+// Control Flow
+        member printer.Print(node: ReturnStatement)=
+            printer.Print("return ", ?loc = node.Loc)
+            printer.Print(node.Argument)
+
+        member printer.Print(node: IfStatement) =
+            printer.AddLocation(node.Loc)
+            printer.Print("if (", ?loc=node.Loc)
+            printer.Print(node.Test)
+            printer.Print(") ")
+            printer.Print(node.Consequent)
+            match node.Alternate with
+            | None -> ()
+            | Some alternate ->
+                if printer.Column > 0 then printer.Print(" ")
+                match alternate with
+                | IfStatement(iff) ->
+                    printer.Print("else ")
+                    printer.Print(iff)
+                | alternate ->
+                    let statements =
+                        match alternate with
+                        | BlockStatement(b) -> b.Body
+                        | alternate -> [|alternate|]
+                    // Get productive statements and skip `else` if they're empty
+                    statements
+                    |> Array.filter printer.IsProductiveStatement
+                    |> function
+                        | [||] -> ()
+                        | statements ->
+                            printer.Print("else ")
+                            printer.PrintBlock(statements)
+            if printer.Column > 0 then
+                printer.PrintNewLine()
+
+        /// A case (if test is an Expression) or default (if test === null) clause in the body of a switch statement.
+        member printer.Print(node: SwitchCase) =
+            printer.AddLocation(node.Loc)
+
+            match node.Test with
+            | None -> printer.Print("default")
+            | Some test ->
+                printer.Print("case ")
+                printer.Print(test)
+
+            printer.Print(":")
+
+            match node.Consequent.Length with
+            | 0 -> printer.PrintNewLine()
+            | 1 ->
+                printer.Print(" ")
+                printer.Print(node.Consequent.[0])
+            | _ ->
+                printer.Print(" ")
+                printer.PrintBlock(node.Consequent)
+
+        member printer.Print(node: SwitchStatement) =
+            printer.Print("switch (", ?loc=node.Loc)
+            printer.Print(node.Discriminant)
+            printer.Print(") ")
+            printer.PrintBlock(node.Cases, (fun p x -> p.Print(x)), fun _ -> ())
+
+// Exceptions
+        member printer.Print(node: ThrowStatement) =
+            printer.Print("throw ", ?loc = node.Loc)
+            printer.Print(node.Argument)
+
+        member printer.Print(node: CatchClause) =
+            // "catch" is being printed by TryStatement
+            printer.Print("(", ?loc = node.Loc)
+            printer.Print(node.Param)
+            printer.Print(") ")
+            printer.Print(node.Body)
+
+        member printer.Print(node: TryStatement) =
+            printer.Print("try ", ?loc = node.Loc)
+            printer.Print(node.Block)
+            printer.PrintOptional(node.Handler, "catch ")
+            printer.PrintOptional(node.Finalizer, "finally ")
+
+// Declarations
+
+        member printer.Print(node: VariableDeclaration) =
+            printer.Print(node.Kind + " ", ?loc = node.Loc)
+            let canConflict = node.Declarations.Length > 1
+
+            for i = 0 to node.Declarations.Length - 1 do
+                let decl = node.Declarations.[i]
+                printer.Print(decl.Id)
+
+                match decl.Init with
+                | None -> ()
+                | Some e ->
+                    printer.Print(" = ")
+                    if canConflict then printer.ComplexExpressionWithParens(e)
+                    else printer.SequenceExpressionWithParens(e)
+                if i < node.Declarations.Length - 1 then
+                    printer.Print(", ")
+
+        member printer.Print(node: WhileStatement) =
+            printer.Print("while (", ?loc = node.Loc)
+            printer.Print(node.Test)
+            printer.Print(") ")
+            printer.Print(node.Body)
+
+        member printer.Print(node: ForStatement) =
+            printer.Print("for (", ?loc = node.Loc)
+            printer.PrintOptional(node.Init)
+            printer.Print("; ")
+            printer.PrintOptional(node.Test)
+            printer.Print("; ")
+            printer.PrintOptional(node.Update)
+            printer.Print(") ")
+            printer.Print(node.Body)
+
+        member printer.Print(node: FunctionDeclaration) =
+            printer.PrintFunction(Some node.Id, node.Params, node.Body, node.TypeParameters, node.ReturnType, node.Loc, isDeclaration=true)
+            printer.PrintNewLine()
+
+        member printer.Print(node: Super) = printer.Print("super", ?loc = node.Loc)
+
+        member printer.Print(node: ThisExpression) = printer.Print("node", ?loc = node.Loc)
+
+        /// A fat arrow function expression, e.g., let foo = (bar) => { /* body */ }.
+        member printer.Print(node: ArrowFunctionExpression) =
+            printer.PrintFunction(
+                None,
+                node.Params,
+                node.Body,
+                node.TypeParameters,
+                node.ReturnType,
+                node.Loc,
+                isArrow = true
+            )
+
+        member printer.Print(node: FunctionExpression)=
+            printer.PrintFunction(node.Id, node.Params, node.Body, node.TypeParameters, node.ReturnType, node.Loc)
+
+        member printer.Print(node: SpreadElement) =
+            printer.Print("...", ?loc = node.Loc)
+            printer.ComplexExpressionWithParens(node.Argument)
+
+        member printer.Print(node: ArrayExpression) =
+            printer.Print("[", ?loc = node.Loc)
+            printer.PrintCommaSeparatedArray(node.Elements)
+            printer.Print("]")
+
+        member printer.Print(node: ObjectMember) =
+            match node with
+            | ObjectProperty(op) -> printer.Print(op)
+            | ObjectMethod(op) -> printer.Print(op)
+
+        member printer.Print(node: ObjectProperty) =
+            if node.Computed then
+                printer.Print("[")
+                printer.Print(node.Key)
+                printer.Print("]")
+            else
+                printer.Print(node.Key)
+            printer.Print(": ")
+            printer.SequenceExpressionWithParens(node.Value)
+
+        member printer.Print(node: ObjectMethod)=
+            printer.AddLocation(node.Loc)
+
+            if node.Kind <> "method" then
+                printer.Print(node.Kind + " ")
+
+            if node.Computed then
+                printer.Print("[")
+                printer.Print(node.Key)
+                printer.Print("]")
+            else
+               printer.Print(node.Key)
+
+            printer.PrintOptional(node.TypeParameters)
+            printer.Print("(")
+            printer.PrintCommaSeparatedArray(node.Params)
+            printer.Print(")")
+            printer.PrintOptional(node.ReturnType)
+            printer.Print(" ")
+
+            printer.PrintBlock(node.Body.Body, skipNewLineAtEnd=true)
+
+        member printer.Print(node: MemberExpression, ?objectWithParens: bool) =
+            printer.AddLocation(node.Loc)
+            match objectWithParens, node.Object with
+            | Some true, _ | _, Literal(NumericLiteral(_)) -> printer.WithParens(node.Object)
+            | _ -> printer.ComplexExpressionWithParens(node.Object)
+            if node.Computed then
+                printer.Print("[")
+                printer.Print(node.Property)
+                printer.Print("]")
+            else
+                printer.Print(".")
+                printer.Print(node.Property)
+
+        member printer.Print(node: ObjectExpression) =
+            let printSeparator(p: Printer) =
+                p.Print(",")
+                p.PrintNewLine()
+
+            printer.AddLocation(node.Loc)
+            if Array.isEmpty node.Properties then printer.Print("{}")
+            else printer.PrintBlock(node.Properties, (fun p x -> p.Print(x)), printSeparator, skipNewLineAtEnd=true)
+
+        member printer.Print(node: ConditionalExpression) =
+            printer.AddLocation(node.Loc)
+            match node.Test with
+            // TODO: Move node optimization to Fable2Babel as with IfStatement?
+            | Literal(BooleanLiteral(b)) ->
+                if b.Value then printer.Print(node.Consequent)
+                else printer.Print(node.Alternate)
+            | _ ->
+                printer.ComplexExpressionWithParens(node.Test)
+                printer.Print(" ? ")
+                printer.ComplexExpressionWithParens(node.Consequent)
+                printer.Print(" : ")
+                printer.ComplexExpressionWithParens(node.Alternate)
+
+        member printer.Print(node: CallExpression) =
+            printer.AddLocation(node.Loc)
+            printer.ComplexExpressionWithParens(node.Callee)
+            printer.Print("(")
+            printer.PrintCommaSeparatedArray(node.Arguments)
+            printer.Print(")")
+
+        member printer.Print(node: NewExpression) =
+            printer.Print("new ", ?loc=node.Loc)
+            printer.ComplexExpressionWithParens(node.Callee)
+            printer.Print("(")
+            printer.PrintCommaSeparatedArray(node.Arguments)
+            printer.Print(")")
+
+        /// A comma-separated sequence of expressions.
+        member printer.Print(node: SequenceExpression) =
+            printer.AddLocation(node.Loc)
+            printer.PrintCommaSeparatedArray(node.Expressions)
+
+        member printer.Print(node: UnaryExpression) =
+            printer.AddLocation(node.Loc)
+            match node.Operator with
+            | "-" | "+" | "!" | "~" -> printer.Print(node.Operator)
+            | _ -> printer.Print(node.Operator + " ")
+            printer.ComplexExpressionWithParens(node.Argument)
+
+        member printer.Print(node: UpdateExpression) =
+            printer.AddLocation(node.Loc)
+            if node.Prefix then
+                printer.Print(node.Operator)
+                printer.ComplexExpressionWithParens(node.Argument)
+            else
+                printer.ComplexExpressionWithParens(node.Argument)
+                printer.Print(node.Operator)
+
+// Binary Operations
+
+        member printer.Print(node: BinaryExpression) =
+            printer.PrintOperation(node.Left, node.Operator, node.Right, node.Loc)
+
+        member printer.Print(node: AssignmentExpression) =
+            printer.PrintOperation(node.Left, node.Operator, node.Right, node.Loc)
+
+        member printer.Print(node: LogicalExpression) =
+            printer.PrintOperation(node.Left, node.Operator, node.Right, node.Loc)
+
+        member printer.Print(node: RestElement) =
+            printer.Print("...", ?loc=node.Loc)
+            printer.Print(node.Argument)
+            printer.PrintOptional(node.TypeAnnotation)
+
+        member printer.Print(node: ClassMember) =
+            match node with
+            | ClassMethod(cm) -> printer.Print(cm)
+            | ClassProperty(cp) -> printer.Print(cp)
+
+        member printer.Print(node: ClassMethod) =
+            printer.AddLocation(node.Loc)
+
+            let keywords = [
+                if node.Static = Some true then yield "static"
+                if node.Abstract = Some true then yield "abstract"
+                if node.Kind = "get" || node.Kind = "set" then yield node.Kind
+            ]
+
+            if not (List.isEmpty keywords) then
+                printer.Print((String.concat " " keywords) + " ")
+
+            if node.Computed then
+                printer.Print("[")
+                printer.Print(node.Key)
+                printer.Print("]")
+            else
+                printer.Print(node.Key)
+
+            printer.PrintOptional(node.TypeParameters)
+            printer.Print("(")
+            printer.PrintCommaSeparatedArray(node.Params)
+            printer.Print(")")
+            printer.PrintOptional(node.ReturnType)
+            printer.Print(" ")
+
+            printer.Print(node.Body)
+
+        member printer.Print(node: ClassProperty) =
+            printer.AddLocation(node.Loc)
+            if node.Static then
+                printer.Print("static ")
+            if node.Computed then
+                printer.Print("[")
+                printer.Print(node.Key)
+                printer.Print("]")
+            else
+                printer.Print(node.Key)
+            if node.Optional then
+                printer.Print("?")
+            printer.PrintOptional(node.TypeAnnotation)
+            printer.PrintOptional(node.Value, ": ")
+
+        member printer.Print(node: ClassImplements) =
+            printer.Print(node.Id)
+            printer.PrintOptional(node.TypeParameters)
+
+        member printer.Print(node: ClassBody) =
+            printer.AddLocation(node.Loc)
+            printer.PrintBlock(node.Body, (fun p x -> p.Print(x)), (fun p -> p.PrintStatementSeparator()))
+
+        member printer.Print(node: ClassDeclaration) =
+            printer.PrintClass(node.Id, node.SuperClass, node.SuperTypeParameters, node.TypeParameters, node.Implements, node.Body, node.Loc)
+
+        member printer.Print(node: ClassExpression) =
+            printer.PrintClass(node.Id, node.SuperClass, node.SuperTypeParameters, node.TypeParameters, node.Implements, node.Body, node.Loc)
+
+        member printer.Print(node: PrivateModuleDeclaration) =
+            if printer.IsProductiveStatement(node.Statement) then
+                printer.Print(node.Statement)
+
+        member printer.Print(node: ImportMemberSpecifier) =
+            // Don't print the braces, node will be done in the import declaration
+            printer.Print(node.Imported)
+            if node.Imported.Name <> node.Local.Name then
+                printer.Print(" as ")
+                printer.Print(node.Local)
+
+        member printer.Print(node: ImportDefaultSpecifier) =
+            printer.Print(node.Local)
+
+        member printer.Print(node: ImportNamespaceSpecifier) =
+            printer.Print("* as ")
+            printer.Print(node.Local)
+
+        member printer.Print(node: ImportDeclaration) =
+            let members = node.Specifiers |> Array.choose (function ImportMemberSpecifier(x) -> Some x | _ -> None)
+            let defaults = node.Specifiers|> Array.choose (function ImportDefaultSpecifier(x) -> Some x | _ -> None)
+            let namespaces = node.Specifiers |> Array.choose (function ImportNamespaceSpecifier(x) -> Some x | _ -> None)
+
+            printer.Print("import ")
+
+            if not(Array.isEmpty defaults) then
+                printer.PrintCommaSeparatedArray(defaults)
+                if not(Array.isEmpty namespaces && Array.isEmpty members) then
+                    printer.Print(", ")
+
+            if not(Array.isEmpty namespaces) then
+                printer.PrintCommaSeparatedArray(namespaces)
+                if not(Array.isEmpty members) then
+                    printer.Print(", ")
+
+            if not(Array.isEmpty members) then
+                printer.Print("{ ")
+                printer.PrintCommaSeparatedArray(members)
+                printer.Print(" }")
+
+            if not(Array.isEmpty defaults && Array.isEmpty namespaces && Array.isEmpty members) then
+                printer.Print(" from ")
+
+            printer.Print("\"")
+            printer.Print(printer.MakeImportPath(node.Source.Value))
+            printer.Print("\"")
+
+        member printer.Print(node: ExportSpecifier) =
+            // Don't print the braces, node will be done in the export declaration
+            printer.Print(node.Local)
+            if node.Exported.Name <> node.Local.Name then
+                printer.Print(" as ")
+                printer.Print(node.Exported)
+
+        member printer.Print(node: ExportNamedDeclaration) =
+            printer.Print("export ")
+            printer.Print(node.Declaration)
+
+        member printer.Print(node: ExportNamedReferences) =
+            printer.Print("export ")
+            printer.Print("{ ")
+            printer.PrintCommaSeparatedArray(node.Specifiers)
+            printer.Print(" }")
+            printer.PrintOptional(node.Source, " from ")
+
+        member printer.Print(node: ExportDefaultDeclaration) =
+            printer.Print("export default ")
+            match node.Declaration with
+            | Choice1Of2 x -> printer.Print(x)
+            | Choice2Of2 x -> printer.Print(x)
+
+        member printer.Print(node: ExportAllDeclaration) =
+            printer.Print("export * from ", ?loc=node.Loc)
+            printer.Print(node.Source)
+
+        member printer.Print(node: TypeAnnotationInfo) =
+            match node with
+            | StringTypeAnnotation -> printer.Print("string")
+            | NumberTypeAnnotation -> printer.Print("number")
+            | TypeAnnotationInfo(an) -> printer.Print(an)
+            | BooleanTypeAnnotation -> printer.Print("boolean")
+            | AnyTypeAnnotation -> printer.Print("any")
+            | VoidTypeAnnotation -> printer.Print("void")
+            | TupleTypeAnnotation(an) -> printer.Print(an)
+            | UnionTypeAnnotation(an) -> printer.Print(an)
+            | FunctionTypeAnnotation(an) -> printer.Print(an)
+            | NullableTypeAnnotation(an) -> printer.Print(an)
+            | GenericTypeAnnotation(an) -> printer.Print(an)
+            | ObjectTypeAnnotation(an) -> printer.Print(an)
+
+        member printer.Print(node: TypeAnnotation) =
+            printer.Print(": ")
+            printer.Print(node.TypeAnnotation)
+
+        member printer.Print(node: TypeParameter) =
+            printer.Print(node.Name)
+            // printer.PrintOptional(bound)
+            // printer.PrintOptional(``default``)
+
+        member printer.Print(node: TypeParameterDeclaration) =
+            printer.Print("<")
+            printer.PrintCommaSeparatedArray(node.Params)
+            printer.Print(">")
+
+        member printer.Print(node: TypeParameterInstantiation) =
+            printer.Print("<")
+            printer.PrintCommaSeparatedArray(node.Params)
+            printer.Print(">")
+
+        member printer.Print(node: TupleTypeAnnotation) =
+            printer.Print("[")
+            printer.PrintCommaSeparatedArray(node.Types)
+            printer.Print("]")
+
+        member printer.Print(node: UnionTypeAnnotation) =
+            printer.PrintArray(node.Types, (fun p x -> p.Print(x)), (fun p -> p.Print(" | ")))
+
+        member printer.Print(node: FunctionTypeParam) =
+            printer.Print(node.Name)
+            if node.Optional = Some true then
+                printer.Print("?")
+            printer.Print(": ")
+            printer.Print(node.TypeAnnotation)
+
+        member printer.Print(node: FunctionTypeAnnotation) =
+            printer.PrintOptional(node.TypeParameters)
+            printer.Print("(")
+            printer.PrintCommaSeparatedArray(node.Params)
+            if Option.isSome node.Rest then
+                printer.Print("...")
+                printer.Print(node.Rest.Value)
+            printer.Print(") => ")
+            printer.Print(node.ReturnType)
+
+        member printer.Print(node: NullableTypeAnnotation) =
+            printer.Print(node.TypeAnnotation)
+
+        member printer.Print(node: GenericTypeAnnotation) =
+            printer.Print(node.Id)
+            printer.PrintOptional(node.TypeParameters)
+
+        member printer.Print(node: ObjectTypeProperty) =
+            if node.Static then
+                printer.Print("static ")
+            if Option.isSome node.Kind then
+                printer.Print(node.Kind.Value + " ")
+            if node.Computed then
+                printer.Print("[")
+                printer.Print(node.Key)
+                printer.Print("]")
+            else
+                printer.Print(node.Key)
+            if node.Optional then
+                printer.Print("?")
+            // TODO: proto, method
+            printer.Print(": ")
+            printer.Print(node.Value)
+
+        member printer.Print(node: ObjectTypeAnnotation) =
+            printer.Print("{")
+            printer.PrintNewLine()
+            printer.PushIndentation()
+            printer.PrintArray(node.Properties, (fun p x -> p.Print(x)), (fun p -> p.PrintStatementSeparator()))
+            printer.PrintArray(node.Indexers, (fun p x -> p.Print(x |> ObjectTypeIndexer)), (fun p -> p.PrintStatementSeparator()))
+            printer.PrintArray(node.CallProperties, (fun p x -> p.Print(x |> ObjectTypeCallProperty)), (fun p -> p.PrintStatementSeparator()))
+            printer.PrintArray(node.InternalSlots, (fun p x -> p.Print(x |> ObjectTypeInternalSlot)), (fun p -> p.PrintStatementSeparator()))
+            printer.PrintNewLine()
+            printer.PopIndentation()
+            printer.Print("}")
+            printer.PrintNewLine()
+
+        member printer.Print(node: InterfaceExtends) =
+            printer.Print(node.Id)
+            printer.PrintOptional(node.TypeParameters)
+
+        member printer.Print(node: InterfaceDeclaration) =
+            printer.Print("interface ")
+            printer.Print(node.Id)
+            printer.PrintOptional(node.TypeParameters)
+
+            if not (Array.isEmpty node.Extends) then
+                printer.Print(" extends ")
+                printer.PrintArray(node.Extends, (fun p x -> p.Print(x)), (fun p -> p.Print(", ")))
+
+            if not (Array.isEmpty node.Implements) then
+                printer.Print(" implements ")
+                printer.PrintArray(node.Implements, (fun p x -> p.Print(x)), (fun p -> p.Print(", ")))
+
+            printer.Print(" ")
+            printer.Print(node.Body)
+
+open PrinterExtensions
+
+let run writer map (program: Program): Async<unit> =
     let printDeclWithExtraLine extraLine (printer: Printer) (decl: ModuleDeclaration) =
-        decl.Print(printer)
+        printer.Print(decl)
 
         if printer.Column > 0 then
             printer.Print(";")
@@ -107,7 +1105,7 @@ let run writer map (program: Program): Async<unit> =
         for decl in imports do
             printDeclWithExtraLine false printer decl
 
-        printer.PrintNewLine()
+        (printer :> Printer).PrintNewLine()
         do! printer.Flush()
 
         for decl in restDecls do

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -343,7 +343,7 @@ module Annotation =
         else
             genParams
             |> Set.toArray
-            |> Array.map (Identifier.Create >> GenericTypeAnnotation.AsTypeAnnotationInfo)
+            |> Array.map (Identifier.Create >> TypeAnnotationInfo.genericTypeAnnotation)
             |> TypeParameterInstantiation.Create |> Some
 
     let mergeTypeParamDecls (decl1: TypeParameterDeclaration option) (decl2: TypeParameterDeclaration option) =
@@ -361,7 +361,7 @@ module Annotation =
 
     let getGenericTypeAnnotation _com _ctx name genParams =
         let typeParamInst = makeTypeParamInst genParams
-        GenericTypeAnnotation.AsTypeAnnotationInfo(Identifier.Create(name), ?typeParameters=typeParamInst)
+        GenericTypeAnnotation(Identifier.Create(name), ?typeParameters=typeParamInst)
         |> TypeAnnotation.Create |> Some
 
     let typeAnnotation com ctx typ: TypeAnnotationInfo =
@@ -389,7 +389,7 @@ module Annotation =
             makeAnonymousRecordTypeAnnotation com ctx fieldNames genArgs
 
     let makeSimpleTypeAnnotation _com _ctx name =
-        GenericTypeAnnotation.AsTypeAnnotationInfo(Identifier.Create(name))
+        TypeAnnotationInfo.genericTypeAnnotation(Identifier.Create(name))
 
     let makeGenTypeParamInst com ctx genArgs =
         match genArgs with
@@ -399,7 +399,7 @@ module Annotation =
 
     let makeGenericTypeAnnotation com ctx genArgs id =
         let typeParamInst = makeGenTypeParamInst com ctx genArgs
-        GenericTypeAnnotation.AsTypeAnnotationInfo(id, ?typeParameters=typeParamInst)
+        GenericTypeAnnotation(id, ?typeParameters=typeParamInst)
 
     let makeNativeTypeAnnotation com ctx genArgs typeName =
         Identifier.Create(typeName)
@@ -439,7 +439,7 @@ module Annotation =
 
     let makeUnionTypeAnnotation com ctx genArgs =
         List.map (typeAnnotation com ctx) genArgs
-        |> List.toArray |> UnionTypeAnnotation.AsTypeAnnotationInfo
+        |> List.toArray |> UnionTypeAnnotation
 
     let makeBuiltinTypeAnnotation com ctx kind =
         match kind with
@@ -1769,7 +1769,7 @@ module Util =
                     ?superTypeParameters = e.SuperTypeParameters,
                     ?typeParameters = e.TypeParameters)
             | FunctionExpression(e) ->
-                FunctionDeclaration.AsDeclaration(
+                Declaration.functionDeclaration(
                     e.Params, e.Body, membName,
                     ?returnType = e.ReturnType,
                     ?typeParameters = e.TypeParameters)

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -529,7 +529,6 @@ module Annotation =
             let args', body' = com.TransformFunction(ctx, name, args, body)
             args', body', None, None
 
-
 module Util =
     open Lib
     open Reflection
@@ -1702,7 +1701,7 @@ module Util =
                 transformBlock com ctx None body,
                 start |> varDeclaration (typedIdent com ctx var |> IdentifierPattern) true,
                 Expression.binaryExpression(op1, identAsExpr var, limit),
-                UpdateExpression.AsExpr(op2, false, identAsExpr var), ?loc=range)|]
+                Expression.updateExpression(op2, false, identAsExpr var), ?loc=range)|]
 
     let transformFunction com ctx name (args: Fable.Ident list) (body: Fable.Expr): Pattern array * BlockStatement =
         let tailcallChance =
@@ -1769,11 +1768,11 @@ module Util =
                     ?implements = e.Implements,
                     ?superTypeParameters = e.SuperTypeParameters,
                     ?typeParameters = e.TypeParameters)
-            | FunctionExpression(e) ->
+            | FunctionExpression(_, ``params``, body, returnType, typeParameters, _) ->
                 Declaration.functionDeclaration(
-                    e.Params, e.Body, membName,
-                    ?returnType = e.ReturnType,
-                    ?typeParameters = e.TypeParameters)
+                    ``params``, body, membName,
+                    ?returnType = returnType,
+                    ?typeParameters = typeParameters)
             | _ -> varDeclaration membName' isMutable expr |> Declaration.VariableDeclaration
         if not isPublic then PrivateModuleDeclaration(decl |> Declaration)
         else ExportNamedDeclaration(decl)

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -335,7 +335,7 @@ module Annotation =
             genParams
             |> Set.toArray
             |> Array.map TypeParameter.Create
-            |> TypeParameterDeclaration.Create |> Some
+            |> TypeParameterDeclaration |> Some
 
     let makeTypeParamInst genParams =
         if (Set.isEmpty genParams) then
@@ -344,17 +344,17 @@ module Annotation =
             genParams
             |> Set.toArray
             |> Array.map (Identifier.identifier >> TypeAnnotationInfo.genericTypeAnnotation)
-            |> TypeParameterInstantiation.Create |> Some
+            |> TypeParameterInstantiation |> Some
 
     let mergeTypeParamDecls (decl1: TypeParameterDeclaration option) (decl2: TypeParameterDeclaration option) =
         match decl1, decl2 with
-        | Some d1, Some d2 ->
+        | Some (TypeParameterDeclaration(``params``=p1)), Some (TypeParameterDeclaration(``params``=p2)) ->
             Array.append
-                (d1.Params |> Array.map (fun x -> x.Name))
-                (d2.Params |> Array.map (fun x -> x.Name))
+                (p1 |> Array.map (fun x -> x.Name))
+                (p2 |> Array.map (fun x -> x.Name))
             |> Array.distinct
             |> Array.map TypeParameter.Create
-            |> TypeParameterDeclaration.Create |> Some
+            |> TypeParameterDeclaration |> Some
         | Some _, None -> decl1
         | None, Some _ -> decl2
         | None, None -> None
@@ -395,7 +395,7 @@ module Annotation =
         match genArgs with
         | [] -> None
         | _  -> genArgs |> List.map (typeAnnotation com ctx)
-                        |> List.toArray |> TypeParameterInstantiation.Create |> Some
+                        |> List.toArray |> TypeParameterInstantiation |> Some
 
     let makeGenericTypeAnnotation com ctx genArgs id =
         let typeParamInst = makeGenTypeParamInst com ctx genArgs

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -726,7 +726,7 @@ module Util =
             variables
             |> List.distinctBy (fun (Identifier(name=name), _value) -> name)
             |> List.mapToArray (fun (id, value) ->
-                VariableDeclarator(id |> IdentifierPattern, value))
+                VariableDeclarator(id |> Pattern.Identifier, value))
         Statement.variableDeclaration(kind, varDeclarators)
 
     let varDeclaration (var: Pattern) (isMutable: bool) value =
@@ -1695,11 +1695,11 @@ module Util =
                 then BinaryOperator.BinaryLessOrEqual, UpdateOperator.UpdatePlus
                 else BinaryOperator.BinaryGreaterOrEqual, UpdateOperator.UpdateMinus
 
-            let a = start |> varDeclaration (typedIdent com ctx var |> IdentifierPattern) true
+            let a = start |> varDeclaration (typedIdent com ctx var |> Pattern.Identifier) true
 
             [|Statement.forStatement(
                 transformBlock com ctx None body,
-                start |> varDeclaration (typedIdent com ctx var |> IdentifierPattern) true,
+                start |> varDeclaration (typedIdent com ctx var |> Pattern.Identifier) true,
                 Expression.binaryExpression(op1, identAsExpr var, limit),
                 Expression.updateExpression(op2, false, identAsExpr var), ?loc=range)|]
 
@@ -1746,7 +1746,7 @@ module Util =
             else
                 let varDeclStatement = multiVarDeclaration Let [for v in declaredVars -> typedIdent com ctx v, None]
                 BlockStatement(Array.append [|varDeclStatement|] body.Body)
-        args |> List.mapToArray IdentifierPattern, body
+        args |> List.mapToArray Pattern.Identifier, body
 
     let declareEntryPoint _com _ctx (funcExpr: Expression) =
         let argv = emitExpression None "typeof process === 'object' ? process.argv.slice(2) : []" []
@@ -1912,8 +1912,8 @@ module Util =
     let transformUnion (com: IBabelCompiler) ctx (ent: Fable.Entity) (entName: string) classMembers =
         let fieldIds = getUnionFieldsAsIdents com ctx ent
         let args =
-            [| typedIdent com ctx fieldIds.[0] |> IdentifierPattern
-               typedIdent com ctx fieldIds.[1] |> IdentifierPattern |> restElement |]
+            [| typedIdent com ctx fieldIds.[0] |> Pattern.Identifier
+               typedIdent com ctx fieldIds.[1] |> Pattern.Identifier |> restElement |]
         let body =
             BlockStatement([|
                 yield callSuperAsStatement []
@@ -1961,7 +1961,7 @@ module Util =
                 |> Seq.toArray
             |])
         let typedPattern x = typedIdent com ctx x
-        let args = fieldIds |> Array.map (typedPattern >> IdentifierPattern)
+        let args = fieldIds |> Array.map (typedPattern >> Pattern.Identifier)
         declareType com ctx ent entName args body baseExpr classMembers
 
     let transformClassWithImplicitConstructor (com: IBabelCompiler) ctx (classDecl: Fable.ClassDecl) classMembers (cons: Fable.MemberDecl) =

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -638,7 +638,7 @@ module Util =
         match memberName with
         | "ToString" -> Expression.identifier("toString"), false
         | n when n.StartsWith("Symbol.") ->
-            MemberExpression.AsExpr(Expression.identifier("Symbol"), Expression.identifier(n.[7..]), false), true
+            Expression.memberExpression(Expression.identifier("Symbol"), Expression.identifier(n.[7..]), false), true
         | n when Naming.hasIdentForbiddenChars n -> Expression.stringLiteral(n), true
         | n -> Expression.identifier(n), false
 
@@ -649,14 +649,14 @@ module Util =
 
     let get r left memberName =
         let expr, computed = memberFromName memberName
-        MemberExpression.AsExpr(left, expr, computed, ?loc=r)
+        Expression.memberExpression(left, expr, computed, ?loc=r)
 
     let getExpr r (object: Expression) (expr: Expression) =
         let expr, computed =
             match expr with
             | Literal(StringLiteral(e)) -> memberFromName e.Value
             | e -> e, true
-        MemberExpression.AsExpr(object, expr, computed, ?loc=r)
+        Expression.memberExpression(object, expr, computed, ?loc=r)
 
     let rec getParts (parts: string list) (expr: Expression) =
         match parts with

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -841,7 +841,7 @@ module Util =
     let makeFunctionExpression name (args, (body: Expression), returnType, typeParamDecl): Expression =
         let id = name |> Option.map Identifier.Create
         let body = wrapExprInBlockWithReturn body
-        FunctionExpression.AsExpr(args, body, ?id=id, ?returnType=returnType, ?typeParameters=typeParamDecl)
+        Expression.functionExpression(args, body, ?id=id, ?returnType=returnType, ?typeParameters=typeParamDecl)
 
     let optimizeTailCall (com: IBabelCompiler) (ctx: Context) range (tc: ITailCallOpportunity) args =
         let rec checkCrossRefs tempVars allArgs = function
@@ -1080,7 +1080,7 @@ module Util =
                 |> Option.defaultValue (None, classMembers)
 
             let classBody = ClassBody.Create(List.toArray classMembers)
-            let classExpr = ClassExpression.AsExpr(classBody, ?superClass=baseExpr)
+            let classExpr = Expression.classExpression(classBody, ?superClass=baseExpr)
             Expression.newExpression(classExpr, [||])
 
     let transformCallArgs (com: IBabelCompiler) ctx hasSpread args =
@@ -1846,7 +1846,7 @@ module Util =
             else Array.empty
         let classMembers = Array.append [| classCons |] classMembers
         let classBody = ClassBody.Create([| yield! classFields; yield! classMembers |])
-        let classExpr = ClassExpression.AsExpr(classBody, ?superClass=baseExpr, ?typeParameters=typeParamDecl, ?implements=implements)
+        let classExpr = Expression.classExpression(classBody, ?superClass=baseExpr, ?typeParameters=typeParamDecl, ?implements=implements)
         classExpr |> declareModuleMember ent.IsPublic entName false
 
     let declareType (com: IBabelCompiler) ctx (ent: Fable.Entity) entName (consArgs: Pattern[]) (consBody: BlockStatement) baseExpr classMembers: ModuleDeclaration list =
@@ -1869,7 +1869,7 @@ module Util =
     let transformModuleFunction (com: IBabelCompiler) ctx (info: Fable.MemberInfo) (membName: string) args body =
         let args, body, returnType, typeParamDecl =
             getMemberArgsAndBody com ctx (NonAttached membName) info.HasSpread args body
-        let expr = FunctionExpression.AsExpr(args, body, ?returnType=returnType, ?typeParameters=typeParamDecl)
+        let expr = Expression.functionExpression(args, body, ?returnType=returnType, ?typeParameters=typeParamDecl)
         info.Attributes
         |> Seq.exists (fun att -> att.Entity.FullName = Atts.entryPoint)
         |> function
@@ -1883,7 +1883,7 @@ module Util =
                 | Declaration(VariableDeclaration(_)) -> true
                 | _ -> false)
         if hasVarDeclarations then
-            [ Expression.callExpression(FunctionExpression.AsExpr([||], BlockStatement.Create(statements)), [||])
+            [ Expression.callExpression(Expression.functionExpression([||], BlockStatement.Create(statements)), [||])
               |> ExpressionStatement |> PrivateModuleDeclaration ]
         else statements |> Array.mapToList (fun x -> PrivateModuleDeclaration(x))
 

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -50,10 +50,10 @@ type IBabelCompiler =
 // to become independent of the specific implementation
 module Lib =
     let libCall (com: IBabelCompiler) ctx r moduleName memberName args =
-        CallExpression.Create(com.TransformImport(ctx, memberName, getLibPath com moduleName), args, ?loc=r)
+        CallExpression.AsExpr(com.TransformImport(ctx, memberName, getLibPath com moduleName), args, ?loc=r)
 
     let libConsCall (com: IBabelCompiler) ctx r moduleName memberName args =
-        NewExpression.Create(com.TransformImport(ctx, memberName, getLibPath com moduleName), args, ?loc=r)
+        NewExpression.AsExpr(com.TransformImport(ctx, memberName, getLibPath com moduleName), args, ?loc=r)
 
     let libValue (com: IBabelCompiler) ctx moduleName memberName =
         com.TransformImport(ctx, memberName, getLibPath com moduleName)
@@ -77,36 +77,36 @@ module Reflection =
     let private transformRecordReflectionInfo com ctx r (ent: Fable.Entity) generics =
         // TODO: Refactor these three bindings to reuse in transformUnionReflectionInfo
         let fullname = ent.FullName
-        let fullnameExpr = StringLiteral.AsExpression(fullname)
+        let fullnameExpr = StringLiteral.AsExpr(fullname)
         let genMap =
             let genParamNames = ent.GenericParameters |> List.mapToArray (fun x -> x.Name) |> Seq.toArray
             Array.zip genParamNames generics |> Map
         let fields =
             ent.FSharpFields |> Seq.map (fun fi ->
                 let typeInfo = transformTypeInfo com ctx r genMap fi.FieldType
-                (ArrayExpression.Create([|StringLiteral.AsExpression(fi.Name); typeInfo|])))
+                (ArrayExpression.AsExpr([|StringLiteral.AsExpr(fi.Name); typeInfo|])))
             |> Seq.toArray
-        let fields = ArrowFunctionExpression.Create([||], ArrayExpression.Create(fields))
-        [|fullnameExpr; ArrayExpression.Create(generics); jsConstructor com ctx ent; fields|]
+        let fields = ArrowFunctionExpression.AsExpr([||], ArrayExpression.AsExpr(fields))
+        [|fullnameExpr; ArrayExpression.AsExpr(generics); jsConstructor com ctx ent; fields|]
         |> libReflectionCall com ctx None "record"
 
     let private transformUnionReflectionInfo com ctx r (ent: Fable.Entity) generics =
         let fullname = ent.FullName
-        let fullnameExpr = StringLiteral.AsExpression(fullname)
+        let fullnameExpr = StringLiteral.AsExpr(fullname)
         let genMap =
             let genParamNames = ent.GenericParameters |> List.map (fun x -> x.Name) |> Seq.toArray
             Array.zip genParamNames generics |> Map
         let cases =
             ent.UnionCases |> Seq.map (fun uci ->
                 uci.UnionCaseFields |> List.mapToArray (fun fi ->
-                    ArrayExpression.Create([|
-                        fi.Name |> StringLiteral.AsExpression
+                    ArrayExpression.AsExpr([|
+                        fi.Name |> StringLiteral.AsExpr
                         transformTypeInfo com ctx r genMap fi.FieldType
                     |]))
-                |> ArrayExpression.Create
+                |> ArrayExpression.AsExpr
             ) |> Seq.toArray
-        let cases = ArrowFunctionExpression.Create([||], ArrayExpression.Create(cases))
-        [|fullnameExpr; ArrayExpression.Create(generics); jsConstructor com ctx ent; cases|]
+        let cases = ArrowFunctionExpression.AsExpr([||], ArrayExpression.AsExpr(cases))
+        [|fullnameExpr; ArrayExpression.AsExpr(generics); jsConstructor com ctx ent; cases|]
         |> libReflectionCall com ctx None "union"
 
     let transformTypeInfo (com: IBabelCompiler) ctx r (genMap: Map<string, Expression>) t: Expression =
@@ -116,7 +116,7 @@ module Reflection =
             getNumberKindName kind
             |> primitiveTypeInfo
         let nonGenericTypeInfo fullname =
-            [| StringLiteral.AsExpression(fullname) |]
+            [| StringLiteral.AsExpr(fullname) |]
             |> libReflectionCall com ctx None "class"
         let resolveGenerics generics: Expression[] =
             generics |> Array.map (transformTypeInfo com ctx r genMap)
@@ -125,9 +125,9 @@ module Reflection =
             libReflectionCall com ctx None name resolved
         let genericEntity (fullname: string) generics =
             libReflectionCall com ctx None "class" [|
-                StringLiteral.AsExpression(fullname)
+                StringLiteral.AsExpr(fullname)
                 if not(Array.isEmpty generics) then
-                    ArrayExpression.Create(generics)
+                    ArrayExpression.AsExpr(generics)
             |]
         match t with
         | Fable.Any -> primitiveTypeInfo "obj"
@@ -136,7 +136,7 @@ module Reflection =
             | Some t -> t
             | None ->
                 Replacements.genericTypeInfoError name |> addError com [] r
-                NullLiteral.Create() |> Literal
+                NullLiteral.AsLiteral() |> Literal
         | Fable.Unit    -> primitiveTypeInfo "unit"
         | Fable.Boolean -> primitiveTypeInfo "bool"
         | Fable.Char    -> primitiveTypeInfo "char"
@@ -155,10 +155,10 @@ module Reflection =
                         None
                     | name ->
                         let value = match fi.LiteralValue with Some v -> System.Convert.ToDouble v | None -> 0.
-                        ArrayExpression.Create([|StringLiteral.AsExpression(name); NumericLiteral.AsExpression(value)|]) |> Some)
+                        ArrayExpression.AsExpr([|StringLiteral.AsExpr(name); NumericLiteral.AsExpr(value)|]) |> Some)
                 |> Seq.toArray
-                |> ArrayExpression.Create
-            [|StringLiteral.AsExpression(entRef.FullName); numberInfo numberKind; cases |]
+                |> ArrayExpression.AsExpr
+            [|StringLiteral.AsExpr(entRef.FullName); numberInfo numberKind; cases |]
             |> libReflectionCall com ctx None "enum"
         | Fable.Number kind ->
             numberInfo kind
@@ -175,7 +175,7 @@ module Reflection =
         | Fable.AnonymousRecordType(fieldNames, genArgs) ->
             let genArgs = resolveGenerics (List.toArray genArgs)
             Array.zip fieldNames genArgs
-            |> Array.map (fun (k, t) -> ArrayExpression.Create[|StringLiteral.AsExpression(k); t|])
+            |> Array.map (fun (k, t) -> ArrayExpression.AsExpr[|StringLiteral.AsExpr(k); t|])
             |> libReflectionCall com ctx None "anonRecord"
         | Fable.DeclaredType(entRef, generics) ->
             let fullName = entRef.FullName
@@ -227,7 +227,7 @@ module Reflection =
                 else
                     let reflectionMethodExpr = FSharp2Fable.Util.entityRefWithSuffix com ent Naming.reflectionSuffix
                     let callee = com.TransformAsExpr(ctx, reflectionMethodExpr)
-                    CallExpression.Create(callee, generics)
+                    CallExpression.AsExpr(callee, generics)
 
     let transformReflectionInfo com ctx r (ent: Fable.Entity) generics =
         if ent.IsFSharpRecord then
@@ -237,10 +237,10 @@ module Reflection =
         else
             let fullname = ent.FullName
             [|
-                yield StringLiteral.AsExpression(fullname)
+                yield StringLiteral.AsExpr(fullname)
                 match generics with
                 | [||] -> yield Util.undefined None
-                | generics -> yield ArrayExpression.Create(generics)
+                | generics -> yield ArrayExpression.AsExpr(generics)
                 match tryJsConstructor com ctx ent with
                 | Some cons -> yield cons
                 | None -> ()
@@ -256,8 +256,8 @@ module Reflection =
             |]
             |> libReflectionCall com ctx r "class"
 
-    let private ofString s = StringLiteral.AsExpression(s)
-    let private ofArray babelExprs = ArrayExpression.Create(List.toArray babelExprs)
+    let private ofString s = StringLiteral.AsExpr(s)
+    let private ofArray babelExprs = ArrayExpression.AsExpr(List.toArray babelExprs)
 
     let transformTypeTest (com: IBabelCompiler) ctx range expr (typ: Fable.Type): Expression =
         let warnAndEvalToFalse msg =
@@ -267,19 +267,19 @@ module Reflection =
             |> Literal
 
         let jsTypeof (primitiveType: string) (Util.TransformExpr com ctx expr): Expression =
-            let typeof = UnaryExpression.Create(UnaryTypeof, expr)
-            BinaryExpression.Create(BinaryEqualStrict, typeof, StringLiteral.AsExpression(primitiveType), ?loc=range)
+            let typeof = UnaryExpression.AsExpr(UnaryTypeof, expr)
+            BinaryExpression.AsExpr(BinaryEqualStrict, typeof, StringLiteral.AsExpr(primitiveType), ?loc=range)
 
         let jsInstanceof consExpr (Util.TransformExpr com ctx expr): Expression =
-            BinaryExpression.Create(BinaryInstanceOf, expr, consExpr, ?loc=range)
+            BinaryExpression.AsExpr(BinaryInstanceOf, expr, consExpr, ?loc=range)
 
         match typ with
         | Fable.Any -> BooleanLiteral.Create(true) |> Literal
-        | Fable.Unit -> BinaryExpression.Create(BinaryEqual, com.TransformAsExpr(ctx, expr), Util.undefined None, ?loc=range)
+        | Fable.Unit -> BinaryExpression.AsExpr(BinaryEqual, com.TransformAsExpr(ctx, expr), Util.undefined None, ?loc=range)
         | Fable.Boolean -> jsTypeof "boolean" expr
         | Fable.Char | Fable.String _ -> jsTypeof "string" expr
         | Fable.Number _ | Fable.Enum _ -> jsTypeof "number" expr
-        | Fable.Regex -> jsInstanceof (Identifier.AsExpression("RegExp")) expr
+        | Fable.Regex -> jsInstanceof (Identifier.AsExpr("RegExp")) expr
         | Fable.LambdaType _ | Fable.DelegateType _ -> jsTypeof "function" expr
         | Fable.Array _ | Fable.Tuple _ ->
             libCall com ctx None "Util" "isArrayLike" [|com.TransformAsExpr(ctx, expr)|]
@@ -344,7 +344,7 @@ module Annotation =
         else
             genParams
             |> Set.toArray
-            |> Array.map (Identifier.Create >> GenericTypeAnnotation.Create)
+            |> Array.map (Identifier.Create >> GenericTypeAnnotation.AsTypeAnnotationInfo)
             |> TypeParameterInstantiation.Create |> Some
 
     let mergeTypeParamDecls (decl1: TypeParameterDeclaration option) (decl2: TypeParameterDeclaration option) =
@@ -362,7 +362,7 @@ module Annotation =
 
     let getGenericTypeAnnotation _com _ctx name genParams =
         let typeParamInst = makeTypeParamInst genParams
-        GenericTypeAnnotation.Create(Identifier.Create(name), ?typeParameters=typeParamInst)
+        GenericTypeAnnotation.AsTypeAnnotationInfo(Identifier.Create(name), ?typeParameters=typeParamInst)
         |> TypeAnnotation.Create |> Some
 
     let typeAnnotation com ctx typ: TypeAnnotationInfo =
@@ -390,7 +390,7 @@ module Annotation =
             makeAnonymousRecordTypeAnnotation com ctx fieldNames genArgs
 
     let makeSimpleTypeAnnotation _com _ctx name =
-        GenericTypeAnnotation.Create(Identifier.Create(name))
+        GenericTypeAnnotation.AsTypeAnnotationInfo(Identifier.Create(name))
 
     let makeGenTypeParamInst com ctx genArgs =
         match genArgs with
@@ -400,7 +400,7 @@ module Annotation =
 
     let makeGenericTypeAnnotation com ctx genArgs id =
         let typeParamInst = makeGenTypeParamInst com ctx genArgs
-        GenericTypeAnnotation.Create(id, ?typeParameters=typeParamInst)
+        GenericTypeAnnotation.AsTypeAnnotationInfo(id, ?typeParameters=typeParamInst)
 
     let makeNativeTypeAnnotation com ctx genArgs typeName =
         Identifier.Create(typeName)
@@ -425,7 +425,7 @@ module Annotation =
 
     let makeTupleTypeAnnotation com ctx genArgs =
         List.map (typeAnnotation com ctx) genArgs
-        |> List.toArray |> TupleTypeAnnotation.Create
+        |> List.toArray |> TupleTypeAnnotation.AsTypeAnnotationInfo
 
     let makeArrayTypeAnnotation com ctx genArg =
         match genArg with
@@ -440,7 +440,7 @@ module Annotation =
 
     let makeUnionTypeAnnotation com ctx genArgs =
         List.map (typeAnnotation com ctx) genArgs
-        |> List.toArray |> UnionTypeAnnotation.Create
+        |> List.toArray |> UnionTypeAnnotation.AsTypeAnnotationInfo
 
     let makeBuiltinTypeAnnotation com ctx kind =
         match kind with
@@ -475,7 +475,7 @@ module Annotation =
         let ctx = { ctx with ScopedTypeParams = Set.union ctx.ScopedTypeParams newTypeParams }
         let returnType = typeAnnotation com ctx returnType
         let typeParamDecl = makeTypeParamDecl newTypeParams
-        FunctionTypeAnnotation.Create(funcTypeParams, returnType, ?typeParameters=typeParamDecl)
+        FunctionTypeAnnotation.AsTypeAnnotationInfo(funcTypeParams, returnType, ?typeParameters=typeParamDecl)
 
     let makeEntityTypeAnnotation com ctx (ent: Fable.EntityRef) genArgs =
         match ent.FullName with
@@ -614,33 +614,33 @@ module Util =
 
     let addErrorAndReturnNull (com: Compiler) (range: SourceLocation option) (error: string) =
         addError com [] range error
-        NullLiteral.Create()
+        NullLiteral.AsLiteral()
 
     let ident (id: Fable.Ident) =
         Identifier.Create(id.Name, ?loc=id.Range)
 
     let identAsExpr (id: Fable.Ident) =
-        Identifier.AsExpression(id.Name, ?loc=id.Range)
+        Identifier.AsExpr(id.Name, ?loc=id.Range)
 
     let identAsPattern (id: Fable.Ident) =
         Identifier.AsPattern(id.Name, ?loc=id.Range)
 
     let thisExpr =
-        ThisExpression.Create()
+        ThisExpression.AsExpr()
 
     let ofInt i =
-        NumericLiteral.Create(float i) |> Literal
+        NumericLiteral.AsLiteral(float i) |> Literal
 
     let ofString s =
-       StringLiteral.AsExpression(s)
+       StringLiteral.AsExpr(s)
 
     let memberFromName (memberName: string): Expression * bool =
         match memberName with
-        | "ToString" -> Identifier.AsExpression("toString"), false
+        | "ToString" -> Identifier.AsExpr("toString"), false
         | n when n.StartsWith("Symbol.") ->
-            MemberExpression.Create(Identifier.AsExpression("Symbol"), Identifier.AsExpression(n.[7..]), false), true
-        | n when Naming.hasIdentForbiddenChars n -> StringLiteral.AsExpression(n), true
-        | n -> Identifier.AsExpression(n), false
+            MemberExpression.AsExpr(Identifier.AsExpr("Symbol"), Identifier.AsExpr(n.[7..]), false), true
+        | n when Naming.hasIdentForbiddenChars n -> StringLiteral.AsExpr(n), true
+        | n -> Identifier.AsExpr(n), false
 
     let memberFromExpr (com: IBabelCompiler) ctx memberExpr: Expression * bool =
         match memberExpr with
@@ -649,14 +649,14 @@ module Util =
 
     let get r left memberName =
         let expr, computed = memberFromName memberName
-        MemberExpression.Create(left, expr, computed, ?loc=r)
+        MemberExpression.AsExpr(left, expr, computed, ?loc=r)
 
     let getExpr r (object: Expression) (expr: Expression) =
         let expr, computed =
             match expr with
             | Literal(StringLiteral(e)) -> memberFromName e.Value
             | e -> e, true
-        MemberExpression.Create(object, expr, computed, ?loc=r)
+        MemberExpression.AsExpr(object, expr, computed, ?loc=r)
 
     let rec getParts (parts: string list) (expr: Expression) =
         match parts with
@@ -671,55 +671,55 @@ module Util =
 
     let makeArray (com: IBabelCompiler) ctx exprs =
         List.mapToArray (fun e -> com.TransformAsExpr(ctx, e)) exprs
-        |> ArrayExpression.Create
+        |> ArrayExpression.AsExpr
 
     let makeTypedArray (com: IBabelCompiler) ctx t (args: Fable.Expr list) =
         match t with
         | Fable.Number kind when com.Options.TypedArrays ->
             let jsName = getTypedArrayName com kind
             let args = [|makeArray com ctx args|]
-            NewExpression.Create(Identifier.AsExpression(jsName), args)
+            NewExpression.AsExpr(Identifier.AsExpr(jsName), args)
         | _ -> makeArray com ctx args
 
     let makeTypedAllocatedFrom (com: IBabelCompiler) ctx typ (fableExpr: Fable.Expr) =
         let getArrayCons t =
             match t with
             | Fable.Number kind when com.Options.TypedArrays ->
-                getTypedArrayName com kind |> Identifier.AsExpression
-            | _ -> Identifier.AsExpression("Array")
+                getTypedArrayName com kind |> Identifier.AsExpr
+            | _ -> Identifier.AsExpr("Array")
 
         match fableExpr with
         | ExprType(Fable.Number _) ->
             let cons = getArrayCons typ
             let expr = com.TransformAsExpr(ctx, fableExpr)
-            NewExpression.Create(cons, [|expr|])
+            NewExpression.AsExpr(cons, [|expr|])
         | Replacements.ArrayOrListLiteral(exprs, _) ->
             makeTypedArray com ctx typ exprs
         | _ ->
             let cons = getArrayCons typ
             let expr = com.TransformAsExpr(ctx, fableExpr)
-            CallExpression.Create(get None cons "from", [|expr|])
+            CallExpression.AsExpr(get None cons "from", [|expr|])
 
     let makeStringArray strings =
         strings
-        |> List.mapToArray (fun x -> StringLiteral.AsExpression(x))
-        |> ArrayExpression.Create
+        |> List.mapToArray (fun x -> StringLiteral.AsExpr(x))
+        |> ArrayExpression.AsExpr
 
     let makeJsObject pairs =
         pairs |> Seq.map (fun (name, value) ->
             let prop, computed = memberFromName name
-            ObjectProperty.Create(prop, value, computed_=computed))
+            ObjectProperty.AsObjectMember(prop, value, computed_=computed))
         |> Seq.toArray
-        |> ObjectExpression.Create
+        |> ObjectExpression.AsExpr
 
     let assign range left right =
-        AssignmentExpression.Create(AssignEqual, left, right, ?loc=range)
+        AssignmentExpression.AsExpr(AssignEqual, left, right, ?loc=range)
 
     /// Immediately Invoked Function Expression
     let iife (com: IBabelCompiler) ctx (expr: Fable.Expr) =
         let _, body = com.TransformFunction(ctx, None, [], expr)
         // Use an arrow function in case we need to capture `this`
-        CallExpression.Create(ArrowFunctionExpression.Create([||], body), [||])
+        CallExpression.AsExpr(ArrowFunctionExpression.AsExpr([||], body), [||])
 
     let multiVarDeclaration kind (variables: (Identifier * Expression option) list) =
         let varDeclarators =
@@ -735,30 +735,30 @@ module Util =
         VariableDeclaration.Create(var, value, kind)
 
     let restElement (var: Pattern) =
-        RestElement.Create(var)
+        RestElement.AsPattern(var)
 
     let callSuper (args: Expression list) =
-        CallExpression.Create(Super.Create(), List.toArray args)
+        CallExpression.AsExpr(Super.AsExpr(), List.toArray args)
 
     let callSuperAsStatement (args: Expression list) =
-        ExpressionStatement.Create(callSuper args)
+        ExpressionStatement.AsStatement(callSuper args)
 
     let makeClassConstructor args body =
-        ClassMethod.Create(ClassImplicitConstructor, Identifier.AsExpression("constructor"), args, body)
+        ClassMethod.AsClassMember(ClassImplicitConstructor, Identifier.AsExpr("constructor"), args, body)
 
     let callFunction r funcExpr (args: Expression list) =
-        CallExpression.Create(funcExpr, List.toArray args, ?loc=r)
+        CallExpression.AsExpr(funcExpr, List.toArray args, ?loc=r)
 
     let callFunctionWithThisContext r funcExpr (args: Expression list) =
-        let args = (Identifier.AsExpression("this"))::args |> List.toArray
-        CallExpression.Create(get None funcExpr "call", args, ?loc=r)
+        let args = (Identifier.AsExpr("this"))::args |> List.toArray
+        CallExpression.AsExpr(get None funcExpr "call", args, ?loc=r)
 
     let emitExpression range (txt: string) args =
-        EmitExpression.Create(txt, List.toArray args, ?loc=range)
+        EmitExpression.AsExpr(txt, List.toArray args, ?loc=range)
 
     let undefined range =
 //        Undefined(?loc=range) :> Expression
-        UnaryExpression.Create(UnaryVoid, NumericLiteral.Create(0.) |> Literal, ?loc=range)
+        UnaryExpression.AsExpr(UnaryVoid, NumericLiteral.AsLiteral(0.) |> Literal, ?loc=range)
 
     let getGenericTypeParams (types: Fable.Type list) =
         let rec getGenParams = function
@@ -820,7 +820,7 @@ module Util =
         match uci.CompiledName with Some cname -> cname | None -> uci.Name
 
     let getUnionExprTag r expr =
-        getExpr r expr (StringLiteral.AsExpression("tag"))
+        getExpr r expr (StringLiteral.AsExpr("tag"))
 
     /// Wrap int expressions with `| 0` to help optimization of JS VMs
     let wrapIntExpression typ (e: Expression) =
@@ -829,19 +829,19 @@ module Util =
         // TODO: Unsigned ints seem to cause problems, should we check only Int32 here?
         | _, Fable.Number(Int8 | Int16 | Int32)
         | _, Fable.Enum _ ->
-            BinaryExpression.Create(BinaryOrBitwise, e, NumericLiteral.Create(0.) |> Literal)
+            BinaryExpression.AsExpr(BinaryOrBitwise, e, NumericLiteral.AsLiteral(0.) |> Literal)
         | _ -> e
 
     let wrapExprInBlockWithReturn e =
-        BlockStatement.Create([|ReturnStatement.Create(e)|])
+        BlockStatement.Create([|ReturnStatement.AsStatement(e)|])
 
     let makeArrowFunctionExpression _name (args, (body: BlockStatement), returnType, typeParamDecl): Expression =
-        ArrowFunctionExpression.Create(args, body, ?returnType=returnType, ?typeParameters=typeParamDecl)
+        ArrowFunctionExpression.AsExpr(args, body, ?returnType=returnType, ?typeParameters=typeParamDecl)
 
     let makeFunctionExpression name (args, (body: Expression), returnType, typeParamDecl): Expression =
         let id = name |> Option.map Identifier.Create
         let body = wrapExprInBlockWithReturn body
-        FunctionExpression.Create(args, body, ?id=id, ?returnType=returnType, ?typeParameters=typeParamDecl)
+        FunctionExpression.AsExpr(args, body, ?id=id, ?returnType=returnType, ?typeParameters=typeParamDecl)
 
     let optimizeTailCall (com: IBabelCompiler) (ctx: Context) range (tc: ITailCallOpportunity) args =
         let rec checkCrossRefs tempVars allArgs = function
@@ -863,14 +863,14 @@ module Util =
         [|
             // First declare temp variables
             for (KeyValue(argId, tempVar)) in tempVars do
-                yield varDeclaration (Identifier.AsPattern(tempVar)) false (Identifier.AsExpression(argId)) |> VariableDeclaration |> Declaration
+                yield varDeclaration (Identifier.AsPattern(tempVar)) false (Identifier.AsExpr(argId)) |> VariableDeclaration |> Declaration
             // Then assign argument expressions to the original argument identifiers
             // See https://github.com/fable-compiler/Fable/issues/1368#issuecomment-434142713
             for (argId, arg) in zippedArgs do
                 let arg = FableTransforms.replaceValues tempVarReplacements arg
                 let arg = com.TransformAsExpr(ctx, arg)
-                yield assign None (Identifier.AsExpression(argId)) arg |> ExpressionStatement.Create
-            yield ContinueStatement.Create(Identifier.Create(tc.Label), ?loc=range)
+                yield assign None (Identifier.AsExpr(argId)) arg |> ExpressionStatement.AsStatement
+            yield ContinueStatement.AsStatement(Identifier.Create(tc.Label), ?loc=range)
         |]
 
     let transformImport (com: IBabelCompiler) ctx r (selector: string) (path: string) =
@@ -915,22 +915,22 @@ module Util =
 
     let transformValue (com: IBabelCompiler) (ctx: Context) r value: Expression =
         match value with
-        | Fable.BaseValue(None,_) -> Super.Create()
+        | Fable.BaseValue(None,_) -> Super.AsExpr()
         | Fable.BaseValue(Some boundIdent,_) -> identAsExpr boundIdent
-        | Fable.ThisValue _ -> ThisExpression.Create()
+        | Fable.ThisValue _ -> ThisExpression.AsExpr()
         | Fable.TypeInfo t -> transformTypeInfo com ctx r Map.empty t
         | Fable.Null _t ->
             // if com.Options.typescript
             //     let ta = typeAnnotation com ctx t |> TypeAnnotation |> Some
             //     upcast Identifier("null", ?typeAnnotation=ta, ?loc=r)
             // else
-                NullLiteral.Create(?loc=r) |> Literal
+                NullLiteral.AsLiteral(?loc=r) |> Literal
         | Fable.UnitConstant -> undefined r
         | Fable.BoolConstant x -> BooleanLiteral.Create(x, ?loc=r)  |> Literal
-        | Fable.CharConstant x -> StringLiteral.AsExpression(string x, ?loc=r)
-        | Fable.StringConstant x -> StringLiteral.AsExpression(x, ?loc=r)
-        | Fable.NumberConstant (x,_) -> NumericLiteral.Create(x, ?loc=r) |> Literal
-        | Fable.RegexConstant (source, flags) -> RegExpLiteral.Create(source, flags, ?loc=r) |> Literal
+        | Fable.CharConstant x -> StringLiteral.AsExpr(string x, ?loc=r)
+        | Fable.StringConstant x -> StringLiteral.AsExpr(x, ?loc=r)
+        | Fable.NumberConstant (x,_) -> NumericLiteral.AsLiteral(x, ?loc=r) |> Literal
+        | Fable.RegexConstant (source, flags) -> RegExpLiteral.AsLiteral(source, flags, ?loc=r) |> Literal
         | Fable.NewArray (values, typ) -> makeTypedArray com ctx typ values
         | Fable.NewArrayFrom (size, typ) -> makeTypedAllocatedFrom com ctx typ size
         | Fable.NewTuple vals -> makeArray com ctx vals
@@ -971,7 +971,7 @@ module Util =
                 if com.Options.Typescript && (ent.FullName = Types.reference)
                 then makeGenTypeParamInst com ctx genArgs
                 else None
-            NewExpression.Create(consRef, values, ?typeArguments=typeParamInst, ?loc=r)
+            NewExpression.AsExpr(consRef, values, ?typeArguments=typeParamInst, ?loc=r)
         | Fable.NewAnonymousRecord(values, fieldNames, _genArgs) ->
             let values = List.mapToArray (fun x -> com.TransformAsExpr(ctx, x)) values
             Array.zip fieldNames values
@@ -985,11 +985,11 @@ module Util =
                 else None
             // let caseName = ent.UnionCases |> List.item tag |> getUnionCaseName |> ofString
             let values = (ofInt tag)::values |> List.toArray
-            NewExpression.Create(consRef, values, ?typeArguments=typeParamInst, ?loc=r)
+            NewExpression.AsExpr(consRef, values, ?typeArguments=typeParamInst, ?loc=r)
 
     let enumerator2iterator com ctx =
-        let enumerator = CallExpression.Create(get None (Identifier.AsExpression("this")) "GetEnumerator", [||])
-        BlockStatement.Create([|ReturnStatement.Create(libCall com ctx None "Seq" "toIterator" [|enumerator|])|])
+        let enumerator = CallExpression.AsExpr(get None (Identifier.AsExpr("this")) "GetEnumerator", [||])
+        BlockStatement.Create([|ReturnStatement.AsStatement(libCall com ctx None "Seq" "toIterator" [|enumerator|])|])
 
     let extractBaseExprFromBaseCall (com: IBabelCompiler) (ctx: Context) (baseType: Fable.DeclaredType option) baseCall =
         match baseCall, baseType with
@@ -1027,7 +1027,7 @@ module Util =
         let makeMethod kind prop computed hasSpread args body =
             let args, body, returnType, typeParamDecl =
                 getMemberArgsAndBody com ctx (Attached(isStatic=false)) hasSpread args body
-            ObjectMethod.Create(kind, prop, args, body, computed_=computed,
+            ObjectMethod.AsObjectMember(kind, prop, args, body, computed_=computed,
                 ?returnType=returnType, ?typeParameters=typeParamDecl)
 
         let members =
@@ -1037,7 +1037,7 @@ module Util =
                 // If compileAsClass is false, it means getters don't have side effects
                 // and can be compiled as object fields (see condition above)
                 if info.IsValue || (not compileAsClass && info.IsGetter) then
-                    [ObjectProperty.Create(prop, com.TransformAsExpr(ctx, memb.Body), computed_=computed)]
+                    [ObjectProperty.AsObjectMember(prop, com.TransformAsExpr(ctx, memb.Body), computed_=computed)]
                 elif info.IsGetter then
                     [makeMethod ObjectGetter prop computed false memb.Args memb.Body]
                 elif info.IsSetter then
@@ -1047,26 +1047,26 @@ module Util =
                     let iterator =
                         let prop, computed = memberFromName "Symbol.iterator"
                         let body = enumerator2iterator com ctx
-                        ObjectMethod.Create(ObjectMeth, prop, [||], body, computed_=computed)
+                        ObjectMethod.AsObjectMember(ObjectMeth, prop, [||], body, computed_=computed)
                     [method; iterator]
                 else
                     [makeMethod ObjectMeth prop computed info.HasSpread memb.Args memb.Body]
             )
 
         if not compileAsClass then
-            ObjectExpression.Create(List.toArray  members)
+            ObjectExpression.AsExpr(List.toArray  members)
         else
             let classMembers =
                 members |> List.choose (function
                     | ObjectProperty(m) ->
-                        ClassProperty.Create(m.Key, m.Value, computed_=m.Computed) |> Some
+                        ClassProperty.AsClassMember(m.Key, m.Value, computed_=m.Computed) |> Some
                     | ObjectMethod(m) ->
                         let kind =
                             match m.Kind with
                             | "get" -> ClassGetter
                             | "set" -> ClassSetter
                             | _ -> ClassFunction
-                        ClassMethod.Create(kind, m.Key, m.Params, m.Body, computed_=m.Computed,
+                        ClassMethod.AsClassMember(kind, m.Key, m.Params, m.Body, computed_=m.Computed,
                             ?returnType=m.ReturnType, ?typeParameters=m.TypeParameters) |> Some)
 
             let baseExpr, classMembers =
@@ -1080,8 +1080,8 @@ module Util =
                 |> Option.defaultValue (None, classMembers)
 
             let classBody = ClassBody.Create(List.toArray classMembers)
-            let classExpr = ClassExpression.Create(classBody, ?superClass=baseExpr)
-            NewExpression.Create(classExpr, [||])
+            let classExpr = ClassExpression.AsExpr(classBody, ?superClass=baseExpr)
+            NewExpression.AsExpr(classExpr, [||])
 
     let transformCallArgs (com: IBabelCompiler) ctx hasSpread args =
         match args with
@@ -1095,27 +1095,27 @@ module Util =
                 rest @ (List.map (fun e -> com.TransformAsExpr(ctx, e)) spreadArgs)
             | last::rest ->
                 let rest = List.rev rest |> List.map (fun e -> com.TransformAsExpr(ctx, e))
-                rest @ [SpreadElement.Create(com.TransformAsExpr(ctx, last))]
+                rest @ [SpreadElement.AsExpr(com.TransformAsExpr(ctx, last))]
         | args -> List.map (fun e -> com.TransformAsExpr(ctx, e)) args
 
     let resolveExpr t strategy babelExpr: Statement =
         match strategy with
-        | None | Some ReturnUnit -> ExpressionStatement.Create(babelExpr)
+        | None | Some ReturnUnit -> ExpressionStatement.AsStatement(babelExpr)
         // TODO: Where to put these int wrappings? Add them also for function arguments?
-        | Some Return -> ReturnStatement.Create(wrapIntExpression t babelExpr)
-        | Some(Assign left) -> ExpressionStatement.Create(assign None left babelExpr)
-        | Some(Target left) -> ExpressionStatement.Create(assign None (left |> Identifier) babelExpr)
+        | Some Return -> ReturnStatement.AsStatement(wrapIntExpression t babelExpr)
+        | Some(Assign left) -> ExpressionStatement.AsStatement(assign None left babelExpr)
+        | Some(Target left) -> ExpressionStatement.AsStatement(assign None (left |> Identifier) babelExpr)
 
     let transformOperation com ctx range opKind: Expression =
         match opKind with
         | Fable.Unary(op, TransformExpr com ctx expr) ->
-            UnaryExpression.Create(op, expr, ?loc=range)
+            UnaryExpression.AsExpr(op, expr, ?loc=range)
 
         | Fable.Binary(op, TransformExpr com ctx left, TransformExpr com ctx right) ->
-            BinaryExpression.Create(op, left, right, ?loc=range)
+            BinaryExpression.AsExpr(op, left, right, ?loc=range)
 
         | Fable.Logical(op, TransformExpr com ctx left, TransformExpr com ctx right) ->
-            LogicalExpression.Create(op, left, right, ?loc=range)
+            LogicalExpression.AsExpr(op, left, right, ?loc=range)
 
     let transformEmit (com: IBabelCompiler) ctx range (info: Fable.EmitInfo) =
         let macro = info.Macro
@@ -1130,7 +1130,7 @@ module Util =
         let args = transformCallArgs com ctx callInfo.HasSpread callInfo.Args
         match callInfo.ThisArg with
         | Some(TransformExpr com ctx thisArg) -> callFunction range callee (thisArg::args)
-        | None when callInfo.IsJsConstructor -> NewExpression.Create(callee, List.toArray args, ?loc=range)
+        | None when callInfo.IsJsConstructor -> NewExpression.AsExpr(callee, List.toArray args, ?loc=range)
         | None -> callFunction range callee args
 
     let transformCurriedApply com ctx range (TransformExpr com ctx applied) args =
@@ -1175,7 +1175,7 @@ module Util =
                 CatchClause.Create(identAsPattern param, transformBlock com ctx returnStrategy body))
         let finalizer =
             finalizer |> Option.map (transformBlock com ctx None)
-        [|TryStatement.Create(transformBlock com ctx returnStrategy body,
+        [|TryStatement.AsStatement(transformBlock com ctx returnStrategy body,
             ?handler=handler, ?finalizer=finalizer, ?loc=r)|]
 
     let rec transformIfStatement (com: IBabelCompiler) ctx r ret guardExpr thenStmnt elseStmnt =
@@ -1187,9 +1187,9 @@ module Util =
         | guardExpr ->
             let thenStmnt = transformBlock com ctx ret thenStmnt
             match com.TransformAsStatements(ctx, ret, elseStmnt) with
-            | [||] -> IfStatement.Create(guardExpr, thenStmnt, ?loc=r)
-            | [|elseStmnt|] -> IfStatement.Create(guardExpr, thenStmnt, elseStmnt, ?loc=r)
-            | statements -> IfStatement.Create(guardExpr, thenStmnt, BlockStatement.AsStatement(statements), ?loc=r)
+            | [||] -> IfStatement.AsStatement(guardExpr, thenStmnt, ?loc=r)
+            | [|elseStmnt|] -> IfStatement.AsStatement(guardExpr, thenStmnt, elseStmnt, ?loc=r)
+            | statements -> IfStatement.AsStatement(guardExpr, thenStmnt, BlockStatement.AsStatement(statements), ?loc=r)
             |> Array.singleton
 
     let transformGet (com: IBabelCompiler) ctx range typ fableExpr (getKind: Fable.GetKind) =
@@ -1230,7 +1230,7 @@ module Util =
 
         | Fable.UnionField(idx, _) ->
             let expr = com.TransformAsExpr(ctx, fableExpr)
-            getExpr range (getExpr None expr (StringLiteral.AsExpression("fields"))) (ofInt idx)
+            getExpr range (getExpr None expr (StringLiteral.AsExpr("fields"))) (ofInt idx)
 
     let transformSet (com: IBabelCompiler) ctx range var (value: Fable.Expr) setKind =
         let var = com.TransformAsExpr(ctx, var)
@@ -1272,15 +1272,15 @@ module Util =
             transformTypeTest com ctx range expr t
         | Fable.OptionTest nonEmpty ->
             let op = if nonEmpty then BinaryUnequal else BinaryEqual
-            BinaryExpression.Create(op, com.TransformAsExpr(ctx, expr), NullLiteral.AsExpression(), ?loc=range)
+            BinaryExpression.AsExpr(op, com.TransformAsExpr(ctx, expr), NullLiteral.AsExpr(), ?loc=range)
         | Fable.ListTest nonEmpty ->
             let expr = com.TransformAsExpr(ctx, expr)
             let op = if nonEmpty then BinaryUnequal else BinaryEqual
-            BinaryExpression.Create(op, get None expr "tail", NullLiteral.AsExpression(), ?loc=range)
+            BinaryExpression.AsExpr(op, get None expr "tail", NullLiteral.AsExpr(), ?loc=range)
         | Fable.UnionCaseTest tag ->
             let expected = ofInt tag
             let actual = com.TransformAsExpr(ctx, expr) |> getUnionExprTag None
-            BinaryExpression.Create(BinaryEqualStrict, actual, expected, ?loc=range)
+            BinaryExpression.AsExpr(BinaryEqualStrict, actual, expected, ?loc=range)
 
     let transformSwitch (com: IBabelCompiler) ctx useBlocks returnStrategy evalExpr cases defaultCase: Statement =
         let consequent caseBody =
@@ -1298,7 +1298,7 @@ module Util =
                     let caseBody =
                         match returnStrategy with
                         | Some Return -> caseBody
-                        | _ -> Array.append caseBody [|BreakStatement.Create()|]
+                        | _ -> Array.append caseBody [|BreakStatement.AsStatement()|]
                     guards @ [SwitchCase.Create(consequent caseBody, com.TransformAsExpr(ctx, lastGuard))]
                 )
         let cases =
@@ -1307,7 +1307,7 @@ module Util =
                 let defaultCaseBody = com.TransformAsStatements(ctx, returnStrategy, expr)
                 cases @ [SwitchCase.Create(consequent defaultCaseBody)]
             | None -> cases
-        SwitchStatement.Create(com.TransformAsExpr(ctx, evalExpr), List.toArray cases)
+        SwitchStatement.AsStatement(com.TransformAsExpr(ctx, evalExpr), List.toArray cases)
 
     let matchTargetIdentAndValues idents values =
         if List.isEmpty idents then []
@@ -1345,8 +1345,8 @@ module Util =
             let assignments =
                 matchTargetIdentAndValues idents boundValues
                 |> List.mapToArray (fun (id, TransformExpr com ctx value) ->
-                    assign None (identAsExpr id) value |> ExpressionStatement.Create)
-            let targetAssignment = assign None (targetId |> Identifier) (ofInt targetIndex) |> ExpressionStatement.Create
+                    assign None (identAsExpr id) value |> ExpressionStatement.AsStatement)
+            let targetAssignment = assign None (targetId |> Identifier) (ofInt targetIndex) |> ExpressionStatement.AsStatement
             Array.append [|targetAssignment|] assignments
         | ret ->
             let bindings, target = getDecisionTargetAndBindValues com ctx targetIndex boundValues
@@ -1551,7 +1551,7 @@ module Util =
         | Fable.IfThenElse(TransformExpr com ctx guardExpr,
                            TransformExpr com ctx thenExpr,
                            TransformExpr com ctx elseExpr, r) ->
-            ConditionalExpression.Create(guardExpr, thenExpr, elseExpr, ?loc=r)
+            ConditionalExpression.AsExpr(guardExpr, thenExpr, elseExpr, ?loc=r)
 
         | Fable.DecisionTree(expr, targets) ->
             transformDecisionTreeAsExpr com ctx targets expr
@@ -1565,19 +1565,19 @@ module Util =
         | Fable.Let(ident, value, body) ->
             if ctx.HoistVars [ident] then
                 let assignment = transformBindingAsExpr com ctx ident value
-                SequenceExpression.Create([|assignment; com.TransformAsExpr(ctx, body)|])
+                SequenceExpression.AsExpr([|assignment; com.TransformAsExpr(ctx, body)|])
             else iife com ctx expr
 
         | Fable.LetRec(bindings, body) ->
             if ctx.HoistVars(List.map fst bindings) then
                 let values = bindings |> List.mapToArray (fun (id, value) ->
                     transformBindingAsExpr com ctx id value)
-                SequenceExpression.Create(Array.append values [|com.TransformAsExpr(ctx, body)|])
+                SequenceExpression.AsExpr(Array.append values [|com.TransformAsExpr(ctx, body)|])
             else iife com ctx expr
 
         | Fable.Sequential exprs ->
             List.mapToArray (fun e -> com.TransformAsExpr(ctx, e)) exprs
-            |> SequenceExpression.Create
+            |> SequenceExpression.AsExpr
 
         | Fable.Emit(info, _, range) ->
             if info.IsJsStatement then iife com ctx expr
@@ -1630,7 +1630,7 @@ module Util =
         | Fable.Emit(info, t, range) ->
             let e = transformEmit com ctx range info
             if info.IsJsStatement then
-                [|ExpressionStatement.Create(e)|] // Ignore the return strategy
+                [|ExpressionStatement.AsStatement(e)|] // Ignore the return strategy
             else [|resolveExpr t returnStrategy e|]
 
         | Fable.Operation(kind, t, range) ->
@@ -1670,7 +1670,7 @@ module Util =
                 let guardExpr' = transformAsExpr com ctx guardExpr
                 let thenExpr' = transformAsExpr com ctx thenExpr
                 let elseExpr' = transformAsExpr com ctx elseExpr
-                [|ConditionalExpression.Create(guardExpr', thenExpr', elseExpr', ?loc=r) |> resolveExpr thenExpr.Type returnStrategy|]
+                [|ConditionalExpression.AsExpr(guardExpr', thenExpr', elseExpr', ?loc=r) |> resolveExpr thenExpr.Type returnStrategy|]
 
         | Fable.Sequential statements ->
             let lasti = (List.length statements) - 1
@@ -1689,7 +1689,7 @@ module Util =
             transformDecisionTreeSuccessAsStatements com ctx returnStrategy idx boundValues
 
         | Fable.WhileLoop(TransformExpr com ctx guard, body, range) ->
-            [|WhileStatement.Create(guard, transformBlock com ctx None body, ?loc=range)|]
+            [|WhileStatement.AsStatement(guard, transformBlock com ctx None body, ?loc=range)|]
 
         | Fable.ForLoop (var, TransformExpr com ctx start, TransformExpr com ctx limit, body, isUp, range) ->
             let op1, op2 =
@@ -1699,11 +1699,11 @@ module Util =
 
             let a = start |> varDeclaration (typedIdent com ctx var |> IdentifierPattern) true
 
-            [|ForStatement.Create(
+            [|ForStatement.AsStatement(
                 transformBlock com ctx None body,
                 start |> varDeclaration (typedIdent com ctx var |> IdentifierPattern) true,
-                BinaryExpression.Create(op1, identAsExpr var, limit),
-                UpdateExpression.Create(op2, false, identAsExpr var), ?loc=range)|]
+                BinaryExpression.AsExpr(op1, identAsExpr var, limit),
+                UpdateExpression.AsExpr(op2, false, identAsExpr var), ?loc=range)|]
 
     let transformFunction com ctx name (args: Fable.Ident list) (body: Fable.Expr): Pattern array * BlockStatement =
         let tailcallChance =
@@ -1734,12 +1734,12 @@ module Util =
                 let varDecls =
                     List.zip args tc.Args
                     |> List.map (fun (id, tcArg) ->
-                        id |> typedIdent com ctx, Some (Identifier.AsExpression(tcArg)))
+                        id |> typedIdent com ctx, Some (Identifier.AsExpr(tcArg)))
                     |> multiVarDeclaration Const
                 let body = BlockStatement.Create(Array.append [|varDecls |> Declaration |] body.Body)
                 // Make sure we don't get trapped in an infinite loop, see #1624
-                let body = BlockStatement.Create(Array.append body.Body [|BreakStatement.Create()|])
-                args', LabeledStatement.Create(Identifier.Create(tc.Label), WhileStatement.Create(BooleanLiteral.AsExpression(true), body))
+                let body = BlockStatement.Create(Array.append body.Body [|BreakStatement.AsStatement()|])
+                args', LabeledStatement.AsStatement(Identifier.Create(tc.Label), WhileStatement.AsStatement(BooleanLiteral.AsExpr(true), body))
                 |> Array.singleton |> BlockStatement.Create
             | _ -> args |> List.map (typedIdent com ctx), body
         let body =
@@ -1751,10 +1751,10 @@ module Util =
 
     let declareEntryPoint _com _ctx (funcExpr: Expression) =
         let argv = emitExpression None "typeof process === 'object' ? process.argv.slice(2) : []" []
-        let main = CallExpression.Create(funcExpr, [|argv|])
+        let main = CallExpression.AsExpr(funcExpr, [|argv|])
         // Don't exit the process after leaving main, as there may be a server running
         // ExpressionStatement(emitExpression funcExpr.loc "process.exit($0)" [main], ?loc=funcExpr.loc)
-        PrivateModuleDeclaration.Create(ExpressionStatement.Create(main))
+        PrivateModuleDeclaration.AsModuleDeclaration(ExpressionStatement.AsStatement(main))
 
     let declareModuleMember isPublic membName isMutable (expr: Expression) =
         let membName' = Identifier.AsPattern(membName)
@@ -1762,7 +1762,7 @@ module Util =
         let decl: Declaration =
             match expr with
             | ClassExpression(e) ->
-                ClassDeclaration.Create(
+                ClassDeclaration.AsDeclaration(
                     e.Body,
                     ?id = Some membName,
                     ?superClass = e.SuperClass,
@@ -1770,13 +1770,13 @@ module Util =
                     ?superTypeParameters = e.SuperTypeParameters,
                     ?typeParameters = e.TypeParameters)
             | FunctionExpression(e) ->
-                FunctionDeclaration.Create(
+                FunctionDeclaration.AsDeclaration(
                     e.Params, e.Body, membName,
                     ?returnType = e.ReturnType,
                     ?typeParameters = e.TypeParameters)
             | _ -> varDeclaration membName' isMutable expr |> VariableDeclaration
-        if not isPublic then PrivateModuleDeclaration.Create(decl |> Declaration)
-        else ExportNamedDeclaration.Create(decl)
+        if not isPublic then PrivateModuleDeclaration.AsModuleDeclaration(decl |> Declaration)
+        else ExportNamedDeclaration.AsModuleDeclaration(decl)
 
     let makeEntityTypeParamDecl (com: IBabelCompiler) _ctx (ent: Fable.Entity) =
         if com.Options.Typescript then
@@ -1843,11 +1843,11 @@ module Util =
                 getEntityFieldsAsProps com ctx ent
                 |> Array.map (fun prop ->
                     let ta = prop.Value |> TypeAnnotation.Create |> Some
-                    ClassProperty.Create(prop.Key, ``static``=prop.Static, ?typeAnnotation=ta))
+                    ClassProperty.AsClassMember(prop.Key, ``static``=prop.Static, ?typeAnnotation=ta))
             else Array.empty
         let classMembers = Array.append [| classCons |] classMembers
         let classBody = ClassBody.Create([| yield! classFields; yield! classMembers |])
-        let classExpr = ClassExpression.Create(classBody, ?superClass=baseExpr, ?typeParameters=typeParamDecl, ?implements=implements)
+        let classExpr = ClassExpression.AsExpr(classBody, ?superClass=baseExpr, ?typeParameters=typeParamDecl, ?implements=implements)
         classExpr |> declareModuleMember ent.IsPublic entName false
 
     let declareType (com: IBabelCompiler) ctx (ent: Fable.Entity) entName (consArgs: Pattern[]) (consBody: BlockStatement) baseExpr classMembers: ModuleDeclaration list =
@@ -1870,7 +1870,7 @@ module Util =
     let transformModuleFunction (com: IBabelCompiler) ctx (info: Fable.MemberInfo) (membName: string) args body =
         let args, body, returnType, typeParamDecl =
             getMemberArgsAndBody com ctx (NonAttached membName) info.HasSpread args body
-        let expr = FunctionExpression.Create(args, body, ?returnType=returnType, ?typeParameters=typeParamDecl)
+        let expr = FunctionExpression.AsExpr(args, body, ?returnType=returnType, ?typeParameters=typeParamDecl)
         info.Attributes
         |> Seq.exists (fun att -> att.Entity.FullName = Atts.entryPoint)
         |> function
@@ -1884,9 +1884,9 @@ module Util =
                 | Declaration(VariableDeclaration(_)) -> true
                 | _ -> false)
         if hasVarDeclarations then
-            [ CallExpression.Create(FunctionExpression.Create([||], BlockStatement.Create(statements)), [||])
-              |> ExpressionStatement.Create |> PrivateModuleDeclaration.Create ]
-        else statements |> Array.mapToList (fun x -> PrivateModuleDeclaration.Create(x))
+            [ CallExpression.AsExpr(FunctionExpression.AsExpr([||], BlockStatement.Create(statements)), [||])
+              |> ExpressionStatement.AsStatement |> PrivateModuleDeclaration.AsModuleDeclaration ]
+        else statements |> Array.mapToList (fun x -> PrivateModuleDeclaration.AsModuleDeclaration(x))
 
     let transformAttachedProperty (com: IBabelCompiler) ctx (memb: Fable.MemberDecl) =
         let isStatic = not memb.Info.IsInstance
@@ -1894,14 +1894,14 @@ module Util =
         let args, body, _returnType, _typeParamDecl =
             getMemberArgsAndBody com ctx (Attached isStatic) false memb.Args memb.Body
         let key, computed = memberFromName memb.Name
-        ClassMethod.Create(kind, key, args, body, computed_=computed, ``static``=isStatic)
+        ClassMethod.AsClassMember(kind, key, args, body, computed_=computed, ``static``=isStatic)
         |> Array.singleton
 
     let transformAttachedMethod (com: IBabelCompiler) ctx (memb: Fable.MemberDecl) =
         let isStatic = not memb.Info.IsInstance
         let makeMethod name args body =
             let key, computed = memberFromName name
-            ClassMethod.Create(ClassFunction, key, args, body, computed_=computed, ``static``=isStatic)
+            ClassMethod.AsClassMember(ClassFunction, key, args, body, computed_=computed, ``static``=isStatic)
         let args, body, _returnType, _typeParamDecl =
             getMemberArgsAndBody com ctx (Attached isStatic) memb.Info.HasSpread memb.Args memb.Body
         [|
@@ -1923,9 +1923,9 @@ module Util =
                     let right =
                         match id.Type with
                         | Fable.Number _ ->
-                            BinaryExpression.Create(BinaryOrBitwise, identAsExpr id, NumericLiteral.AsExpression(0.))
+                            BinaryExpression.AsExpr(BinaryOrBitwise, identAsExpr id, NumericLiteral.AsExpr(0.))
                         | _ -> identAsExpr id
-                    assign None left right |> ExpressionStatement.Create)
+                    assign None left right |> ExpressionStatement.AsStatement)
             |])
         let cases =
             let body =
@@ -1933,10 +1933,10 @@ module Util =
                 |> Seq.map (getUnionCaseName >> makeStrConst)
                 |> Seq.toList
                 |> makeArray com ctx
-                |> ReturnStatement.Create
+                |> ReturnStatement.AsStatement
                 |> Array.singleton
                 |> BlockStatement.Create
-            ClassMethod.Create(ClassFunction, Identifier.AsExpression("cases"), [||], body)
+            ClassMethod.AsClassMember(ClassFunction, Identifier.AsExpr("cases"), [||], body)
 
         let baseExpr = libValue com ctx "Types" "Union" |> Some
         let classMembers = Array.append [|cases|] classMembers
@@ -1958,7 +1958,7 @@ module Util =
                 yield! ent.FSharpFields |> Seq.mapi (fun i field ->
                     let left = get None thisExpr field.Name
                     let right = wrapIntExpression field.FieldType args.[i]
-                    assign None left right |> ExpressionStatement.Create)
+                    assign None left right |> ExpressionStatement.AsStatement)
                 |> Seq.toArray
             |])
         let typedPattern x = typedIdent com ctx x
@@ -1967,7 +1967,7 @@ module Util =
 
     let transformClassWithImplicitConstructor (com: IBabelCompiler) ctx (classDecl: Fable.ClassDecl) classMembers (cons: Fable.MemberDecl) =
         let classEnt = com.GetEntity(classDecl.Entity)
-        let classIdent = Identifier.AsExpression(classDecl.Name)
+        let classIdent = Identifier.AsExpr(classDecl.Name)
         let consArgs, consBody, returnType, typeParamDecl =
             getMemberArgsAndBody com ctx ClassConstructor cons.Info.HasSpread cons.Args cons.Body
 
@@ -1982,8 +1982,8 @@ module Util =
                 returnType, typeParamDecl
 
         let exposedCons =
-            let argExprs = consArgs |> Array.map (fun p -> Identifier.AsExpression(p.Name))
-            let exposedConsBody = NewExpression.Create(classIdent, argExprs)
+            let argExprs = consArgs |> Array.map (fun p -> Identifier.AsExpr(p.Name))
+            let exposedConsBody = NewExpression.AsExpr(classIdent, argExprs)
             makeFunctionExpression None (consArgs, exposedConsBody, returnType, typeParamDecl)
 
         let baseExpr, consBody =
@@ -2032,7 +2032,7 @@ module Util =
                         [transformModuleFunction com ctx decl.Info decl.Name decl.Args decl.Body]
 
                 if decl.ExportDefault then
-                    decls @ [ExportDefaultDeclaration.Create(Choice2Of2(Identifier.AsExpression(decl.Name)))]
+                    decls @ [ExportDefaultDeclaration.AsModuleDeclaration(Choice2Of2(Identifier.AsExpr(decl.Name)))]
                 else decls
 
         | Fable.ClassDeclaration decl ->
@@ -2065,9 +2065,9 @@ module Util =
                 |> Option.map (fun localId ->
                     let localId = Identifier.Create(localId)
                     match import.Selector with
-                    | "*" -> ImportNamespaceSpecifier.Create(localId)
-                    | "default" | "" -> ImportDefaultSpecifier.Create(localId)
-                    | memb -> ImportMemberSpecifier.Create(localId, Identifier.Create(memb)))
+                    | "*" -> ImportNamespaceSpecifier.AsImportSpecifier(localId)
+                    | "default" | "" -> ImportDefaultSpecifier.AsImportSpecifier(localId)
+                    | memb -> ImportMemberSpecifier.AsImportSpecifier(localId, Identifier.Create(memb)))
             import.Path, specifier)
         |> Seq.groupBy fst
         |> Seq.collect (fun (path, specifiers) ->
@@ -2083,13 +2083,13 @@ module Util =
             [mems; defs; alls] |> List.choose (function
                 | [] -> None
                 | specifiers ->
-                    ImportDeclaration.Create(List.toArray specifiers, StringLiteral.Create(path))
+                    ImportDeclaration.AsModuleDeclaration(List.toArray specifiers, StringLiteral.Create(path))
                     |> Some)
             |> function
                 | [] ->
                     // If there are no specifiers, this is just an import for side effects,
                     // put it after the other ones to match standard JS practices, see #2228
-                    ImportDeclaration.Create([||], StringLiteral.Create(path))
+                    ImportDeclaration.AsModuleDeclaration([||], StringLiteral.Create(path))
                     |> statefulImports.Add
                     []
                 | decls -> decls
@@ -2125,8 +2125,8 @@ module Compiler =
                 match imports.TryGetValue(cachedName) with
                 | true, i ->
                     match i.LocalIdent with
-                    | Some localIdent -> Identifier.AsExpression(localIdent)
-                    | None -> NullLiteral.AsExpression()
+                    | Some localIdent -> Identifier.AsExpr(localIdent)
+                    | None -> NullLiteral.AsExpr()
                 | false, _ ->
                     let localId = getIdentForImport ctx path selector
                     let i =
@@ -2139,8 +2139,8 @@ module Compiler =
                         LocalIdent = localId }
                     imports.Add(cachedName, i)
                     match localId with
-                    | Some localId -> Identifier.AsExpression(localId)
-                    | None -> NullLiteral.AsExpression()
+                    | Some localId -> Identifier.AsExpr(localId)
+                    | None -> NullLiteral.AsExpr()
             member _.GetAllImports() = imports.Values :> _
             member bcom.TransformAsExpr(ctx, e) = transformAsExpr bcom ctx e
             member bcom.TransformAsStatements(ctx, ret, e) = transformAsStatements bcom ctx ret e

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -465,7 +465,7 @@ module Annotation =
         let funcTypeParams =
             argTypes
             |> List.mapi (fun i argType ->
-                FunctionTypeParam.Create(
+                FunctionTypeParam.functionTypeParam(
                     Identifier.identifier("arg" + (string i)),
                     typeAnnotation com ctx argType))
             |> List.toArray

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -1095,7 +1095,7 @@ module Util =
                 rest @ (List.map (fun e -> com.TransformAsExpr(ctx, e)) spreadArgs)
             | last::rest ->
                 let rest = List.rev rest |> List.map (fun e -> com.TransformAsExpr(ctx, e))
-                rest @ [SpreadElement.AsExpr(com.TransformAsExpr(ctx, last))]
+                rest @ [Expression.spreadElement(com.TransformAsExpr(ctx, last))]
         | args -> List.map (fun e -> com.TransformAsExpr(ctx, e)) args
 
     let resolveExpr t strategy babelExpr: Statement =
@@ -1761,7 +1761,7 @@ module Util =
         let decl: Declaration =
             match expr with
             | ClassExpression(e) ->
-                ClassDeclaration.AsDeclaration(
+                Declaration.classDeclaration(
                     e.Body,
                     ?id = Some membName,
                     ?superClass = e.SuperClass,

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -1027,7 +1027,7 @@ module Util =
         let makeMethod kind prop computed hasSpread args body =
             let args, body, returnType, typeParamDecl =
                 getMemberArgsAndBody com ctx (Attached(isStatic=false)) hasSpread args body
-            ObjectMethod.AsObjectMember(kind, prop, args, body, computed_=computed,
+            ObjectMember.objectMethod(kind, prop, args, body, computed_=computed,
                 ?returnType=returnType, ?typeParameters=typeParamDecl)
 
         let members =
@@ -1047,7 +1047,7 @@ module Util =
                     let iterator =
                         let prop, computed = memberFromName "Symbol.iterator"
                         let body = enumerator2iterator com ctx
-                        ObjectMethod.AsObjectMember(ObjectMeth, prop, [||], body, computed_=computed)
+                        ObjectMember.objectMethod(ObjectMeth, prop, [||], body, computed_=computed)
                     [method; iterator]
                 else
                     [makeMethod ObjectMeth prop computed info.HasSpread memb.Args memb.Body]

--- a/src/Fable.Transforms/Global/Babel.fs
+++ b/src/Fable.Transforms/Global/Babel.fs
@@ -706,16 +706,11 @@ type TypeParameter =
           Default = ``default`` }
 
 type TypeParameterDeclaration =
-    { Params: TypeParameter array }
-
-    static member Create(``params``) = { Params = ``params`` }
+    | TypeParameterDeclaration of ``params``: TypeParameter array
 
 
 type TypeParameterInstantiation =
-    { Params: TypeAnnotationInfo array }
-
-    static member Create(``params``) = { Params = ``params`` }
-
+    | TypeParameterInstantiation of ``params``: TypeAnnotationInfo array
 
 
 type FunctionTypeParam =

--- a/src/Fable.Transforms/Global/Babel.fs
+++ b/src/Fable.Transforms/Global/Babel.fs
@@ -36,7 +36,6 @@ type Node =
     | TypeParameterDeclaration of TypeParameterDeclaration
     | TypeParameterInstantiation of TypeParameterInstantiation
 
-
 /// Since the left-hand side of an assignment may be any expression in general, an expression can also be a pattern.
 type Expression =
     | Literal of Literal
@@ -96,7 +95,6 @@ type Statement =
     | TryStatement of block: BlockStatement * handler: CatchClause option * finalizer: BlockStatement option * loc: SourceLocation option
     | ForStatement of body: BlockStatement * init: VariableDeclaration option * test: Expression option * update: Expression option * loc: SourceLocation option
 
-
 /// Note that declarations are considered statements; this is because declarations can appear in any statement context.
 type Declaration =
     | ClassDeclaration of ClassDeclaration
@@ -114,8 +112,6 @@ type ModuleDeclaration =
     | ExportDefaultDeclaration of ExportDefaultDeclaration
 
     /// An export batch declaration, e.g., export * from "mod";.
-
-
 // Template Literals
 //type TemplateElement(value: string, tail, ?loc) =
 //    inherit Node("TemplateElement", ?loc = loc)
@@ -191,7 +187,6 @@ type BlockStatement =
     static member Create(body) = // ?directives_,
         { Body = body }
 
-
 //    let directives = [||] // defaultArg directives_ [||]
 //    member _.Directives: Directive array = directives
 
@@ -259,7 +254,6 @@ type VariableDeclaration =
     static member Create(var, ?init, ?kind, ?loc) =
         VariableDeclaration.Create(defaultArg kind Let, [| VariableDeclarator.Create(var, ?init = init) |], ?loc = loc)
 
-
 // Loops
 
 //type DoWhileStatement(body, test, ?loc) =
@@ -307,7 +301,6 @@ type FunctionDeclaration =
 //    member _.Declare: bool option = declare
 
 // Expressions
-
 
 //    let async = defaultArg async_ false
 //    let generator = defaultArg generator_ false
@@ -388,7 +381,7 @@ type ObjectMethod =
       TypeParameters: TypeParameterDeclaration option
       Loc: SourceLocation option }
 
-    static member AsObjectMember(kind_, key, ``params``, body, ?computed_, ?returnType, ?typeParameters, ?loc) : ObjectMember = // ?async_, ?generator_,
+    static member Create(kind_, key, ``params``, body, ?computed_, ?returnType, ?typeParameters, ?loc) = // ?async_, ?generator_,
         let kind =
             match kind_ with
             | ObjectGetter -> "get"
@@ -407,7 +400,6 @@ type ObjectMethod =
           ReturnType = returnType
           TypeParameters = typeParameters
           Loc = loc }
-        |> ObjectMethod
 
 
 /// A conditional expression, i.e., a ternary ?/: expression.
@@ -1037,6 +1029,9 @@ module Helpers =
         static member objectProperty(key, value, ?computed_) = // ?shorthand_,
             let computed = defaultArg computed_ false
             ObjectProperty(key, value, computed)
+        static member objectMethod(kind_, key, ``params``, body, ?computed_, ?returnType, ?typeParameters, ?loc) =
+            ObjectMethod.Create(kind_, key, ``params``, body, ?computed_=computed_, ?returnType=returnType, ?typeParameters=typeParameters, ?loc=loc)
+            |> ObjectMethod
 
     type ModuleDeclaration with
         static member exportAllDeclaration(source, ?loc) = ExportAllDeclaration(source, loc)

--- a/src/Fable.Transforms/Global/Babel.fs
+++ b/src/Fable.Transforms/Global/Babel.fs
@@ -366,9 +366,8 @@ type SpreadElement =
     { Argument: Expression
       Loc: SourceLocation option }
 
-    static member AsExpr(argument, ?loc): Expression =
+    static member Create(argument, ?loc) =
         { Argument = argument; Loc = loc }
-        |> SpreadElement
 
 type ObjectMember =
     | ObjectProperty of key: Expression * value: Expression * computed: bool
@@ -630,7 +629,7 @@ type ClassDeclaration =
       TypeParameters: TypeParameterDeclaration option
       Loc: SourceLocation option }
 
-    static member AsDeclaration(body, ?id, ?superClass, ?superTypeParameters, ?typeParameters, ?implements, ?loc) : Declaration =
+    static member Create(body, ?id, ?superClass, ?superTypeParameters, ?typeParameters, ?implements, ?loc) =
         { Body = body
           Id = id
           SuperClass = superClass
@@ -638,7 +637,6 @@ type ClassDeclaration =
           SuperTypeParameters = superTypeParameters
           TypeParameters = typeParameters
           Loc = loc }
-        |> ClassDeclaration
 
 /// Anonymous class: e.g., var myClass = class { }
 type ClassExpression =
@@ -915,14 +913,14 @@ module Helpers =
         static member unaryExpression(operator_, argument, ?loc) =
             UnaryExpression.Create(operator_, argument, ?loc=loc)
             |> UnaryExpression
-        static member identifier(name, ?optional, ?typeAnnotation, ?loc): Expression =
+        static member identifier(name, ?optional, ?typeAnnotation, ?loc) =
             Identifier.Create(name, ?optional = optional, ?typeAnnotation = typeAnnotation, ?loc = loc)
             |> Identifier
-        static member regExpLiteral(pattern, flags_, ?loc) : Expression =
+        static member regExpLiteral(pattern, flags_, ?loc) =
             Literal.regExpLiteral(pattern, flags_, ?loc=loc) |> Literal
         /// A function or method call expression.
         static member callExpression(callee, arguments, ?loc) = CallExpression(callee, arguments, loc)
-        static member assignmentExpression(operator_, left, right, ?loc): Expression =
+        static member assignmentExpression(operator_, left, right, ?loc) =
             let operator =
                 match operator_ with
                 | AssignEqual -> "="
@@ -959,7 +957,7 @@ module Helpers =
             Expression.arrowFunctionExpression(``params``, body, ?returnType = returnType, ?typeParameters = typeParameters, ?loc = loc)
         /// If computed is true, the node corresponds to a computed (a[b]) member expression and property is an Expression.
         /// If computed is false, the node corresponds to a static (a.b) member expression and property is an Identifier.
-        static member memberExpression(object, property, ?computed_, ?loc) : Expression =
+        static member memberExpression(object, property, ?computed_, ?loc) =
             let computed = defaultArg computed_ false
             let name =
                 match property with
@@ -972,6 +970,8 @@ module Helpers =
         static member classExpression(body, ?id, ?superClass, ?superTypeParameters, ?typeParameters, ?implements, ?loc) =
             ClassExpression.Create(body, ?id=id, ?superClass=superClass, ?superTypeParameters=superTypeParameters, ?typeParameters=typeParameters, ?implements=implements, ?loc=loc)
             |> ClassExpression
+        static member spreadElement(argument, ?loc) =
+            SpreadElement.Create(argument, ?loc=loc) |> SpreadElement
 
     type Statement with
         static member returnStatement(argument, ?loc) = ReturnStatement(argument, loc)
@@ -1003,10 +1003,10 @@ module Helpers =
             RestElement.Create(argument, ?typeAnnotation=typeAnnotation, ?loc=loc) |> RestElement
 
     type Declaration with
-        static member variableDeclaration(kind, declarations, ?loc): Declaration =
+        static member variableDeclaration(kind, declarations, ?loc) =
             VariableDeclaration.Create(kind, declarations, ?loc = loc)
             |> VariableDeclaration
-        static member variableDeclaration(var, ?init, ?kind, ?loc): Declaration =
+        static member variableDeclaration(var, ?init, ?kind, ?loc) =
             Declaration.variableDeclaration(
                 defaultArg kind Let,
                 [| VariableDeclarator.Create(var, ?init = init) |],
@@ -1015,6 +1015,9 @@ module Helpers =
         static member functionDeclaration(``params``, body, id, ?returnType, ?typeParameters, ?loc) =
             FunctionDeclaration.Create(``params``, body, id, ?returnType=returnType, ?typeParameters=typeParameters, ?loc=loc)
             |> FunctionDeclaration
+        static member classDeclaration(body, ?id, ?superClass, ?superTypeParameters, ?typeParameters, ?implements, ?loc) =
+            ClassDeclaration.Create(body, ?id=id, ?superClass=superClass, ?superTypeParameters=superTypeParameters, ?typeParameters=typeParameters, ?implements=implements, ?loc=loc)
+            |> ClassDeclaration
 
     type Literal with
         static member nullLiteral(?loc) = NullLiteral loc
@@ -1031,7 +1034,7 @@ module Helpers =
             RegExp(pattern, flags, loc)
 
     type ObjectMember with
-        static member objectProperty(key, value, ?computed_): ObjectMember = // ?shorthand_,
+        static member objectProperty(key, value, ?computed_) = // ?shorthand_,
             let computed = defaultArg computed_ false
             ObjectProperty(key, value, computed)
 

--- a/src/Fable.Transforms/Global/Babel.fs
+++ b/src/Fable.Transforms/Global/Babel.fs
@@ -40,7 +40,14 @@ type Node =
 type Expression =
     | Literal of Literal
     | Identifier of Identifier
-    | ClassExpression of ClassExpression
+    | ClassExpression of
+        body: ClassBody *
+        id: Identifier option *
+        superClass: Expression option *
+        implements: ClassImplements array option *
+        superTypeParameters: TypeParameterInstantiation option *
+        typeParameters: TypeParameterDeclaration option *
+        loc: SourceLocation option
     | ClassImplements of ClassImplements
     | Super of loc: SourceLocation option
     | Undefined of Loc: SourceLocation option
@@ -108,7 +115,14 @@ type Statement =
 
 /// Note that declarations are considered statements; this is because declarations can appear in any statement context.
 type Declaration =
-    | ClassDeclaration of ClassDeclaration
+    | ClassDeclaration of
+        body: ClassBody *
+        id: Identifier option *
+        superClass: Expression option *
+        implements: ClassImplements array option *
+        superTypeParameters: TypeParameterInstantiation option *
+        typeParameters: TypeParameterDeclaration option *
+        loc: SourceLocation option
     | VariableDeclaration of VariableDeclaration
     | FunctionDeclaration of
         ``params``: Pattern array *
@@ -289,46 +303,22 @@ type VariableDeclaration =
 //    inherit Node("SpreadProperty", ?loc = loc)
 //    member _.Argument: Expression = argument
 
-
 type ObjectMember =
     | ObjectProperty of key: Expression * value: Expression * computed: bool
-    | ObjectMethod of ObjectMethod
+    | ObjectMethod of
+        kind: string *
+        key: Expression *
+        ``params``: Pattern array *
+        body: BlockStatement *
+        computed: bool *
+        returnType: TypeAnnotation option *
+        typeParameters: TypeParameterDeclaration option *
+        loc: SourceLocation option
 
 //    let shorthand = defaultArg shorthand_ false
 //    member _.Shorthand: bool = shorthand
 
 type ObjectMethodKind = ObjectGetter | ObjectSetter | ObjectMeth
-
-type ObjectMethod =
-    { Kind: string
-      Key: Expression
-      Params: Pattern array
-      Body: BlockStatement
-      Computed: bool
-      ReturnType: TypeAnnotation option
-      TypeParameters: TypeParameterDeclaration option
-      Loc: SourceLocation option }
-
-    static member objectMethod(kind_, key, ``params``, body, ?computed_, ?returnType, ?typeParameters, ?loc) = // ?async_, ?generator_,
-        let kind =
-            match kind_ with
-            | ObjectGetter -> "get"
-            | ObjectSetter -> "set"
-            | ObjectMeth -> "method"
-        let computed = defaultArg computed_ false
-        //    let async = defaultArg async_ false
-        //    let generator = defaultArg generator_ false
-        //    member _.Async: bool = async
-        //    member _.Generator: bool = generator
-        { Kind = kind
-          Key = key
-          Params = ``params``
-          Body = body
-          Computed = computed
-          ReturnType = returnType
-          TypeParameters = typeParameters
-          Loc = loc }
-
 
 // Patterns
 // type AssignmentProperty(key, value, ?loc) =
@@ -354,23 +344,28 @@ type ObjectMethod =
 
 // Classes
 type ClassMember =
-    | ClassMethod of ClassMethod
-    | ClassProperty of key: Expression * value: Expression option * computed: bool * ``static``: bool * optional: bool * typeAnnotation: TypeAnnotation option * loc: SourceLocation option
+    | ClassMethod of
+        kind: string *
+        key: Expression *
+        ``params``: Pattern array *
+        body: BlockStatement *
+        Computed: bool *
+        ``static``: bool option *
+        ``abstract``: bool option *
+        returnType: TypeAnnotation option *
+        typeParameters: TypeParameterDeclaration option *
+        loc: SourceLocation option
+    | ClassProperty of
+        key: Expression *
+        value: Expression option *
+        computed: bool *
+        ``static``: bool *
+        optional: bool *
+        typeAnnotation: TypeAnnotation option *
+        loc: SourceLocation option
 
 type ClassMethodKind =
     | ClassImplicitConstructor | ClassFunction | ClassGetter | ClassSetter
-
-type ClassMethod =
-    { Kind: string
-      Key: Expression
-      Params: Pattern array
-      Body: BlockStatement
-      Computed: bool
-      Static: bool option
-      Abstract: bool option
-      ReturnType: TypeAnnotation option
-      TypeParameters: TypeParameterDeclaration option
-      Loc: SourceLocation option }
 
     // This appears in astexplorer.net but it's not documented
     // member _.Expression: bool = false
@@ -383,43 +378,6 @@ type ClassImplements =
 
 type ClassBody =
     | ClassBody of body: ClassMember array * loc: SourceLocation option
-
-type ClassDeclaration =
-    { Body: ClassBody
-      Id: Identifier option
-      SuperClass: Expression option
-      Implements: ClassImplements array option
-      SuperTypeParameters: TypeParameterInstantiation option
-      TypeParameters: TypeParameterDeclaration option
-      Loc: SourceLocation option }
-
-    static member Create(body, ?id, ?superClass, ?superTypeParameters, ?typeParameters, ?implements, ?loc) =
-        { Body = body
-          Id = id
-          SuperClass = superClass
-          Implements = implements
-          SuperTypeParameters = superTypeParameters
-          TypeParameters = typeParameters
-          Loc = loc }
-
-/// Anonymous class: e.g., var myClass = class { }
-type ClassExpression =
-    { Body: ClassBody
-      Id: Identifier option
-      SuperClass: Expression option
-      Implements: ClassImplements array option
-      SuperTypeParameters: TypeParameterInstantiation option
-      TypeParameters: TypeParameterDeclaration option
-      Loc: SourceLocation option }
-
-    static member Create(body, ?id, ?superClass, ?superTypeParameters, ?typeParameters, ?implements, ?loc) =
-        { Body = body
-          Id = id
-          SuperClass = superClass
-          Implements = implements
-          SuperTypeParameters = superTypeParameters
-          TypeParameters = typeParameters
-          Loc = loc }
 
 // type MetaProperty(meta, property, ?loc) =
 //     interface Expression with
@@ -488,26 +446,15 @@ type FunctionTypeParam =
     | FunctionTypeParam of name: Identifier * typeAnnotation: TypeAnnotationInfo * optional: bool option
 
 type ObjectTypeProperty =
-    { Key: Expression
-      Value: TypeAnnotationInfo
-      Kind: string option
-      Computed: bool
-      Static: bool
-      Optional: bool
-      Proto: bool
-      Method: bool }
-
-    static member Create(key, value, ?computed_, ?kind, ?``static``, ?optional, ?proto, ?method) =
-        let computed = defaultArg computed_ false
-
-        { Key = key
-          Value = value
-          Kind = kind
-          Computed = computed
-          Static = defaultArg ``static`` false
-          Optional = defaultArg optional false
-          Proto = defaultArg proto false
-          Method = defaultArg method false }
+    | ObjectTypeProperty of
+        key: Expression *
+        value: TypeAnnotationInfo *
+        kind: string option *
+        computed: bool *
+        ``static``: bool *
+        optional: bool *
+        proto: bool *
+        method: bool
 
 type ObjectTypeIndexer =
     | ObjectTypeIndexer of id: Identifier option * key: Identifier * value: TypeAnnotationInfo * ``static``: bool option
@@ -519,24 +466,12 @@ type ObjectTypeInternalSlot =
     | ObjectTypeInternalSlot of id: Identifier * value: TypeAnnotationInfo * optional: bool * ``static``: bool * method: bool
 
 type ObjectTypeAnnotation =
-    { Properties: ObjectTypeProperty array
-      Indexers: ObjectTypeIndexer array
-      CallProperties: ObjectTypeCallProperty array
-      InternalSlots: ObjectTypeInternalSlot array
-      Exact: bool }
-
-    static member Create(properties, ?indexers_, ?callProperties_, ?internalSlots_, ?exact_) =
-        let exact = defaultArg exact_ false
-        let indexers = defaultArg indexers_ [||]
-        let callProperties = defaultArg callProperties_ [||]
-        let internalSlots = defaultArg internalSlots_ [||]
-
-        { Properties = properties
-          Indexers = indexers
-          CallProperties = callProperties
-          InternalSlots = internalSlots
-          Exact = exact }
-
+    | ObjectTypeAnnotation of
+        properties: ObjectTypeProperty array *
+        indexers: ObjectTypeIndexer array *
+        callProperties: ObjectTypeCallProperty array *
+        internalSlots: ObjectTypeInternalSlot array *
+        exact: bool
 type InterfaceExtends =
     | InterfaceExtends of id: Identifier * typeParameters: TypeParameterInstantiation option
 
@@ -608,8 +543,7 @@ module Helpers =
         static member functionExpression(``params``, body, ?id, ?returnType, ?typeParameters, ?loc) = //?generator_, ?async_
             FunctionExpression(id, ``params``, body, returnType, typeParameters, loc)
         static member classExpression(body, ?id, ?superClass, ?superTypeParameters, ?typeParameters, ?implements, ?loc) =
-            ClassExpression.Create(body, ?id=id, ?superClass=superClass, ?superTypeParameters=superTypeParameters, ?typeParameters=typeParameters, ?implements=implements, ?loc=loc)
-            |> ClassExpression
+            ClassExpression(body, id, superClass, implements, superTypeParameters, typeParameters, loc)
         static member spreadElement(argument, ?loc) =
             SpreadElement(argument, ?loc=loc)
         static member conditionalExpression(test, consequent, alternate, ?loc): Expression =
@@ -735,8 +669,7 @@ module Helpers =
         static member functionDeclaration(``params``, body, id, ?returnType, ?typeParameters, ?loc) =
             FunctionDeclaration(``params``, body, id, returnType, typeParameters, loc)
         static member classDeclaration(body, ?id, ?superClass, ?superTypeParameters, ?typeParameters, ?implements, ?loc) =
-            ClassDeclaration.Create(body, ?id=id, ?superClass=superClass, ?superTypeParameters=superTypeParameters, ?typeParameters=typeParameters, ?implements=implements, ?loc=loc)
-            |> ClassDeclaration
+            ClassDeclaration(body, id, superClass, implements, superTypeParameters, typeParameters, loc)
         static member interfaceDeclaration(id, body, ?extends_, ?typeParameters, ?implements_): Declaration = // ?mixins_,
             let extends = defaultArg extends_ [||]
             let implements = defaultArg implements_ [||]
@@ -777,18 +710,7 @@ module Helpers =
                 | ClassSetter -> "set"
                 | ClassFunction -> "method"
             let computed = defaultArg computed_ false
-
-            { Kind = kind
-              Key = key
-              Params = ``params``
-              Body = body
-              Computed = computed
-              Static = ``static``
-              Abstract = ``abstract``
-              ReturnType = returnType
-              TypeParameters = typeParameters
-              Loc = loc }
-            |> ClassMethod
+            ClassMethod(kind, key, ``params``, body, computed, ``static``, ``abstract``, returnType, typeParameters, loc)
         static member classProperty(key, ?value, ?computed_, ?``static``, ?optional, ?typeAnnotation, ?loc): ClassMember =
             let computed = defaultArg computed_ false
             ClassProperty(key, value, computed, defaultArg ``static`` false, defaultArg optional false, typeAnnotation, loc)
@@ -815,8 +737,22 @@ module Helpers =
             let computed = defaultArg computed_ false
             ObjectProperty(key, value, computed)
         static member objectMethod(kind_, key, ``params``, body, ?computed_, ?returnType, ?typeParameters, ?loc) =
-            ObjectMethod.objectMethod(kind_, key, ``params``, body, ?computed_=computed_, ?returnType=returnType, ?typeParameters=typeParameters, ?loc=loc)
-            |> ObjectMethod
+            let kind =
+                match kind_ with
+                | ObjectGetter -> "get"
+                | ObjectSetter -> "set"
+                | ObjectMeth -> "method"
+            let computed = defaultArg computed_ false
+            ObjectMethod(kind, key, ``params``, body, computed, returnType, typeParameters, loc)
+
+    type ObjectTypeProperty with
+        static member objectTypeProperty(key, value, ?computed_, ?kind, ?``static``, ?optional, ?proto, ?method) =
+            let computed = defaultArg computed_ false
+            let optional = defaultArg optional false
+            let method = defaultArg method false
+            let ``static`` = defaultArg ``static`` false
+            let proto = defaultArg proto false
+            ObjectTypeProperty(key, value, kind, computed, ``static``, optional, proto, method)
 
     type ModuleDeclaration with
         static member exportAllDeclaration(source, ?loc) = ExportAllDeclaration(source, loc)
@@ -828,6 +764,15 @@ module Helpers =
             GenericTypeAnnotation (id, typeParameters)
         static member functionTypeAnnotation(``params``, returnType, ?typeParameters, ?rest): TypeAnnotationInfo =
             FunctionTypeAnnotation(``params``,returnType, typeParameters, rest)
+
+    type ObjectTypeAnnotation with
+        static member objectTypeAnnotation(properties, ?indexers_, ?callProperties_, ?internalSlots_, ?exact_) =
+            let exact = defaultArg exact_ false
+            let indexers = defaultArg indexers_ [||]
+            let callProperties = defaultArg callProperties_ [||]
+            let internalSlots = defaultArg internalSlots_ [||]
+
+            ObjectTypeAnnotation(properties, indexers, callProperties, internalSlots, exact)
 
     type TypeParameter with
         static member typeParameter(name, ?bound, ?``default``) =

--- a/src/Fable.Transforms/Global/Babel.fs
+++ b/src/Fable.Transforms/Global/Babel.fs
@@ -16,7 +16,7 @@ type Printer =
 
 module PrinterExtensions =
     type Printer with
-        member printer.Print(node: IPrintable) =
+        member printer.Print(node: Node) =
             node.Print(printer)
 
         member printer.PrintBlock(nodes: 'a array, printNode: Printer -> 'a -> unit, printSeparator: Printer -> unit, ?skipNewLineAtEnd) =
@@ -59,7 +59,7 @@ module PrinterExtensions =
 
         member printer.PrintProductiveStatement(s: Statement, ?printSeparator) =
             if printer.IsProductiveStatement(s) then
-                printer.Print(s)
+                s.Print(printer)
                 printSeparator |> Option.iter (fun f -> f printer)
 
         member printer.PrintProductiveStatements(statements: Statement[]) =
@@ -72,17 +72,40 @@ module PrinterExtensions =
                                (fun p -> p.PrintStatementSeparator()),
                                ?skipNewLineAtEnd=skipNewLineAtEnd)
 
-        member printer.PrintOptional(before: string, node: #IPrintable option) =
+        member printer.PrintOptional(node: Node option, ?before: string) =
             match node with
             | None -> ()
             | Some node ->
-                printer.Print(before)
-                printer.Print(node)
+                match before with
+                | Some before ->
+                    printer.Print(before)
+                | _ -> ()
+                node.Print(printer)
 
-        member printer.PrintOptional(node: #IPrintable option) =
-            match node with
-            | None -> ()
-            | Some node -> printer.Print(node)
+        member printer.PrintOptional(node: Expression option, ?before: string) =
+            printer.PrintOptional(node |> Option.map Expression, ?before=before)
+        member printer.PrintOptional(node: TypeParameterDeclaration option, ?before: string) =
+            printer.PrintOptional(node |> Option.map TypeParameterDeclaration, ?before=before)
+        member printer.PrintOptional(node: TypeAnnotation option, ?before: string) =
+            printer.PrintOptional(node |> Option.map TypeAnnotation, ?before=before)
+        member printer.PrintOptional(node: Identifier option, ?before: string) =
+            printer.PrintOptional(node |> Option.map Identifier, ?before=before)
+        member printer.PrintOptional(node: Literal option, ?before: string) =
+            printer.PrintOptional(node |> Option.map Literal, ?before=before)
+        member printer.PrintOptional(node: StringLiteral option, ?before: string) =
+            printer.PrintOptional(node |> Option.map StringLiteral, ?before=before)
+        member printer.PrintOptional(node: TypeParameterInstantiation option, ?before: string) =
+            printer.PrintOptional(node |> Option.map TypeParameterInstantiation, ?before=before)
+        member printer.PrintOptional(node: Statement option, ?before: string) =
+            printer.PrintOptional(node |> Option.map Statement, ?before=before)
+        member printer.PrintOptional(node: Declaration option, ?before: string) =
+            printer.PrintOptional(node |> Option.map Declaration, ?before=before)
+        member printer.PrintOptional(node: VariableDeclaration option, ?before: string) =
+            printer.PrintOptional(node |> Option.map VariableDeclaration, ?before=before)
+        member printer.PrintOptional(node: CatchClause option, ?before: string) =
+            printer.PrintOptional(node |> Option.map CatchClause, ?before=before)
+        member printer.PrintOptional(node: BlockStatement option, ?before: string) =
+            printer.PrintOptional(node |> Option.map BlockStatement, ?before=before)
 
         member printer.PrintArray(nodes: 'a array, printNode: Printer -> 'a -> unit, printSeparator: Printer -> unit) =
             for i = 0 to nodes.Length - 1 do
@@ -90,11 +113,29 @@ module PrinterExtensions =
                 if i < nodes.Length - 1 then
                     printSeparator printer
 
+        member printer.PrintCommaSeparatedArray(nodes: Node array) =
+            printer.PrintArray(nodes, (fun p x -> x.Print(p)), (fun p -> p.Print(", ")))
+        member printer.PrintCommaSeparatedArray(nodes: Pattern array) =
+            printer.PrintArray(nodes, (fun p x -> x.Print(p)), (fun p -> p.Print(", ")))
+        member printer.PrintCommaSeparatedArray(nodes: ImportDefaultSpecifier array) =
+            printer.PrintArray(nodes, (fun p x -> x.Print(p)), (fun p -> p.Print(", ")))
+        member printer.PrintCommaSeparatedArray(nodes: ImportNamespaceSpecifier array) =
+            printer.PrintArray(nodes, (fun p x -> x.Print(p)), (fun p -> p.Print(", ")))
+        member printer.PrintCommaSeparatedArray(nodes: ImportMemberSpecifier array) =
+            printer.PrintArray(nodes, (fun p x -> x.Print(p)), (fun p -> p.Print(", ")))
+        member printer.PrintCommaSeparatedArray(nodes: ExportSpecifier array) =
+            printer.PrintArray(nodes, (fun p x -> x.Print(p)), (fun p -> p.Print(", ")))
+        member printer.PrintCommaSeparatedArray(nodes: FunctionTypeParam array) =
+            printer.PrintArray(nodes, (fun p x -> x.Print(p)), (fun p -> p.Print(", ")))
+        member printer.PrintCommaSeparatedArray(nodes: TypeAnnotationInfo array) =
+            printer.PrintArray(nodes, (fun p x -> x.Print(p)), (fun p -> p.Print(", ")))
+        member printer.PrintCommaSeparatedArray(nodes: TypeParameter array) =
+            printer.PrintArray(nodes, (fun p x -> x.Print(p)), (fun p -> p.Print(", ")))
+
         member printer.PrintCommaSeparatedArray(nodes: Expression array) =
             printer.PrintArray(nodes, (fun p x -> p.SequenceExpressionWithParens(x)), (fun p -> p.Print(", ")))
 
-        member printer.PrintCommaSeparatedArray(nodes: #IPrintable array) =
-            printer.PrintArray(nodes, (fun p x -> p.Print(x)), (fun p -> p.Print(", ")))
+
 
         // TODO: (super) type parameters, implements
         member printer.PrintClass(id: Identifier option, superClass: Expression option,
@@ -102,21 +143,21 @@ module PrinterExtensions =
                 typeParameters: TypeParameterDeclaration option,
                 implements: ClassImplements array option, body: ClassBody, loc) =
             printer.Print("class", ?loc=loc)
-            printer.PrintOptional(" ", id)
-            printer.PrintOptional(typeParameters)
+            printer.PrintOptional(id, " ")
+            printer.PrintOptional(typeParameters |> Option.map TypeParameterDeclaration)
             match superClass with
             | Some (Identifier(id)) when id.TypeAnnotation.IsSome ->
                 printer.Print(" extends ");
-                printer.Print(id.TypeAnnotation.Value.TypeAnnotation)
-            | _ -> printer.PrintOptional(" extends ", superClass)
+                id.TypeAnnotation.Value.TypeAnnotation.Print(printer)
+            | _ -> printer.PrintOptional(superClass, " extends ")
             // printer.PrintOptional(superTypeParameters)
             match implements with
             | Some implements when not (Array.isEmpty implements) ->
                 printer.Print(" implements ")
-                printer.PrintArray(implements, (fun p x -> p.Print(x)), (fun p -> p.Print(", ")))
+                printer.PrintArray(implements, (fun p x -> x.Print(p)), (fun p -> p.Print(", ")))
             | _ -> ()
             printer.Print(" ")
-            printer.Print(body)
+            body.Print(printer)
 
         member printer.PrintFunction(id: Identifier option, parameters: Pattern array, body: BlockStatement,
                 typeParameters: TypeParameterDeclaration option, returnType: TypeAnnotation option, loc, ?isDeclaration, ?isArrow) =
@@ -147,20 +188,22 @@ module PrinterExtensions =
                 | _ -> None
 
             match skipExpr with
-            | Some e -> printer.Print(e)
+            | Some e -> e.Print(printer)
             | None ->
                 if isArrow then
                     // Remove parens if we only have one argument? (and no annotation)
                     printer.PrintOptional(typeParameters)
                     printer.Print("(")
                     printer.PrintCommaSeparatedArray(parameters)
+                    printer.PrintArray(parameters, (fun p x -> x.Print(p)), (fun p -> p.Print(", ")))
+
                     printer.Print(")")
                     printer.PrintOptional(returnType)
                     printer.Print(" => ")
                     match body.Body with
                     | [| ReturnStatement(r) |] ->
                         match r.Argument with
-                        | ObjectExpression(e) -> printer.WithParens(e)
+                        | ObjectExpression(e) -> printer.WithParens(e |> ObjectExpression)
                         | MemberExpression(e) ->
                             match e.Object with
                             | ObjectExpression(o) -> e.Print(printer, objectWithParens=true)
@@ -178,15 +221,15 @@ module PrinterExtensions =
                     printer.Print(" ")
                     printer.PrintBlock(body.Body, skipNewLineAtEnd=true)
 
-        member printer.WithParens(expr: IPrintable) =
+        member printer.WithParens(expr: Expression) =
             printer.Print("(")
-            printer.Print(expr)
+            expr.Print(printer)
             printer.Print(")")
 
         member printer.SequenceExpressionWithParens(expr: Expression) =
             match expr with
             | SequenceExpression(_) -> printer.WithParens(expr)
-            | _ -> printer.Print(expr)
+            | _ -> expr.Print(printer)
 
         /// Surround with parens anything that can potentially conflict with operator precedence
         member printer.ComplexExpressionWithParens(expr: Expression) =
@@ -203,7 +246,7 @@ module PrinterExtensions =
             | Super(_)
             | SpreadElement(_)
             | ArrayExpression(_)
-            | ObjectExpression(_) -> printer.Print(expr)
+            | ObjectExpression(_) -> expr.Print(printer)
             | _ -> printer.WithParens(expr)
 
         member printer.PrintOperation(left, operator, right, loc) =
@@ -219,9 +262,6 @@ module PrinterExtensions =
 /// If the node contains no information about the source location, the field is null;
 /// otherwise it is an object consisting of a start position (the position of the first character of the parsed source region)
 /// and an end position (the position of the first character after the parsed source region):
-type IPrintable =
-    abstract Print: Printer -> unit
-
 type Node =
     | Pattern of Pattern
     | Program of Program
@@ -248,33 +288,32 @@ type Node =
     | TypeParameterDeclaration of TypeParameterDeclaration
     | TypeParameterInstantiation of TypeParameterInstantiation
 
-    interface IPrintable with
-        member this.Print(printer) =
-            match this with
-            | Pattern(n) -> printer.Print(n)
-            | Program(n) -> printer.Print("(program)")
-            | Statement(n) -> printer.Print(n)
-            | Directive(n) -> printer.Print(n)
-            | ClassBody(n) -> printer.Print(n)
-            | Expression(n) -> printer.Print(n)
-            | SwitchCase(n) -> printer.Print(n)
-            | CatchClause(n) -> printer.Print(n)
-            | ObjectMember(n) -> printer.Print(n)
-            | TypeParameter(n) -> printer.Print(n)
-            | TypeAnnotation(n) -> printer.Print(n)
-            | ExportSpecifier(n) -> printer.Print(n)
-            | ImportSpecifier(n) -> printer.Print(n)
-            | InterfaceExtends(n) -> printer.Print(n)
-            | ObjectTypeIndexer(n) -> printer.Print(n)
-            | FunctionTypeParam(n) -> printer.Print(n)
-            | ModuleDeclaration(n) -> printer.Print(n)
-            | VariableDeclarator(n) -> printer.Print(n)
-            | TypeAnnotationInfo(n) -> printer.Print(n)
-            | ObjectTypeProperty(n) -> printer.Print(n)
-            | ObjectTypeCallProperty (n) -> printer.Print(n)
-            | ObjectTypeInternalSlot(n) -> printer.Print(n)
-            | TypeParameterDeclaration(n) -> printer.Print(n)
-            | TypeParameterInstantiation(n) -> printer.Print(n)
+    member this.Print(printer) =
+        match this with
+        | Pattern(n) -> n.Print(printer)
+        | Program(n) -> printer.Print("(program)")
+        | Statement(n) -> n.Print(printer)
+        | Directive(n) -> n.Print(printer)
+        | ClassBody(n) -> n.Print(printer)
+        | Expression(n) -> n.Print(printer)
+        | SwitchCase(n) -> n.Print(printer)
+        | CatchClause(n) -> n.Print(printer)
+        | ObjectMember(n) -> n.Print(printer)
+        | TypeParameter(n) -> n.Print(printer)
+        | TypeAnnotation(n) -> n.Print(printer)
+        | ExportSpecifier(n) -> n.Print(printer)
+        | ImportSpecifier(n) -> n.Print(printer)
+        | InterfaceExtends(n) -> n.Print(printer)
+        | ObjectTypeIndexer(n) -> n.Print(printer)
+        | FunctionTypeParam(n) -> n.Print(printer)
+        | ModuleDeclaration(n) -> n.Print(printer)
+        | VariableDeclarator(n) -> n.Print(printer)
+        | TypeAnnotationInfo(n) -> n.Print(printer)
+        | ObjectTypeProperty(n) -> n.Print(printer)
+        | ObjectTypeCallProperty (n) -> n.Print(printer)
+        | ObjectTypeInternalSlot(n) -> n.Print(printer)
+        | TypeParameterDeclaration(n) -> n.Print(printer)
+        | TypeParameterInstantiation(n) -> n.Print(printer)
 
 /// Since the left-hand side of an assignment may be any expression in general, an expression can also be a pattern.
 type Expression =
@@ -302,43 +341,41 @@ type Expression =
     | ConditionalExpression of ConditionalExpression
     | ArrowFunctionExpression of ArrowFunctionExpression
 
-    interface IPrintable with
-        member this.Print(printer) =
-            match this with
-            | Super(n) -> printer.Print(n)
-            | Literal(n) -> printer.Print(n)
-            | Undefined(n) -> printer.Print(n)
-            | Identifier(n) -> printer.Print(n)
-            | NewExpression(n) -> printer.Print(n)
-            | SpreadElement(n) -> printer.Print(n)
-            | ThisExpression(n) -> printer.Print(n)
-            | CallExpression(n) -> printer.Print(n)
-            | EmitExpression(n) -> printer.Print(n)
-            | ArrayExpression(n) -> printer.Print(n)
-            | ClassExpression(n) -> printer.Print(n)
-            | ClassImplements(n) -> printer.Print(n)
-            | UnaryExpression(n) -> printer.Print(n)
-            | UpdateExpression(n) -> printer.Print(n)
-            | ObjectExpression(n) -> printer.Print(n)
-            | BinaryExpression(n) -> printer.Print(n)
-            | MemberExpression(n) -> printer.Print(n)
-            | LogicalExpression(n) -> printer.Print(n)
-            | SequenceExpression(n) -> printer.Print(n)
-            | FunctionExpression(n) -> printer.Print(n)
-            | AssignmentExpression(n) -> printer.Print(n)
-            | ConditionalExpression(n) -> printer.Print(n)
-            | ArrowFunctionExpression(n) -> printer.Print(n)
+    member this.Print(printer) =
+        match this with
+        | Super(n) -> n.Print(printer)
+        | Literal(n) -> n.Print(printer)
+        | Undefined(n) -> n.Print(printer)
+        | Identifier(n) -> n.Print(printer)
+        | NewExpression(n) -> n.Print(printer)
+        | SpreadElement(n) -> n.Print(printer)
+        | ThisExpression(n) -> n.Print(printer)
+        | CallExpression(n) -> n.Print(printer)
+        | EmitExpression(n) -> n.Print(printer)
+        | ArrayExpression(n) -> n.Print(printer)
+        | ClassExpression(n) -> n.Print(printer)
+        | ClassImplements(n) -> n.Print(printer)
+        | UnaryExpression(n) -> n.Print(printer)
+        | UpdateExpression(n) -> n.Print(printer)
+        | ObjectExpression(n) -> n.Print(printer)
+        | BinaryExpression(n) -> n.Print(printer)
+        | MemberExpression(n) -> n.Print(printer)
+        | LogicalExpression(n) -> n.Print(printer)
+        | SequenceExpression(n) -> n.Print(printer)
+        | FunctionExpression(n) -> n.Print(printer)
+        | AssignmentExpression(n) -> n.Print(printer)
+        | ConditionalExpression(n) -> n.Print(printer)
+        | ArrowFunctionExpression(n) -> n.Print(printer)
 
 
 type Pattern =
     | IdentifierPattern of Identifier
     | RestElement of RestElement
 
-    interface IPrintable with
-        member this.Print(printer) =
-            match this with
-            | IdentifierPattern(p) -> printer.Print(p)
-            | RestElement(e) -> printer.Print(e)
+    member this.Print(printer) =
+        match this with
+        | IdentifierPattern(p) -> p.Print(printer)
+        | RestElement(e) -> e.Print(printer)
 
     member this.Name =
         match this with
@@ -353,15 +390,14 @@ type Literal =
     | NumericLiteral of NumericLiteral
     | DirectiveLiteral of DirectiveLiteral
 
-    interface IPrintable with
-        member this.Print(printer) =
-            match this with
-            | RegExp(l) -> printer.Print(l)
-            | NullLiteral(l) -> printer.Print(l)
-            | StringLiteral(l) -> printer.Print(l)
-            | BooleanLiteral(l) -> printer.Print(l)
-            | NumericLiteral(l) -> printer.Print(l)
-            | DirectiveLiteral(l) -> printer.Print(l)
+    member this.Print(printer: Printer) =
+        match this with
+        | RegExp(l) -> l.Print(printer)
+        | NullLiteral(l) -> l.Print(printer)
+        | StringLiteral(l) -> l.Print(printer)
+        | BooleanLiteral(l) -> l.Print(printer)
+        | NumericLiteral(l) -> l.Print(printer)
+        | DirectiveLiteral(l) -> l.Print(printer)
 
 type Statement =
     | Declaration of Declaration
@@ -379,23 +415,22 @@ type Statement =
     | ContinueStatement of ContinueStatement
     | ExpressionStatement of ExpressionStatement
 
-    interface IPrintable with
-        member this.Print(printer) =
-            match this with
-            | Declaration(s) -> printer.Print(s)
-            | IfStatement(s) -> printer.Print(s)
-            | TryStatement(s) -> printer.Print(s)
-            | ForStatement(s) -> printer.Print(s)
-            | BreakStatement(s) -> printer.Print(s)
-            | WhileStatement(s) -> printer.Print(s)
-            | ThrowStatement(s) -> printer.Print(s)
-            | BlockStatement(s) -> printer.Print(s)
-            | ReturnStatement(s) -> printer.Print(s)
-            | SwitchStatement(s) -> printer.Print(s)
-            | LabeledStatement(s) -> printer.Print(s)
-            | DebuggerStatement(s) -> printer.Print(s)
-            | ContinueStatement(s) -> printer.Print(s)
-            | ExpressionStatement(s) -> printer.Print(s)
+    member this.Print(printer) =
+        match this with
+        | Declaration(s) -> s.Print(printer)
+        | IfStatement(s) -> s.Print(printer)
+        | TryStatement(s) -> s.Print(printer)
+        | ForStatement(s) -> s.Print(printer)
+        | BreakStatement(s) -> s.Print(printer)
+        | WhileStatement(s) -> s.Print(printer)
+        | ThrowStatement(s) -> s.Print(printer)
+        | BlockStatement(s) -> s.Print(printer)
+        | ReturnStatement(s) -> s.Print(printer)
+        | SwitchStatement(s) -> s.Print(printer)
+        | LabeledStatement(s) -> s.Print(printer)
+        | DebuggerStatement(s) -> s.Print(printer)
+        | ContinueStatement(s) -> s.Print(printer)
+        | ExpressionStatement(s) -> s.Print(printer)
 
 /// Note that declarations are considered statements; this is because declarations can appear in any statement context.
 type Declaration =
@@ -404,13 +439,12 @@ type Declaration =
     | FunctionDeclaration of FunctionDeclaration
     | InterfaceDeclaration of InterfaceDeclaration
 
-    interface IPrintable with
-        member this.Print(printer) =
-            match this with
-            | ClassDeclaration(d) -> printer.Print(d)
-            | VariableDeclaration(d) -> printer.Print(d)
-            | FunctionDeclaration(d) -> printer.Print(d)
-            | InterfaceDeclaration(d) -> printer.Print(d)
+    member this.Print(printer: Printer) =
+        match this with
+        | ClassDeclaration(d) -> d.Print(printer)
+        | VariableDeclaration(d) -> d.Print(printer)
+        | FunctionDeclaration(d) -> d.Print(printer)
+        | InterfaceDeclaration(d) -> d.Print(printer)
 
 /// A module import or export declaration.
 type ModuleDeclaration =
@@ -421,18 +455,14 @@ type ModuleDeclaration =
     | PrivateModuleDeclaration of PrivateModuleDeclaration
     | ExportDefaultDeclaration of ExportDefaultDeclaration
 
-    interface IPrintable with
-        member this.Print(printer) =
-            this.Print(printer)
-
     member this.Print(printer: Printer) =
-            match this with
-            | ImportDeclaration(d) -> printer.Print(d)
-            | ExportAllDeclaration(d) -> printer.Print(d)
-            | ExportNamedReferences(d) -> printer.Print(d)
-            | ExportNamedDeclaration(d) -> printer.Print(d)
-            | PrivateModuleDeclaration(d) -> printer.Print(d)
-            | ExportDefaultDeclaration(d) -> printer.Print(d)
+        match this with
+        | ImportDeclaration(d) -> d.Print(printer)
+        | ExportAllDeclaration(d) -> d.Print(printer)
+        | ExportNamedReferences(d) -> d.Print(printer)
+        | ExportNamedDeclaration(d) -> d.Print(printer)
+        | PrivateModuleDeclaration(d) -> d.Print(printer)
+        | ExportDefaultDeclaration(d) -> d.Print(printer)
 
 /// Not in Babel specs
 type EmitExpression =
@@ -446,80 +476,79 @@ type EmitExpression =
           Loc = loc }
         |> EmitExpression
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.AddLocation(this.Loc)
+    member this.Print(printer) =
+        printer.AddLocation(this.Loc)
 
-            let inline replace pattern (f: System.Text.RegularExpressions.Match -> string) input =
-                System.Text.RegularExpressions.Regex.Replace(input, pattern, f)
+        let inline replace pattern (f: System.Text.RegularExpressions.Match -> string) input =
+            System.Text.RegularExpressions.Regex.Replace(input, pattern, f)
 
-            let printSegment (printer: Printer) (value: string) segmentStart segmentEnd =
-                let segmentLength = segmentEnd - segmentStart
-                if segmentLength > 0 then
-                    let segment = value.Substring(segmentStart, segmentLength)
-                    let subSegments = System.Text.RegularExpressions.Regex.Split(segment, @"\r?\n")
-                    for i = 1 to subSegments.Length do
-                        let subSegment =
-                            // Remove whitespace in front of new lines,
-                            // indent will be automatically applied
-                            if printer.Column = 0 then subSegments.[i - 1].TrimStart()
-                            else subSegments.[i - 1]
-                        if subSegment.Length > 0 then
-                            printer.Print(subSegment)
-                            if i < subSegments.Length then
-                                printer.PrintNewLine()
+        let printSegment (printer: Printer) (value: string) segmentStart segmentEnd =
+            let segmentLength = segmentEnd - segmentStart
+            if segmentLength > 0 then
+                let segment = value.Substring(segmentStart, segmentLength)
+                let subSegments = System.Text.RegularExpressions.Regex.Split(segment, @"\r?\n")
+                for i = 1 to subSegments.Length do
+                    let subSegment =
+                        // Remove whitespace in front of new lines,
+                        // indent will be automatically applied
+                        if printer.Column = 0 then subSegments.[i - 1].TrimStart()
+                        else subSegments.[i - 1]
+                    if subSegment.Length > 0 then
+                        printer.Print(subSegment)
+                        if i < subSegments.Length then
+                            printer.PrintNewLine()
 
-            // Macro transformations
-            // https://fable.io/docs/communicate/js-from-fable.html#Emit-when-F-is-not-enough
-            let value =
-                this.Value
-                |> replace @"\$(\d+)\.\.\." (fun m ->
-                    let rep = ResizeArray()
-                    let i = int m.Groups.[1].Value
-                    for j = i to this.Args.Length - 1 do
-                        rep.Add("$" + string j)
-                    String.concat ", " rep)
+        // Macro transformations
+        // https://fable.io/docs/communicate/js-from-fable.html#Emit-when-F-is-not-enough
+        let value =
+            this.Value
+            |> replace @"\$(\d+)\.\.\." (fun m ->
+                let rep = ResizeArray()
+                let i = int m.Groups.[1].Value
+                for j = i to this.Args.Length - 1 do
+                    rep.Add("$" + string j)
+                String.concat ", " rep)
 
-                |> replace @"\{\{\s*\$(\d+)\s*\?(.*?)\:(.*?)\}\}" (fun m ->
-                    let i = int m.Groups.[1].Value
-                    match this.Args.[i] with
-                    | Literal(BooleanLiteral(b)) when b.Value -> m.Groups.[2].Value
-                    | _ -> m.Groups.[3].Value)
+            |> replace @"\{\{\s*\$(\d+)\s*\?(.*?)\:(.*?)\}\}" (fun m ->
+                let i = int m.Groups.[1].Value
+                match this.Args.[i] with
+                | Literal(BooleanLiteral(b)) when b.Value -> m.Groups.[2].Value
+                | _ -> m.Groups.[3].Value)
 
-                |> replace @"\{\{([^\}]*\$(\d+).*?)\}\}" (fun m ->
-                    let i = int m.Groups.[2].Value
-                    match Array.tryItem i this.Args with
-                    | Some _ -> m.Groups.[1].Value
-                    | None -> "")
+            |> replace @"\{\{([^\}]*\$(\d+).*?)\}\}" (fun m ->
+                let i = int m.Groups.[2].Value
+                match Array.tryItem i this.Args with
+                | Some _ -> m.Groups.[1].Value
+                | None -> "")
 
-                // This is to emit string literals as JS, I think it's no really
-                // used and it shouldn't be necessary with the new emitJsExpr
-    //            |> replace @"\$(\d+)!" (fun m ->
-    //                let i = int m.Groups.[1].Value
-    //                match Array.tryItem i args with
-    //                | Some(:? StringLiteral as s) -> s.Value
-    //                | _ -> "")
+            // This is to emit string literals as JS, I think it's no really
+            // used and it shouldn't be necessary with the new emitJsExpr
+//            |> replace @"\$(\d+)!" (fun m ->
+//                let i = int m.Groups.[1].Value
+//                match Array.tryItem i args with
+//                | Some(:? StringLiteral as s) -> s.Value
+//                | _ -> "")
 
-            let matches = System.Text.RegularExpressions.Regex.Matches(value, @"\$\d+")
-            if matches.Count > 0 then
-                for i = 0 to matches.Count - 1 do
-                    let m = matches.[i]
+        let matches = System.Text.RegularExpressions.Regex.Matches(value, @"\$\d+")
+        if matches.Count > 0 then
+            for i = 0 to matches.Count - 1 do
+                let m = matches.[i]
 
-                    let segmentStart =
-                        if i > 0 then matches.[i-1].Index + matches.[i-1].Length
-                        else 0
+                let segmentStart =
+                    if i > 0 then matches.[i-1].Index + matches.[i-1].Length
+                    else 0
 
-                    printSegment printer value segmentStart m.Index
+                printSegment printer value segmentStart m.Index
 
-                    let argIndex = int m.Value.[1..]
-                    match Array.tryItem argIndex this.Args with
-                    | Some e -> printer.ComplexExpressionWithParens(e)
-                    | None -> printer.Print("undefined")
+                let argIndex = int m.Value.[1..]
+                match Array.tryItem argIndex this.Args with
+                | Some e -> printer.ComplexExpressionWithParens(e)
+                | None -> printer.Print("undefined")
 
-                let lastMatch = matches.[matches.Count - 1]
-                printSegment printer value (lastMatch.Index + lastMatch.Length) value.Length
-            else
-                printSegment printer value 0 value.Length
+            let lastMatch = matches.[matches.Count - 1]
+            printSegment printer value (lastMatch.Index + lastMatch.Length) value.Length
+        else
+            printSegment printer value 0 value.Length
 
 // Template Literals
 //type TemplateElement(value: string, tail, ?loc) =
@@ -559,12 +588,11 @@ type Identifier =
         Identifier.Create(name, ?optional = optional, ?typeAnnotation = typeAnnotation, ?loc = loc)
         |> IdentifierPattern
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print(this.Name, ?loc=this.Loc)
-            if this.Optional = Some true then
-                printer.Print("?")
-            printer.PrintOptional(this.TypeAnnotation)
+    member this.Print(printer) =
+        printer.Print(this.Name, ?loc=this.Loc)
+        if this.Optional = Some true then
+            printer.Print("?")
+        printer.PrintOptional(this.TypeAnnotation)
 
 // Literals
 type RegExpLiteral =
@@ -585,12 +613,12 @@ type RegExpLiteral =
           |> RegExp
     static member AsExpr(pattern, flags_, ?loc) : Expression =
         RegExpLiteral.AsLiteral(pattern, flags_, ?loc=loc) |> Literal
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print("/", ?loc=this.Loc)
-            printer.Print(this.Pattern)
-            printer.Print("/")
-            printer.Print(this.Flags)
+
+    member this.Print(printer: Printer) =
+        printer.Print("/", ?loc=this.Loc)
+        printer.Print(this.Pattern)
+        printer.Print("/")
+        printer.Print(this.Flags)
 
 type Undefined =
     { Loc: SourceLocation option }
@@ -598,9 +626,8 @@ type Undefined =
     static member AsExpr(?loc): Expression = { Loc = loc } |> Undefined
 
     // TODO: Use `void 0` instead? Just remove this node?
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print("undefined", ?loc=this.Loc)
+    member this.Print(printer: Printer) =
+        printer.Print("undefined", ?loc=this.Loc)
 
 type NullLiteral =
     { Loc: SourceLocation option }
@@ -611,9 +638,8 @@ type NullLiteral =
 
     static member AsExpr(?loc) : Expression =
         NullLiteral.AsLiteral(?loc=loc) |> Literal
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print("null", ?loc=this.Loc)
+    member this.Print(printer: Printer) =
+        printer.Print("null", ?loc=this.Loc)
 
 type StringLiteral =
     { Value: string
@@ -627,11 +653,10 @@ type StringLiteral =
         StringLiteral.Create(value, ?loc=loc) |> StringLiteral
     static member AsExpr(value, ?loc) : Expression =
         StringLiteral.AsLiteral(value, ?loc=loc) |> Literal
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print("\"", ?loc=this.Loc)
-            printer.Print(printer.EscapeJsStringLiteral(this.Value))
-            printer.Print("\"")
+    member this.Print(printer: Printer) =
+        printer.Print("\"", ?loc=this.Loc)
+        printer.Print(printer.EscapeJsStringLiteral(this.Value))
+        printer.Print("\"")
 
 type BooleanLiteral =
     { Value: bool
@@ -645,9 +670,8 @@ type BooleanLiteral =
     static member AsExpr(value, ?loc) : Expression =
          BooleanLiteral.Create(value, ?loc=loc) |> Literal
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print((if this.Value then "true" else "false"), ?loc=this.Loc)
+    member this.Print(printer: Printer) =
+        printer.Print((if this.Value then "true" else "false"), ?loc=this.Loc)
 
 type NumericLiteral =
     { Value: float
@@ -662,14 +686,13 @@ type NumericLiteral =
         NumericLiteral.AsLiteral(value, ?loc=loc)
         |> Literal
 
-    interface IPrintable with
-        member this.Print(printer) =
-            let value =
-                match this.Value.ToString(System.Globalization.CultureInfo.InvariantCulture) with
-                | "∞" -> "Infinity"
-                | "-∞" -> "-Infinity"
-                | value -> value
-            printer.Print(value, ?loc=this.Loc)
+    member this.Print(printer: Printer) =
+        let value =
+            match this.Value.ToString(System.Globalization.CultureInfo.InvariantCulture) with
+            | "∞" -> "Infinity"
+            | "-∞" -> "-Infinity"
+            | value -> value
+        printer.Print(value, ?loc=this.Loc)
 
 // Misc
 //type Decorator(value, ?loc) =
@@ -681,8 +704,7 @@ type DirectiveLiteral =
 
     static member Create(value) = { Value = value }
 
-    interface IPrintable with
-        member _.Print(_) = failwith "not implemented"
+    member _.Print(_) = failwith "not implemented"
 
 /// e.g. "use strict";
 type Directive =
@@ -690,8 +712,7 @@ type Directive =
 
     static member Create(value) = { Value = value }
 
-    interface IPrintable with
-        member _.Print(_) = failwith "not implemented"
+    member _.Print(_) = failwith "not implemented"
 
 // Program
 
@@ -715,8 +736,7 @@ type ExpressionStatement =
 
     static member AsStatement(expression): Statement = { Expression = expression } |> ExpressionStatement
 
-    interface IPrintable with
-        member this.Print(printer) = printer.Print(this.Expression)
+    member this.Print(printer) = this.Expression.Print(printer)
 
 /// A block statement, i.e., a sequence of statements surrounded by braces.
 type BlockStatement =
@@ -728,8 +748,7 @@ type BlockStatement =
     static member AsStatement(body) = BlockStatement.Create(body) |> BlockStatement
     //    let directives = [||] // defaultArg directives_ [||]
 //    member _.Directives: Directive array = directives
-    interface IPrintable with
-        member this.Print(printer) = printer.PrintBlock(this.Body)
+    member this.Print(printer) = printer.PrintBlock(this.Body)
 
 /// An empty statement, i.e., a solitary semicolon.
 //type EmptyStatement(?loc) =
@@ -741,8 +760,7 @@ type DebuggerStatement =
 
     static member AsStatement(?loc): Statement = { Loc = loc } |> DebuggerStatement
 
-    interface IPrintable with
-        member this.Print(printer) = printer.Print("debugger", ?loc = this.Loc)
+    member this.Print(printer: Printer) = printer.Print("debugger", ?loc = this.Loc)
 
 /// Statement (typically loop) prefixed with a label (for continue and break)
 type LabeledStatement =
@@ -751,13 +769,12 @@ type LabeledStatement =
 
     static member AsStatement(label, body): Statement = { Body = body; Label = label } |> LabeledStatement
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print(this.Label)
-            printer.Print(":")
-            printer.PrintNewLine()
-            // Don't push indent
-            printer.Print(this.Body)
+    member this.Print(printer: Printer) =
+        this.Label.Print(printer)
+        printer.Print(":")
+        printer.PrintNewLine()
+        // Don't push indent
+        this.Body.Print(printer)
 
 /// Break can optionally take a label of a loop to break
 type BreakStatement =
@@ -766,8 +783,7 @@ type BreakStatement =
 
     static member AsStatement(?label, ?loc): Statement = { Label = label; Loc = loc } |> BreakStatement
 
-    interface IPrintable with
-        member this.Print(printer) = printer.Print("break", ?loc = this.Loc)
+    member this.Print(printer) = printer.Print("break", ?loc = this.Loc)
 
 /// Continue can optionally take a label of a loop to continue
 type ContinueStatement =
@@ -776,10 +792,9 @@ type ContinueStatement =
 
     static member AsStatement(?label, ?loc): Statement = { Label = label; Loc = loc } |> ContinueStatement
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print("continue", ?loc=this.Loc)
-            printer.PrintOptional(" ", this.Label)
+    member this.Print(printer) =
+        printer.Print("continue", ?loc=this.Loc)
+        printer.PrintOptional(this.Label, " ")
 
 // type WithStatement
 
@@ -792,10 +807,9 @@ type ReturnStatement =
         { Argument = argument; Loc = loc }
         |> ReturnStatement
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print("return ", ?loc = this.Loc)
-            printer.Print(this.Argument)
+    member this.Print(printer) =
+        printer.Print("return ", ?loc = this.Loc)
+        this.Argument.Print(printer)
 
 type IfStatement =
     { Test: Expression
@@ -810,36 +824,35 @@ type IfStatement =
           Loc = loc }
         |> IfStatement
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.AddLocation(this.Loc)
-            printer.Print("if (", ?loc=this.Loc)
-            printer.Print(this.Test)
-            printer.Print(") ")
-            printer.Print(this.Consequent)
-            match this.Alternate with
-            | None -> ()
-            | Some alternate ->
-                if printer.Column > 0 then printer.Print(" ")
-                match alternate with
-                | IfStatement(iff) ->
-                    printer.Print("else ")
-                    printer.Print(iff)
-                | alternate ->
-                    let statements =
-                        match alternate with
-                        | BlockStatement(b) -> b.Body
-                        | alternate -> [|alternate|]
-                    // Get productive statements and skip `else` if they're empty
-                    statements
-                    |> Array.filter printer.IsProductiveStatement
-                    |> function
-                        | [||] -> ()
-                        | statements ->
-                            printer.Print("else ")
-                            printer.PrintBlock(statements)
-            if printer.Column > 0 then
-                printer.PrintNewLine()
+    member this.Print(printer) =
+        printer.AddLocation(this.Loc)
+        printer.Print("if (", ?loc=this.Loc)
+        this.Test.Print(printer)
+        printer.Print(") ")
+        this.Consequent.Print(printer)
+        match this.Alternate with
+        | None -> ()
+        | Some alternate ->
+            if printer.Column > 0 then printer.Print(" ")
+            match alternate with
+            | IfStatement(iff) ->
+                printer.Print("else ")
+                iff.Print(printer)
+            | alternate ->
+                let statements =
+                    match alternate with
+                    | BlockStatement(b) -> b.Body
+                    | alternate -> [|alternate|]
+                // Get productive statements and skip `else` if they're empty
+                statements
+                |> Array.filter printer.IsProductiveStatement
+                |> function
+                    | [||] -> ()
+                    | statements ->
+                        printer.Print("else ")
+                        printer.PrintBlock(statements)
+        if printer.Column > 0 then
+            printer.PrintNewLine()
 
 /// A case (if test is an Expression) or default (if test === null) clause in the body of a switch statement.
 type SwitchCase =
@@ -852,26 +865,25 @@ type SwitchCase =
           Consequent = consequent
           Loc = loc }
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.AddLocation(this.Loc)
+    member this.Print(printer) =
+        printer.AddLocation(this.Loc)
 
-            match this.Test with
-            | None -> printer.Print("default")
-            | Some test ->
-                printer.Print("case ")
-                printer.Print(test)
+        match this.Test with
+        | None -> printer.Print("default")
+        | Some test ->
+            printer.Print("case ")
+            test.Print(printer)
 
-            printer.Print(":")
+        printer.Print(":")
 
-            match this.Consequent.Length with
-            | 0 -> printer.PrintNewLine()
-            | 1 ->
-                printer.Print(" ")
-                printer.Print(this.Consequent.[0])
-            | _ ->
-                printer.Print(" ")
-                printer.PrintBlock(this.Consequent)
+        match this.Consequent.Length with
+        | 0 -> printer.PrintNewLine()
+        | 1 ->
+            printer.Print(" ")
+            this.Consequent.[0].Print(printer)
+        | _ ->
+            printer.Print(" ")
+            printer.PrintBlock(this.Consequent)
 
 type SwitchStatement =
     { Discriminant: Expression
@@ -884,12 +896,11 @@ type SwitchStatement =
           Loc = loc }
         |> SwitchStatement
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print("switch (", ?loc=this.Loc)
-            printer.Print(this.Discriminant)
-            printer.Print(") ")
-            printer.PrintBlock(this.Cases, (fun p x -> p.Print(x)), fun _ -> ())
+    member this.Print(printer) =
+        printer.Print("switch (", ?loc=this.Loc)
+        this.Discriminant.Print(printer)
+        printer.Print(") ")
+        printer.PrintBlock(this.Cases, (fun p x -> x.Print(p)), fun _ -> ())
 
 // Exceptions
 type ThrowStatement =
@@ -900,10 +911,9 @@ type ThrowStatement =
         { Argument = argument; Loc = loc }
         |> ThrowStatement
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print("throw ", ?loc = this.Loc)
-            printer.Print(this.Argument)
+    member this.Print(printer) =
+        printer.Print("throw ", ?loc = this.Loc)
+        this.Argument.Print(printer)
 
 /// A catch clause following a try block.
 type CatchClause =
@@ -916,13 +926,12 @@ type CatchClause =
           Body = body
           Loc = loc }
 
-    interface IPrintable with
-        member this.Print(printer) =
-            // "catch" is being printed by TryStatement
-            printer.Print("(", ?loc = this.Loc)
-            printer.Print(this.Param)
-            printer.Print(") ")
-            printer.Print(this.Body)
+    member this.Print(printer) =
+        // "catch" is being printed by TryStatement
+        printer.Print("(", ?loc = this.Loc)
+        this.Param.Print(printer)
+        printer.Print(") ")
+        this.Body.Print(printer)
 
 /// If handler is null then finalizer must be a BlockStatement.
 type TryStatement =
@@ -938,12 +947,11 @@ type TryStatement =
           Loc = loc }
         |> TryStatement
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print("try ", ?loc = this.Loc)
-            printer.Print(this.Block)
-            printer.PrintOptional("catch ", this.Handler)
-            printer.PrintOptional("finally ", this.Finalizer)
+    member this.Print(printer) =
+        printer.Print("try ", ?loc = this.Loc)
+        this.Block.Print(printer)
+        printer.PrintOptional(this.Handler, "catch ")
+        printer.PrintOptional(this.Finalizer, "finally ")
 
 // Declarations
 type VariableDeclarator =
@@ -952,8 +960,7 @@ type VariableDeclarator =
 
     static member Create(id, ?init) = { Id = id; Init = init }
 
-    interface IPrintable with
-        member this.Print(printer) = failwith "Not implemented"
+    member this.Print(printer) = failwith "Not implemented"
 
 type VariableDeclarationKind =
     | Var
@@ -998,23 +1005,22 @@ type VariableDeclaration =
         VariableDeclaration.AsDeclaration(var, ?init = init, ?kind = kind, ?loc = loc)
         |> Declaration
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print(this.Kind + " ", ?loc = this.Loc)
-            let canConflict = this.Declarations.Length > 1
+    member this.Print(printer: Printer) =
+        printer.Print(this.Kind + " ", ?loc = this.Loc)
+        let canConflict = this.Declarations.Length > 1
 
-            for i = 0 to this.Declarations.Length - 1 do
-                let decl = this.Declarations.[i]
-                printer.Print(decl.Id)
+        for i = 0 to this.Declarations.Length - 1 do
+            let decl = this.Declarations.[i]
+            decl.Id.Print(printer)
 
-                match decl.Init with
-                | None -> ()
-                | Some e ->
-                    printer.Print(" = ")
-                    if canConflict then printer.ComplexExpressionWithParens(e)
-                    else printer.SequenceExpressionWithParens(e)
-                if i < this.Declarations.Length - 1 then
-                    printer.Print(", ")
+            match decl.Init with
+            | None -> ()
+            | Some e ->
+                printer.Print(" = ")
+                if canConflict then printer.ComplexExpressionWithParens(e)
+                else printer.SequenceExpressionWithParens(e)
+            if i < this.Declarations.Length - 1 then
+                printer.Print(", ")
 
 // Loops
 type WhileStatement =
@@ -1026,12 +1032,11 @@ type WhileStatement =
         { Test = test; Body = body; Loc = loc }
         |> WhileStatement
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print("while (", ?loc = this.Loc)
-            printer.Print(this.Test)
-            printer.Print(") ")
-            printer.Print(this.Body)
+    member this.Print(printer: Printer) =
+        printer.Print("while (", ?loc = this.Loc)
+        this.Test.Print(printer)
+        printer.Print(") ")
+        this.Body.Print(printer)
 
 //type DoWhileStatement(body, test, ?loc) =
 //    inherit Statement("DoWhileStatement", ?loc = loc)
@@ -1055,16 +1060,15 @@ type ForStatement =
           Loc = loc }
         |> ForStatement
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print("for (", ?loc = this.Loc)
-            printer.PrintOptional(this.Init)
-            printer.Print("; ")
-            printer.PrintOptional(this.Test)
-            printer.Print("; ")
-            printer.PrintOptional(this.Update)
-            printer.Print(") ")
-            printer.Print(this.Body)
+    member this.Print(printer) =
+        printer.Print("for (", ?loc = this.Loc)
+        printer.PrintOptional(this.Init)
+        printer.Print("; ")
+        printer.PrintOptional(this.Test)
+        printer.Print("; ")
+        printer.PrintOptional(this.Update)
+        printer.Print(") ")
+        this.Body.Print(printer)
 
 /// When passing a VariableDeclaration, the bound value must go through
 /// the `right` parameter instead of `init` property in VariableDeclarator
@@ -1104,10 +1108,9 @@ type FunctionDeclaration =
 //    member _.Async: bool = async
 //    member _.Generator: bool = generator
 //    member _.Declare: bool option = declare
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.PrintFunction(Some this.Id, this.Params, this.Body, this.TypeParameters, this.ReturnType, this.Loc, isDeclaration=true)
-            printer.PrintNewLine()
+    member this.Print(printer: Printer) =
+        printer.PrintFunction(Some this.Id, this.Params, this.Body, this.TypeParameters, this.ReturnType, this.Loc, isDeclaration=true)
+        printer.PrintNewLine()
 
 // Expressions
 
@@ -1117,16 +1120,14 @@ type Super =
 
     static member AsExpr(?loc): Expression = { Loc = loc } |> Super
 
-    interface IPrintable with
-        member this.Print(printer) = printer.Print("super", ?loc = this.Loc)
+    member this.Print(printer: Printer) = printer.Print("super", ?loc = this.Loc)
 
 type ThisExpression =
     { Loc: SourceLocation option }
 
     static member AsExpr(?loc): Expression = { Loc = loc } |> ThisExpression
 
-    interface IPrintable with
-        member this.Print(printer) = printer.Print("this", ?loc = this.Loc)
+    member this.Print(printer: Printer) = printer.Print("this", ?loc = this.Loc)
 
 /// A fat arrow function expression, e.g., let foo = (bar) => { /* body */ }.
 type ArrowFunctionExpression =
@@ -1152,17 +1153,16 @@ type ArrowFunctionExpression =
 //    let generator = defaultArg generator_ false
 //    member _.Async: bool = async
 //    member _.Generator: bool = generator
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.PrintFunction(
-                None,
-                this.Params,
-                this.Body,
-                this.TypeParameters,
-                this.ReturnType,
-                this.Loc,
-                isArrow = true
-            )
+    member this.Print(printer) =
+        printer.PrintFunction(
+            None,
+            this.Params,
+            this.Body,
+            this.TypeParameters,
+            this.ReturnType,
+            this.Loc,
+            isArrow = true
+        )
 
 type FunctionExpression =
     { Id: Identifier option
@@ -1185,9 +1185,8 @@ type FunctionExpression =
 //    let generator = defaultArg generator_ false
 //    member _.Async: bool = async
 //    member _.Generator: bool = generator
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.PrintFunction(this.Id, this.Params, this.Body, this.TypeParameters, this.ReturnType, this.Loc)
+    member this.Print(printer: Printer) =
+        printer.PrintFunction(this.Id, this.Params, this.Body, this.TypeParameters, this.ReturnType, this.Loc)
 
 ///// e.g., x = do { var t = f(); t * t + 1 };
 ///// http://wiki.ecmascript.org/doku.php?id=strawman:do_expressions
@@ -1224,10 +1223,9 @@ type SpreadElement =
         { Argument = argument; Loc = loc }
         |> SpreadElement
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print("...", ?loc = this.Loc)
-            printer.ComplexExpressionWithParens(this.Argument)
+    member this.Print(printer: Printer) =
+        printer.Print("...", ?loc = this.Loc)
+        printer.ComplexExpressionWithParens(this.Argument)
 
 type ArrayExpression =
     { // Elements: Choice<Expression, SpreadElement> option array
@@ -1240,21 +1238,19 @@ type ArrayExpression =
           Loc = loc }
         |> ArrayExpression
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print("[", ?loc = this.Loc)
-            printer.PrintCommaSeparatedArray(this.Elements)
-            printer.Print("]")
+    member this.Print(printer: Printer) =
+        printer.Print("[", ?loc = this.Loc)
+        printer.PrintCommaSeparatedArray(this.Elements)
+        printer.Print("]")
 
 type ObjectMember =
     | ObjectProperty of ObjectProperty
     | ObjectMethod of ObjectMethod
 
-    interface IPrintable with
-        member this.Print(printer) =
-            match this with
-            | ObjectProperty(op) -> printer.Print(op)
-            | ObjectMethod(op) -> printer.Print(op)
+    member this.Print(printer) =
+        match this with
+        | ObjectProperty(op) -> op.Print(printer)
+        | ObjectMethod(op) -> op.Print(printer)
 
 type ObjectProperty =
     { Key: Expression
@@ -1270,16 +1266,15 @@ type ObjectProperty =
         |> ObjectProperty
 //    let shorthand = defaultArg shorthand_ false
 //    member _.Shorthand: bool = shorthand
-    interface IPrintable with
-        member this.Print(printer) =
-            if this.Computed then
-                printer.Print("[")
-                printer.Print(this.Key)
-                printer.Print("]")
-            else
-                printer.Print(this.Key)
-            printer.Print(": ")
-            printer.SequenceExpressionWithParens(this.Value)
+    member this.Print(printer: Printer) =
+        if this.Computed then
+            printer.Print("[")
+            this.Key.Print(printer)
+            printer.Print("]")
+        else
+            this.Key.Print(printer)
+        printer.Print(": ")
+        printer.SequenceExpressionWithParens(this.Value)
 
 type ObjectMethodKind = ObjectGetter | ObjectSetter | ObjectMeth
 
@@ -1314,28 +1309,27 @@ type ObjectMethod =
           Loc = loc }
         |> ObjectMethod
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.AddLocation(this.Loc)
+    member this.Print(printer: Printer) =
+        printer.AddLocation(this.Loc)
 
-            if this.Kind <> "method" then
-                printer.Print(this.Kind + " ")
+        if this.Kind <> "method" then
+            printer.Print(this.Kind + " ")
 
-            if this.Computed then
-                printer.Print("[")
-                printer.Print(this.Key)
-                printer.Print("]")
-            else
-                printer.Print(this.Key)
+        if this.Computed then
+            printer.Print("[")
+            this.Key.Print(printer)
+            printer.Print("]")
+        else
+            this.Key.Print(printer)
 
-            printer.PrintOptional(this.TypeParameters)
-            printer.Print("(")
-            printer.PrintCommaSeparatedArray(this.Params)
-            printer.Print(")")
-            printer.PrintOptional(this.ReturnType)
-            printer.Print(" ")
+        printer.PrintOptional(this.TypeParameters)
+        printer.Print("(")
+        printer.PrintCommaSeparatedArray(this.Params)
+        printer.Print(")")
+        printer.PrintOptional(this.ReturnType)
+        printer.Print(" ")
 
-            printer.PrintBlock(this.Body.Body, skipNewLineAtEnd=true)
+        printer.PrintBlock(this.Body.Body, skipNewLineAtEnd=true)
 
 /// If computed is true, the node corresponds to a computed (a[b]) member expression and property is an Expression.
 /// If computed is false, the node corresponds to a static (a.b) member expression and property is an Identifier.
@@ -1360,8 +1354,6 @@ type MemberExpression =
           Loc = loc }
         |> MemberExpression
 
-    interface IPrintable with
-        member this.Print(printer) = this.Print(printer)
     member this.Print(printer, ?objectWithParens: bool) =
         printer.AddLocation(this.Loc)
         match objectWithParens, this.Object with
@@ -1369,11 +1361,11 @@ type MemberExpression =
         | _ -> printer.ComplexExpressionWithParens(this.Object)
         if this.Computed then
             printer.Print("[")
-            printer.Print(this.Property)
+            this.Property.Print(printer)
             printer.Print("]")
         else
             printer.Print(".")
-            printer.Print(this.Property)
+            this.Property.Print(printer)
 
 type ObjectExpression =
     { Properties: ObjectMember array
@@ -1383,15 +1375,14 @@ type ObjectExpression =
         { Properties = properties; Loc = loc }
         |> ObjectExpression
 
-    interface IPrintable with
-        member this.Print(printer) =
-            let printSeparator(p: Printer) =
-                p.Print(",")
-                p.PrintNewLine()
+    member this.Print(printer) =
+        let printSeparator(p: Printer) =
+            p.Print(",")
+            p.PrintNewLine()
 
-            printer.AddLocation(this.Loc)
-            if Array.isEmpty this.Properties then printer.Print("{}")
-            else printer.PrintBlock(this.Properties, (fun p x -> p.Print(x)), printSeparator, skipNewLineAtEnd=true)
+        printer.AddLocation(this.Loc)
+        if Array.isEmpty this.Properties then printer.Print("{}")
+        else printer.PrintBlock(this.Properties, (fun p x -> x.Print(p)), printSeparator, skipNewLineAtEnd=true)
 
 /// A conditional expression, i.e., a ternary ?/: expression.
 type ConditionalExpression =
@@ -1407,20 +1398,19 @@ type ConditionalExpression =
           Loc = loc }
         |> ConditionalExpression
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.AddLocation(this.Loc)
-            match this.Test with
-            // TODO: Move this optimization to Fable2Babel as with IfStatement?
-            | Literal(BooleanLiteral(b)) ->
-                if b.Value then printer.Print(this.Consequent)
-                else printer.Print(this.Alternate)
-            | _ ->
-                printer.ComplexExpressionWithParens(this.Test)
-                printer.Print(" ? ")
-                printer.ComplexExpressionWithParens(this.Consequent)
-                printer.Print(" : ")
-                printer.ComplexExpressionWithParens(this.Alternate)
+    member this.Print(printer) =
+        printer.AddLocation(this.Loc)
+        match this.Test with
+        // TODO: Move this optimization to Fable2Babel as with IfStatement?
+        | Literal(BooleanLiteral(b)) ->
+            if b.Value then this.Consequent.Print(printer)
+            else this.Alternate.Print(printer)
+        | _ ->
+            printer.ComplexExpressionWithParens(this.Test)
+            printer.Print(" ? ")
+            printer.ComplexExpressionWithParens(this.Consequent)
+            printer.Print(" : ")
+            printer.ComplexExpressionWithParens(this.Alternate)
 
 /// A function or method call expression.
 type CallExpression =
@@ -1435,13 +1425,12 @@ type CallExpression =
           Loc = loc }
         |> CallExpression
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.AddLocation(this.Loc)
-            printer.ComplexExpressionWithParens(this.Callee)
-            printer.Print("(")
-            printer.PrintCommaSeparatedArray(this.Arguments)
-            printer.Print(")")
+    member this.Print(printer) =
+        printer.AddLocation(this.Loc)
+        printer.ComplexExpressionWithParens(this.Callee)
+        printer.Print("(")
+        printer.PrintCommaSeparatedArray(this.Arguments)
+        printer.Print(")")
 
 type NewExpression =
     { Callee: Expression
@@ -1457,13 +1446,12 @@ type NewExpression =
           Loc = loc }
         |> NewExpression
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print("new ", ?loc=this.Loc)
-            printer.ComplexExpressionWithParens(this.Callee)
-            printer.Print("(")
-            printer.PrintCommaSeparatedArray(this.Arguments)
-            printer.Print(")")
+    member this.Print(printer) =
+        printer.Print("new ", ?loc=this.Loc)
+        printer.ComplexExpressionWithParens(this.Callee)
+        printer.Print("(")
+        printer.PrintCommaSeparatedArray(this.Arguments)
+        printer.Print(")")
 
 /// A comma-separated sequence of expressions.
 type SequenceExpression =
@@ -1474,10 +1462,9 @@ type SequenceExpression =
         { Expressions = expressions; Loc = loc }
         |> SequenceExpression
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.AddLocation(this.Loc)
-            printer.PrintCommaSeparatedArray(this.Expressions)
+    member this.Print(printer) =
+        printer.AddLocation(this.Loc)
+        printer.PrintCommaSeparatedArray(this.Expressions)
 
 // Unary Operations
 type UnaryExpression =
@@ -1504,13 +1491,12 @@ type UnaryExpression =
           Loc = loc }
         |> UnaryExpression
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.AddLocation(this.Loc)
-            match this.Operator with
-            | "-" | "+" | "!" | "~" -> printer.Print(this.Operator)
-            | _ -> printer.Print(this.Operator + " ")
-            printer.ComplexExpressionWithParens(this.Argument)
+    member this.Print(printer) =
+        printer.AddLocation(this.Loc)
+        match this.Operator with
+        | "-" | "+" | "!" | "~" -> printer.Print(this.Operator)
+        | _ -> printer.Print(this.Operator + " ")
+        printer.ComplexExpressionWithParens(this.Argument)
 
 type UpdateExpression =
     { Prefix: bool
@@ -1530,15 +1516,14 @@ type UpdateExpression =
           Loc = loc }
         |> UpdateExpression
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.AddLocation(this.Loc)
-            if this.Prefix then
-                printer.Print(this.Operator)
-                printer.ComplexExpressionWithParens(this.Argument)
-            else
-                printer.ComplexExpressionWithParens(this.Argument)
-                printer.Print(this.Operator)
+    member this.Print(printer) =
+        printer.AddLocation(this.Loc)
+        if this.Prefix then
+            printer.Print(this.Operator)
+            printer.ComplexExpressionWithParens(this.Argument)
+        else
+            printer.ComplexExpressionWithParens(this.Argument)
+            printer.Print(this.Operator)
 
 // Binary Operations
 type BinaryExpression =
@@ -1578,9 +1563,9 @@ type BinaryExpression =
           Operator = operator
           Loc = loc }
         |> BinaryExpression
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.PrintOperation(this.Left, this.Operator, this.Right, this.Loc)
+
+    member this.Print(printer) =
+        printer.PrintOperation(this.Left, this.Operator, this.Right, this.Loc)
 
 type AssignmentExpression =
     { Left: Expression
@@ -1609,9 +1594,9 @@ type AssignmentExpression =
           Operator = operator
           Loc = loc }
         |> AssignmentExpression
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.PrintOperation(this.Left, this.Operator, this.Right, this.Loc)
+
+    member this.Print(printer) =
+        printer.PrintOperation(this.Left, this.Operator, this.Right, this.Loc)
 
 type LogicalExpression =
     { Left: Expression
@@ -1630,9 +1615,9 @@ type LogicalExpression =
           Operator = operator
           Loc = loc }
         |> LogicalExpression
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.PrintOperation(this.Left, this.Operator, this.Right, this.Loc)
+
+    member this.Print(printer) =
+        printer.PrintOperation(this.Left, this.Operator, this.Right, this.Loc)
 
 // Patterns
 // type AssignmentProperty(key, value, ?loc) =
@@ -1667,22 +1652,21 @@ type RestElement =
           TypeAnnotation = typeAnnotation
           Loc = loc }
         |> RestElement
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print("...", ?loc=this.Loc)
-            printer.Print(this.Argument)
-            printer.PrintOptional(this.TypeAnnotation)
+
+    member this.Print(printer: Printer) =
+        printer.Print("...", ?loc=this.Loc)
+        this.Argument.Print(printer)
+        printer.PrintOptional(this.TypeAnnotation)
 
 // Classes
 type ClassMember =
     | ClassMethod of ClassMethod
     | ClassProperty of ClassProperty
 
-    interface IPrintable with
-        member this.Print(printer) =
-            match this with
-            | ClassMethod(cm) -> printer.Print(cm)
-            | ClassProperty(cp) -> printer.Print(cp)
+    member this.Print(printer) =
+        match this with
+        | ClassMethod(cm) -> cm.Print(printer)
+        | ClassProperty(cp) -> cp.Print(printer)
 
 type ClassMethodKind =
     | ClassImplicitConstructor | ClassFunction | ClassGetter | ClassSetter
@@ -1721,34 +1705,33 @@ type ClassMethod =
         |> ClassMethod
     // This appears in astexplorer.net but it's not documented
     // member _.Expression: bool = false
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.AddLocation(this.Loc)
+    member this.Print(printer: Printer) =
+        printer.AddLocation(this.Loc)
 
-            let keywords = [
-                if this.Static = Some true then yield "static"
-                if this.Abstract = Some true then yield "abstract"
-                if this.Kind = "get" || this.Kind = "set" then yield this.Kind
-            ]
+        let keywords = [
+            if this.Static = Some true then yield "static"
+            if this.Abstract = Some true then yield "abstract"
+            if this.Kind = "get" || this.Kind = "set" then yield this.Kind
+        ]
 
-            if not (List.isEmpty keywords) then
-                printer.Print((String.concat " " keywords) + " ")
+        if not (List.isEmpty keywords) then
+            printer.Print((String.concat " " keywords) + " ")
 
-            if this.Computed then
-                printer.Print("[")
-                printer.Print(this.Key)
-                printer.Print("]")
-            else
-                printer.Print(this.Key)
+        if this.Computed then
+            printer.Print("[")
+            this.Key.Print(printer)
+            printer.Print("]")
+        else
+            this.Key.Print(printer)
 
-            printer.PrintOptional(this.TypeParameters)
-            printer.Print("(")
-            printer.PrintCommaSeparatedArray(this.Params)
-            printer.Print(")")
-            printer.PrintOptional(this.ReturnType)
-            printer.Print(" ")
+        printer.PrintOptional(this.TypeParameters)
+        printer.Print("(")
+        printer.PrintCommaSeparatedArray(this.Params)
+        printer.Print(")")
+        printer.PrintOptional(this.ReturnType)
+        printer.Print(" ")
 
-            printer.Print(this.Body)
+        this.Body.Print(printer)
 
 /// ES Class Fields & Static Properties
 /// https://github.com/jeffmo/es-class-fields-and-static-properties
@@ -1774,21 +1757,20 @@ type ClassProperty =
           Loc = loc }
         |> ClassProperty
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.AddLocation(this.Loc)
-            if this.Static then
-                printer.Print("static ")
-            if this.Computed then
-                printer.Print("[")
-                printer.Print(this.Key)
-                printer.Print("]")
-            else
-                printer.Print(this.Key)
-            if this.Optional then
-                printer.Print("?")
-            printer.PrintOptional(this.TypeAnnotation)
-            printer.PrintOptional(": ", this.Value)
+    member this.Print(printer: Printer) =
+        printer.AddLocation(this.Loc)
+        if this.Static then
+            printer.Print("static ")
+        if this.Computed then
+            printer.Print("[")
+            this.Key.Print(printer)
+            printer.Print("]")
+        else
+            this.Key.Print(printer)
+        if this.Optional then
+            printer.Print("?")
+        printer.PrintOptional(this.TypeAnnotation)
+        printer.PrintOptional(this.Value, ": ")
 
 type ClassImplements =
     { Id: Identifier
@@ -1798,10 +1780,9 @@ type ClassImplements =
         { Id = id
           TypeParameters = typeParameters }
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print(this.Id)
-            printer.PrintOptional(this.TypeParameters)
+    member this.Print(printer) =
+        this.Id.Print(printer)
+        printer.PrintOptional(this.TypeParameters)
 
 type ClassBody =
     { Body: ClassMember array
@@ -1811,10 +1792,9 @@ type ClassBody =
         { Body = body
           Loc = loc }
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.AddLocation(this.Loc)
-            printer.PrintBlock(this.Body, (fun p x -> p.Print(x)), (fun p -> p.PrintStatementSeparator()))
+    member this.Print(printer) =
+        printer.AddLocation(this.Loc)
+        printer.PrintBlock(this.Body, (fun p x -> x.Print(p)), (fun p -> p.PrintStatementSeparator()))
 
 type ClassDeclaration =
     { Body: ClassBody
@@ -1835,9 +1815,8 @@ type ClassDeclaration =
           Loc = loc }
         |> ClassDeclaration
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.PrintClass(this.Id, this.SuperClass, this.SuperTypeParameters, this.TypeParameters, this.Implements, this.Body, this.Loc)
+    member this.Print(printer: Printer) =
+        printer.PrintClass(this.Id, this.SuperClass, this.SuperTypeParameters, this.TypeParameters, this.Implements, this.Body, this.Loc)
 
 /// Anonymous class: e.g., var myClass = class { }
 type ClassExpression =
@@ -1859,9 +1838,8 @@ type ClassExpression =
           Loc = loc }
         |> ClassExpression
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.PrintClass(this.Id, this.SuperClass, this.SuperTypeParameters, this.TypeParameters, this.Implements, this.Body, this.Loc)
+    member this.Print(printer) =
+        printer.PrintClass(this.Id, this.SuperClass, this.SuperTypeParameters, this.TypeParameters, this.Implements, this.Body, this.Loc)
 
 // type MetaProperty(meta, property, ?loc) =
 //     interface Expression with
@@ -1876,19 +1854,17 @@ type PrivateModuleDeclaration =
         { Statement = statement }
         |> PrivateModuleDeclaration
 
-    interface IPrintable with
-        member this.Print(printer) =
-            if printer.IsProductiveStatement(this.Statement) then
-                printer.Print(this.Statement)
+    member this.Print(printer: Printer) =
+        if printer.IsProductiveStatement(this.Statement) then
+            this.Statement.Print(printer)
 
 type ImportSpecifier =
     | ImportMemberSpecifier of ImportMemberSpecifier
     | ImportDefaultSpecifier of ImportDefaultSpecifier
     | ImportNamespaceSpecifier of ImportNamespaceSpecifier
 
-    interface IPrintable with
-        member this.Print(printer) =
-            failwith "not implemented"
+    member this.Print(printer) =
+        failwith "not implemented"
 
 /// An imported variable binding, e.g., {foo} in import {foo} from "mod" or {foo as bar} in import {foo as bar} from "mod".
 /// The imported field refers to the name of the export imported from the module.
@@ -1903,13 +1879,12 @@ type ImportMemberSpecifier =
         { Local = local; Imported = imported }
         |> ImportMemberSpecifier
 
-    interface IPrintable with
-        member this.Print(printer) =
-            // Don't print the braces, this will be done in the import declaration
-            printer.Print(this.Imported)
-            if this.Imported.Name <> this.Local.Name then
-                printer.Print(" as ")
-                printer.Print(this.Local)
+    member this.Print(printer) =
+        // Don't print the braces, this will be done in the import declaration
+        this.Imported.Print(printer)
+        if this.Imported.Name <> this.Local.Name then
+            printer.Print(" as ")
+            this.Local.Print(printer)
 
 /// A default import specifier, e.g., foo in import foo from "mod".
 type ImportDefaultSpecifier =
@@ -1917,9 +1892,8 @@ type ImportDefaultSpecifier =
 
     static member AsImportSpecifier(local): ImportSpecifier = { Local = local } |> ImportDefaultSpecifier
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print(this.Local)
+    member this.Print(printer) =
+        this.Local.Print(printer)
 
 /// A namespace import specifier, e.g., * as foo in import * as foo from "mod".
 type ImportNamespaceSpecifier =
@@ -1927,10 +1901,9 @@ type ImportNamespaceSpecifier =
 
     static member AsImportSpecifier(local): ImportSpecifier = { Local = local } |> ImportNamespaceSpecifier
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print("* as ")
-            printer.Print(this.Local)
+    member this.Print(printer: Printer) =
+        printer.Print("* as ")
+        this.Local.Print(printer)
 
 /// e.g., import foo from "mod";.
 type ImportDeclaration =
@@ -1942,35 +1915,34 @@ type ImportDeclaration =
           Source = source }
         |> ImportDeclaration
 
-    interface IPrintable with
-        member this.Print(printer) =
-            let members = this.Specifiers |> Array.choose (function ImportMemberSpecifier(x) -> Some x | _ -> None)
-            let defaults = this.Specifiers|> Array.choose (function ImportDefaultSpecifier(x) -> Some x | _ -> None)
-            let namespaces = this.Specifiers |> Array.choose (function ImportNamespaceSpecifier(x) -> Some x | _ -> None)
+    member this.Print(printer: Printer) =
+        let members = this.Specifiers |> Array.choose (function ImportMemberSpecifier(x) -> Some x | _ -> None)
+        let defaults = this.Specifiers|> Array.choose (function ImportDefaultSpecifier(x) -> Some x | _ -> None)
+        let namespaces = this.Specifiers |> Array.choose (function ImportNamespaceSpecifier(x) -> Some x | _ -> None)
 
-            printer.Print("import ")
+        printer.Print("import ")
 
-            if not(Array.isEmpty defaults) then
-                printer.PrintCommaSeparatedArray(defaults)
-                if not(Array.isEmpty namespaces && Array.isEmpty members) then
-                    printer.Print(", ")
+        if not(Array.isEmpty defaults) then
+            printer.PrintCommaSeparatedArray(defaults)
+            if not(Array.isEmpty namespaces && Array.isEmpty members) then
+                printer.Print(", ")
 
-            if not(Array.isEmpty namespaces) then
-                printer.PrintCommaSeparatedArray(namespaces)
-                if not(Array.isEmpty members) then
-                    printer.Print(", ")
-
+        if not(Array.isEmpty namespaces) then
+            printer.PrintCommaSeparatedArray(namespaces)
             if not(Array.isEmpty members) then
-                printer.Print("{ ")
-                printer.PrintCommaSeparatedArray(members)
-                printer.Print(" }")
+                printer.Print(", ")
 
-            if not(Array.isEmpty defaults && Array.isEmpty namespaces && Array.isEmpty members) then
-                printer.Print(" from ")
+        if not(Array.isEmpty members) then
+            printer.Print("{ ")
+            printer.PrintCommaSeparatedArray(members)
+            printer.Print(" }")
 
-            printer.Print("\"")
-            printer.Print(printer.MakeImportPath(this.Source.Value))
-            printer.Print("\"")
+        if not(Array.isEmpty defaults && Array.isEmpty namespaces && Array.isEmpty members) then
+            printer.Print(" from ")
+
+        printer.Print("\"")
+        printer.Print(printer.MakeImportPath(this.Source.Value))
+        printer.Print("\"")
 
 /// An exported variable binding, e.g., {foo} in export {foo} or {bar as foo} in export {bar as foo}.
 /// The exported field refers to the name exported in the module.
@@ -1983,13 +1955,12 @@ type ExportSpecifier =
       Exported: Identifier }
 
     static member Create(local, exported) = { Local = local; Exported = exported }
-    interface IPrintable with
-        member this.Print(printer) =
-            // Don't print the braces, this will be done in the export declaration
-            printer.Print(this.Local)
-            if this.Exported.Name <> this.Local.Name then
-                printer.Print(" as ")
-                printer.Print(this.Exported)
+    member this.Print(printer: Printer) =
+        // Don't print the braces, this will be done in the export declaration
+        this.Local.Print(printer)
+        if this.Exported.Name <> this.Local.Name then
+            printer.Print(" as ")
+            this.Exported.Print(printer)
 
 /// An export named declaration, e.g., export {foo, bar};, export {foo} from "mod"; or export var foo = 1;.
 /// Note: Having declaration populated with non-empty specifiers or non-null source results in an invalid state.
@@ -2000,10 +1971,9 @@ type ExportNamedDeclaration =
         { Declaration = declaration }
         |> ExportNamedDeclaration
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print("export ")
-            printer.Print(this.Declaration)
+    member this.Print(printer: Printer) =
+        printer.Print("export ")
+        this.Declaration.Print(printer)
 
 type ExportNamedReferences =
     { Specifiers: ExportSpecifier array
@@ -2014,13 +1984,12 @@ type ExportNamedReferences =
           Source = source }
         |> ExportNamedReferences
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print("export ")
-            printer.Print("{ ")
-            printer.PrintCommaSeparatedArray(this.Specifiers)
-            printer.Print(" }")
-            printer.PrintOptional(" from ", this.Source)
+    member this.Print(printer: Printer) =
+        printer.Print("export ")
+        printer.Print("{ ")
+        printer.PrintCommaSeparatedArray(this.Specifiers)
+        printer.Print(" }")
+        printer.PrintOptional(this.Source, " from ")
 
 /// An export default declaration, e.g., export default function () {}; or export default 1;.
 type ExportDefaultDeclaration =
@@ -2030,12 +1999,11 @@ type ExportDefaultDeclaration =
         { Declaration = declaration }
         |> ExportDefaultDeclaration
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print("export default ")
-            match this.Declaration with
-            | Choice1Of2 x -> printer.Print(x)
-            | Choice2Of2 x -> printer.Print(x)
+    member this.Print(printer: Printer) =
+        printer.Print("export default ")
+        match this.Declaration with
+        | Choice1Of2 x -> x.Print(printer)
+        | Choice2Of2 x -> x.Print(printer)
 
 /// An export batch declaration, e.g., export * from "mod";.
 type ExportAllDeclaration =
@@ -2046,10 +2014,9 @@ type ExportAllDeclaration =
         { Source = source; Loc = loc }
         |> ExportAllDeclaration
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print("export * from ", ?loc=this.Loc)
-            printer.Print(this.Source)
+    member this.Print(printer: Printer) =
+        printer.Print("export * from ", ?loc=this.Loc)
+        this.Source.Print(printer)
 
 // Type Annotations
 type TypeAnnotationInfo =
@@ -2066,31 +2033,29 @@ type TypeAnnotationInfo =
     | GenericTypeAnnotation of GenericTypeAnnotation
     | ObjectTypeAnnotation of ObjectTypeAnnotation
 
-    interface IPrintable with
-        member this.Print(printer) =
-            match this with
-            | StringTypeAnnotation -> printer.Print("string")
-            | NumberTypeAnnotation -> printer.Print("number")
-            | TypeAnnotationInfo(an) -> printer.Print(an)
-            | BooleanTypeAnnotation -> printer.Print("boolean")
-            | AnyTypeAnnotation -> printer.Print("any")
-            | VoidTypeAnnotation -> printer.Print("void")
-            | TupleTypeAnnotation(an) -> printer.Print(an)
-            | UnionTypeAnnotation(an) -> printer.Print(an)
-            | FunctionTypeAnnotation(an) -> printer.Print(an)
-            | NullableTypeAnnotation(an) -> printer.Print(an)
-            | GenericTypeAnnotation(an) -> printer.Print(an)
-            | ObjectTypeAnnotation(an) -> printer.Print(an)
+    member this.Print(printer) =
+        match this with
+        | StringTypeAnnotation -> printer.Print("string")
+        | NumberTypeAnnotation -> printer.Print("number")
+        | TypeAnnotationInfo(an) -> an.Print(printer)
+        | BooleanTypeAnnotation -> printer.Print("boolean")
+        | AnyTypeAnnotation -> printer.Print("any")
+        | VoidTypeAnnotation -> printer.Print("void")
+        | TupleTypeAnnotation(an) -> an.Print(printer)
+        | UnionTypeAnnotation(an) -> an.Print(printer)
+        | FunctionTypeAnnotation(an) -> an.Print(printer)
+        | NullableTypeAnnotation(an) -> an.Print(printer)
+        | GenericTypeAnnotation(an) -> an.Print(printer)
+        | ObjectTypeAnnotation(an) -> an.Print(printer)
 
 type TypeAnnotation =
     { TypeAnnotation: TypeAnnotationInfo }
 
     static member Create(typeAnnotation) = { TypeAnnotation = typeAnnotation }
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print(": ")
-            printer.Print(this.TypeAnnotation)
+    member this.Print(printer) =
+        printer.Print(": ")
+        this.TypeAnnotation.Print(printer)
 
 type TypeParameter =
     { Name: string
@@ -2102,53 +2067,48 @@ type TypeParameter =
           Bound = bound
           Default = ``default`` }
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print(this.Name)
-            // printer.PrintOptional(bound)
-            // printer.PrintOptional(``default``)
+    member this.Print(printer) =
+        printer.Print(this.Name)
+        // printer.PrintOptional(bound)
+        // printer.PrintOptional(``default``)
 
 type TypeParameterDeclaration =
     { Params: TypeParameter array }
 
     static member Create(``params``) = { Params = ``params`` }
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print("<")
-            printer.PrintCommaSeparatedArray(this.Params)
-            printer.Print(">")
+    member this.Print(printer) =
+        printer.Print("<")
+        printer.PrintCommaSeparatedArray(this.Params)
+        printer.Print(">")
 
 type TypeParameterInstantiation =
     { Params: TypeAnnotationInfo array }
 
     static member Create(``params``) = { Params = ``params`` }
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print("<")
-            printer.PrintCommaSeparatedArray(this.Params)
-            printer.Print(">")
+    member this.Print(printer) =
+        printer.Print("<")
+        printer.PrintCommaSeparatedArray(this.Params)
+        printer.Print(">")
 
 type TupleTypeAnnotation =
     { Types: TypeAnnotationInfo array }
 
     static member AsTypeAnnotationInfo(types): TypeAnnotationInfo = { Types = types } |> TupleTypeAnnotation
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print("[")
-            printer.PrintCommaSeparatedArray(this.Types)
-            printer.Print("]")
+    member this.Print(printer) =
+        printer.Print("[")
+        printer.PrintCommaSeparatedArray(this.Types)
+        printer.Print("]")
 
 type UnionTypeAnnotation =
     { Types: TypeAnnotationInfo array }
 
     static member AsTypeAnnotationInfo(types): TypeAnnotationInfo = { Types = types } |> UnionTypeAnnotation
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.PrintArray(this.Types, (fun p x -> p.Print(x)), (fun p -> p.Print(" | ")))
+    member this.Print(printer) =
+        printer.PrintArray(this.Types, (fun p x -> x.Print(p)), (fun p -> p.Print(" | ")))
 
 type FunctionTypeParam =
     { Name: Identifier
@@ -2160,13 +2120,12 @@ type FunctionTypeParam =
           TypeAnnotation = typeInfo
           Optional = optional }
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print(this.Name)
-            if this.Optional = Some true then
-                printer.Print("?")
-            printer.Print(": ")
-            printer.Print(this.TypeAnnotation)
+    member this.Print(printer) =
+        this.Name.Print(printer)
+        if this.Optional = Some true then
+            printer.Print("?")
+        printer.Print(": ")
+        this.TypeAnnotation.Print(printer)
 
 type FunctionTypeAnnotation =
     { Params: FunctionTypeParam array
@@ -2181,16 +2140,15 @@ type FunctionTypeAnnotation =
           Rest = rest }
         |> FunctionTypeAnnotation
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.PrintOptional(this.TypeParameters)
-            printer.Print("(")
-            printer.PrintCommaSeparatedArray(this.Params)
-            if Option.isSome this.Rest then
-                printer.Print("...")
-                printer.Print(this.Rest.Value)
-            printer.Print(") => ")
-            printer.Print(this.ReturnType)
+    member this.Print(printer) =
+        printer.PrintOptional(this.TypeParameters)
+        printer.Print("(")
+        printer.PrintCommaSeparatedArray(this.Params)
+        if Option.isSome this.Rest then
+            printer.Print("...")
+            this.Rest.Value.Print(printer)
+        printer.Print(") => ")
+        this.ReturnType.Print(printer)
 
 type NullableTypeAnnotation =
     { TypeAnnotation: TypeAnnotationInfo }
@@ -2199,9 +2157,8 @@ type NullableTypeAnnotation =
         { TypeAnnotation = ``type`` }
         |> NullableTypeAnnotation
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print(this.TypeAnnotation)
+    member this.Print(printer) =
+        this.TypeAnnotation.Print(printer)
 
 type GenericTypeAnnotation =
     { Id: Identifier
@@ -2212,10 +2169,9 @@ type GenericTypeAnnotation =
           TypeParameters = typeParameters }
         |> GenericTypeAnnotation
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print(this.Id)
-            printer.PrintOptional(this.TypeParameters)
+    member this.Print(printer) =
+        this.Id.Print(printer)
+        printer.PrintOptional(this.TypeParameters)
 
 type ObjectTypeProperty =
     { Key: Expression
@@ -2239,23 +2195,22 @@ type ObjectTypeProperty =
           Proto = defaultArg proto false
           Method = defaultArg method false }
 
-    interface IPrintable with
-        member this.Print(printer) =
-            if this.Static then
-                printer.Print("static ")
-            if Option.isSome this.Kind then
-                printer.Print(this.Kind.Value + " ")
-            if this.Computed then
-                printer.Print("[")
-                printer.Print(this.Key)
-                printer.Print("]")
-            else
-                printer.Print(this.Key)
-            if this.Optional then
-                printer.Print("?")
-            // TODO: proto, method
-            printer.Print(": ")
-            printer.Print(this.Value)
+    member this.Print(printer) =
+        if this.Static then
+            printer.Print("static ")
+        if Option.isSome this.Kind then
+            printer.Print(this.Kind.Value + " ")
+        if this.Computed then
+            printer.Print("[")
+            this.Key.Print(printer)
+            printer.Print("]")
+        else
+            this.Key.Print(printer)
+        if this.Optional then
+            printer.Print("?")
+        // TODO: proto, method
+        printer.Print(": ")
+        this.Value.Print(printer)
 
 type ObjectTypeIndexer =
     { Id: Identifier option
@@ -2270,8 +2225,7 @@ type ObjectTypeIndexer =
           Static = ``static`` }
         |> ObjectTypeIndexer
 
-    interface IPrintable with
-        member _.Print(_) = failwith "not implemented"
+    member _.Print(_) = failwith "not implemented"
 
 type ObjectTypeCallProperty =
     { Value: TypeAnnotationInfo
@@ -2279,8 +2233,7 @@ type ObjectTypeCallProperty =
 
     static member Create(value, ?``static``) = { Value = value; Static = ``static`` }
 
-    interface IPrintable with
-        member _.Print(_) = failwith "not implemented"
+    member _.Print(_) = failwith "not implemented"
 
 type ObjectTypeInternalSlot =
     { Id: Identifier
@@ -2295,8 +2248,7 @@ type ObjectTypeInternalSlot =
           Optional = optional
           Static = ``static``
           Method = method }
-    interface IPrintable with
-        member _.Print(_) = failwith "not implemented"
+    member _.Print(_) = failwith "not implemented"
 
 type ObjectTypeAnnotation =
     { Properties: ObjectTypeProperty array
@@ -2317,19 +2269,18 @@ type ObjectTypeAnnotation =
           InternalSlots = internalSlots
           Exact = exact }
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print("{")
-            printer.PrintNewLine()
-            printer.PushIndentation()
-            printer.PrintArray(this.Properties, (fun p x -> p.Print(x)), (fun p -> p.PrintStatementSeparator()))
-            printer.PrintArray(this.Indexers, (fun p x -> p.Print(x)), (fun p -> p.PrintStatementSeparator()))
-            printer.PrintArray(this.CallProperties, (fun p x -> p.Print(x)), (fun p -> p.PrintStatementSeparator()))
-            printer.PrintArray(this.InternalSlots, (fun p x -> p.Print(x)), (fun p -> p.PrintStatementSeparator()))
-            printer.PrintNewLine()
-            printer.PopIndentation()
-            printer.Print("}")
-            printer.PrintNewLine()
+    member this.Print(printer) =
+        printer.Print("{")
+        printer.PrintNewLine()
+        printer.PushIndentation()
+        printer.PrintArray(this.Properties, (fun p x -> x.Print(p)), (fun p -> p.PrintStatementSeparator()))
+        printer.PrintArray(this.Indexers, (fun p x -> x.Print(p)), (fun p -> p.PrintStatementSeparator()))
+        printer.PrintArray(this.CallProperties, (fun p x -> x.Print(p)), (fun p -> p.PrintStatementSeparator()))
+        printer.PrintArray(this.InternalSlots, (fun p x -> x.Print(p)), (fun p -> p.PrintStatementSeparator()))
+        printer.PrintNewLine()
+        printer.PopIndentation()
+        printer.Print("}")
+        printer.PrintNewLine()
 
 type InterfaceExtends =
     { Id: Identifier
@@ -2339,10 +2290,9 @@ type InterfaceExtends =
         { Id = id
           TypeParameters = typeParameters }
 
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print(this.Id)
-            printer.PrintOptional(this.TypeParameters)
+    member this.Print(printer) =
+        this.Id.Print(printer)
+        printer.PrintOptional(this.TypeParameters)
 
 type InterfaceDeclaration =
     { Id: Identifier
@@ -2364,19 +2314,18 @@ type InterfaceDeclaration =
 
 //    let mixins = defaultArg mixins_ [||]
 //    member _.Mixins: InterfaceExtends array = mixins
-    interface IPrintable with
-        member this.Print(printer) =
-            printer.Print("interface ")
-            printer.Print(this.Id)
-            printer.PrintOptional(this.TypeParameters)
+    member this.Print(printer: Printer) =
+        printer.Print("interface ")
+        this.Id.Print(printer)
+        printer.PrintOptional(this.TypeParameters)
 
-            if not (Array.isEmpty this.Extends) then
-                printer.Print(" extends ")
-                printer.PrintArray(this.Extends, (fun p x -> p.Print(x)), (fun p -> p.Print(", ")))
+        if not (Array.isEmpty this.Extends) then
+            printer.Print(" extends ")
+            printer.PrintArray(this.Extends, (fun p x -> x.Print(p)), (fun p -> p.Print(", ")))
 
-            if not (Array.isEmpty this.Implements) then
-                printer.Print(" implements ")
-                printer.PrintArray(this.Implements, (fun p x -> p.Print(x)), (fun p -> p.Print(", ")))
+        if not (Array.isEmpty this.Implements) then
+            printer.Print(" implements ")
+            printer.PrintArray(this.Implements, (fun p x -> x.Print(p)), (fun p -> p.Print(", ")))
 
-            printer.Print(" ")
-            printer.Print(this.Body)
+        printer.Print(" ")
+        this.Body.Print(printer)

--- a/src/Fable.Transforms/Global/Babel.fs
+++ b/src/Fable.Transforms/Global/Babel.fs
@@ -590,6 +590,8 @@ type RegExpLiteral =
             Flags = flags
             Loc = loc
         } |> RegExp
+    static member AsExpr(pattern, flags_, ?loc) : Expression =
+        RegExpLiteral.AsLiteral(pattern, flags_, ?loc=loc) |> Literal
     interface IPrintable with
         member this.Print(printer) =
             printer.Print("/", ?loc=this.Loc)
@@ -1038,6 +1040,9 @@ type VariableDeclaration =
     static member AsDeclaration(kind, declarations, ?loc) : Declaration =
         VariableDeclaration.Create(kind, declarations, ?loc=loc)
         |> VariableDeclaration
+    static member AsStatement(kind, declarations, ?loc) : Statement =
+        VariableDeclaration.AsDeclaration(kind, declarations, ?loc=loc)
+        |> Declaration
     static member AsDeclaration(var, ?init, ?kind, ?loc) : Declaration =
         VariableDeclaration.AsDeclaration(defaultArg kind Let, [|VariableDeclarator.Create(var, ?init=init)|], ?loc=loc)
     static member AsStatement(var, ?init, ?kind, ?loc) : Statement =

--- a/src/Fable.Transforms/Global/Babel.fs
+++ b/src/Fable.Transforms/Global/Babel.fs
@@ -16,7 +16,7 @@ type Printer =
 
 module PrinterExtensions =
     type Printer with
-        member printer.Print(node: #IPrintable) =
+        member printer.Print(node: IPrintable) =
             node.Print(printer)
 
         member printer.PrintBlock(nodes: 'a array, printNode: Printer -> 'a -> unit, printSeparator: Printer -> unit, ?skipNewLineAtEnd) =
@@ -397,7 +397,6 @@ type Statement =
             | ContinueStatement(s) -> printer.Print(s)
             | ExpressionStatement(s) -> printer.Print(s)
 
-
 /// Note that declarations are considered statements; this is because declarations can appear in any statement context.
 type Declaration =
     | ClassDeclaration of ClassDeclaration
@@ -412,7 +411,6 @@ type Declaration =
             | VariableDeclaration(d) -> printer.Print(d)
             | FunctionDeclaration(d) -> printer.Print(d)
             | InterfaceDeclaration(d) -> printer.Print(d)
-
 
 /// A module import or export declaration.
 type ModuleDeclaration =
@@ -435,7 +433,6 @@ type ModuleDeclaration =
             | ExportNamedDeclaration(d) -> printer.Print(d)
             | PrivateModuleDeclaration(d) -> printer.Print(d)
             | ExportDefaultDeclaration(d) -> printer.Print(d)
-
 
 /// Not in Babel specs
 type EmitExpression =
@@ -637,33 +634,34 @@ type StringLiteral =
             printer.Print("\"")
 
 type BooleanLiteral =
-    {
-        Value: bool
-        Loc: SourceLocation option
-    }
+    { Value: bool
+      Loc: SourceLocation option }
+
     static member Create(value, ?loc) : Literal =
-        {
-            Value = value
-            Loc = loc
-        } |> BooleanLiteral
+        { Value = value
+          Loc = loc }
+        |> BooleanLiteral
+
     static member AsExpr(value, ?loc) : Expression =
          BooleanLiteral.Create(value, ?loc=loc) |> Literal
+
     interface IPrintable with
         member this.Print(printer) =
             printer.Print((if this.Value then "true" else "false"), ?loc=this.Loc)
 
 type NumericLiteral =
-    {
-        Value: float
-        Loc: SourceLocation option
-    }
+    { Value: float
+      Loc: SourceLocation option }
+
     static member AsLiteral(value, ?loc) : Literal =
-        {
-            Value =value
-            Loc = loc
-        } |> NumericLiteral
+        { Value =value
+          Loc = loc }
+        |> NumericLiteral
+
     static member AsExpr(value, ?loc) : Expression =
-        NumericLiteral.AsLiteral(value, ?loc=loc) |> Literal
+        NumericLiteral.AsLiteral(value, ?loc=loc)
+        |> Literal
+
     interface IPrintable with
         member this.Print(printer) =
             let value =
@@ -1270,7 +1268,7 @@ type ObjectProperty =
           Value = value
           Computed = computed }
         |> ObjectProperty
-    //    let shorthand = defaultArg shorthand_ false
+//    let shorthand = defaultArg shorthand_ false
 //    member _.Shorthand: bool = shorthand
     interface IPrintable with
         member this.Print(printer) =
@@ -1690,18 +1688,17 @@ type ClassMethodKind =
     | ClassImplicitConstructor | ClassFunction | ClassGetter | ClassSetter
 
 type ClassMethod =
-    {
-        Kind: string
-        Key: Expression
-        Params: Pattern array
-        Body: BlockStatement
-        Computed: bool
-        Static: bool option
-        Abstract: bool option
-        ReturnType: TypeAnnotation option
-        TypeParameters: TypeParameterDeclaration option
-        Loc: SourceLocation option
-    }
+    { Kind: string
+      Key: Expression
+      Params: Pattern array
+      Body: BlockStatement
+      Computed: bool
+      Static: bool option
+      Abstract: bool option
+      ReturnType: TypeAnnotation option
+      TypeParameters: TypeParameterDeclaration option
+      Loc: SourceLocation option }
+
     static member AsClassMember(kind_, key, ``params``, body, ?computed_, ?``static``, ?``abstract``, ?returnType, ?typeParameters, ?loc) : ClassMember =
         let kind =
             match kind_ with
@@ -1794,55 +1791,50 @@ type ClassProperty =
             printer.PrintOptional(": ", this.Value)
 
 type ClassImplements =
-    {
-        Id: Identifier
-        TypeParameters: TypeParameterInstantiation option
-    }
+    { Id: Identifier
+      TypeParameters: TypeParameterInstantiation option }
+
     static member Create(id, ?typeParameters) =
-        {
-            Id = id
-            TypeParameters = typeParameters
-        }
+        { Id = id
+          TypeParameters = typeParameters }
+
     interface IPrintable with
         member this.Print(printer) =
             printer.Print(this.Id)
             printer.PrintOptional(this.TypeParameters)
 
 type ClassBody =
-    {
-        Body: ClassMember array
-        Loc: SourceLocation option
-    }
+    { Body: ClassMember array
+      Loc: SourceLocation option }
+
     static member Create(body, ?loc) =
-        {
-            Body = body
-            Loc = loc
-        }
+        { Body = body
+          Loc = loc }
+
     interface IPrintable with
         member this.Print(printer) =
             printer.AddLocation(this.Loc)
             printer.PrintBlock(this.Body, (fun p x -> p.Print(x)), (fun p -> p.PrintStatementSeparator()))
 
 type ClassDeclaration =
-    {
-        Body: ClassBody
-        Id: Identifier option
-        SuperClass: Expression option
-        Implements: ClassImplements array option
-        SuperTypeParameters: TypeParameterInstantiation option
-        TypeParameters: TypeParameterDeclaration option
-        Loc: SourceLocation option
-    }
+    { Body: ClassBody
+      Id: Identifier option
+      SuperClass: Expression option
+      Implements: ClassImplements array option
+      SuperTypeParameters: TypeParameterInstantiation option
+      TypeParameters: TypeParameterDeclaration option
+      Loc: SourceLocation option }
+
     static member AsDeclaration(body, ?id, ?superClass, ?superTypeParameters, ?typeParameters, ?implements, ?loc) : Declaration =
-        {
-            Body = body
-            Id = id
-            SuperClass = superClass
-            Implements = implements
-            SuperTypeParameters = superTypeParameters
-            TypeParameters = typeParameters
-            Loc = loc
-        } |> ClassDeclaration
+        { Body = body
+          Id = id
+          SuperClass = superClass
+          Implements = implements
+          SuperTypeParameters = superTypeParameters
+          TypeParameters = typeParameters
+          Loc = loc }
+        |> ClassDeclaration
+
     interface IPrintable with
         member this.Print(printer) =
             printer.PrintClass(this.Id, this.SuperClass, this.SuperTypeParameters, this.TypeParameters, this.Implements, this.Body, this.Loc)
@@ -1866,6 +1858,7 @@ type ClassExpression =
           TypeParameters = typeParameters
           Loc = loc }
         |> ClassExpression
+
     interface IPrintable with
         member this.Print(printer) =
             printer.PrintClass(this.Id, this.SuperClass, this.SuperTypeParameters, this.TypeParameters, this.Implements, this.Body, this.Loc)
@@ -1882,6 +1875,7 @@ type PrivateModuleDeclaration =
     static member AsModuleDeclaration(statement): ModuleDeclaration =
         { Statement = statement }
         |> PrivateModuleDeclaration
+
     interface IPrintable with
         member this.Print(printer) =
             if printer.IsProductiveStatement(this.Statement) then
@@ -2118,6 +2112,7 @@ type TypeParameterDeclaration =
     { Params: TypeParameter array }
 
     static member Create(``params``) = { Params = ``params`` }
+
     interface IPrintable with
         member this.Print(printer) =
             printer.Print("<")
@@ -2128,6 +2123,7 @@ type TypeParameterInstantiation =
     { Params: TypeAnnotationInfo array }
 
     static member Create(``params``) = { Params = ``params`` }
+
     interface IPrintable with
         member this.Print(printer) =
             printer.Print("<")
@@ -2138,6 +2134,7 @@ type TupleTypeAnnotation =
     { Types: TypeAnnotationInfo array }
 
     static member AsTypeAnnotationInfo(types): TypeAnnotationInfo = { Types = types } |> TupleTypeAnnotation
+
     interface IPrintable with
         member this.Print(printer) =
             printer.Print("[")
@@ -2148,6 +2145,7 @@ type UnionTypeAnnotation =
     { Types: TypeAnnotationInfo array }
 
     static member AsTypeAnnotationInfo(types): TypeAnnotationInfo = { Types = types } |> UnionTypeAnnotation
+
     interface IPrintable with
         member this.Print(printer) =
             printer.PrintArray(this.Types, (fun p x -> p.Print(x)), (fun p -> p.Print(" | ")))

--- a/src/Fable.Transforms/Global/Babel.fs
+++ b/src/Fable.Transforms/Global/Babel.fs
@@ -439,18 +439,15 @@ type ModuleDeclaration =
 
 /// Not in Babel specs
 type EmitExpression =
-    {
-        Value: string
-        Args: Expression array
-        Loc: SourceLocation option
-    }
+    { Value: string
+      Args: Expression array
+      Loc: SourceLocation option }
 
-    static member AsExpr(value, args, ?loc) : Expression =
-        {
-            Value = value
-            Args = args
-            Loc = loc
-        } |> EmitExpression
+    static member AsExpr(value, args, ?loc): Expression =
+        { Value = value
+          Args = args
+          Loc = loc }
+        |> EmitExpression
 
     interface IPrintable with
         member this.Print(printer) =
@@ -546,23 +543,24 @@ type EmitExpression =
 // Identifier
 /// Note that an identifier may be an expression or a destructuring pattern.
 type Identifier =
-    {
-        Name: string
-        Optional: bool option
-        TypeAnnotation: TypeAnnotation option
-        Loc: SourceLocation option
-    }
-    static member Create(name, ?optional, ?typeAnnotation, ?loc) : Identifier =
-        {
-            Name = name
-            Optional = optional
-            TypeAnnotation = typeAnnotation
-            Loc = loc
-        }
-    static member AsExpr(name, ?optional, ?typeAnnotation, ?loc) : Expression =
-        Identifier.Create(name, ?optional=optional, ?typeAnnotation=typeAnnotation, ?loc=loc) |> Identifier
-    static member AsPattern(name, ?optional, ?typeAnnotation, ?loc) : Pattern =
-        Identifier.Create(name, ?optional=optional, ?typeAnnotation=typeAnnotation, ?loc=loc) |> IdentifierPattern
+    { Name: string
+      Optional: bool option
+      TypeAnnotation: TypeAnnotation option
+      Loc: SourceLocation option }
+
+    static member Create(name, ?optional, ?typeAnnotation, ?loc): Identifier =
+        { Name = name
+          Optional = optional
+          TypeAnnotation = typeAnnotation
+          Loc = loc }
+
+    static member AsExpr(name, ?optional, ?typeAnnotation, ?loc): Expression =
+        Identifier.Create(name, ?optional = optional, ?typeAnnotation = typeAnnotation, ?loc = loc)
+        |> Identifier
+
+    static member AsPattern(name, ?optional, ?typeAnnotation, ?loc): Pattern =
+        Identifier.Create(name, ?optional = optional, ?typeAnnotation = typeAnnotation, ?loc = loc)
+        |> IdentifierPattern
 
     interface IPrintable with
         member this.Print(printer) =
@@ -573,23 +571,21 @@ type Identifier =
 
 // Literals
 type RegExpLiteral =
-    {
-        Pattern: string
-        Flags: string
-        Loc: SourceLocation option
-    }
-    static member AsLiteral(pattern, flags_, ?loc) : Literal =
+    { Pattern: string
+      Flags: string
+      Loc: SourceLocation option }
+
+    static member AsLiteral(pattern, flags_, ?loc): Literal =
         let flags =
             flags_ |> Seq.map (function
                 | RegexGlobal -> "g"
                 | RegexIgnoreCase -> "i"
                 | RegexMultiline -> "m"
                 | RegexSticky -> "y") |> Seq.fold (+) ""
-        {
-            Pattern = pattern
-            Flags = flags
-            Loc = loc
-        } |> RegExp
+        { Pattern = pattern
+          Flags = flags
+          Loc = loc }
+          |> RegExp
     static member AsExpr(pattern, flags_, ?loc) : Expression =
         RegExpLiteral.AsLiteral(pattern, flags_, ?loc=loc) |> Literal
     interface IPrintable with
@@ -600,13 +596,9 @@ type RegExpLiteral =
             printer.Print(this.Flags)
 
 type Undefined =
-    {
-        Loc: SourceLocation option
-    }
-    static member AsExpr(?loc) : Expression =
-        {
-            Loc = loc
-        } |> Undefined
+    { Loc: SourceLocation option }
+
+    static member AsExpr(?loc): Expression = { Loc = loc } |> Undefined
 
     // TODO: Use `void 0` instead? Just remove this node?
     interface IPrintable with
@@ -614,13 +606,12 @@ type Undefined =
             printer.Print("undefined", ?loc=this.Loc)
 
 type NullLiteral =
-    {
-        Loc: SourceLocation option
-    }
+    { Loc: SourceLocation option }
+
     static member AsLiteral(?loc) : Literal =
-        {
-            Loc = loc
-        } |> NullLiteral
+        { Loc = loc }
+        |> NullLiteral
+
     static member AsExpr(?loc) : Expression =
         NullLiteral.AsLiteral(?loc=loc) |> Literal
     interface IPrintable with
@@ -628,16 +619,13 @@ type NullLiteral =
             printer.Print("null", ?loc=this.Loc)
 
 type StringLiteral =
-    {
-        Value: string
-        Loc: SourceLocation option
-    }
+    { Value: string
+      Loc: SourceLocation option }
 
     static member Create(value, ?loc) =
-        {
-            Value = value
-            Loc = loc
-        }
+        { Value = value
+          Loc = loc }
+
     static member AsLiteral(value, ?loc) : Literal =
         StringLiteral.Create(value, ?loc=loc) |> StringLiteral
     static member AsExpr(value, ?loc) : Expression =
@@ -691,25 +679,19 @@ type NumericLiteral =
 //    member _.Value = value
 //
 type DirectiveLiteral =
-    {
-        Value: string
-    }
-    static member Create(value) =
-        {
-            Value = value
-        }
+    { Value: string }
+
+    static member Create(value) = { Value = value }
+
     interface IPrintable with
         member _.Print(_) = failwith "not implemented"
 
 /// e.g. "use strict";
 type Directive =
-    {
-        Value: DirectiveLiteral
-    }
-    static member Create(value) =
-        {
-            Value = value
-        }
+    { Value: DirectiveLiteral }
+
+    static member Create(value) = { Value = value }
+
     interface IPrintable with
         member _.Print(_) = failwith "not implemented"
 
@@ -719,13 +701,10 @@ type Directive =
 /// Parsers must specify sourceType as "module" if the source has been parsed as an ES6 module.
 /// Otherwise, sourceType must be "script".
 type Program =
-    {
-        Body: ModuleDeclaration array
-    }
+    { Body: ModuleDeclaration array }
+
     static member Create(body) = // ?directives_,
-        {
-            Body = body
-        }
+        { Body = body }
 
 //    let sourceType = "module" // Don't use "script"
 //    member _.Directives: Directive array = directives
@@ -734,34 +713,25 @@ type Program =
 // Statements
 /// An expression statement, i.e., a statement consisting of a single expression.
 type ExpressionStatement =
-    {
-        Expression: Expression
-    }
-    static member AsStatement(expression) : Statement =
-        {
-            Expression = expression
-        } |> ExpressionStatement
+    { Expression: Expression }
+
+    static member AsStatement(expression): Statement = { Expression = expression } |> ExpressionStatement
+
     interface IPrintable with
-        member this.Print(printer) =
-            printer.Print(this.Expression)
+        member this.Print(printer) = printer.Print(this.Expression)
 
 /// A block statement, i.e., a sequence of statements surrounded by braces.
 type BlockStatement =
-    {
-        Body: Statement array
-    }
+    { Body: Statement array }
 
     static member Create(body) = // ?directives_,
-        {
-            Body = body
-        }
-    static member AsStatement(body) =
-        BlockStatement.Create(body) |> BlockStatement
-//    let directives = [||] // defaultArg directives_ [||]
+        { Body = body }
+
+    static member AsStatement(body) = BlockStatement.Create(body) |> BlockStatement
+    //    let directives = [||] // defaultArg directives_ [||]
 //    member _.Directives: Directive array = directives
     interface IPrintable with
-        member this.Print(printer) =
-            printer.PrintBlock(this.Body)
+        member this.Print(printer) = printer.PrintBlock(this.Body)
 
 /// An empty statement, i.e., a solitary semicolon.
 //type EmptyStatement(?loc) =
@@ -769,28 +739,20 @@ type BlockStatement =
 //    member _.Print(_) = ()
 
 type DebuggerStatement =
-    {
-        Loc: SourceLocation option
-    }
-    static member AsStatement(?loc) : Statement =
-        {
-            Loc = loc
-        } |> DebuggerStatement
+    { Loc: SourceLocation option }
+
+    static member AsStatement(?loc): Statement = { Loc = loc } |> DebuggerStatement
+
     interface IPrintable with
-        member this.Print(printer) =
-            printer.Print("debugger", ?loc=this.Loc)
+        member this.Print(printer) = printer.Print("debugger", ?loc = this.Loc)
 
 /// Statement (typically loop) prefixed with a label (for continue and break)
 type LabeledStatement =
-    {
-        Body: Statement
-        Label: Identifier
-    }
-    static member AsStatement(label, body) : Statement =
-        {
-            Body = body
-            Label = label
-        } |> LabeledStatement
+    { Body: Statement
+      Label: Identifier }
+
+    static member AsStatement(label, body): Statement = { Body = body; Label = label } |> LabeledStatement
+
     interface IPrintable with
         member this.Print(printer) =
             printer.Print(this.Label)
@@ -801,31 +763,20 @@ type LabeledStatement =
 
 /// Break can optionally take a label of a loop to break
 type BreakStatement =
-    {
-        Label: Identifier option
-        Loc: SourceLocation option
-    }
-    static member AsStatement(?label, ?loc) : Statement =
-        {
-            Label = label
-            Loc = loc
-        } |> BreakStatement
+    { Label: Identifier option
+      Loc: SourceLocation option }
+
+    static member AsStatement(?label, ?loc): Statement = { Label = label; Loc = loc } |> BreakStatement
 
     interface IPrintable with
-        member this.Print(printer) =
-            printer.Print("break", ?loc=this.Loc)
+        member this.Print(printer) = printer.Print("break", ?loc = this.Loc)
 
 /// Continue can optionally take a label of a loop to continue
 type ContinueStatement =
-    {
-        Label: Identifier option
-        Loc: SourceLocation option
-    }
-    static member AsStatement(?label, ?loc) : Statement =
-        {
-            Label = label
-            Loc = loc
-        } |> ContinueStatement
+    { Label: Identifier option
+      Loc: SourceLocation option }
+
+    static member AsStatement(?label, ?loc): Statement = { Label = label; Loc = loc } |> ContinueStatement
 
     interface IPrintable with
         member this.Print(printer) =
@@ -836,34 +787,31 @@ type ContinueStatement =
 
 // Control Flow
 type ReturnStatement =
-    {
-        Argument: Expression
-        Loc: SourceLocation option
-    }
-    static member AsStatement(argument, ?loc) : Statement =
-        {
-            Argument = argument
-            Loc = loc
-        } |> ReturnStatement
+    { Argument: Expression
+      Loc: SourceLocation option }
+
+    static member AsStatement(argument, ?loc): Statement =
+        { Argument = argument; Loc = loc }
+        |> ReturnStatement
+
     interface IPrintable with
         member this.Print(printer) =
-            printer.Print("return ", ?loc=this.Loc)
+            printer.Print("return ", ?loc = this.Loc)
             printer.Print(this.Argument)
 
 type IfStatement =
-    {
-        Test: Expression
-        Consequent: BlockStatement
-        Alternate: Statement option
-        Loc: SourceLocation option
-    }
-    static member AsStatement(test, consequent, ?alternate, ?loc) : Statement =
-        {
-            Test = test
-            Consequent = consequent
-            Alternate = alternate
-            Loc = loc
-        } |> IfStatement
+    { Test: Expression
+      Consequent: BlockStatement
+      Alternate: Statement option
+      Loc: SourceLocation option }
+
+    static member AsStatement(test, consequent, ?alternate, ?loc): Statement =
+        { Test = test
+          Consequent = consequent
+          Alternate = alternate
+          Loc = loc }
+        |> IfStatement
+
     interface IPrintable with
         member this.Print(printer) =
             printer.AddLocation(this.Loc)
@@ -897,26 +845,27 @@ type IfStatement =
 
 /// A case (if test is an Expression) or default (if test === null) clause in the body of a switch statement.
 type SwitchCase =
-    {
-        Test: Expression option
-        Consequent: Statement array
-        Loc: SourceLocation option
-    }
+    { Test: Expression option
+      Consequent: Statement array
+      Loc: SourceLocation option }
+
     static member Create(consequent, ?test, ?loc) =
-        {
-            Test = test
-            Consequent = consequent
-            Loc = loc
-        }
+        { Test = test
+          Consequent = consequent
+          Loc = loc }
+
     interface IPrintable with
         member this.Print(printer) =
             printer.AddLocation(this.Loc)
+
             match this.Test with
             | None -> printer.Print("default")
             | Some test ->
                 printer.Print("case ")
                 printer.Print(test)
+
             printer.Print(":")
+
             match this.Consequent.Length with
             | 0 -> printer.PrintNewLine()
             | 1 ->
@@ -927,17 +876,16 @@ type SwitchCase =
                 printer.PrintBlock(this.Consequent)
 
 type SwitchStatement =
-    {
-        Discriminant: Expression
-        Cases: SwitchCase array
-        Loc: SourceLocation option
-    }
-    static member AsStatement(discriminant, cases, ?loc) : Statement =
-        {
-            Discriminant = discriminant
-            Cases = cases
-            Loc = loc
-        } |> SwitchStatement
+    { Discriminant: Expression
+      Cases: SwitchCase array
+      Loc: SourceLocation option }
+
+    static member AsStatement(discriminant, cases, ?loc): Statement =
+        { Discriminant = discriminant
+          Cases = cases
+          Loc = loc }
+        |> SwitchStatement
+
     interface IPrintable with
         member this.Print(printer) =
             printer.Print("switch (", ?loc=this.Loc)
@@ -947,114 +895,120 @@ type SwitchStatement =
 
 // Exceptions
 type ThrowStatement =
-    {
-        Argument: Expression
-        Loc: SourceLocation option
-    }
-    static member AsStatement(argument, ?loc) : Statement =
-        {
-            Argument = argument
-            Loc = loc
-        } |> ThrowStatement
+    { Argument: Expression
+      Loc: SourceLocation option }
+
+    static member AsStatement(argument, ?loc): Statement =
+        { Argument = argument; Loc = loc }
+        |> ThrowStatement
+
     interface IPrintable with
         member this.Print(printer) =
-            printer.Print("throw ", ?loc=this.Loc)
+            printer.Print("throw ", ?loc = this.Loc)
             printer.Print(this.Argument)
 
 /// A catch clause following a try block.
 type CatchClause =
-    {
-        Param: Pattern
-        Body: BlockStatement
-        Loc: SourceLocation option
-    }
+    { Param: Pattern
+      Body: BlockStatement
+      Loc: SourceLocation option }
+
     static member Create(param, body, ?loc) =
-        {
-            Param = param
-            Body = body
-            Loc = loc
-        }
+        { Param = param
+          Body = body
+          Loc = loc }
+
     interface IPrintable with
         member this.Print(printer) =
             // "catch" is being printed by TryStatement
-            printer.Print("(", ?loc=this.Loc)
+            printer.Print("(", ?loc = this.Loc)
             printer.Print(this.Param)
             printer.Print(") ")
             printer.Print(this.Body)
 
 /// If handler is null then finalizer must be a BlockStatement.
 type TryStatement =
-    {
-        Block: BlockStatement
-        Handler: CatchClause option
-        Finalizer: BlockStatement option
-        Loc: SourceLocation option
-    }
-    static member AsStatement(block, ?handler, ?finalizer, ?loc) : Statement =
-        {
-            Block = block
-            Handler = handler
-            Finalizer = finalizer
-            Loc = loc
-        } |> TryStatement
+    { Block: BlockStatement
+      Handler: CatchClause option
+      Finalizer: BlockStatement option
+      Loc: SourceLocation option }
+
+    static member AsStatement(block, ?handler, ?finalizer, ?loc): Statement =
+        { Block = block
+          Handler = handler
+          Finalizer = finalizer
+          Loc = loc }
+        |> TryStatement
+
     interface IPrintable with
         member this.Print(printer) =
-            printer.Print("try ", ?loc=this.Loc)
+            printer.Print("try ", ?loc = this.Loc)
             printer.Print(this.Block)
             printer.PrintOptional("catch ", this.Handler)
             printer.PrintOptional("finally ", this.Finalizer)
 
 // Declarations
 type VariableDeclarator =
-    {
-        Id: Pattern
-        Init: Expression option
-    }
-    static member Create(id, ?init)  =
-        {
-            Id = id
-            Init = init
-        }
-    interface IPrintable with
-        member this.Print(printer) =
-            failwith "Not implemented"
+    { Id: Pattern
+      Init: Expression option }
 
-type VariableDeclarationKind = Var | Let | Const
+    static member Create(id, ?init) = { Id = id; Init = init }
+
+    interface IPrintable with
+        member this.Print(printer) = failwith "Not implemented"
+
+type VariableDeclarationKind =
+    | Var
+    | Let
+    | Const
 
 type VariableDeclaration =
-    {
-        Declarations: VariableDeclarator array
-        Kind: string
-        Loc: SourceLocation option
-    }
+    { Declarations: VariableDeclarator array
+      Kind: string
+      Loc: SourceLocation option }
 
     static member Create(kind, declarations, ?loc) =
-        let kind = match kind with Var -> "var" | Let -> "let" | Const -> "const"
-        {
-            Declarations = declarations
-            Kind = kind
-            Loc = loc
-        }
+        let kind =
+            match kind with
+            | Var -> "var"
+            | Let -> "let"
+            | Const -> "const"
+
+        { Declarations = declarations
+          Kind = kind
+          Loc = loc }
+
     static member Create(var, ?init, ?kind, ?loc) =
-        VariableDeclaration.Create(defaultArg kind Let, [|VariableDeclarator.Create(var, ?init=init)|], ?loc=loc)
-    static member AsDeclaration(kind, declarations, ?loc) : Declaration =
-        VariableDeclaration.Create(kind, declarations, ?loc=loc)
+        VariableDeclaration.Create(defaultArg kind Let, [| VariableDeclarator.Create(var, ?init = init) |], ?loc = loc)
+
+    static member AsDeclaration(kind, declarations, ?loc): Declaration =
+        VariableDeclaration.Create(kind, declarations, ?loc = loc)
         |> VariableDeclaration
-    static member AsStatement(kind, declarations, ?loc) : Statement =
-        VariableDeclaration.AsDeclaration(kind, declarations, ?loc=loc)
+
+    static member AsStatement(kind, declarations, ?loc): Statement =
+        VariableDeclaration.AsDeclaration(kind, declarations, ?loc = loc)
         |> Declaration
-    static member AsDeclaration(var, ?init, ?kind, ?loc) : Declaration =
-        VariableDeclaration.AsDeclaration(defaultArg kind Let, [|VariableDeclarator.Create(var, ?init=init)|], ?loc=loc)
-    static member AsStatement(var, ?init, ?kind, ?loc) : Statement =
-        VariableDeclaration.AsDeclaration(var, ?init=init, ?kind=kind, ?loc=loc) |> Declaration
+
+    static member AsDeclaration(var, ?init, ?kind, ?loc): Declaration =
+        VariableDeclaration.AsDeclaration(
+            defaultArg kind Let,
+            [| VariableDeclarator.Create(var, ?init = init) |],
+            ?loc = loc
+        )
+
+    static member AsStatement(var, ?init, ?kind, ?loc): Statement =
+        VariableDeclaration.AsDeclaration(var, ?init = init, ?kind = kind, ?loc = loc)
+        |> Declaration
 
     interface IPrintable with
         member this.Print(printer) =
-            printer.Print(this.Kind + " ", ?loc=this.Loc)
+            printer.Print(this.Kind + " ", ?loc = this.Loc)
             let canConflict = this.Declarations.Length > 1
+
             for i = 0 to this.Declarations.Length - 1 do
                 let decl = this.Declarations.[i]
                 printer.Print(decl.Id)
+
                 match decl.Init with
                 | None -> ()
                 | Some e ->
@@ -1066,20 +1020,17 @@ type VariableDeclaration =
 
 // Loops
 type WhileStatement =
-    {
-        Test: Expression
-        Body: BlockStatement
-        Loc: SourceLocation option
-    }
-    static member AsStatement(test, body, ?loc) : Statement =
-        {
-            Test = test
-            Body = body
-            Loc = loc
-        } |> WhileStatement
+    { Test: Expression
+      Body: BlockStatement
+      Loc: SourceLocation option }
+
+    static member AsStatement(test, body, ?loc): Statement =
+        { Test = test; Body = body; Loc = loc }
+        |> WhileStatement
+
     interface IPrintable with
         member this.Print(printer) =
-            printer.Print("while (", ?loc=this.Loc)
+            printer.Print("while (", ?loc = this.Loc)
             printer.Print(this.Test)
             printer.Print(") ")
             printer.Print(this.Body)
@@ -1090,26 +1041,25 @@ type WhileStatement =
 //    member _.Test: Expression = test
 
 type ForStatement =
-    {
-        Body: BlockStatement
-        // In JS this can be an expression too
-        Init: VariableDeclaration option
-        Test: Expression option
-        Update: Expression option
-        Loc: SourceLocation option
-    }
-    static member AsStatement(body, ?init, ?test, ?update, ?loc) : Statement =
-        {
-            Body = body
-            // In JS this can be an expression too
-            Init = init
-            Test = test
-            Update = update
-            Loc = loc
-        } |> ForStatement
+    { Body: BlockStatement
+      // In JS this can be an expression too
+      Init: VariableDeclaration option
+      Test: Expression option
+      Update: Expression option
+      Loc: SourceLocation option }
+
+    static member AsStatement(body, ?init, ?test, ?update, ?loc): Statement =
+        { Body = body
+          // In JS this can be an expression too
+          Init = init
+          Test = test
+          Update = update
+          Loc = loc }
+        |> ForStatement
+
     interface IPrintable with
         member this.Print(printer) =
-            printer.Print("for (", ?loc=this.Loc)
+            printer.Print("for (", ?loc = this.Loc)
             printer.PrintOptional(this.Init)
             printer.Print("; ")
             printer.PrintOptional(this.Test)
@@ -1136,24 +1086,22 @@ type ForStatement =
 
 /// A function declaration. Note that id cannot be null.
 type FunctionDeclaration =
-    {
-        Params: Pattern array
-        Body: BlockStatement
-        Id: Identifier
-        ReturnType: TypeAnnotation option
-        TypeParameters: TypeParameterDeclaration option
-        Loc: SourceLocation option
-    }
-    static member AsDeclaration(``params``, body, id, ?returnType, ?typeParameters, ?loc) : Declaration = // ?async_, ?generator_, ?declare,
-        {
-            Params = ``params``
-            Body = body
-            Id = id
-            ReturnType = returnType
-            TypeParameters = typeParameters
-            Loc = loc
-        } |> FunctionDeclaration
-//    let async = defaultArg async_ false
+    { Params: Pattern array
+      Body: BlockStatement
+      Id: Identifier
+      ReturnType: TypeAnnotation option
+      TypeParameters: TypeParameterDeclaration option
+      Loc: SourceLocation option }
+
+    static member AsDeclaration(``params``, body, id, ?returnType, ?typeParameters, ?loc): Declaration = // ?async_, ?generator_, ?declare,
+        { Params = ``params``
+          Body = body
+          Id = id
+          ReturnType = returnType
+          TypeParameters = typeParameters
+          Loc = loc }
+        |> FunctionDeclaration
+    //    let async = defaultArg async_ false
 //    let generator = defaultArg generator_ false
 //    member _.Async: bool = async
 //    member _.Generator: bool = generator
@@ -1167,50 +1115,40 @@ type FunctionDeclaration =
 
 /// A super pseudo-expression.
 type Super =
-    {
-        Loc: SourceLocation option
-    }
-    static member AsExpr(?loc) : Expression =
-        {
-            Loc = loc
-        } |> Super
+    { Loc: SourceLocation option }
+
+    static member AsExpr(?loc): Expression = { Loc = loc } |> Super
+
     interface IPrintable with
-        member this.Print(printer) =
-            printer.Print("super", ?loc=this.Loc)
+        member this.Print(printer) = printer.Print("super", ?loc = this.Loc)
 
 type ThisExpression =
-    {
-        Loc: SourceLocation option
-    }
-    static member AsExpr(?loc) : Expression =
-        {
-            Loc = loc
-        } |> ThisExpression
+    { Loc: SourceLocation option }
+
+    static member AsExpr(?loc): Expression = { Loc = loc } |> ThisExpression
 
     interface IPrintable with
-        member this.Print(printer) =
-            printer.Print("this", ?loc=this.Loc)
+        member this.Print(printer) = printer.Print("this", ?loc = this.Loc)
 
 /// A fat arrow function expression, e.g., let foo = (bar) => { /* body */ }.
 type ArrowFunctionExpression =
-    {
-        Params: Pattern array
-        Body: BlockStatement
-        ReturnType: TypeAnnotation option
-        TypeParameters: TypeParameterDeclaration option
-        Loc: SourceLocation option
-    }
-    static member AsExpr(``params``, body: BlockStatement, ?returnType, ?typeParameters, ?loc) : Expression = //?async_, ?generator_,
-        {
-            Params = ``params``
-            Body = body
-            ReturnType = returnType
-            TypeParameters = typeParameters
-            Loc = loc
-        } |> ArrowFunctionExpression
-    static member AsExpr(``params``, body: Expression, ?returnType, ?typeParameters, ?loc) : Expression =
-        let body = { Body = [|ReturnStatement.AsStatement(body) |] }
-        ArrowFunctionExpression.AsExpr(``params``, body, ?returnType=returnType, ?typeParameters=typeParameters, ?loc=loc)
+    { Params: Pattern array
+      Body: BlockStatement
+      ReturnType: TypeAnnotation option
+      TypeParameters: TypeParameterDeclaration option
+      Loc: SourceLocation option }
+
+    static member AsExpr(``params``, body: BlockStatement, ?returnType, ?typeParameters, ?loc): Expression = //?async_, ?generator_,
+        { Params = ``params``
+          Body = body
+          ReturnType = returnType
+          TypeParameters = typeParameters
+          Loc = loc }
+        |> ArrowFunctionExpression
+
+    static member AsExpr(``params``, body: Expression, ?returnType, ?typeParameters, ?loc): Expression =
+        let body = { Body = [| ReturnStatement.AsStatement(body) |] }
+        ArrowFunctionExpression.AsExpr(``params``, body, ?returnType = returnType, ?typeParameters = typeParameters, ?loc = loc)
 
 //    let async = defaultArg async_ false
 //    let generator = defaultArg generator_ false
@@ -1218,26 +1156,33 @@ type ArrowFunctionExpression =
 //    member _.Generator: bool = generator
     interface IPrintable with
         member this.Print(printer) =
-            printer.PrintFunction(None, this.Params, this.Body, this.TypeParameters, this.ReturnType, this.Loc, isArrow=true)
+            printer.PrintFunction(
+                None,
+                this.Params,
+                this.Body,
+                this.TypeParameters,
+                this.ReturnType,
+                this.Loc,
+                isArrow = true
+            )
 
 type FunctionExpression =
-    {
-        Id: Identifier option
-        Params: Pattern array
-        Body: BlockStatement
-        ReturnType: TypeAnnotation option
-        TypeParameters: TypeParameterDeclaration option
-        Loc: SourceLocation option
-    }
-    static member AsExpr(``params``, body, ?id, ?returnType, ?typeParameters, ?loc) : Expression = //?generator_, ?async_
-        {
-            Id = id
-            Params = ``params``
-            Body = body
-            ReturnType = returnType
-            TypeParameters = typeParameters
-            Loc = loc
-        } |> FunctionExpression
+    { Id: Identifier option
+      Params: Pattern array
+      Body: BlockStatement
+      ReturnType: TypeAnnotation option
+      TypeParameters: TypeParameterDeclaration option
+      Loc: SourceLocation option }
+
+    static member AsExpr(``params``, body, ?id, ?returnType, ?typeParameters, ?loc): Expression = //?generator_, ?async_
+        { Id = id
+          Params = ``params``
+          Body = body
+          ReturnType = returnType
+          TypeParameters = typeParameters
+          Loc = loc }
+        |> FunctionExpression
+
 //    let async = defaultArg async_ false
 //    let generator = defaultArg generator_ false
 //    member _.Async: bool = async
@@ -1274,35 +1219,32 @@ type FunctionExpression =
 
 // Should derive from Node, but make it an expression for simplicity
 type SpreadElement =
-    {
-        Argument: Expression
-        Loc: SourceLocation option
-    }
-    static member AsExpr(argument, ?loc) : Expression =
-        {
-            Argument = argument
-            Loc = loc
-        } |> SpreadElement
+    { Argument: Expression
+      Loc: SourceLocation option }
+
+    static member AsExpr(argument, ?loc): Expression =
+        { Argument = argument; Loc = loc }
+        |> SpreadElement
+
     interface IPrintable with
         member this.Print(printer) =
-            printer.Print("...", ?loc=this.Loc)
+            printer.Print("...", ?loc = this.Loc)
             printer.ComplexExpressionWithParens(this.Argument)
 
 type ArrayExpression =
-    {
-        // Elements: Choice<Expression, SpreadElement> option array
-        Elements: Expression array
-        Loc: SourceLocation option
-    }
-    static member AsExpr(elements, ?loc) : Expression =
-        {
-            // Elements: Choice<Expression, SpreadElement> option array
-            Elements = elements
-            Loc = loc
-        } |> ArrayExpression
+    { // Elements: Choice<Expression, SpreadElement> option array
+      Elements: Expression array
+      Loc: SourceLocation option }
+
+    static member AsExpr(elements, ?loc): Expression =
+        { // Elements: Choice<Expression, SpreadElement> option array
+          Elements = elements
+          Loc = loc }
+        |> ArrayExpression
+
     interface IPrintable with
         member this.Print(printer) =
-            printer.Print("[", ?loc=this.Loc)
+            printer.Print("[", ?loc = this.Loc)
             printer.PrintCommaSeparatedArray(this.Elements)
             printer.Print("]")
 
@@ -1317,19 +1259,18 @@ type ObjectMember =
             | ObjectMethod(op) -> printer.Print(op)
 
 type ObjectProperty =
-    {
-        Key: Expression
-        Value: Expression
-        Computed: bool
-    }
-    static member AsObjectMember(key, value, ?computed_) : ObjectMember = // ?shorthand_,
+    { Key: Expression
+      Value: Expression
+      Computed: bool }
+
+    static member AsObjectMember(key, value, ?computed_): ObjectMember = // ?shorthand_,
         let computed = defaultArg computed_ false
-        {
-            Key = key
-            Value = value
-            Computed = computed
-        } |> ObjectProperty
-//    let shorthand = defaultArg shorthand_ false
+
+        { Key = key
+          Value = value
+          Computed = computed }
+        |> ObjectProperty
+    //    let shorthand = defaultArg shorthand_ false
 //    member _.Shorthand: bool = shorthand
     interface IPrintable with
         member this.Print(printer) =
@@ -1345,16 +1286,15 @@ type ObjectProperty =
 type ObjectMethodKind = ObjectGetter | ObjectSetter | ObjectMeth
 
 type ObjectMethod =
-    {
-        Kind: string
-        Key: Expression
-        Params: Pattern array
-        Body: BlockStatement
-        Computed: bool
-        ReturnType: TypeAnnotation option
-        TypeParameters: TypeParameterDeclaration option
-        Loc: SourceLocation option
-    }
+    { Kind: string
+      Key: Expression
+      Params: Pattern array
+      Body: BlockStatement
+      Computed: bool
+      ReturnType: TypeAnnotation option
+      TypeParameters: TypeParameterDeclaration option
+      Loc: SourceLocation option }
+
     static member AsObjectMember(kind_, key, ``params``, body, ?computed_, ?returnType, ?typeParameters, ?loc) : ObjectMember = // ?async_, ?generator_,
         let kind =
             match kind_ with
@@ -1362,20 +1302,20 @@ type ObjectMethod =
             | ObjectSetter -> "set"
             | ObjectMeth -> "method"
         let computed = defaultArg computed_ false
-    //    let async = defaultArg async_ false
-    //    let generator = defaultArg generator_ false
-    //    member _.Async: bool = async
-    //    member _.Generator: bool = generator
-        {
-            Kind = kind
-            Key = key
-            Params = ``params``
-            Body = body
-            Computed = computed
-            ReturnType = returnType
-            TypeParameters = typeParameters
-            Loc = loc
-        } |> ObjectMethod
+        //    let async = defaultArg async_ false
+        //    let generator = defaultArg generator_ false
+        //    member _.Async: bool = async
+        //    member _.Generator: bool = generator
+        { Kind = kind
+          Key = key
+          Params = ``params``
+          Body = body
+          Computed = computed
+          ReturnType = returnType
+          TypeParameters = typeParameters
+          Loc = loc }
+        |> ObjectMethod
+
     interface IPrintable with
         member this.Print(printer) =
             printer.AddLocation(this.Loc)
@@ -1402,26 +1342,25 @@ type ObjectMethod =
 /// If computed is true, the node corresponds to a computed (a[b]) member expression and property is an Expression.
 /// If computed is false, the node corresponds to a static (a.b) member expression and property is an Identifier.
 type MemberExpression =
-    {
-        Name: string
-        Object: Expression
-        Property: Expression
-        Computed: bool
-        Loc: SourceLocation option
-    }
+    { Name: string
+      Object: Expression
+      Property: Expression
+      Computed: bool
+      Loc: SourceLocation option }
+
     static member AsExpr(object, property, ?computed_, ?loc) : Expression =
         let computed = defaultArg computed_ false
         let name =
             match property with
             | Identifier(id) -> id.Name
             | _ -> ""
-        {
-            Name = name
-            Object = object
-            Property = property
-            Computed = computed
-            Loc = loc
-        } |> MemberExpression
+
+        { Name = name
+          Object = object
+          Property = property
+          Computed = computed
+          Loc = loc }
+        |> MemberExpression
 
     interface IPrintable with
         member this.Print(printer) = this.Print(printer)
@@ -1439,18 +1378,16 @@ type MemberExpression =
             printer.Print(this.Property)
 
 type ObjectExpression =
-    {
-        Properties: ObjectMember array
-        Loc: SourceLocation option
-    }
-    static member AsExpr(properties, ?loc) : Expression =
-        {
-            Properties = properties
-            Loc = loc
-        } |> ObjectExpression
+    { Properties: ObjectMember array
+      Loc: SourceLocation option }
+
+    static member AsExpr(properties, ?loc): Expression =
+        { Properties = properties; Loc = loc }
+        |> ObjectExpression
+
     interface IPrintable with
         member this.Print(printer) =
-            let printSeparator (p: Printer) =
+            let printSeparator(p: Printer) =
                 p.Print(",")
                 p.PrintNewLine()
 
@@ -1460,19 +1397,18 @@ type ObjectExpression =
 
 /// A conditional expression, i.e., a ternary ?/: expression.
 type ConditionalExpression =
-    {
-        Test: Expression
-        Consequent: Expression
-        Alternate: Expression
-        Loc: SourceLocation option
-    }
-    static member AsExpr(test, consequent, alternate, ?loc) : Expression =
-        {
-            Test = test
-            Consequent = consequent
-            Alternate = alternate
-            Loc = loc
-        } |> ConditionalExpression
+    { Test: Expression
+      Consequent: Expression
+      Alternate: Expression
+      Loc: SourceLocation option }
+
+    static member AsExpr(test, consequent, alternate, ?loc): Expression =
+        { Test = test
+          Consequent = consequent
+          Alternate = alternate
+          Loc = loc }
+        |> ConditionalExpression
+
     interface IPrintable with
         member this.Print(printer) =
             printer.AddLocation(this.Loc)
@@ -1490,18 +1426,17 @@ type ConditionalExpression =
 
 /// A function or method call expression.
 type CallExpression =
-    {
-        Callee: Expression
-        // Arguments: Choice<Expression, SpreadElement> array
-        Arguments: Expression array
-        Loc: SourceLocation option
-    }
-    static member AsExpr(callee, arguments, ?loc) : Expression =
-        {
-            Callee = callee
-            Arguments = arguments
-            Loc = loc
-        } |> CallExpression
+    { Callee: Expression
+      // Arguments: Choice<Expression, SpreadElement> array
+      Arguments: Expression array
+      Loc: SourceLocation option }
+
+    static member AsExpr(callee, arguments, ?loc): Expression =
+        { Callee = callee
+          Arguments = arguments
+          Loc = loc }
+        |> CallExpression
+
     interface IPrintable with
         member this.Print(printer) =
             printer.AddLocation(this.Loc)
@@ -1511,20 +1446,19 @@ type CallExpression =
             printer.Print(")")
 
 type NewExpression =
-    {
-        Callee: Expression
-        // Arguments: Choice<Expression, SpreadElement> array = arguments
-        Arguments: Expression array
-        TypeArguments: TypeParameterInstantiation option
-        Loc: SourceLocation option
-    }
-    static member AsExpr(callee, arguments, ?typeArguments, ?loc) : Expression =
-        {
-            Callee = callee
-            Arguments = arguments
-            TypeArguments = typeArguments
-            Loc = loc
-        } |> NewExpression
+    { Callee: Expression
+      // Arguments: Choice<Expression, SpreadElement> array = arguments
+      Arguments: Expression array
+      TypeArguments: TypeParameterInstantiation option
+      Loc: SourceLocation option }
+
+    static member AsExpr(callee, arguments, ?typeArguments, ?loc): Expression =
+        { Callee = callee
+          Arguments = arguments
+          TypeArguments = typeArguments
+          Loc = loc }
+        |> NewExpression
+
     interface IPrintable with
         member this.Print(printer) =
             printer.Print("new ", ?loc=this.Loc)
@@ -1535,15 +1469,13 @@ type NewExpression =
 
 /// A comma-separated sequence of expressions.
 type SequenceExpression =
-    {
-        Expressions: Expression array
-        Loc: SourceLocation option
-    }
-    static member AsExpr(expressions, ?loc) : Expression =
-        {
-            Expressions = expressions
-            Loc = loc
-        } |> SequenceExpression
+    { Expressions: Expression array
+      Loc: SourceLocation option }
+
+    static member AsExpr(expressions, ?loc): Expression =
+        { Expressions = expressions; Loc = loc }
+        |> SequenceExpression
+
     interface IPrintable with
         member this.Print(printer) =
             printer.AddLocation(this.Loc)
@@ -1551,12 +1483,11 @@ type SequenceExpression =
 
 // Unary Operations
 type UnaryExpression =
-    {
-        Prefix: bool
-        Argument: Expression
-        Operator: string
-        Loc: SourceLocation option
-    }
+    { Prefix: bool
+      Argument: Expression
+      Operator: string
+      Loc: SourceLocation option }
+
     static member AsExpr(operator_, argument, ?loc) : Expression =
         let prefix = true
         let operator =
@@ -1568,12 +1499,13 @@ type UnaryExpression =
             | UnaryTypeof -> "typeof"
             | UnaryVoid -> "void"
             | UnaryDelete -> "delete"
-        {
-            Prefix = prefix
-            Argument = argument
-            Operator = operator
-            Loc = loc
-        } |> UnaryExpression
+
+        { Prefix = prefix
+          Argument = argument
+          Operator = operator
+          Loc = loc }
+        |> UnaryExpression
+
     interface IPrintable with
         member this.Print(printer) =
             printer.AddLocation(this.Loc)
@@ -1583,23 +1515,22 @@ type UnaryExpression =
             printer.ComplexExpressionWithParens(this.Argument)
 
 type UpdateExpression =
-    {
-        Prefix: bool
-        Argument: Expression
-        Operator: string
-        Loc: SourceLocation option
-    }
+    { Prefix: bool
+      Argument: Expression
+      Operator: string
+      Loc: SourceLocation option }
+
     static member AsExpr(operator_, prefix, argument, ?loc) : Expression =
         let operator =
             match operator_ with
             | UpdateMinus -> "--"
             | UpdatePlus -> "++"
-        {
-            Prefix = prefix
-            Argument = argument
-            Operator = operator
-            Loc = loc
-        } |> UpdateExpression
+
+        { Prefix = prefix
+          Argument = argument
+          Operator = operator
+          Loc = loc }
+        |> UpdateExpression
 
     interface IPrintable with
         member this.Print(printer) =
@@ -1613,13 +1544,12 @@ type UpdateExpression =
 
 // Binary Operations
 type BinaryExpression =
-    {
-        Left: Expression
-        Right: Expression
-        Operator: string
-        Loc: SourceLocation option
-    }
-    static member AsExpr(operator_, left, right, ?loc) : Expression =
+    { Left: Expression
+      Right: Expression
+      Operator: string
+      Loc: SourceLocation option }
+
+    static member AsExpr(operator_, left, right, ?loc): Expression =
         let operator =
             match operator_ with
             | BinaryEqual -> "=="
@@ -1644,24 +1574,23 @@ type BinaryExpression =
             | BinaryAndBitwise -> "&"
             | BinaryIn -> "in"
             | BinaryInstanceOf -> "instanceof"
-        {
-            Left = left
-            Right = right
-            Operator = operator
-            Loc = loc
-        } |> BinaryExpression
+
+        { Left = left
+          Right = right
+          Operator = operator
+          Loc = loc }
+        |> BinaryExpression
     interface IPrintable with
         member this.Print(printer) =
             printer.PrintOperation(this.Left, this.Operator, this.Right, this.Loc)
 
 type AssignmentExpression =
-    {
-        Left: Expression
-        Right: Expression
-        Operator: string
-        Loc: SourceLocation option
-    }
-    static member AsExpr(operator_, left, right, ?loc) : Expression =
+    { Left: Expression
+      Right: Expression
+      Operator: string
+      Loc: SourceLocation option }
+
+    static member AsExpr(operator_, left, right, ?loc): Expression =
         let operator =
             match operator_ with
             | AssignEqual -> "="
@@ -1676,34 +1605,33 @@ type AssignmentExpression =
             | AssignOrBitwise -> "|="
             | AssignXorBitwise -> "^="
             | AssignAndBitwise -> "&="
-        {
-            Left = left
-            Right = right
-            Operator = operator
-            Loc = loc
-        } |> AssignmentExpression
+
+        { Left = left
+          Right = right
+          Operator = operator
+          Loc = loc }
+        |> AssignmentExpression
     interface IPrintable with
         member this.Print(printer) =
             printer.PrintOperation(this.Left, this.Operator, this.Right, this.Loc)
 
 type LogicalExpression =
-    {
-        Left: Expression
-        Right: Expression
-        Operator: string
-        Loc: SourceLocation option
-    }
-    static member AsExpr(operator_, left, right, ?loc) : Expression =
+    { Left: Expression
+      Right: Expression
+      Operator: string
+      Loc: SourceLocation option }
+
+    static member AsExpr(operator_, left, right, ?loc): Expression =
         let operator =
             match operator_ with
             | LogicalOr -> "||"
-            | LogicalAnd-> "&&"
-        {
-            Left = left
-            Right = right
-            Operator = operator
-            Loc = loc
-        } |> LogicalExpression
+            | LogicalAnd -> "&&"
+
+        { Left = left
+          Right = right
+          Operator = operator
+          Loc = loc }
+        |> LogicalExpression
     interface IPrintable with
         member this.Print(printer) =
             printer.PrintOperation(this.Left, this.Operator, this.Right, this.Loc)
@@ -1730,19 +1658,17 @@ type LogicalExpression =
 //    member _.TypeAnnotation: TypeAnnotation option = typeAnnotation
 
 type RestElement =
-    {
-        Name: string
-        Argument: Pattern
-        TypeAnnotation: TypeAnnotation option
-        Loc: SourceLocation option
-    }
-    static member AsPattern(argument: Pattern, ?typeAnnotation, ?loc) : Pattern =
-        {
-            Name = argument.Name
-            Argument = argument
-            TypeAnnotation = typeAnnotation
-            Loc = loc
-        } |> RestElement
+    { Name: string
+      Argument: Pattern
+      TypeAnnotation: TypeAnnotation option
+      Loc: SourceLocation option }
+
+    static member AsPattern(argument: Pattern, ?typeAnnotation, ?loc): Pattern =
+        { Name = argument.Name
+          Argument = argument
+          TypeAnnotation = typeAnnotation
+          Loc = loc }
+        |> RestElement
     interface IPrintable with
         member this.Print(printer) =
             printer.Print("...", ?loc=this.Loc)
@@ -1784,18 +1710,18 @@ type ClassMethod =
             | ClassSetter -> "set"
             | ClassFunction -> "method"
         let computed = defaultArg computed_ false
-        {
-            Kind = kind
-            Key = key
-            Params = ``params``
-            Body = body
-            Computed = computed
-            Static = ``static``
-            Abstract = ``abstract``
-            ReturnType = returnType
-            TypeParameters = typeParameters
-            Loc = loc
-        } |> ClassMethod
+
+        { Kind = kind
+          Key = key
+          Params = ``params``
+          Body = body
+          Computed = computed
+          Static = ``static``
+          Abstract = ``abstract``
+          ReturnType = returnType
+          TypeParameters = typeParameters
+          Loc = loc }
+        |> ClassMethod
     // This appears in astexplorer.net but it's not documented
     // member _.Expression: bool = false
     interface IPrintable with
@@ -1831,26 +1757,26 @@ type ClassMethod =
 /// https://github.com/jeffmo/es-class-fields-and-static-properties
 /// e.g, class MyClass { static myStaticProp = 5; myProp /* = 10 */; }
 type ClassProperty =
-    {
-        Key: Expression
-        Value: Expression option
-        Computed: bool
-        Static: bool
-        Optional: bool
-        TypeAnnotation: TypeAnnotation option
-        Loc: SourceLocation option
-    }
-    static member AsClassMember(key, ?value, ?computed_, ?``static``, ?optional, ?typeAnnotation, ?loc) : ClassMember =
+    { Key: Expression
+      Value: Expression option
+      Computed: bool
+      Static: bool
+      Optional: bool
+      TypeAnnotation: TypeAnnotation option
+      Loc: SourceLocation option }
+
+    static member AsClassMember(key, ?value, ?computed_, ?``static``, ?optional, ?typeAnnotation, ?loc): ClassMember =
         let computed = defaultArg computed_ false
-        {
-            Key = key
-            Value = value
-            Computed = computed
-            Static = defaultArg ``static`` false
-            Optional = defaultArg optional false
-            TypeAnnotation = typeAnnotation
-            Loc = loc
-        } |> ClassProperty
+
+        { Key = key
+          Value = value
+          Computed = computed
+          Static = defaultArg ``static`` false
+          Optional = defaultArg optional false
+          TypeAnnotation = typeAnnotation
+          Loc = loc }
+        |> ClassProperty
+
     interface IPrintable with
         member this.Print(printer) =
             printer.AddLocation(this.Loc)
@@ -1923,25 +1849,23 @@ type ClassDeclaration =
 
 /// Anonymous class: e.g., var myClass = class { }
 type ClassExpression =
-    {
-        Body: ClassBody
-        Id: Identifier option
-        SuperClass: Expression option
-        Implements: ClassImplements array option
-        SuperTypeParameters: TypeParameterInstantiation option
-        TypeParameters: TypeParameterDeclaration option
-        Loc: SourceLocation option
-    }
-    static member AsExpr(body, ?id, ?superClass, ?superTypeParameters, ?typeParameters, ?implements, ?loc) : Expression =
-        {
-            Body = body
-            Id = id
-            SuperClass = superClass
-            Implements = implements
-            SuperTypeParameters = superTypeParameters
-            TypeParameters = typeParameters
-            Loc = loc
-        } |> ClassExpression
+    { Body: ClassBody
+      Id: Identifier option
+      SuperClass: Expression option
+      Implements: ClassImplements array option
+      SuperTypeParameters: TypeParameterInstantiation option
+      TypeParameters: TypeParameterDeclaration option
+      Loc: SourceLocation option }
+
+    static member AsExpr(body, ?id, ?superClass, ?superTypeParameters, ?typeParameters, ?implements, ?loc): Expression =
+        { Body = body
+          Id = id
+          SuperClass = superClass
+          Implements = implements
+          SuperTypeParameters = superTypeParameters
+          TypeParameters = typeParameters
+          Loc = loc }
+        |> ClassExpression
     interface IPrintable with
         member this.Print(printer) =
             printer.PrintClass(this.Id, this.SuperClass, this.SuperTypeParameters, this.TypeParameters, this.Implements, this.Body, this.Loc)
@@ -1953,13 +1877,11 @@ type ClassExpression =
 
 // Modules
 type PrivateModuleDeclaration =
-    {
-        Statement: Statement
-    }
-    static member AsModuleDeclaration(statement) : ModuleDeclaration =
-        {
-            Statement = statement
-        } |> PrivateModuleDeclaration
+    { Statement: Statement }
+
+    static member AsModuleDeclaration(statement): ModuleDeclaration =
+        { Statement = statement }
+        |> PrivateModuleDeclaration
     interface IPrintable with
         member this.Print(printer) =
             if printer.IsProductiveStatement(this.Statement) then
@@ -1980,15 +1902,12 @@ type ImportSpecifier =
 /// If it is a basic named import, such as in import {foo} from "mod", both imported and local are equivalent Identifier nodes; in this case an Identifier node representing foo.
 /// If it is an aliased import, such as in import {foo as bar} from "mod", the imported field is an Identifier node representing foo, and the local field is an Identifier node representing bar.
 type ImportMemberSpecifier =
-    {
-        Local: Identifier
-        Imported: Identifier
-    }
-    static member AsImportSpecifier(local, imported) : ImportSpecifier =
-        {
-            Local = local
-            Imported = imported
-        } |> ImportMemberSpecifier
+    { Local: Identifier
+      Imported: Identifier }
+
+    static member AsImportSpecifier(local, imported): ImportSpecifier =
+        { Local = local; Imported = imported }
+        |> ImportMemberSpecifier
 
     interface IPrintable with
         member this.Print(printer) =
@@ -2000,13 +1919,9 @@ type ImportMemberSpecifier =
 
 /// A default import specifier, e.g., foo in import foo from "mod".
 type ImportDefaultSpecifier =
-    {
-        Local: Identifier
-    }
-    static member AsImportSpecifier(local) : ImportSpecifier =
-        {
-            Local = local
-        } |> ImportDefaultSpecifier
+    { Local: Identifier }
+
+    static member AsImportSpecifier(local): ImportSpecifier = { Local = local } |> ImportDefaultSpecifier
 
     interface IPrintable with
         member this.Print(printer) =
@@ -2014,13 +1929,10 @@ type ImportDefaultSpecifier =
 
 /// A namespace import specifier, e.g., * as foo in import * as foo from "mod".
 type ImportNamespaceSpecifier =
-    {
-        Local: Identifier
-    }
-    static member AsImportSpecifier(local) : ImportSpecifier =
-        {
-            Local = local
-        } |> ImportNamespaceSpecifier
+    { Local: Identifier }
+
+    static member AsImportSpecifier(local): ImportSpecifier = { Local = local } |> ImportNamespaceSpecifier
+
     interface IPrintable with
         member this.Print(printer) =
             printer.Print("* as ")
@@ -2028,15 +1940,14 @@ type ImportNamespaceSpecifier =
 
 /// e.g., import foo from "mod";.
 type ImportDeclaration =
-    {
-        Specifiers: ImportSpecifier array
-        Source: StringLiteral
-    }
-    static member AsModuleDeclaration(specifiers, source) : ModuleDeclaration =
-        {
-            Specifiers = specifiers
-            Source = source
-        } |> ImportDeclaration
+    { Specifiers: ImportSpecifier array
+      Source: StringLiteral }
+
+    static member AsModuleDeclaration(specifiers, source): ModuleDeclaration =
+        { Specifiers = specifiers
+          Source = source }
+        |> ImportDeclaration
+
     interface IPrintable with
         member this.Print(printer) =
             let members = this.Specifiers |> Array.choose (function ImportMemberSpecifier(x) -> Some x | _ -> None)
@@ -2074,15 +1985,10 @@ type ImportDeclaration =
 /// in this case an Identifier node representing foo. If it is an aliased export, such as in export {bar as foo},
 /// the exported field is an Identifier node representing foo, and the local field is an Identifier node representing bar.
 type ExportSpecifier =
-    {
-        Local: Identifier
-        Exported: Identifier
-    }
-    static member Create(local, exported) =
-        {
-            Local = local
-            Exported = exported
-        }
+    { Local: Identifier
+      Exported: Identifier }
+
+    static member Create(local, exported) = { Local = local; Exported = exported }
     interface IPrintable with
         member this.Print(printer) =
             // Don't print the braces, this will be done in the export declaration
@@ -2094,28 +2000,26 @@ type ExportSpecifier =
 /// An export named declaration, e.g., export {foo, bar};, export {foo} from "mod"; or export var foo = 1;.
 /// Note: Having declaration populated with non-empty specifiers or non-null source results in an invalid state.
 type ExportNamedDeclaration =
-    {
-        Declaration: Declaration
-    }
-    static member AsModuleDeclaration(declaration) : ModuleDeclaration =
-        {
-            Declaration = declaration
-        } |> ExportNamedDeclaration
+    { Declaration: Declaration }
+
+    static member AsModuleDeclaration(declaration): ModuleDeclaration =
+        { Declaration = declaration }
+        |> ExportNamedDeclaration
+
     interface IPrintable with
         member this.Print(printer) =
             printer.Print("export ")
             printer.Print(this.Declaration)
 
 type ExportNamedReferences =
-    {
-        Specifiers: ExportSpecifier array
-        Source: StringLiteral option
-    }
-    static member AsModuleDeclaration(specifiers, ?source) : ModuleDeclaration =
-        {
-            Specifiers = specifiers
-            Source = source
-        } |> ExportNamedReferences
+    { Specifiers: ExportSpecifier array
+      Source: StringLiteral option }
+
+    static member AsModuleDeclaration(specifiers, ?source): ModuleDeclaration =
+        { Specifiers = specifiers
+          Source = source }
+        |> ExportNamedReferences
+
     interface IPrintable with
         member this.Print(printer) =
             printer.Print("export ")
@@ -2126,13 +2030,12 @@ type ExportNamedReferences =
 
 /// An export default declaration, e.g., export default function () {}; or export default 1;.
 type ExportDefaultDeclaration =
-    {
-        Declaration: Choice<Declaration, Expression>
-    }
-    static member AsModuleDeclaration(declaration) : ModuleDeclaration =
-        {
-            Declaration = declaration
-        } |> ExportDefaultDeclaration
+    { Declaration: Choice<Declaration, Expression> }
+
+    static member AsModuleDeclaration(declaration): ModuleDeclaration =
+        { Declaration = declaration }
+        |> ExportDefaultDeclaration
+
     interface IPrintable with
         member this.Print(printer) =
             printer.Print("export default ")
@@ -2142,15 +2045,13 @@ type ExportDefaultDeclaration =
 
 /// An export batch declaration, e.g., export * from "mod";.
 type ExportAllDeclaration =
-    {
-        Source: Literal
-        Loc: SourceLocation option
-    }
-    static member AsModuleDeclaration(source, ?loc) : ModuleDeclaration =
-        {
-            Source = source
-            Loc = loc
-        } |> ExportAllDeclaration
+    { Source: Literal
+      Loc: SourceLocation option }
+
+    static member AsModuleDeclaration(source, ?loc): ModuleDeclaration =
+        { Source = source; Loc = loc }
+        |> ExportAllDeclaration
+
     interface IPrintable with
         member this.Print(printer) =
             printer.Print("export * from ", ?loc=this.Loc)
@@ -2188,30 +2089,25 @@ type TypeAnnotationInfo =
             | ObjectTypeAnnotation(an) -> printer.Print(an)
 
 type TypeAnnotation =
-    {
-        TypeAnnotation: TypeAnnotationInfo
-    }
-    static member Create(typeAnnotation) =
-        {
-            TypeAnnotation = typeAnnotation
-        }
+    { TypeAnnotation: TypeAnnotationInfo }
+
+    static member Create(typeAnnotation) = { TypeAnnotation = typeAnnotation }
+
     interface IPrintable with
         member this.Print(printer) =
             printer.Print(": ")
             printer.Print(this.TypeAnnotation)
 
 type TypeParameter =
-    {
-        Name: string
-        Bound: TypeAnnotation option
-        Default: TypeAnnotationInfo option
-    }
+    { Name: string
+      Bound: TypeAnnotation option
+      Default: TypeAnnotationInfo option }
+
     static member Create(name, ?bound, ?``default``) =
-        {
-            Name = name
-            Bound = bound
-            Default = ``default``
-        }
+        { Name = name
+          Bound = bound
+          Default = ``default`` }
+
     interface IPrintable with
         member this.Print(printer) =
             printer.Print(this.Name)
@@ -2219,13 +2115,9 @@ type TypeParameter =
             // printer.PrintOptional(``default``)
 
 type TypeParameterDeclaration =
-    {
-        Params: TypeParameter array
-    }
-    static member Create(``params``) =
-        {
-            Params = ``params``
-        }
+    { Params: TypeParameter array }
+
+    static member Create(``params``) = { Params = ``params`` }
     interface IPrintable with
         member this.Print(printer) =
             printer.Print("<")
@@ -2233,13 +2125,9 @@ type TypeParameterDeclaration =
             printer.Print(">")
 
 type TypeParameterInstantiation =
-    {
-        Params: TypeAnnotationInfo array
-    }
-    static member Create(``params``) =
-        {
-            Params = ``params``
-        }
+    { Params: TypeAnnotationInfo array }
+
+    static member Create(``params``) = { Params = ``params`` }
     interface IPrintable with
         member this.Print(printer) =
             printer.Print("<")
@@ -2247,13 +2135,9 @@ type TypeParameterInstantiation =
             printer.Print(">")
 
 type TupleTypeAnnotation =
-    {
-        Types: TypeAnnotationInfo array
-    }
-    static member AsTypeAnnotationInfo(types) : TypeAnnotationInfo =
-        {
-            Types = types
-        } |> TupleTypeAnnotation
+    { Types: TypeAnnotationInfo array }
+
+    static member AsTypeAnnotationInfo(types): TypeAnnotationInfo = { Types = types } |> TupleTypeAnnotation
     interface IPrintable with
         member this.Print(printer) =
             printer.Print("[")
@@ -2261,29 +2145,23 @@ type TupleTypeAnnotation =
             printer.Print("]")
 
 type UnionTypeAnnotation =
-    {
-        Types: TypeAnnotationInfo array
-    }
-    static member AsTypeAnnotationInfo(types) : TypeAnnotationInfo =
-        {
-            Types = types
-        } |> UnionTypeAnnotation
+    { Types: TypeAnnotationInfo array }
+
+    static member AsTypeAnnotationInfo(types): TypeAnnotationInfo = { Types = types } |> UnionTypeAnnotation
     interface IPrintable with
         member this.Print(printer) =
             printer.PrintArray(this.Types, (fun p x -> p.Print(x)), (fun p -> p.Print(" | ")))
 
 type FunctionTypeParam =
-    {
-        Name: Identifier
-        TypeAnnotation: TypeAnnotationInfo
-        Optional: bool option
-    }
+    { Name: Identifier
+      TypeAnnotation: TypeAnnotationInfo
+      Optional: bool option }
+
     static member Create(name, typeInfo, ?optional) =
-        {
-            Name = name
-            TypeAnnotation = typeInfo
-            Optional = optional
-        }
+        { Name = name
+          TypeAnnotation = typeInfo
+          Optional = optional }
+
     interface IPrintable with
         member this.Print(printer) =
             printer.Print(this.Name)
@@ -2293,19 +2171,18 @@ type FunctionTypeParam =
             printer.Print(this.TypeAnnotation)
 
 type FunctionTypeAnnotation =
-    {
-        Params: FunctionTypeParam array
-        ReturnType: TypeAnnotationInfo
-        TypeParameters: TypeParameterDeclaration option
-        Rest: FunctionTypeParam option
-    }
-    static member AsTypeAnnotationInfo(``params``, returnType, ?typeParameters, ?rest) : TypeAnnotationInfo =
-        {
-            Params = ``params``
-            ReturnType = returnType
-            TypeParameters = typeParameters
-            Rest = rest
-        } |> FunctionTypeAnnotation
+    { Params: FunctionTypeParam array
+      ReturnType: TypeAnnotationInfo
+      TypeParameters: TypeParameterDeclaration option
+      Rest: FunctionTypeParam option }
+
+    static member AsTypeAnnotationInfo(``params``, returnType, ?typeParameters, ?rest): TypeAnnotationInfo =
+        { Params = ``params``
+          ReturnType = returnType
+          TypeParameters = typeParameters
+          Rest = rest }
+        |> FunctionTypeAnnotation
+
     interface IPrintable with
         member this.Print(printer) =
             printer.PrintOptional(this.TypeParameters)
@@ -2318,55 +2195,52 @@ type FunctionTypeAnnotation =
             printer.Print(this.ReturnType)
 
 type NullableTypeAnnotation =
-    {
-        TypeAnnotation: TypeAnnotationInfo
-    }
-    static member AsTypeAnnotationInfo(``type``) : TypeAnnotationInfo =
-        {
-            TypeAnnotation = ``type``
-        } |> NullableTypeAnnotation
+    { TypeAnnotation: TypeAnnotationInfo }
+
+    static member AsTypeAnnotationInfo(``type``): TypeAnnotationInfo =
+        { TypeAnnotation = ``type`` }
+        |> NullableTypeAnnotation
+
     interface IPrintable with
         member this.Print(printer) =
             printer.Print(this.TypeAnnotation)
 
 type GenericTypeAnnotation =
-    {
-        Id: Identifier
-        TypeParameters: TypeParameterInstantiation option
-    }
-    static member AsTypeAnnotationInfo(id, ?typeParameters) : TypeAnnotationInfo =
-        {
-            Id = id
-            TypeParameters = typeParameters
-        } |> GenericTypeAnnotation
+    { Id: Identifier
+      TypeParameters: TypeParameterInstantiation option }
+
+    static member AsTypeAnnotationInfo(id, ?typeParameters): TypeAnnotationInfo =
+        { Id = id
+          TypeParameters = typeParameters }
+        |> GenericTypeAnnotation
+
     interface IPrintable with
         member this.Print(printer) =
             printer.Print(this.Id)
             printer.PrintOptional(this.TypeParameters)
 
 type ObjectTypeProperty =
-    {
-        Key: Expression
-        Value: TypeAnnotationInfo
-        Kind: string option
-        Computed: bool
-        Static: bool
-        Optional: bool
-        Proto: bool
-        Method: bool
-    }
+    { Key: Expression
+      Value: TypeAnnotationInfo
+      Kind: string option
+      Computed: bool
+      Static: bool
+      Optional: bool
+      Proto: bool
+      Method: bool }
+
     static member Create(key, value, ?computed_, ?kind, ?``static``, ?optional, ?proto, ?method) =
         let computed = defaultArg computed_ false
-        {
-            Key = key
-            Value = value
-            Kind = kind
-            Computed = computed
-            Static = defaultArg ``static`` false
-            Optional = defaultArg optional false
-            Proto = defaultArg proto false
-            Method = defaultArg method false
-        }
+
+        { Key = key
+          Value = value
+          Kind = kind
+          Computed = computed
+          Static = defaultArg ``static`` false
+          Optional = defaultArg optional false
+          Proto = defaultArg proto false
+          Method = defaultArg method false }
+
     interface IPrintable with
         member this.Print(printer) =
             if this.Static then
@@ -2386,74 +2260,65 @@ type ObjectTypeProperty =
             printer.Print(this.Value)
 
 type ObjectTypeIndexer =
-    {
-        Id: Identifier option
-        Key: Identifier
-        Value: TypeAnnotationInfo
-        Static: bool option
-    }
-    static member Create(key, value, ?id, ?``static``) : Node =
-        {
-            Id = id
-            Key = key
-            Value = value
-            Static = ``static``
-        } |> ObjectTypeIndexer
+    { Id: Identifier option
+      Key: Identifier
+      Value: TypeAnnotationInfo
+      Static: bool option }
+
+    static member Create(key, value, ?id, ?``static``): Node =
+        { Id = id
+          Key = key
+          Value = value
+          Static = ``static`` }
+        |> ObjectTypeIndexer
+
     interface IPrintable with
         member _.Print(_) = failwith "not implemented"
 
 type ObjectTypeCallProperty =
-    {
-        Value: TypeAnnotationInfo
-        Static: bool option
-    }
-    static member Create(value, ?``static``)  =
-        {
-            Value = value
-            Static = ``static``
-        }
+    { Value: TypeAnnotationInfo
+      Static: bool option }
+
+    static member Create(value, ?``static``) = { Value = value; Static = ``static`` }
+
     interface IPrintable with
         member _.Print(_) = failwith "not implemented"
 
 type ObjectTypeInternalSlot =
-    {
-        Id: Identifier
-        Value: TypeAnnotationInfo
-        Optional: bool
-        Static: bool
-        Method: bool
-    }
-    static member Create(id, value, optional, ``static``, method)  =
-        {
-            Id = id
-            Value = value
-            Optional = optional
-            Static = ``static``
-            Method = method
-        }
+    { Id: Identifier
+      Value: TypeAnnotationInfo
+      Optional: bool
+      Static: bool
+      Method: bool }
+
+    static member Create(id, value, optional, ``static``, method) =
+        { Id = id
+          Value = value
+          Optional = optional
+          Static = ``static``
+          Method = method }
     interface IPrintable with
         member _.Print(_) = failwith "not implemented"
 
 type ObjectTypeAnnotation =
-    {
-        Properties: ObjectTypeProperty array
-        Indexers: ObjectTypeIndexer array
-        CallProperties: ObjectTypeCallProperty array
-        InternalSlots: ObjectTypeInternalSlot array
-        Exact: bool
-    }
+    { Properties: ObjectTypeProperty array
+      Indexers: ObjectTypeIndexer array
+      CallProperties: ObjectTypeCallProperty array
+      InternalSlots: ObjectTypeInternalSlot array
+      Exact: bool }
+
     static member Create(properties, ?indexers_, ?callProperties_, ?internalSlots_, ?exact_) =
         let exact = defaultArg exact_ false
         let indexers = defaultArg indexers_ [||]
         let callProperties = defaultArg callProperties_ [||]
         let internalSlots = defaultArg internalSlots_ [||]
-        {
-            Properties = properties
-            Indexers = indexers
-            CallProperties = callProperties
-            InternalSlots = internalSlots
-            Exact = exact
-        }
+
+        { Properties = properties
+          Indexers = indexers
+          CallProperties = callProperties
+          InternalSlots = internalSlots
+          Exact = exact }
+
     interface IPrintable with
         member this.Print(printer) =
             printer.Print("{")
@@ -2469,40 +2334,36 @@ type ObjectTypeAnnotation =
             printer.PrintNewLine()
 
 type InterfaceExtends =
-    {
-        Id: Identifier
-        TypeParameters: TypeParameterInstantiation option
-    }
+    { Id: Identifier
+      TypeParameters: TypeParameterInstantiation option }
+
     static member Create(id, ?typeParameters) =
-        {
-            Id = id
-            TypeParameters = typeParameters
-        }
+        { Id = id
+          TypeParameters = typeParameters }
+
     interface IPrintable with
         member this.Print(printer) =
             printer.Print(this.Id)
             printer.PrintOptional(this.TypeParameters)
 
 type InterfaceDeclaration =
-    {
-        Id: Identifier
-        Body: ObjectTypeAnnotation
-        Extends: InterfaceExtends array
-        Implements: ClassImplements array
+    { Id: Identifier
+      Body: ObjectTypeAnnotation
+      Extends: InterfaceExtends array
+      Implements: ClassImplements array
+      TypeParameters: TypeParameterDeclaration option }
 
-        TypeParameters: TypeParameterDeclaration option
-    }
-    static member Create(id, body, ?extends_, ?typeParameters, ?implements_) : Declaration = // ?mixins_,
+    static member Create(id, body, ?extends_, ?typeParameters, ?implements_): Declaration = // ?mixins_,
         let extends = defaultArg extends_ [||]
         let implements = defaultArg implements_ [||]
-        {
-            Id = id
-            Body = body
-            Extends = extends
-            Implements = implements
 
-            TypeParameters = typeParameters
-        } |> InterfaceDeclaration
+        { Id = id
+          Body = body
+          Extends = extends
+          Implements = implements
+          TypeParameters = typeParameters }
+        |> InterfaceDeclaration
+
 //    let mixins = defaultArg mixins_ [||]
 //    member _.Mixins: InterfaceExtends array = mixins
     interface IPrintable with
@@ -2510,12 +2371,14 @@ type InterfaceDeclaration =
             printer.Print("interface ")
             printer.Print(this.Id)
             printer.PrintOptional(this.TypeParameters)
+
             if not (Array.isEmpty this.Extends) then
                 printer.Print(" extends ")
                 printer.PrintArray(this.Extends, (fun p x -> p.Print(x)), (fun p -> p.Print(", ")))
+
             if not (Array.isEmpty this.Implements) then
                 printer.Print(" implements ")
                 printer.PrintArray(this.Implements, (fun p x -> p.Print(x)), (fun p -> p.Print(", ")))
+
             printer.Print(" ")
             printer.Print(this.Body)
-

--- a/src/Fable.Transforms/Global/Babel.fs
+++ b/src/Fable.Transforms/Global/Babel.fs
@@ -136,7 +136,6 @@ module PrinterExtensions =
             printer.PrintArray(nodes, (fun p x -> p.SequenceExpressionWithParens(x)), (fun p -> p.Print(", ")))
 
 
-
         // TODO: (super) type parameters, implements
         member printer.PrintClass(id: Identifier option, superClass: Expression option,
                 superTypeParameters: TypeParameterInstantiation option,
@@ -195,8 +194,6 @@ module PrinterExtensions =
                     printer.PrintOptional(typeParameters)
                     printer.Print("(")
                     printer.PrintCommaSeparatedArray(parameters)
-                    printer.PrintArray(parameters, (fun p x -> x.Print(p)), (fun p -> p.Print(", ")))
-
                     printer.Print(")")
                     printer.PrintOptional(returnType)
                     printer.Print(" => ")
@@ -366,7 +363,6 @@ type Expression =
         | AssignmentExpression(n) -> n.Print(printer)
         | ConditionalExpression(n) -> n.Print(printer)
         | ArrowFunctionExpression(n) -> n.Print(printer)
-
 
 type Pattern =
     | IdentifierPattern of Identifier

--- a/src/Fable.Transforms/Global/Babel.fs
+++ b/src/Fable.Transforms/Global/Babel.fs
@@ -250,7 +250,31 @@ type Node =
 
     interface IPrinter with
         member this.Print(printer) =
-            failwith "Not implemented"
+            match this with
+            | Pattern(n) -> printer.Print(n)
+            | Program(n) -> printer.Print("(program)")
+            | Statement(n) -> printer.Print(n)
+            | Directive(n) -> printer.Print(n)
+            | ClassBody(n) -> printer.Print(n)
+            | Expression(n) -> printer.Print(n)
+            | SwitchCase(n) -> printer.Print(n)
+            | CatchClause(n) -> printer.Print(n)
+            | ObjectMember(n) -> printer.Print(n)
+            | TypeParameter(n) -> printer.Print(n)
+            | TypeAnnotation(n) -> printer.Print(n)
+            | ExportSpecifier(n) -> printer.Print(n)
+            | ImportSpecifier(n) -> printer.Print(n)
+            | InterfaceExtends(n) -> printer.Print(n)
+            | ObjectTypeIndexer(n) -> printer.Print(n)
+            | FunctionTypeParam(n) -> printer.Print(n)
+            | ModuleDeclaration(n) -> printer.Print(n)
+            | VariableDeclarator(n) -> printer.Print(n)
+            | TypeAnnotationInfo(n) -> printer.Print(n)
+            | ObjectTypeProperty(n) -> printer.Print(n)
+            | ObjectTypeCallProperty (n) -> printer.Print(n)
+            | ObjectTypeInternalSlot(n) -> printer.Print(n)
+            | TypeParameterDeclaration(n) -> printer.Print(n)
+            | TypeParameterInstantiation(n) -> printer.Print(n)
 
 /// Since the left-hand side of an assignment may be any expression in general, an expression can also be a pattern.
 type Expression =
@@ -280,14 +304,46 @@ type Expression =
 
     interface IPrinter with
         member this.Print(printer) =
-            failwith "Not implemented"
+            match this with
+            | Super(n) -> printer.Print(n)
+            | Literal(n) -> printer.Print(n)
+            | Undefined(n) -> printer.Print(n)
+            | Identifier(n) -> printer.Print(n)
+            | NewExpression(n) -> printer.Print(n)
+            | SpreadElement(n) -> printer.Print(n)
+            | ThisExpression(n) -> printer.Print(n)
+            | CallExpression(n) -> printer.Print(n)
+            | EmitExpression(n) -> printer.Print(n)
+            | ArrayExpression(n) -> printer.Print(n)
+            | ClassExpression(n) -> printer.Print(n)
+            | ClassImplements(n) -> printer.Print(n)
+            | UnaryExpression(n) -> printer.Print(n)
+            | UpdateExpression(n) -> printer.Print(n)
+            | ObjectExpression(n) -> printer.Print(n)
+            | BinaryExpression(n) -> printer.Print(n)
+            | MemberExpression(n) -> printer.Print(n)
+            | LogicalExpression(n) -> printer.Print(n)
+            | SequenceExpression(n) -> printer.Print(n)
+            | FunctionExpression(n) -> printer.Print(n)
+            | AssignmentExpression(n) -> printer.Print(n)
+            | ConditionalExpression(n) -> printer.Print(n)
+            | ArrowFunctionExpression(n) -> printer.Print(n)
+
 
 type Pattern =
+    | IdentifierPattern of Identifier
     | RestElement of RestElement
 
     interface IPrinter with
         member this.Print(printer) =
-            failwith "Not implemented"
+            match this with
+            | IdentifierPattern(p) -> printer.Print(p)
+            | RestElement(e) -> printer.Print(e)
+
+    member this.Name =
+        match this with
+        | IdentifierPattern(id) -> id.Name
+        | RestElement(el) -> el.Name
 
 type Literal =
     | RegExp of RegExpLiteral
@@ -299,51 +355,87 @@ type Literal =
 
     interface IPrinter with
         member this.Print(printer) =
-            failwith "Not implemented"
+            match this with
+            | RegExp(l) -> printer.Print(l)
+            | NullLiteral(l) -> printer.Print(l)
+            | StringLiteral(l) -> printer.Print(l)
+            | BooleanLiteral(l) -> printer.Print(l)
+            | NumericLiteral(l) -> printer.Print(l)
+            | DirectiveLiteral(l) -> printer.Print(l)
 
 type Statement =
     | Declaration of Declaration
-    | ExpressionStatement of ExpressionStatement
-    | BlockStatement of BlockStatement
-    | DebuggerStatement of DebuggerStatement
-    | LabeledStatement of LabeledStatement
-    | BreakStatement of BreakStatement
-    | ContinueStatement of ContinueStatement
-    | ReturnStatement of ReturnStatement
     | IfStatement of IfStatement
-    | SwitchStatement of SwitchStatement
     | TryStatement of TryStatement
-    | WhileStatement of WhileStatement
     | ForStatement of ForStatement
+    | BreakStatement of BreakStatement
+    | WhileStatement of WhileStatement
     | ThrowStatement of ThrowStatement
+    | BlockStatement of BlockStatement
+    | ReturnStatement of ReturnStatement
+    | SwitchStatement of SwitchStatement
+    | LabeledStatement of LabeledStatement
+    | DebuggerStatement of DebuggerStatement
+    | ContinueStatement of ContinueStatement
+    | ExpressionStatement of ExpressionStatement
 
     interface IPrinter with
         member this.Print(printer) =
-            failwith "Not implemented"
+            match this with
+            | Declaration(s) -> printer.Print(s)
+            | IfStatement(s) -> printer.Print(s)
+            | TryStatement(s) -> printer.Print(s)
+            | ForStatement(s) -> printer.Print(s)
+            | BreakStatement(s) -> printer.Print(s)
+            | WhileStatement(s) -> printer.Print(s)
+            | ThrowStatement(s) -> printer.Print(s)
+            | BlockStatement(s) -> printer.Print(s)
+            | ReturnStatement(s) -> printer.Print(s)
+            | SwitchStatement(s) -> printer.Print(s)
+            | LabeledStatement(s) -> printer.Print(s)
+            | DebuggerStatement(s) -> printer.Print(s)
+            | ContinueStatement(s) -> printer.Print(s)
+            | ExpressionStatement(s) -> printer.Print(s)
+
 
 /// Note that declarations are considered statements; this is because declarations can appear in any statement context.
 type Declaration =
+    | ClassDeclaration of ClassDeclaration
     | VariableDeclaration of VariableDeclaration
     | FunctionDeclaration of FunctionDeclaration
-    | ClassDeclaration of ClassDeclaration
     | InterfaceDeclaration of InterfaceDeclaration
 
     interface IPrinter with
         member this.Print(printer) =
-            failwith "Not implemented"
+            match this with
+            | ClassDeclaration(d) -> printer.Print(d)
+            | VariableDeclaration(d) -> printer.Print(d)
+            | FunctionDeclaration(d) -> printer.Print(d)
+            | InterfaceDeclaration(d) -> printer.Print(d)
+
 
 /// A module import or export declaration.
 type ModuleDeclaration =
-    | PrivateModuleDeclaration of PrivateModuleDeclaration
     | ImportDeclaration of ImportDeclaration
-    | ExportNamedDeclaration of ExportNamedDeclaration
-    | ExportDefaultDeclaration of ExportDefaultDeclaration
     | ExportAllDeclaration of ExportAllDeclaration
     | ExportNamedReferences of ExportNamedReferences
+    | ExportNamedDeclaration of ExportNamedDeclaration
+    | PrivateModuleDeclaration of PrivateModuleDeclaration
+    | ExportDefaultDeclaration of ExportDefaultDeclaration
 
     interface IPrinter with
         member this.Print(printer) =
-            failwith "Not implemented"
+            this.Print(printer)
+
+    member this.Print(printer: Printer) =
+            match this with
+            | ImportDeclaration(d) -> printer.Print(d)
+            | ExportAllDeclaration(d) -> printer.Print(d)
+            | ExportNamedReferences(d) -> printer.Print(d)
+            | ExportNamedDeclaration(d) -> printer.Print(d)
+            | PrivateModuleDeclaration(d) -> printer.Print(d)
+            | ExportDefaultDeclaration(d) -> printer.Print(d)
+
 
 /// Not in Babel specs
 type EmitExpression =
@@ -467,8 +559,10 @@ type Identifier =
             TypeAnnotation = typeAnnotation
             Loc = loc
         }
-    static member CreateExpression(name, ?optional, ?typeAnnotation, ?loc) : Expression =
+    static member AsExpression(name, ?optional, ?typeAnnotation, ?loc) : Expression =
         Identifier.Create(name, ?optional=optional, ?typeAnnotation=typeAnnotation, ?loc=loc) |> Identifier
+    static member AsPattern(name, ?optional, ?typeAnnotation, ?loc) : Pattern =
+        Identifier.Create(name, ?optional=optional, ?typeAnnotation=typeAnnotation, ?loc=loc) |> IdentifierPattern
 
     interface IPrinter with
         member this.Print(printer) =
@@ -525,7 +619,7 @@ type NullLiteral =
         {
             Loc = loc
         } |> NullLiteral
-    static member CreateExpression(?loc) : Expression =
+    static member AsExpression(?loc) : Expression =
         NullLiteral.Create(?loc=loc) |> Literal
     interface IPrinter with
         member this.Print(printer) =
@@ -536,13 +630,16 @@ type StringLiteral =
         Value: string
         Loc: SourceLocation option
     }
-    static member CreateLiteral(value, ?loc) : Literal =
+
+    static member Create(value, ?loc) =
         {
             Value = value
             Loc = loc
-        } |> StringLiteral
-    static member CreateExpression(value, ?loc) : Expression =
-        StringLiteral.CreateLiteral(value, ?loc=loc) |> Literal
+        }
+    static member AsLiteral(value, ?loc) : Literal =
+        StringLiteral.Create(value, ?loc=loc) |> StringLiteral
+    static member AsExpression(value, ?loc) : Expression =
+        StringLiteral.AsLiteral(value, ?loc=loc) |> Literal
     interface IPrinter with
         member this.Print(printer) =
             printer.Print("\"", ?loc=this.Loc)
@@ -559,6 +656,8 @@ type BooleanLiteral =
             Value = value
             Loc = loc
         } |> BooleanLiteral
+    static member AsExpression(value, ?loc) : Expression =
+         BooleanLiteral.Create(value, ?loc=loc) |> Literal
     interface IPrinter with
         member this.Print(printer) =
             printer.Print((if this.Value then "true" else "false"), ?loc=this.Loc)
@@ -573,7 +672,7 @@ type NumericLiteral =
             Value =value
             Loc = loc
         } |> NumericLiteral
-    static member CreateExpression(value, ?loc) : Expression =
+    static member AsExpression(value, ?loc) : Expression =
         NumericLiteral.Create(value, ?loc=loc) |> Literal
     interface IPrinter with
         member this.Print(printer) =
@@ -654,7 +753,7 @@ type BlockStatement =
         {
             Body = body
         }
-    static member CreateStatement(body) =
+    static member AsStatement(body) =
         BlockStatement.Create(body) |> BlockStatement
 //    let directives = [||] // defaultArg directives_ [||]
 //    member _.Directives: Directive array = directives
@@ -914,7 +1013,9 @@ type VariableDeclarator =
             Id = id
             Init = init
         }
-
+    interface IPrinter with
+        member this.Print(printer) =
+            failwith "Not implemented"
 
 type VariableDeclarationKind = Var | Let | Const
 
@@ -925,16 +1026,23 @@ type VariableDeclaration =
         Loc: SourceLocation option
     }
 
-    static member Create(kind_, declarations, ?loc) : Declaration =
-        let kind = match kind_ with Var -> "var" | Let -> "let" | Const -> "const"
+    static member Create(kind, declarations, ?loc) =
+        let kind = match kind with Var -> "var" | Let -> "let" | Const -> "const"
         {
             Declarations = declarations
             Kind = kind
             Loc = loc
-        } |> VariableDeclaration
-    static member Create(var, ?init, ?kind, ?loc) : Statement =
+        }
+    static member Create(var, ?init, ?kind, ?loc) =
         VariableDeclaration.Create(defaultArg kind Let, [|VariableDeclarator.Create(var, ?init=init)|], ?loc=loc)
-        |> Declaration
+    static member AsDeclaration(kind, declarations, ?loc) : Declaration =
+        VariableDeclaration.Create(kind, declarations, ?loc=loc)
+        |> VariableDeclaration
+    static member AsDeclaration(var, ?init, ?kind, ?loc) : Declaration =
+        VariableDeclaration.AsDeclaration(defaultArg kind Let, [|VariableDeclarator.Create(var, ?init=init)|], ?loc=loc)
+    static member AsStatement(var, ?init, ?kind, ?loc) : Statement =
+        VariableDeclaration.AsDeclaration(var, ?init=init, ?kind=kind, ?loc=loc) |> Declaration
+
     interface IPrinter with
         member this.Print(printer) =
             printer.Print(this.Kind + " ", ?loc=this.Loc)
@@ -1316,6 +1424,9 @@ type MemberExpression =
             Computed = computed
             Loc = loc
         } |> MemberExpression
+
+    interface IPrinter with
+        member this.Print(printer) = this.Print(printer)
     member this.Print(printer, ?objectWithParens: bool) =
         printer.AddLocation(this.Loc)
         match objectWithParens, this.Object with
@@ -1628,9 +1739,8 @@ type RestElement =
         Loc: SourceLocation option
     }
     static member Create(argument: Pattern, ?typeAnnotation, ?loc) : Pattern =
-        let (RestElement elem) = argument
         {
-            Name = elem.Name
+            Name = argument.Name
             Argument = argument
             TypeAnnotation = typeAnnotation
             Loc = loc
@@ -1764,11 +1874,11 @@ type ClassImplements =
         Id: Identifier
         TypeParameters: TypeParameterInstantiation option
     }
-    static member Create(id, ?typeParameters) : Expression =
+    static member Create(id, ?typeParameters) =
         {
             Id = id
             TypeParameters = typeParameters
-        } |> ClassImplements
+        }
     interface IPrinter with
         member this.Print(printer) =
             printer.Print(this.Id)


### PR DESCRIPTION
Refactor Babel AST into records and unions to simplify pattern matching for Babel transformation (e.g Python).  I use records consistently (instead of tuples) since they enable keyed lookup and it's easier to add eg source location etc. The PR tries to keep the existing code style of Fable2Babel.fs and uses `.Create()` methods to support optional parameters. E.g previous code such as:

```fs
CallExpression(com.TransformImport(ctx, memberName, getLibPath com moduleName), args, ?loc=r) :> Expression
```

Now becomes:
```fs
Expression.callExpression(com.TransformImport(ctx, memberName, getLibPath com moduleName), args, ?loc=r)
```

This PR Fixes #2158 