### PR TITLE
Fix polling watcher exception

### DIFF
--- a/src/Fable.Cli/FileWatchers.fs
+++ b/src/Fable.Cli/FileWatchers.fs
@@ -106,7 +106,9 @@ type PollingFileWatcher (watchedDirectoryPath, ignoredDirectoryNameRegexes) =
                 with
                     | :? FileNotFoundException ->
                         knownEntities.[fullFilePath] <- { fileMeta with FoundAgain = false }
-            tempDictionary.Add(f.FullName, { FileInfo = f; FoundAgain = false }))
+            // TryAdd instead of Add because sometimes we get duplicates (?!)
+            // (Saw multiple times on Linux. Not sure where it came from...)
+            tempDictionary.TryAdd(f.FullName, { FileInfo = f; FoundAgain = false }) |> ignore)
 
         for file in knownEntities do
             if not (file.Value.FoundAgain)


### PR DESCRIPTION
I ran into a crash with the same stack multiple times with the polling file watcher under WSL.

I'm still not sure what caused it, because I couldn't reproduce the issue with a debugger attached, but it looks like maybe enumerating files in a directory sometimes returns duplicates. This sounds like it should be impossible, but I have no other explanation :/

Anyway, this is an attempt to blindly fix the problem.

Stack trace (The path of the problematic file is not always the same, but the rest of the stack is):
```
TODO

Unhandled exception. System.ArgumentException: An item with the same key has already been added. Key: /mnt/d/Data/Dev/Projects/LastFmStats/src/Dapper/Dapper.Tests.Performance/Program.cs
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at Fable.Cli.FileWatcher.clo@95-1.Invoke(FileSystemInfo f) in /home/alfonso/repos/Fable/src/Fable.Cli/FileWatchers.fs:line 108
   at Fable.Cli.FileWatcher.PollingFileWatcher.foreachEntityInDirectory(DirectoryInfo dirInfo, FSharpFunc`2 fileAction) in /home/alfonso/repos/Fable/src/Fable.Cli/FileWatchers.fs:line 76
   at Fable.Cli.FileWatcher.PollingFileWatcher.foreachEntityInDirectory(DirectoryInfo dirInfo, FSharpFunc`2 fileAction) in /home/alfonso/repos/Fable/src/Fable.Cli/FileWatchers.fs:line 78
   at Fable.Cli.FileWatcher.PollingFileWatcher.foreachEntityInDirectory(DirectoryInfo dirInfo, FSharpFunc`2 fileAction) in /home/alfonso/repos/Fable/src/Fable.Cli/FileWatchers.fs:line 78
   at Fable.Cli.FileWatcher.PollingFileWatcher.checkForChangedFiles() in /home/alfonso/repos/Fable/src/Fable.Cli/FileWatchers.fs:line 111
   at Fable.Cli.FileWatcher.PollingFileWatcher.pollingLoop() in /home/alfonso/repos/Fable/src/Fable.Cli/FileWatchers.fs:line 141
   at Fable.Cli.FileWatcher.pollingThread@145.Invoke() in /home/alfonso/repos/Fable/src/Fable.Cli/FileWatchers.fs:line 145
   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location where exception was thrown ---
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.ThreadHelper.ThreadStart()
npm ERR! code ELIFECYCLE
npm ERR! errno 134
npm ERR! @ start: `dotnet fable watch src --verbose --sourceMaps --runWatch webpack serve`
npm ERR! Exit status 134
npm ERR!
npm ERR! Failed at the @ start script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/yaurthek/.npm/_logs/2021-02-14T09_12_23_446Z-debug.log
```

I also added a new path candidate for `fable-library` because the existing ones were not sufficient to debug with Visual Studio (Windows). This is a separate commit so I can remove it easily if this is an unwanted change.