### PR TITLE
Fix: #2394 interpolate doesn't unescape %% correctly

### DIFF
--- a/src/fable-library/String.ts
+++ b/src/fable-library/String.ts
@@ -114,7 +114,7 @@ export function interpolate(input: string, values: any[]): string {
   let i = 0;
   return input.replace(interpolateRegExp, (_, prefix, flags, padLength, precision, format) => {
     return formatReplacement(values[i++], prefix, flags, padLength, precision, format);
-  });
+  }).replace(/%%/g, "%");
 }
 
 function continuePrint(cont: (x: string) => any, arg: IPrintfFormat | string) {

--- a/tests/Main/StringTests.fs
+++ b/tests/Main/StringTests.fs
@@ -885,4 +885,10 @@ let tests =
       // See #1628, though I'm not sure if the compiled tests are passing just the function reference without wrapping it
       testCase "Passing Char.IsDigit as a function reference doesn't make String.filter hang" <| fun () ->
             "Hello! 123" |> String.filter System.Char.IsDigit |> equal "123"
-]
+
+      testCase "sprintf with double % should be unescaped" <| fun () ->
+            sprintf "%d%%" 100 |> equal "100%"
+
+      testCase "interpolated string with double % should be unescaped" <| fun () ->
+            $"{100}%%" |> equal "100%"
+  ]


### PR DESCRIPTION
This is a fix for #2394 