### PR TITLE
Generate ThisExpression instead of "this" identifier.

### DIFF
--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -751,7 +751,7 @@ module Util =
         CallExpression(funcExpr, List.toArray args, ?loc=r) :> Expression
 
     let callFunctionWithThisContext r funcExpr (args: Expression list) =
-        let args = (Identifier "this" :> Expression)::args |> List.toArray
+        let args = thisExpr::args |> List.toArray
         CallExpression(get None funcExpr "call", args, ?loc=r) :> Expression
 
     let emitExpression range (txt: string) args =


### PR DESCRIPTION
Generate Babel `ThisExpression` instead of an identifier called `this`. Makes it easier to translate the Babel AST to e.g Python where `this` needs to be translated to `self`. 