### PR TITLE
Fix: Accessing named capture group in Regex only works with string constant

### DIFF
--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -2707,8 +2707,8 @@ let regex com (ctx: Context) r t (i: CallInfo) (thisArg: Expr option) (args: Exp
     | "get_Item" when i.DeclaringEntityFullName = "System.Text.RegularExpressions.GroupCollection" ->
         // can be group index or group name
         //        `m.Groups.[0]` `m.Groups.["name"]`
-        match args |> List.head with
-        | Value (StringConstant name, _) ->
+        match (args |> List.head).Type with
+        | String ->
             // name
             (* `groups` might not exist -> check first:
                 (`m`: `thisArg.Value`; `name`: `args.Head`)

--- a/tests/Main/RegexTests.fs
+++ b/tests/Main/RegexTests.fs
@@ -317,6 +317,57 @@ let tests =
 
                 m.Groups.["exact"].Success |> equal false
 
+            testCase "group name from string" <| fun _ ->
+                let r = Regex "(?<number>\\d+)"
+                let m = r.Match "Number 12345 is positive"
+
+                m.Groups.["number"].Value |> equal "12345"
+
+            testCase "group name from variable" <| fun _ ->
+                let r = Regex "(?<number>\\d+)"
+                let m = r.Match "Number 12345 is positive"
+
+                let g = "number"
+                m.Groups.[g].Value |> equal "12345"
+
+            testCase "group name from addition" <| fun _ ->
+                let r = Regex "(?<number>\\d+)"
+                let m = r.Match "Number 12345 is positive"
+
+                m.Groups.["num" + "ber"].Value |> equal "12345"
+
+            testCase "group name from string in function" <| fun _ ->
+                let r = Regex "(?<number>\\d+)"
+                let m = r.Match "Number 12345 is positive"
+
+                let namedGroup (name: string) (m: Match): string =
+                    m.Groups.[name].Value
+
+                m |> namedGroup "number" |> equal "12345"
+
+            testCase "group name from variable in function" <| fun _ ->
+                let r = Regex "(?<number>\\d+)"
+                let m = r.Match "Number 12345 is positive"
+
+                let namedGroup (name: string) (m: Match): string =
+                    m.Groups.[name].Value
+
+                let g = "number"
+                m |> namedGroup g |> equal "12345"
+
+            testCase "group name from function call" <| fun _ ->
+                let r = Regex "(?<number>\\d+)"
+                let m = r.Match "Number 12345 is positive"
+
+                let getName () = "number"
+                m.Groups.[getName ()].Value |> equal "12345"
+
+            testCase "group name from if expression" <| fun _ ->
+                let r = Regex "(?<number>\\d+)"
+                let m = r.Match "Number 12345 is positive"
+
+                m.Groups.[if m.Success then "number" else failwith "Regex didn't match!"].Value |> equal "12345"
+
 
 #if FABLE_COMPILER
             testList "on not existing group" [
@@ -372,6 +423,42 @@ let tests =
                 let actual =
                     r.Matches text
                     |> Seq.map (fun m -> m.Groups.["country"].Value, m.Groups.["num"].Value)
+                    |> Seq.toList
+
+                actual |> equal expected
+
+            testCase "group name from string" <| fun _ ->
+                let r = Regex "\\+(?<country>\\d{1,3}) (?<num>\\d+)"
+                let text = "Numbers: +1 12; +49 456; +44 7890;"
+
+                let expected = [
+                    ("1", "12")
+                    ("49", "456")
+                    ("44", "7890")
+                ]
+
+                let actual =
+                    r.Matches text
+                    |> Seq.map (fun m -> m.Groups.["country"].Value, m.Groups.["num"].Value)
+                    |> Seq.toList
+
+                actual |> equal expected
+
+            testCase "group name from variable" <| fun _ ->
+                let r = Regex "\\+(?<country>\\d{1,3}) (?<num>\\d+)"
+                let text = "Numbers: +1 12; +49 456; +44 7890;"
+
+                let expected = [
+                    ("1", "12")
+                    ("49", "456")
+                    ("44", "7890")
+                ]
+
+                let g1, g2 = ("country", "num")
+
+                let actual =
+                    r.Matches text
+                    |> Seq.map (fun m -> m.Groups.[g1].Value, m.Groups.[g2].Value)
                     |> Seq.toList
 
                 actual |> equal expected


### PR DESCRIPTION
Support for named capture groups in Regexes was introduced in #2364.

But there's an issue: Accessing a group by name can only be done via string constant, not via string variable (or any other string expression):
```fsharp
let regex = Regex "(?<num>\d+)"
let text = "Text 123 Text"
let m = regex.Match text

let gc = m.Groups.["num"].Value
printfn "gc=%s" gc  // gc=123

let g = "num"
let gv = m.Groups.[g].Value
printfn "gc=%s" gv  // gv=

let ga = m.Groups.["nu" + "m"].Value
printfn "ga=%s" ga  // ga=
```
([repl](https://fable.io/repl/#?code=PYBwpgdgBAygngZwC5gLYDoAqYAeT0BKYA5gK4A2AhgE4CiOI1YCCAlsBAgLABQv5YJFCbFcUALxQionFABEACgD8AHgilUAPgA6AEwDUASjn9BUFHgnzslgIwAmAMxQbSEzwFDUVkbnQBZSiQAYwALc1wkXlMhYmCrDABxamBSEAR0AG05dVQ5AF10ADVKclIwXkZWCCQAM2g5OPEAUgQ5KDioKAB6bqgAd2BqAGtuPg8zYiscjXdPDoA3BPRk1PSs4kKSsoqeKpr6+WIFlrbFrt6oXWBmCAByIUGR6InYymXVtIzs9Xb9eTyW1K5Uq1GqdQaxEop3aUIufWutweAyGw14QA&html=Q&css=Q))


-> I only added handling of `StringConstant` (https://github.com/fable-compiler/Fable/blob/d8f8ab1642ebda8890b6658ef269e8d043d5a019/src/Fable.Transforms/Replacements.fs#L2711), but not anything that returns a String.

-> fixed. Should now work with everything stringy.