### PR TITLE
Raise an error when the name of an interface property clashes

### DIFF
--- a/src/Fable.Transforms/FSharp2Fable.fs
+++ b/src/Fable.Transforms/FSharp2Fable.fs
@@ -114,10 +114,13 @@ let private resolveImportMemberBinding (ident: Fable.Ident) (info: Fable.ImportI
 
 let private getAttachedMemberInfo com ctx r nonMangledNameConflicts
                 (declaringEntity: Fable.Entity option) (sign: FSharpAbstractSignature) attributes =
-    let declaringEntityName, declaringEntityFields =
+    let declaringEntityFields = HashSet<_>()
+    let declaringEntityName =
         match declaringEntity with
-        | Some x -> x.FullName, (x.FSharpFields |> List.map (fun x -> x.Name))
-        | None   -> "", []
+        | Some x ->
+            x.FSharpFields |> List.iter (fun x -> declaringEntityFields.Add(x.Name) |> ignore)
+            x.FullName
+        | None   -> ""
 
     let isGetter = sign.Name.StartsWith("get_")
     let isSetter = not isGetter && sign.Name.StartsWith("set_")
@@ -152,17 +155,12 @@ let private getAttachedMemberInfo com ctx r nonMangledNameConflicts
                         if indexedProp then sign.Name, false, false
                         else Naming.removeGetSetPrefix sign.Name, isGetter, isSetter
                     // Setters can have same name as getters, assume there will always be a getter
-                    if not isSetter then
-                        if nonMangledNameConflicts declaringEntityName name then
-                            sprintf "Member %s is duplicated, use Mangle attribute to prevent conflicts with interfaces" name
-                            // TODO: Temporarily emitting a warning, because this errors in old libraries,
-                            // like Fable.React.HookBindings
-                            |> addWarning com ctx.InlinePath r
-
-                        if declaringEntityFields |> List.contains name then
-                            sprintf "Interface member %s.%s conflicts with existing member on type %s, add the Mangle attribute to the interface to prevent conflicts"
-                                sign.DeclaringType.TypeDefinition.FullName name declaringEntityName
-                            |> addError com ctx.InlinePath r
+                    if not isSetter &&
+                        (nonMangledNameConflicts declaringEntityName name || declaringEntityFields.Contains(name)) then
+                        sprintf "Member %s is duplicated, use Mangle attribute to prevent conflicts with interfaces" name
+                        // TODO: Temporarily emitting a warning, because this errors in old libraries,
+                        // like Fable.React.HookBindings
+                        |> addWarning com ctx.InlinePath r
                     name, isGetter, isSetter
             name, isMangled, isGetter, isSetter, isEnumerator, hasSpread
         | None ->


### PR DESCRIPTION
Raise an error when the name of an interface property clashes with an existing member.

Fixes #1343.