### PR TITLE
ProjectCracker: support setting a configuration

### DIFF
--- a/src/Fable.AST/Plugins.fs
+++ b/src/Fable.AST/Plugins.fs
@@ -14,6 +14,7 @@ type CompilerOptions =
       abstract ClampByteArrays: bool
       abstract Typescript: bool
       abstract Define: string list
+      abstract Configuration: string
       abstract DebugMode: bool
       abstract OptimizeFSharpAst: bool
       abstract Verbosity: Verbosity

--- a/src/Fable.Cli/Entry.fs
+++ b/src/Fable.Cli/Entry.fs
@@ -56,6 +56,7 @@ Arguments:
   -s|--sourceMaps   Enable source maps
 
   --define          Defines a symbol for use in conditional compilation
+  --configuration   The configuration to use for building the project, the default is 'Debug'
   --verbose         Print more info during compilation
   --typedArrays     Compile numeric arrays as JS typed arrays (default true)
 
@@ -135,12 +136,20 @@ type Runner =
                 Verbosity.Verbose
             else Verbosity.Normal
 
+        let configuration =
+            let defaultConfiguration = "Debug"
+            let configurationArg = argValue "--configuration" args |> Option.defaultValue defaultConfiguration
+            if String.IsNullOrWhiteSpace configurationArg then
+                defaultConfiguration
+            else
+                configurationArg
+
         let define =
             argValues "--define" args
             |> List.append [
                 "FABLE_COMPILER"
                 "FABLE_COMPILER_3"
-                if watch then "DEBUG"
+                configuration.ToUpperInvariant()
             ]
             |> List.distinct
 
@@ -152,6 +161,7 @@ type Runner =
                                        typedArrays = typedArrays,
                                        fileExtension = fileExt,
                                        define = define,
+                                       configuration = configuration,
                                        optimizeFSharpAst = flagEnabled "--optimize" args,
                                        verbosity = verbosity)
 

--- a/src/Fable.Cli/ProjectCoreCracker.fs
+++ b/src/Fable.Cli/ProjectCoreCracker.fs
@@ -155,6 +155,5 @@ let rec private projInfo additionalMSBuildProps (file: string) =
       let projRefs = p2ps |> List.map (fun p2p -> p2p.ProjectReferenceFullPath)
       projOptions, projRefs, props
 
-let GetProjectOptionsFromProjectFile (file : string) =
-    // projInfo ["Configuration", ""] file // this removes --define:DEBUG, if needed
-    projInfo [] file
+let GetProjectOptionsFromProjectFile configuration (file : string) =
+    projInfo ["Configuration", configuration] file

--- a/src/Fable.Cli/ProjectCracker.fs
+++ b/src/Fable.Cli/ProjectCracker.fs
@@ -317,7 +317,7 @@ let fullCrack (opts: CrackerOptions): CrackedFsproj =
 
     Log.always("Parsing " + File.getRelativePathFromCwd projFile + "...")
     let projOpts, projRefs, _msbuildProps =
-        ProjectCoreCracker.GetProjectOptionsFromProjectFile projFile
+        ProjectCoreCracker.GetProjectOptionsFromProjectFile opts.FableOptions.Configuration projFile
 
     // let targetFramework =
     //     match Map.tryFind "TargetFramework" msbuildProps with
@@ -358,9 +358,9 @@ let fullCrack (opts: CrackerOptions): CrackedFsproj =
       OtherCompilerOptions = otherOpts }
 
 /// For project references of main project, ignore dll and package references
-let easyCrack opts dllRefs (projFile: string): CrackedFsproj =
+let easyCrack (opts: CrackerOptions) dllRefs (projFile: string): CrackedFsproj =
     let projOpts, projRefs, _msbuildProps =
-        ProjectCoreCracker.GetProjectOptionsFromProjectFile projFile
+        ProjectCoreCracker.GetProjectOptionsFromProjectFile opts.FableOptions.Configuration projFile
 
     let sourceFiles, otherOpts =
         (projOpts.OtherOptions, ([], []))

--- a/src/Fable.Transforms/Global/Compiler.fs
+++ b/src/Fable.Transforms/Global/Compiler.fs
@@ -8,6 +8,7 @@ type CompilerOptionsHelper =
     static member Make(?typedArrays,
                        ?typescript,
                        ?define,
+                       ?configuration,
                        ?optimizeFSharpAst,
                        ?verbosity,
                        ?fileExtension,
@@ -16,6 +17,7 @@ type CompilerOptionsHelper =
         let isDebug = List.contains "DEBUG" define
         { new CompilerOptions with
               member _.Define = define
+              member _.Configuration = defaultArg configuration "Debug"
               member _.DebugMode = isDebug
               member _.Typescript = defaultArg typescript false
               member _.TypedArrays = defaultArg typedArrays true


### PR DESCRIPTION
Hello wonderful Fable team

For #2401

Technically this changes behaviour since it defaulted to not being set at all. With this change it would default to "Debug" and also not define DEBUG anymore for watch, since that would also deviate from what the project might define. Not sure if that is actually a correct approach.
 
Might be a very naive implementation, since I don't really know how most of these things work from the inside and don't know the code base. Please let me know if I need to change anything.