### PR TITLE
Fix #2410, #2411, #2151: DateTimeOffset

### DIFF
--- a/src/fable-library/DateOffset.ts
+++ b/src/fable-library/DateOffset.ts
@@ -19,9 +19,21 @@ import { FSharpRef } from "./Types.js";
 import { compareDates, DateKind, IDateTime, IDateTimeOffset, padWithZeros } from "./Util.js";
 
 export default function DateTimeOffset(value: number, offset?: number) {
+  checkOffsetInRange(offset);
   const d = new Date(value) as IDateTimeOffset;
   d.offset = offset != null ? offset : new Date().getTimezoneOffset() * -60000;
   return d;
+}
+
+function checkOffsetInRange(offset?: number) {
+  if (offset != null && offset !== 0) {
+    if (offset % 60000 !== 0) {
+      throw new Error("Offset must be specified in whole minutes.");
+    }
+    if (Math.abs(offset / 3600000) > 14) {
+      throw new Error("Offset must be within plus or minus 14 hours.");
+    }
+  }
 }
 
 export function fromDate(date: IDateTime, offset?: number) {
@@ -84,14 +96,7 @@ export function create(
     offset = ms;
     ms = 0;
   }
-  if (offset !== 0) {
-    if (offset % 60000 !== 0) {
-      throw new Error("Offset must be specified in whole minutes");
-    }
-    if (~~(offset / 3600000) > 14) {
-      throw new Error("Offset must be within plus or minus 14 hour");
-    }
-  }
+  checkOffsetInRange(offset);
   let date: Date;
   if (offset === 0) {
     date = new Date(Date.UTC(year, month - 1, day, h, m, s, ms));

--- a/src/fable-library/DateOffset.ts
+++ b/src/fable-library/DateOffset.ts
@@ -299,3 +299,7 @@ export function op_Addition(x: IDateTimeOffset, y: number) {
 export function op_Subtraction(x: IDateTimeOffset, y: number | IDateTimeOffset) {
   return subtract(x, y);
 }
+
+export function toOffset(d: IDateTimeOffset, offset: number): IDateTimeOffset {
+  return DateTimeOffset(d.getTime(), offset);
+}

--- a/src/fable-library/DateOffset.ts
+++ b/src/fable-library/DateOffset.ts
@@ -37,13 +37,34 @@ function checkOffsetInRange(offset?: number) {
 }
 
 export function fromDate(date: IDateTime, offset?: number) {
-  const isUtc = date.kind === DateKind.UTC;
-  const offset2 = isUtc ? 0 : date.getTimezoneOffset() * -60000;
-  if (offset != null && offset !== offset2) {
-    throw new Error(isUtc
-      ? "The UTC Offset for Utc DateTime instances must be 0."
-      : "The UTC Offset of the local dateTime parameter does not match the offset argument.");
+  let offset2: number = 0;
+  switch (date.kind) {
+    case DateKind.UTC:
+      if(offset != null && offset !== 0) {
+        throw new Error("The UTC Offset for Utc DateTime instances must be 0.");
+      }
+      offset2 = 0;
+      break;
+
+    case DateKind.Local:
+      offset2 = date.getTimezoneOffset() * -60_000;
+      if(offset != null && offset !== offset2) {
+        throw new Error("The UTC Offset of the local dateTime parameter does not match the offset argument.");
+      }
+
+      break;
+
+    case DateKind.Unspecified:
+    default:
+      if(offset == null) {
+        offset2 = date.getTimezoneOffset() * -60_000;
+      }
+      else {
+        offset2 = offset;
+      }
+      break;
   }
+
   return DateTimeOffset(date.getTime(), offset2);
 }
 

--- a/tests/Main/DateTimeOffsetTests.fs
+++ b/tests/Main/DateTimeOffsetTests.fs
@@ -660,4 +660,125 @@ let tests =
             |> List.map toTestCase
         )
     ]
+
+    testList "ToOffset" [
+
+        // source: https://docs.microsoft.com/en-us/dotnet/api/system.datetimeoffset.tooffset?view=net-5.0#System_DateTimeOffset_ToOffset_System_TimeSpan_
+
+        testCase "Convert to same time" <| fun () ->
+            let source = DateTimeOffset(2007, 9, 1, 9, 30, 0, TimeSpan(-5, 0, 0))
+            let target = source.ToOffset(TimeSpan(-5, 0, 0))
+
+            let expected = source
+
+            target |> equal expected
+
+        testCase "Convert to UTC (0 offset)" <| fun () ->
+            let source = DateTimeOffset(2007, 9, 1, 9, 30, 0, TimeSpan(-5, 0, 0))
+            let target = source.ToOffset(TimeSpan.Zero)
+
+            let expected = DateTimeOffset(2007, 9, 1, 14, 30, 0, TimeSpan(0, 0, 0))
+
+            target |> equal expected
+
+        testCase "Convert to 8 hours behind UTC" <| fun () ->
+            let source = DateTimeOffset(2007, 9, 1, 9, 30, 0, TimeSpan(-5, 0, 0))
+            let target = source.ToOffset(TimeSpan(-8, 0, 0))
+
+            let expected = DateTimeOffset(2007, 9, 1, 6, 30, 0, TimeSpan(-8, 0, 0))
+
+            target |> equal expected
+
+        testCase "Convert to 3 hours ahead of UTC" <| fun () ->
+            let source = DateTimeOffset(2007, 9, 1, 9, 30, 0, TimeSpan(-5, 0, 0))
+            let target = source.ToOffset(TimeSpan(3, 0, 0))
+
+            let expected = DateTimeOffset(2007, 9, 1, 17, 30, 0, TimeSpan(3, 0, 0))
+
+            target |> equal expected
+
+        testCase "Convert to 3 hours and 30 min ahead of UTC" <| fun () ->
+            let source = DateTimeOffset(2007, 9, 1, 9, 30, 0, TimeSpan(-5, 0, 0))
+            let target = source.ToOffset(TimeSpan(3, 30, 0))
+
+            let expected = DateTimeOffset(2007, 9, 1, 18, 0, 0, TimeSpan(3, 30, 0))
+
+            target |> equal expected
+
+        testCase "UTC: Convert to 5 hours behind UTC" <| fun () ->
+            let source = DateTimeOffset(2007, 9, 1, 14, 30, 0, TimeSpan.Zero)
+            let target = source.ToOffset(TimeSpan(-5, 0, 0))
+
+            let expected = DateTimeOffset(2007, 9, 1, 9, 30, 0, TimeSpan(-5, 0, 0))
+
+            target |> equal expected
+
+        testCase "UTC: Convert to UTC (0 offset)" <| fun () ->
+            let source = DateTimeOffset(2007, 9, 1, 14, 30, 0, TimeSpan.Zero)
+            let target = source.ToOffset(TimeSpan.Zero)
+
+            let expected = DateTimeOffset(2007, 9, 1, 14, 30, 0, TimeSpan(0, 0, 0))
+
+            target |> equal expected
+
+        testCase "UTC: Convert to 8 hours behind UTC" <| fun () ->
+            let source = DateTimeOffset(2007, 9, 1, 14, 30, 0, TimeSpan.Zero)
+            let target = source.ToOffset(TimeSpan(-8, 0, 0))
+
+            let expected = DateTimeOffset(2007, 9, 1, 6, 30, 0, TimeSpan(-8, 0, 0))
+
+            target |> equal expected
+
+        testCase "UTC: Convert to 3 hours ahead of UTC" <| fun () ->
+            let source = DateTimeOffset(2007, 9, 1, 14, 30, 0, TimeSpan.Zero)
+            let target = source.ToOffset(TimeSpan(3, 0, 0))
+
+            let expected = DateTimeOffset(2007, 9, 1, 17, 30, 0, TimeSpan(3, 0, 0))
+
+            target |> equal expected
+
+        testCase "UTC: Convert to 3 hours and 30 min ahead of UTC" <| fun () ->
+            let source = DateTimeOffset(2007, 9, 1, 14, 30, 0, TimeSpan.Zero)
+            let target = source.ToOffset(TimeSpan(3, 30, 0))
+
+            let expected = DateTimeOffset(2007, 9, 1, 18, 0, 0, TimeSpan(3, 30, 0))
+
+            target |> equal expected
+
+        testCase "14h offset doesn't throw exception" <| fun () ->
+            let source = DateTimeOffset(2007, 9, 1, 14, 30, 0, TimeSpan.Zero)
+            source.ToOffset(TimeSpan(14, 0, 0))
+            |> ignore
+        testCase "-14h offset doesn't throw exception" <| fun () ->
+            let source = DateTimeOffset(2007, 9, 1, 14, 30, 0, TimeSpan.Zero)
+            source.ToOffset(TimeSpan(-14, 0, 0))
+            |> ignore
+
+        testCase "14h 30min offset throws exception" <| fun () ->
+            let source = DateTimeOffset(2007, 9, 1, 14, 30, 0, TimeSpan.Zero)
+            (fun _ -> source.ToOffset(TimeSpan(14, 30, 0)))
+            |> Util.throwsErrorContaining "Offset must be within plus or minus 14 hour"
+        testCase "-(14h 30min) offset throws exception" <| fun () ->
+            let source = DateTimeOffset(2007, 9, 1, 14, 30, 0, TimeSpan.Zero)
+            (fun _ -> source.ToOffset(TimeSpan(-14, -30, 0)))
+            |> Util.throwsErrorContaining "Offset must be within plus or minus 14 hour"
+
+        testCase "100h offset throws exception" <| fun () ->
+            let source = DateTimeOffset(2007, 9, 1, 14, 30, 0, TimeSpan.Zero)
+            (fun _ -> source.ToOffset(TimeSpan(100, 0, 0)))
+            |> Util.throwsErrorContaining "Offset must be within plus or minus 14 hour"
+        testCase "-100h offset throws exception" <| fun () ->
+            let source = DateTimeOffset(2007, 9, 1, 14, 30, 0, TimeSpan.Zero)
+            (fun _ -> source.ToOffset(TimeSpan(-100, 0, 0)))
+            |> Util.throwsErrorContaining "Offset must be within plus or minus 14 hour"
+
+        testCase "10s offset throws exception" <| fun () ->
+            let source = DateTimeOffset(2007, 9, 1, 14, 30, 0, TimeSpan.Zero)
+            (fun _ -> source.ToOffset(TimeSpan(0, 0, 10)))
+            |> Util.throwsErrorContaining "Offset must be specified in whole minutes"
+        testCase "-10s offset throws exception" <| fun () ->
+            let source = DateTimeOffset(2007, 9, 1, 14, 30, 0, TimeSpan.Zero)
+            (fun _ -> source.ToOffset(TimeSpan(0, 0, -10)))
+            |> Util.throwsErrorContaining "Offset must be specified in whole minutes"
+    ]
   ]

--- a/tests/Main/DateTimeOffsetTests.fs
+++ b/tests/Main/DateTimeOffsetTests.fs
@@ -507,7 +507,6 @@ let tests =
 
                 // positive range
                 TimeSpan.FromMinutes(30.0), shouldSucceed
-                TimeSpan.FromHours(1.0), shouldSucceed
                 TimeSpan.FromHours(2.0), shouldSucceed
                 TimeSpan(13, 59, 0), shouldSucceed
                 TimeSpan.FromHours(14.0), shouldSucceed
@@ -522,7 +521,6 @@ let tests =
 
                 // negative range
                 TimeSpan.FromMinutes(-30.0), shouldSucceed
-                TimeSpan.FromHours(-1.0), shouldSucceed
                 TimeSpan.FromHours(-2.0), shouldSucceed
                 TimeSpan(-13, -59, 0), shouldSucceed
                 TimeSpan.FromHours(-14.0), shouldSucceed
@@ -631,17 +629,14 @@ let tests =
             yield!
                 offsets
                 |> List.map (fun (offset, _) ->
-                    // ensure offset isn't local offset -> doesn't throw
-                    let offset =
-                        if offset = localOffset then
-                            // adjust towards 0, otherwise might get out of range (+/- 14h)
-                            if offset.TotalHours < 0.0 then
-                                offset.Add(TimeSpan.FromMinutes(1.0))
-                            else
-                                offset.Subtract(TimeSpan.FromMinutes(1.0))
-                        else
-                            offset
-                    (offset, shouldThrowUTCOffsetAndLocalDateTimeDontMatch)
+                    // offset = local offset doesn't throw
+                    if offset = localOffset then
+                        // don't adjust to throw: generated test name might conflict with other test case
+                        // instead emit succeeding test to keep test count same
+                        // -> same as single testCase below (`offset = localOffset (...) succeeds`)
+                        (offset, shouldSucceed)
+                    else
+                        (offset, shouldThrowUTCOffsetAndLocalDateTimeDontMatch)
                 )
                 |> withCtor fromLocalDateTime
                 |> List.map toTestCase

--- a/tests/Main/Fable.Tests.fsproj
+++ b/tests/Main/Fable.Tests.fsproj
@@ -31,6 +31,7 @@
     <Compile Include="Util/Util2.fs" />
     <Compile Include="Util/Util3.fs" />
     <Compile Include="../../tests_external/Util3.fs" />
+    <Compile Include="Util/UtilTests.fs" />
     <Compile Include="ApplicativeTests.fs" />
     <Compile Include="ArithmeticTests.fs" />
     <Compile Include="ArrayTests.fs" />

--- a/tests/Main/Main.fs
+++ b/tests/Main/Main.fs
@@ -3,6 +3,7 @@ open System
 
 let allTests =
   [|
+    UtilTests.tests
     Applicative.tests
     Arithmetic.tests
     Arrays.tests

--- a/tests/Main/Util/Util.fs
+++ b/tests/Main/Util/Util.fs
@@ -46,26 +46,89 @@ let ``1foo`` = 5
 
 open Testing
 
+module private RunResult =
+#if FABLE_COMPILER
+    let private isString value : bool =
+        Fable.Core.JsInterop.emitJsExpr
+            (value)
+            // literal string: `"foo"`   // string object: `new String("foo")`
+            "typeof $0 === \"string\" || $0 instanceof String"
+    let private stringify result =
+        let stringifyValue value =
+            if value = Fable.Core.JS.undefined then
+                ""  // probably `unit`
+            elif value |> isString then
+                sprintf "\"%s\"" (string value)
+            else
+                sprintf "%A" value
+        let stringifyHead head value =
+            match stringifyValue value with
+            | "" -> head
+            | str -> sprintf "%s %s" head str
+
+        match result with
+        | Ok value -> stringifyHead "Ok" value
+        | Error msg -> stringifyHead "Error" msg
+#endif
+
+    let private equal expected actual =
+#if FABLE_COMPILER
+        // In JS: `{ "fields": [ "Error msg" ], "tag": 1 }`
+        // -> stringify for prettier formatting and diff
+        if expected <> actual then
+            equal (stringify expected) (stringify actual)
+#else
+        equal expected actual
+#endif
+
+    let wasSuccess actual =
+        match actual with
+        | Ok _ -> ()
+        | Error actual ->
+            equal (Ok ()) (Error actual)
+
+    let wasAnyError actual =
+        match actual with
+        | Error _ -> ()
+        | Ok value ->
+            equal (Error ()) (Ok value)
+
+    let wasError expected actual =
+        match actual with
+        | Error _ when String.IsNullOrEmpty expected -> ()
+        | Error actual -> equal (Error expected) (Error actual)
+        | Ok value  -> equal (Error expected) (Ok value)
+
+    let wasErrorContaining expected actual =
+        match actual with
+        | Error _ when String.IsNullOrEmpty expected -> ()
+        | Error (actual: string) when actual.Contains expected -> ()
+        | Error actual -> equal (Error expected) (Error actual)
+        | Ok value  -> equal (Error expected) (Ok value)
+
+let private run (f: unit -> 'a) =
+    try
+        f()
+        |> Ok
+    with e ->
+        Error e.Message
 let throwsError (expected: string) (f: unit -> 'a): unit =
-    let success =
-        try
-            f () |> ignore
-            true
-        with e ->
-            if not <| String.IsNullOrEmpty(expected) then
-                equal expected e.Message
-            false
-    // TODO better error messages
-    equal false success
+    run f
+    |> RunResult.wasError expected
+
+/// While `throwsError` tests exception message for equality,
+/// this checks if error message CONTAINS passed message
+let throwsErrorContaining (expected: string) (f: unit -> 'a): unit =
+    run f
+    |> RunResult.wasErrorContaining expected
 
 let throwsAnyError (f: unit -> 'a): unit =
-    let result =
-        try
-            f () |> ignore
-            "succeeded"
-        with _ ->
-            "failed"
-    equal "failed" result
+    run f
+    |> RunResult.wasAnyError
+
+let doesntThrow (f: unit -> 'a): unit =
+    run f
+    |> RunResult.wasSuccess
 
 let rec sumFirstSeq (zs: seq<float>) (n: int): float =
    match n with

--- a/tests/Main/Util/Util.fs
+++ b/tests/Main/Util/Util.fs
@@ -48,19 +48,12 @@ open Testing
 
 module private RunResult =
 #if FABLE_COMPILER
-    let private isString value : bool =
-        Fable.Core.JsInterop.emitJsExpr
-            (value)
-            // literal string: `"foo"`   // string object: `new String("foo")`
-            "typeof $0 === \"string\" || $0 instanceof String"
     let private stringify result =
-        let stringifyValue value =
-            if value = Fable.Core.JS.undefined then
-                ""  // probably `unit`
-            elif value |> isString then
-                sprintf "\"%s\"" (string value)
-            else
-                sprintf "%A" value
+        let stringifyValue (value: obj) =
+            match value with
+            | _ when value = Fable.Core.JS.undefined -> "" // probably `unit`
+            | :? string as value -> sprintf "\"%s\"" value
+            | _ -> sprintf "%A" value
         let stringifyHead head value =
             match stringifyValue value with
             | "" -> head

--- a/tests/Main/Util/UtilTests.fs
+++ b/tests/Main/Util/UtilTests.fs
@@ -1,0 +1,116 @@
+module Fable.Tests.UtilTests
+
+open System
+open Util.Testing
+open Fable.Tests.Util
+
+let tests =
+  testList "Tests.Util" [
+    testList "doesntThrow" [
+      testCase "succeeds when no exception" <| fun _ ->
+        (fun _ -> ())
+        |> doesntThrow
+
+      testCase "fails when exception" <| fun _ ->
+        let exThrown =
+          try
+            (fun _ -> failwith "oh no")
+            |> doesntThrow
+            false
+          with
+          | _ -> true
+        equal true exThrown
+    ]
+
+    testList "throwsAnyError" [
+      testCase "fails when no exception" <| fun _ ->
+        let exThrown =
+          try
+            (fun _ -> ())
+            |> throwsAnyError
+            false
+          with
+          | _ -> true
+        equal true exThrown
+
+      testCase "succeeds when exception" <| fun _ ->
+        (fun _ -> failwith "oh no")
+        |> throwsAnyError
+    ]
+
+    testList "throwsError" [
+      testCase "fails when no exception" <| fun _ ->
+        let exThrown =
+          try
+            (fun _ -> ())
+            |> throwsError "oh no"
+            false
+          with
+          | _ -> true
+        equal true exThrown
+
+      testCase "succeeds when exception with same message" <| fun _ ->
+        (fun _ -> failwith "oh no")
+        |> throwsError "oh no"
+
+      testCase "fails when different exception" <| fun _ ->
+        let exThrown =
+          try
+            (fun _ -> failwith "oh no")
+            |> throwsError "hell yeah!"
+            false
+          with
+          | _ -> true
+        equal true exThrown
+
+      testCase "fails when exception not exact match" <| fun _ ->
+        let exThrown =
+          try
+            (fun _ -> failwith "oh no")
+            |> throwsError "no"
+            false
+          with
+          | _ -> true
+        equal true exThrown
+    ]
+
+    testList "throwsErrorContaining" [
+      testCase "fails when no exception" <| fun _ ->
+        let exThrown =
+          try
+            (fun _ -> ())
+            |> throwsErrorContaining "oh no"
+            false
+          with
+          | _ -> true
+        equal true exThrown
+
+      testCase "succeeds when exception with same message" <| fun _ ->
+        (fun _ -> failwith "oh no")
+        |> throwsErrorContaining "oh no"
+
+      testCase "fails when different exception" <| fun _ ->
+        let exThrown =
+          try
+            (fun _ -> failwith "oh no")
+            |> throwsErrorContaining "hell yeah!"
+            false
+          with
+          | _ -> true
+        equal true exThrown
+
+      testCase "succeeds when exception with containing match" <| fun _ ->
+        (fun _ -> failwith "oh no")
+        |> throwsErrorContaining "no"
+
+      testCase "fails when exception part of match" <| fun _ ->
+        let exThrown =
+          try
+            (fun _ -> failwith "oh no")
+            |> throwsErrorContaining "oh no, not again"
+            false
+          with
+          | _ -> true
+        equal true exThrown
+    ]
+  ]


### PR DESCRIPTION
* Fix #2410: Invalid offsets are accepted  
* Fix #2411: DateTime(Unspecified) fails when offset not local timezone
* Fix #2151: Implement `DateTimeOffset.toOffset`


Some test have to deal with local offset -- which is system timezone dependent.  
-> Some Tests are different on different systems.  
... but should work....hopefully.....😅

(for fixing timezone: see #2375 ... not done here)

----------------------

Additional:  
Prettier unit test error messages for exception tests:  
For test functions (in `Util/Util.fs`) like `throwsError` or `throwsAnyError`:

Previously error when an exception was expected, but not thrown, looked like:
> Error: Expected: true - Actual: false

Updated error messages (no exception):
> Error: Expected: Error "my error message" - Actual: Ok

or (wrong exception):
> Error: Expected: Error "my error message" - Actual: Error "some other message"