### PR TITLE
Added byref parameters support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -72,17 +72,17 @@
             "request": "launch",
             "name": "Run bench-compiler (Node)",
             "program": "${workspaceRoot}/src/fable-standalone/test/bench-compiler/out-node/app.js",
-            // "args": ["${workspaceRoot}/tests/Main/Fable.Tests.fsproj", "out-tests"],
-            "args": ["${workspaceRoot}/../fable-test/fable-test.fsproj", "out-test"],
+            // "args": ["${workspaceRoot}/tests/Main/Fable.Tests.fsproj", "out-tests", "--fableLib", "out-lib"],
+            "args": ["${workspaceRoot}/../fable-test/fable-test.fsproj", "out-test", "--fableLib", "out-lib"],
             "cwd": "${workspaceRoot}/src/fable-standalone/test/bench-compiler"
         },
         {
             "type": "coreclr",
             "request": "launch",
             "name": "Run bench-compiler (.NET)",
-            "program": "${workspaceFolder}/src/fable-standalone/test/bench-compiler/bin/Debug/netcoreapp3.1/bench-compiler.dll",
-            // "args": ["${workspaceRoot}/tests/Main/Fable.Tests.fsproj", "out-tests"],
-            "args": ["${workspaceRoot}/../fable-test/fable-test.fsproj", "out-test"],
+            "program": "${workspaceFolder}/src/fable-standalone/test/bench-compiler/bin/Debug/net5.0/bench-compiler.dll",
+            // "args": ["${workspaceRoot}/tests/Main/Fable.Tests.fsproj", "out-tests", "--fableLib", "out-lib"],
+            "args": ["${workspaceRoot}/../fable-test/fable-test.fsproj", "out-test", "--fableLib", "out-lib"],
             "cwd": "${workspaceFolder}/src/fable-standalone/test/bench-compiler"
         },
         {

--- a/src/fable-library/BigInt.fs
+++ b/src/fable-library/BigInt.fs
@@ -4,16 +4,16 @@ type bigint = BigInt.BigInteger
 
 let isBigInt (x: obj) = x :? bigint
 
-let tryParse str res =
+let tryParse (str: string) (res: byref<_>) =
     try
-        res := bigint.Parse str
+        res <- bigint.Parse str
         true
     with _ ->
         false
 
-let divRem x y (remainder: _ ref) =
+let divRem x y (remainder: byref<_>) =
     let quotient, remainder' = bigint.DivRem(x, y)
-    remainder := remainder'
+    remainder <- remainder'
     quotient
 
 let parse = bigint.Parse

--- a/src/fable-library/Map.fs
+++ b/src/fable-library/Map.fs
@@ -648,9 +648,9 @@ type Map<[<EqualityConditionalOn>]'Key, [<EqualityConditionalOn; ComparisonCondi
     member m.Remove key =
         new Map<'Key, 'Value>(comparer, MapTree.remove comparer key tree)
 
-    member __.TryGetValue(key: 'Key, value: 'Value ref) =
+    member __.TryGetValue(key: 'Key, value: byref<'Value>) =
         match MapTree.tryFind comparer key tree with
-        | Some v -> value := v; true
+        | Some v -> value <- v; true
         | None -> false
 
     member m.TryFind key =

--- a/src/fable-library/MutableMap.fs
+++ b/src/fable-library/MutableMap.fs
@@ -117,7 +117,6 @@ type MutableMap<'Key, 'Value when 'Key: equality>(pairs: KeyValuePair<'Key, 'Val
                 true
             | _ -> false
 
-#if !FABLE_COMPILER
     interface IDictionary<'Key, 'Value> with
         member this.Add(key: 'Key, value: 'Value): unit =
             this.Add(key, value)
@@ -138,7 +137,6 @@ type MutableMap<'Key, 'Value when 'Key: equality>(pairs: KeyValuePair<'Key, 'Val
             | _ -> false
         member this.Values: ICollection<'Value> =
             [| for pair in this -> pair.Value |] :> ICollection<'Value>
-#endif
 
     interface Fable.Core.JS.Map<'Key, 'Value> with
         member this.size = this.Count

--- a/tests/Main/ConvertTests.fs
+++ b/tests/Main/ConvertTests.fs
@@ -10,20 +10,20 @@ open Fable.Tests.Util
 //-------------------------------------
 
 let tryParse f initial (value: string) =
-    #if FABLE_COMPILER
-    f(value)
-    #else
     let res = ref initial
+#if FABLE_COMPILER
+    let success = f(value, res)
+#else
     let success = f(value, NumberStyles.Number, CultureInfo("en-US"), res)
+#endif
     (success, !res)
-    #endif
 
 let parse f (a: string) =
-    #if FABLE_COMPILER
+#if FABLE_COMPILER
     f(a)
-    #else
+#else
     f(a, CultureInfo("en-US"))
-    #endif
+#endif
 
 let tests =
   testList "Convert" [

--- a/tests/Main/MiscTests.fs
+++ b/tests/Main/MiscTests.fs
@@ -422,6 +422,15 @@ type ValueType =
     val public X : int
   end
 
+type MutableFoo =
+    { mutable x: int }
+
+let incByRef (a: int) (b: byref<int>) = b <- a + b
+let addInRef (a: int) (b: inref<int>) = a + b
+let setOutRef (a: int) (b: outref<int>) = b <- a
+
+let mutable mutX = 3
+
 open FSharp.UMX
 
 [<Measure>] type customerId
@@ -1112,4 +1121,35 @@ let tests =
     testCase "Can import files specified via globbing patterns" <| fun () -> // See #1942
         Glob.hello "Albert"
         |> equal "Hello Albert from Glob"
+
+    testCase "Mutable variables can be passed by reference" <| fun () ->
+        let a = 1
+        let mutable b = 2
+        incByRef a &b
+        b |> equal 3
+        addInRef a &b |> equal 4
+        b |> equal 3
+        setOutRef a &b
+        b |> equal 1
+
+    testCase "Public mutable variables can be passed by reference" <| fun () ->
+        let a = 1
+        mutX <- 2
+        incByRef a &mutX
+        mutX |> equal 3
+        addInRef a &mutX |> equal 4
+        mutX |> equal 3
+        setOutRef a &mutX
+        mutX |> equal 1
+
+    testCase "Mutable fields can be passed by reference" <| fun () ->
+        let a = 1
+        let foo: MutableFoo = { x = 2 }
+        incByRef a &foo.x
+        foo.x |> equal 3
+        addInRef a &foo.x |> equal 4
+        foo.x |> equal 3
+        setOutRef a &foo.x
+        foo.x |> equal 1
+
   ]


### PR DESCRIPTION
- Fixes #694
- Adds general `byref/inref/outref` parameter support.

Note:
- `byref/inref/outref` args are converted to `FSharpRef` on the fly at each call site, in order to not change the generated code. This is how Fable already works, this PR just broadens the `byref` support beyond just `TryGetValue/TryParse/DivRem`.
- This means there are no performance improvements related to this PR (it's more or less the same as the status quo).
- In order to get some performance wins, we'll have to change how mutable variables are represented, instead of capturing them as `FSharpRef` at each call site. They should be created as `FSharpRef` from the beginning, but that is for another PR.