### PR TITLE
Add a --sourceMapsRoot CLI option to set source maps sourceRoot

### DIFF
--- a/src/Fable.Cli/Entry.fs
+++ b/src/Fable.Cli/Entry.fs
@@ -72,6 +72,7 @@ Arguments:
   --noCache         Recompile all files, including sources from packages
   --exclude         Don't merge sources of referenced projects with specified pattern
                     (Intended for plugin development)
+  --sourceMapsRoot  Set the value of the `sourceRoot` property in generated source maps
 
   --optimize        Compile with optimized F# AST (experimental)
   --typescript      Compile to TypeScript (experimental)
@@ -173,6 +174,7 @@ type Runner =
               Configuration = configuration
               OutDir = argValueMulti ["-o"; "--outDir"] args |> Option.map normalizeAbsolutePath
               SourceMaps = flagEnabled "-s" args || flagEnabled "--sourceMaps" args
+              SourceMapsRoot = argValue "--sourceMapsRoot" args
               NoRestore = flagEnabled "--noRestore" args
               NoCache = flagEnabled "--noCache" args || flagEnabled "--forcePkgs" args // backwards compatibility
               Exclude = argValue "--exclude" args

--- a/src/Fable.Cli/Fable.Cli.fsproj
+++ b/src/Fable.Cli/Fable.Cli.fsproj
@@ -37,7 +37,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Dotnet.ProjInfo" Version="0.44.0" />
-    <PackageReference Include="source-map-sharp" Version="1.0.5" />
+    <PackageReference Include="source-map-sharp" Version="1.0.7" />
     <!-- <PackageReference Include="FSharp.Core" Version="5.0.0" /> -->
   </ItemGroup>
 </Project>

--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -139,7 +139,7 @@ module private Util =
             if fileExt.EndsWith(".ts") then Path.replaceExtension ".js" fileExt else fileExt
         let targetDir = Path.GetDirectoryName(targetPath)
         let stream = new IO.StreamWriter(targetPath)
-        let mapGenerator = lazy (SourceMapSharp.SourceMapGenerator())
+        let mapGenerator = lazy (SourceMapSharp.SourceMapGenerator(?sourceRoot = cliArgs.SourceMapsRoot))
         interface BabelPrinter.Writer with
             member _.Write(str) =
                 stream.WriteAsync(str) |> Async.AwaitTask
@@ -182,8 +182,8 @@ module private Util =
             if cliArgs.SourceMaps then
                 let mapPath = outPath + ".map"
                 do! IO.File.AppendAllLinesAsync(outPath, [$"//# sourceMappingURL={IO.Path.GetFileName(mapPath)}"]) |> Async.AwaitTask
-                use sw = IO.File.Open(mapPath, IO.FileMode.Create)
-                do! Text.Json.JsonSerializer.SerializeAsync(sw, writer.SourceMap) |> Async.AwaitTask
+                use fs = IO.File.Open(mapPath, IO.FileMode.Create)
+                do! writer.SourceMap.SerializeAsync(fs) |> Async.AwaitTask
 
             logger("Compiled " + File.getRelativePathFromCwd com.CurrentFile)
 

--- a/src/Fable.Cli/Util.fs
+++ b/src/Fable.Cli/Util.fs
@@ -18,6 +18,7 @@ type CliArgs =
       NoRestore: bool
       NoCache: bool
       SourceMaps: bool
+      SourceMapsRoot: string option
       Exclude: string option
       Replace: Map<string, string>
       RunProcess: RunProcess option

--- a/src/fable-compiler-js/src/fable-compiler-js.fsproj
+++ b/src/fable-compiler-js/src/fable-compiler-js.fsproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="source-map-sharp" Version="1.0.5" />
+    <PackageReference Include="source-map-sharp" Version="1.0.7" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #2427

By setting `--sourceMaps --sourceMapsRoot "file:///"`, this PR makes it possible to use source maps without a bundler :) (does not work on Firefox for now, see #2427 for more details)

I went the simplest way that worked.

I did not use a macro-like syntax like you suggested, since the source maps `sourceRoot` property is not supposed to be a complete path. Maybe you were suggesting this syntax so that it could be used to set the source maps `sources` paths instead, bypassing the `sourceRoot` property completely?
(It would have been a workaround for the Firefox bug, but I didn't feel it was the right thing to do...)

Tell me if you think I missed something, or if I should have done differently.