### PR TITLE
Fix events issues and implement FSharpEvent`2

### DIFF
--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -667,7 +667,14 @@ module Patterns =
                 Lambda(_callback, NewDelegate(_, Lambda(_delegateArg0, Lambda(_delegateArg1, Application(Value _callback',[],[Value _delegateArg0'; Value _delegateArg1'])))))])
           when createEvent.FullName = Types.createEvent ->
             let eventName = addEvent.CompiledName.Replace("add_","")
-            Some (callee, eventName)
+            match addEvent.DeclaringEntity with
+            | Some klass ->
+                klass.MembersFunctionsAndValues
+                |> Seq.tryFind (fun m -> m.LogicalName = eventName)
+                |> function
+                | Some memb -> Some (callee, memb)
+                | _ -> None
+            | _ -> None
         | _ -> None
 
     let (|ConstructorCall|_|) = function

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -1723,6 +1723,8 @@ let stringModule (com: ICompiler) (ctx: Context) r t (i: CallInfo) (_: Expr opti
 let seqModule (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (thisArg: Expr option) (args: Expr list) =
     match i.CompiledName, args with
     | "Cast", [arg] -> Some arg // Erase
+    | "CreateEvent", [addHandler; removeHandler; createHandler] ->
+        Helper.LibCall(com, "Event", "createEvent", t, [addHandler; removeHandler], i.SignatureArgTypes, ?loc=r) |> Some
     | ("Distinct" | "DistinctBy" | "Except" | "GroupBy" | "CountBy" as meth), args ->
         let meth = Naming.lowerFirst meth
         let args = injectArg com ctx r "Seq2" meth i.GenericArgs args

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -3172,6 +3172,7 @@ let private replacedModules =
     "Microsoft.FSharp.Control.LazyExtensions", laziness
     "Microsoft.FSharp.Control.CommonExtensions", controlExtensions
     "Microsoft.FSharp.Control.FSharpEvent`1", events
+    "Microsoft.FSharp.Control.FSharpEvent`2", events
     "Microsoft.FSharp.Control.EventModule", events
     "Microsoft.FSharp.Control.ObservableModule", observable
     Types.type_, types

--- a/src/fable-library/Event.ts
+++ b/src/fable-library/Event.ts
@@ -12,8 +12,6 @@ export interface IDelegateEvent<T> {
 }
 
 export interface IEvent<T> extends IObservable<T>, IDelegateEvent<T> {
-  Publish: IEvent<T>;
-  Trigger(x: T): void;
 }
 
 export class Event<T> implements IEvent<T> {
@@ -215,6 +213,20 @@ export function split<T, U1, U2>(splitter: (x: T) => FSharpChoice$2<U1, U2>, sou
     choose((v) => Choice_tryValueIfChoice1Of2(splitter(v)), sourceEvent),
     choose((v) => Choice_tryValueIfChoice2Of2(splitter(v)), sourceEvent),
   ];
+}
+
+export function createEvent<T>(addHandler: (h: DotNetDelegate<T>) => void, removeHandler: (h: DotNetDelegate<T>) => void): IEvent<T> {
+  return {
+    AddHandler(h) { addHandler(h); },
+    RemoveHandler(h) { removeHandler(h); },
+    Subscribe(r) {
+      const h: DotNetDelegate<T> = (_, args) => r.OnNext(args);
+      addHandler(h);
+      return {
+        Dispose() { removeHandler(h); }
+      };
+    }
+  };
 }
 
 export default Event;

--- a/src/fable-library/Timer.ts
+++ b/src/fable-library/Timer.ts
@@ -17,7 +17,7 @@ export class Timer implements IDisposable {
     this._elapsed = new Event<Date>();
   }
 
-  get Elapsed() {
+  Elapsed() {
     return this._elapsed;
   }
 

--- a/tests/Main/EventTests.fs
+++ b/tests/Main/EventTests.fs
@@ -171,13 +171,12 @@ let tests =
         source.Trigger 6
         equal 0 result
 
-    // TODO!!!
-    // testCase "Classes can trigger CLI events" <| fun () ->
-    //     let mutable result = 0
-    //     let classWithEvent = new ClassWithCLIEvent()
-    //     classWithEvent.Event.Add(fun (sender, x) -> result <- x)
-    //     classWithEvent.TestEvent(5)
-    //     equal 5 result
+    testCase "Classes can trigger CLI events" <| fun () ->
+        let mutable result = 0
+        let classWithEvent = new ClassWithCLIEvent()
+        classWithEvent.Event.Add(fun (sender, x) -> result <- x)
+        classWithEvent.TestEvent(5)
+        equal 5 result
 
     testCase "Classes can trigger non-CLI events" <| fun () ->
         let mutable result = ""

--- a/tests/Main/EventTests.fs
+++ b/tests/Main/EventTests.fs
@@ -15,6 +15,18 @@ type ClassWithNonCLIEvent() =
     member this.TestEvent(arg) =
         event.Trigger(this, arg)
 
+type InterfaceWithCLIEvent<'t> =
+    [<CLIEvent>]
+    abstract Event : IEvent<System.Action<obj,'t>,'t>
+
+type ClassWithInterfaceWithCLIEvent<'t>() =
+    let event = new Event<_,_>()
+    member this.TestEvent(arg) =
+        event.Trigger(this, arg)
+    interface InterfaceWithCLIEvent<'t> with
+        [<CLIEvent>]
+        member __.Event = event.Publish
+
 let tests =
   testList "Event" [
     testCase "Event.add works" <| fun () ->
@@ -186,6 +198,35 @@ let tests =
         disp.Dispose()
         classWithEvent.TestEvent("Bye")
         equal "Hello" result
+
+    testCase "Classes can trigger CLI events on interfaces" <| fun () ->
+        let mutable result = 0
+        let mutable sender = null
+        let classWithEvent = new ClassWithInterfaceWithCLIEvent<_>()
+        (classWithEvent :> InterfaceWithCLIEvent<_>).Event.AddHandler(fun s x ->
+            sender <- s
+            result <- x
+        )
+        classWithEvent.TestEvent(5)
+        equal 5 result
+        equal (box classWithEvent) sender
+
+    testCase "Generic interface expression can have CLI events" <| fun () ->
+        let mutable actualSender = ""
+        let mutable result = false
+        let event = Event<_,_>()
+        let ifaceWIthEvent =
+            { new InterfaceWithCLIEvent<_> with
+                [<CLIEvent>]
+                member __.Event = event.Publish }
+        ifaceWIthEvent.Event.AddHandler(fun sender arg ->
+            actualSender <- string sender
+            result <- arg)
+        let expectedSender = "SENDER"
+        let expectedResult = true
+        event.Trigger(expectedSender, expectedResult)
+        equal expectedSender actualSender
+        equal expectedResult result
 
     testCase "Events are unsubscribed correctly" <| fun () -> // See #609
         let mutable counter = 0


### PR DESCRIPTION
Hello! For my first PR to Fable, there are 3 things related to events, described briefly in the sections below.

## Fix CLI events

As mentioned in #1950, there is some nifty logic in `(|CreateEvent|_|)` to match what the F# compiler emits to wrap CLI events. [This SO answer](https://stackoverflow.com/a/13387792) has some nice details about CLI vs non-CLI events. There are a couple implications for Fable:

1. For a CLI event called `Event`, the F# compiler emits `add_Event` and `remove_Event` methods. These are the only members in the contract of a CLI event, but an `Event` property is also emitted that exposes the `IEvent`. In the cases where the type is statically known, we can find that `Event` property, which is what `(|CreateEvent|_|)` attempts to do. Previously it wasn't working in all cases because it was just emitting `foo.Event` instead of calling the mangled property getter function, so this PR fixes that.

2. When a CLI event is in an interface, we cannot find the property because it is not in the contract, so we need an implementation for `CreateEvent`, which wraps the `add_Event` and `remove_Event` methods into an anonymous `IEvent`. This PR adds that.

Fixes #1950 

## Implement ``FSharpEvent`2``

Currently, Fable only supports ``FSharpEvent`1``. It turns out it's fairly straightforward to modify the existing TypeScript `Event` class to serve as both ``FSharpEvent`1`` and ``FSharpEvent`2``. We can simply put both types of delegates into the same array and eliminate the `Map`, simplifying the implementation.

## Streamline Events module

As part of the above, I took a look at the functions in the Events module. These seemed to all depend on implementation details of `Event`, when they should really work on any `IEvent` (such as the ones returned by the new `createEvent` implementation). So I rewrote these to more closely match the [implementations in `FSharp.Core`](https://github.com/dotnet/fsharp/blob/main/src/fsharp/FSharp.Core/eventmodule.fs) - and the implementations are now much simpler and easier to understand IMHO.
