### PR TITLE
Check for correct types in Anonymous Record when assigning to Interface with `[<EmitIndexer>]` via `!!`

### DIFF
--- a/Fable.sln
+++ b/Fable.sln
@@ -40,6 +40,8 @@ Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fable.Tests.Integration", "
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fable.Standalone", "src\fable-standalone\src\Fable.Standalone.fsproj", "{B67CB1A1-982F-4551-8A95-C36B516F53C4}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Compiler", "tests\Compiler\Compiler.fsproj", "{B880F891-0D65-4085-901D-F8A7D510B826}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -242,6 +244,18 @@ Global
 		{B67CB1A1-982F-4551-8A95-C36B516F53C4}.Release|x64.Build.0 = Release|Any CPU
 		{B67CB1A1-982F-4551-8A95-C36B516F53C4}.Release|x86.ActiveCfg = Release|Any CPU
 		{B67CB1A1-982F-4551-8A95-C36B516F53C4}.Release|x86.Build.0 = Release|Any CPU
+		{B880F891-0D65-4085-901D-F8A7D510B826}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B880F891-0D65-4085-901D-F8A7D510B826}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B880F891-0D65-4085-901D-F8A7D510B826}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B880F891-0D65-4085-901D-F8A7D510B826}.Debug|x64.Build.0 = Debug|Any CPU
+		{B880F891-0D65-4085-901D-F8A7D510B826}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B880F891-0D65-4085-901D-F8A7D510B826}.Debug|x86.Build.0 = Debug|Any CPU
+		{B880F891-0D65-4085-901D-F8A7D510B826}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B880F891-0D65-4085-901D-F8A7D510B826}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B880F891-0D65-4085-901D-F8A7D510B826}.Release|x64.ActiveCfg = Release|Any CPU
+		{B880F891-0D65-4085-901D-F8A7D510B826}.Release|x64.Build.0 = Release|Any CPU
+		{B880F891-0D65-4085-901D-F8A7D510B826}.Release|x86.ActiveCfg = Release|Any CPU
+		{B880F891-0D65-4085-901D-F8A7D510B826}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/build.fsx
+++ b/build.fsx
@@ -333,6 +333,10 @@ let testReact() =
     runFableWithArgs "tests/React" []
     runInDir "tests/React" "npm i && npm test"
 
+
+let testCompiler() =
+    runInDir "tests/Compiler" "dotnet run -c Release"
+
 let testIntegration() =
     runInDir "tests/Integration" "dotnet run -c Release"
 
@@ -353,6 +357,8 @@ let test() =
     runInDir projectDir "dotnet run"
 
     testReact()
+
+    testCompiler()
 
     testIntegration()
 
@@ -523,6 +529,7 @@ match argsLower with
 | "test-js"::_ -> testJs(minify)
 | "test-js-fast"::_ -> testJsFast()
 | "test-react"::_ -> testReact()
+| "test-compiler"::_ -> testCompiler()
 | "test-integration"::_ -> testIntegration()
 | "quicktest"::_ ->
     buildLibraryIfNotExists()

--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -939,38 +939,318 @@ module TypeHelpers =
                 else false)
         | _ -> None
 
-    let fitsAnonRecordInInterface _com (argExprs: Fable.Expr list) fieldNames (interface_: Fable.Entity) =
+    [<RequireQualifiedAccess; Flags>]
+    type private Allow =
+    | TheUsual      = 0b0000
+      /// Enums in F# are uint32
+      /// -> Allow into all int & uint
+    | EnumIntoInt   = 0b0001
+      /// Erased Unions are reduced to `Any`
+      /// -> Cannot distinguish between 'normal' Any (like `obj`) and Erased Union (like Erased Union with string field)
+      ///
+      /// For interface members the FSharp Type is available
+      /// -> `Ux<...>` receive special treatment and its types are extracted
+      /// -> `abstract Value: U2<int,string>` -> extract `int` & `string`
+      /// BUT: for Expressions in Anon Records that's not possible, and `U2<int,string>` is only recognized as `Any`
+      /// -> `{| Value = v |}`: `v: int` and `v: string` are recognized as matching,
+      ///    but `v: U2<int,string>` isn't: only `Any`/`obj` as Type available
+      /// To recognize as matching, we must allow all `Any` expressions for `U2` in interface place.
+      ///
+      /// Note: Only `Ux<...>` are currently handled (on interface side), not other Erased Unions!
+    | AnyIntoErased = 0b0010
+      /// Unlike `AnyIntoErased`, this allows all expressions of type `Any` in all interface properties.
+      /// (The other way is always allow: Expression of all Types fits into `Any`)
+    | AlwaysAny     = 0b0100
+    let fitsAnonRecordInInterface
+        (_com: IFableCompiler)
+        (argExprs: Fable.Expr list)
+        (fieldNames: string array)
+        (interface_: Fable.Entity)
+        (range: SourceLocation option)
+        =
         match interface_ with
         | :? FsEnt as fsEnt ->
             let interface_ = fsEnt.FSharpEntity
+            let interfaceMembers =
+                getAllInterfaceMembers interface_
+                |> Seq.toList
+
+            let makeType = makeType Map.empty
+            /// Returns for:
+            /// * `Ux<...>`: extracted types from `<....>`: `U2<string,int>` -> `[String; Int]`
+            /// * `Option<Ux<...>>`: extracted types from `<...>`, then made Optional: `Option<U2<string,int>>` -> `[Option String; Option Int]`
+            /// * 'normal' type: `makeType`ed type: `string` -> `[String]`
+            ///     Note: Erased Unions (except handled `Ux<...>`) are reduced to `Any`
+            ///
+            /// Extracting necessary: Erased Unions are reduced to `Any` -> special handling for `Ux<...>`
+            ///
+            /// Note: nested types aren't handled: `U2<string, U<int, float>>` -> `[Int; Any]`
+            let rec collectTypes (ty: FSharpType) : Fable.Type list =
+                // Special treatment for Ux<...> and Option<Ux<...>>: extract types in Ux
+                // This is necessary because: `makeType` reduces Erased Unions (including Ux) to `Any` -> no type info any more
+                //
+                // Note: no handling of nested types: `U2<string, U<int, float>>` -> `int` & `float` don't get extract
+                match ty with
+                | UType tys ->
+                    tys
+                    |> List.map makeType
+                    |> List.distinct
+                | OptionType (UType tys) ->
+                    tys
+                    |> List.map (makeType >> Fable.Option)
+                    |> List.distinct
+                | _ ->
+                    makeType ty
+                    |> List.singleton
+            and (|OptionType|_|) (ty: FSharpType) =
+                match ty with
+                | TypeDefinition tdef ->
+                    match FsEnt.FullName tdef with
+                    | Types.valueOption | Types.option ->
+                        ty.GenericArguments.[0]
+                        |> Some
+                    | _ -> None
+                | _ -> None
+            and (|UType|_|) (ty: FSharpType) =
+                let (|UName|_|) (tdef: FSharpEntity) =
+                    if
+                        tdef.Namespace = Some "Fable.Core"
+                        &&
+                        (
+                            let name = tdef.DisplayName
+                            name.Length = 2 && name.[0] = 'U' && Char.IsDigit name.[1]
+                        )
+                    then
+                        Some ()
+                    else
+                        None
+                match ty with
+                | TypeDefinition UName ->
+                    ty.GenericArguments
+                    |> Seq.toList
+                    |> Some
+                | _ -> None
+
+            /// Special Rules mostly for Indexers:
+            ///     For direct interface member implementation we want to be precise (-> exact_ish match)
+            ///     But for indexer allow a bit more types like erased union with string field when indexer is string
+            let fitsInto (rules: Allow) (expected: Fable.Type list) (actual: Fable.Type) =
+                assert(expected |> List.isEmpty |> not)
+
+                let (|IntNumber|_|) =
+                    function
+                    | Fable.Number (Int8 | UInt8 | Int16 | UInt16 | Int32 | UInt32) -> Some ()
+                    | _ -> None
+                let fitsIntoSingle (rules: Allow) (expected: Fable.Type) (actual: Fable.Type) =
+                    match expected, actual with
+                    | Fable.Any, _ -> true
+                    | _, Fable.Any when rules.HasFlag Allow.AlwaysAny ->
+                        // Erased Unions are reduced to `Any`
+                        // -> cannot distinguish between 'normal' Any (like 'obj')
+                        // and Erased Union (like Erased Union with string field)
+                        true
+                    | IntNumber, Fable.Enum _ when rules.HasFlag Allow.EnumIntoInt ->
+                        // the underlying type of enum in F# is uint32
+                        // For practicality: allow in all uint & int fields
+                        true
+                    | Fable.Option t1, Fable.Option t2
+                    | Fable.Option t1, t2
+                    | t1, t2 ->
+                        typeEquals false t1 t2
+                let fitsIntoMulti (rules: Allow) (expected: Fable.Type list) (actual: Fable.Type) =
+                    expected |> List.contains Fable.Any
+                    ||
+                    (
+                        // special treatment for actual=Any & multiple expected:
+                        // multiple expected -> `Ux<...>` -> extracted types
+                        // BUT: in actual that's not possible -> in actual `Ux<...>` = `Any`
+                        //      -> no way to distinguish Ux (or other Erased Unions) from 'normal` Any (like obj)
+                        rules.HasFlag Allow.AnyIntoErased
+                        &&
+                        expected |> List.isMultiple
+                        &&
+                        actual = Fable.Any
+                    )
+                    ||
+                    expected |> List.exists (fun expected -> fitsIntoSingle rules expected actual)
+
+                fitsIntoMulti rules expected actual
+
+            let quote = sprintf "'%s'"
+            let formatType = getTypeFullName true
+            let formatTypes = List.map (formatType >> quote) >> String.concat "; "
+            let unreachable () = failwith "unreachable"
+            let formatMissingFieldError
+                (fieldName: string)
+                (expectedTypes: Fable.Type list)
+                =
+                assert(expectedTypes |> List.isEmpty |> not)
+
+                let interfaceName = interface_.DisplayName
+
+                // adjust error messages based on:
+                // * 1, more expectedTypes
+                let msg =
+                    match expectedTypes with
+                    | [] -> unreachable ()
+                    | [expectedType] ->
+                        let expectedType = expectedType |> formatType
+                        $"Object doesn't contain field '{fieldName}' of type '{expectedType}' required by interface '{interfaceName}'"
+                    | _ ->
+                        let expectedTypes = expectedTypes |> formatTypes
+                        $"Object doesn't contain field '{fieldName}' of any type [{expectedTypes}] required by interface '{interfaceName}'"
+
+                (range, fieldName, msg)
+
+            let formatUnexpectedTypeError
+                (indexers: FSharpMemberOrFunctionOrValue list option)
+                (fieldName: string)
+                (expectedTypes: Fable.Type list)
+                (actualType: Fable.Type)
+                (r: SourceLocation option)
+                =
+                assert(expectedTypes |> List.isEmpty |> not)
+
+                let interfaceName = interface_.DisplayName
+                let actualType = actualType |> formatType
+
+                // adjust error messages based on:
+                // * 1, more expectedTypes
+                // * 0 (None), 1, more indexer
+                let msg =
+                    match indexers with
+                    | None ->
+                        match expectedTypes with
+                        | [] -> unreachable ()
+                        | [expectedType] ->
+                            let expectedType = expectedType |> formatType
+                            $"Expected type '{expectedType}' for field '{fieldName}' in interface '{interfaceName}', but is '{actualType}'"
+                        | _ ->
+                            let expectedTypes = expectedTypes |> formatTypes
+                            $"Expected any type of [{expectedTypes}] for field '{fieldName}' in interface '{interfaceName}', but is '{actualType}'"
+                    | Some indexers ->
+                        assert(indexers |> List.isEmpty |> not)
+
+                        let indexers =
+                            indexers
+                            |> List.map (fun i -> i.DisplayName)
+                            |> List.distinct
+
+                        match indexers with
+                        | [] -> unreachable ()
+                        | [indexerName] ->
+                            match expectedTypes with
+                            | [] -> unreachable ()
+                            | [expectedType] ->
+                                let expectedType = expectedType |> formatType
+                                $"Expected type '{expectedType}' for field '{fieldName}' because of Indexer '{indexerName}' in interface '{interfaceName}', but is '{actualType}'"
+                            | _ ->
+                                let expectedTypes = expectedTypes |> formatTypes
+                                $"Expected any type of [{expectedTypes}] for field '{fieldName}' because of Indexer '{indexerName}' in interface '{interfaceName}', but is '{actualType}'"
+                        | _ ->
+                            let indexerNames =
+                                indexers
+                                |> List.map (quote)
+                                |> String.concat "; "
+                            match expectedTypes with
+                            | [] -> unreachable ()
+                            | [expectedType] ->
+                                let expectedType = expectedType |> formatType
+                                $"Expected type '{expectedType}' for field '{fieldName}' because of Indexers [{indexerNames}] in interface '{interfaceName}', but is '{actualType}'"
+                            | _ ->
+                                let expectedTypes = expectedTypes |> formatTypes
+                                $"Expected any type of [{expectedTypes}] for field '{fieldName}' because of Indexers [{indexerNames}] in interface '{interfaceName}', but is '{actualType}'"
+
+                let r = r |> Option.orElse range // fall back to anon record range
+
+                (r, fieldName, msg)
+
+            /// Returns: errors
+            let fitsInterfaceMembers (fieldsToIgnore: Set<string>) =
+                interfaceMembers
+                |> List.filter (fun m -> not (m.Attributes |> hasAttribute Atts.emitIndexer))
+                |> List.filter (fun m -> m.IsPropertyGetterMethod)
+                |> List.choose (fun m ->
+                    if fieldsToIgnore |> Set.contains m.DisplayName then
+                        None
+                    else
+                        let expectedTypes = m.ReturnParameter.Type |> collectTypes
+                        fieldNames
+                        |> Array.tryFindIndex ((=) m.DisplayName)
+                        |> function
+                           | None ->
+                                if expectedTypes |> List.forall (function | Fable.Option _ -> true | _ -> false) then
+                                    None    // Optional fields can be missing
+                                else
+                                    formatMissingFieldError m.DisplayName expectedTypes
+                                    |> Some
+                           | Some i ->
+                                let expr = List.item i argExprs
+                                let ty = expr.Type
+                                if ty |> fitsInto (Allow.TheUsual ||| Allow.AnyIntoErased) expectedTypes then
+                                    None
+                                else
+                                    formatUnexpectedTypeError None m.DisplayName expectedTypes ty expr.Range
+                                    |> Some
+                )
+
+            /// Returns errors
+            let fitsInterfaceIndexers (fieldsToIgnore: Set<string>) =
+                // Note: Indexers are assumed to be "valid" index properties (like `string` and/or `int` input (TS rules))
+                let indexers =
+                    interfaceMembers
+                    |> List.filter (fun m -> m.Attributes |> hasAttribute Atts.emitIndexer)
+                        // Indexer:
+                        // * with explicit get: IsPropertyGetterMethod
+                        // * with explicit set: IsPropertySetterMetod
+                        // * without explicit get (readonly -> same as get): IsPropertyGetterMethod = false
+                    |> List.filter (fun m -> not m.IsPropertySetterMethod)
+                // far from perfect: Erased Types are `Fable.Any` instead of their actual type
+                // (exception: `Ux<...>` (and `Option<Ux<...>>`) -> types get extracted)
+                let validTypes =
+                    indexers
+                    |> List.collect (fun i -> collectTypes i.ReturnParameter.Type)
+                    |> List.distinct
+
+                match validTypes with
+                | [] -> []  // no indexer
+                | _ when validTypes |> List.contains Fable.Any -> []
+                | _ ->
+                    List.zip (fieldNames |> Array.toList) argExprs
+                    |> List.filter (fun (fieldName, _) -> fieldsToIgnore |> Set.contains fieldName |> not )
+                    |> List.choose (fun (name, expr) ->
+                        let ty = expr.Type
+                        if fitsInto (Allow.TheUsual ||| Allow.EnumIntoInt ||| Allow.AnyIntoErased) validTypes ty then
+                            None
+                        else
+                            formatUnexpectedTypeError (Some indexers) name validTypes ty expr.Range
+                            |> Some
+                    )
+
+            let withoutErrored
+                (interfaceMembers: FSharpMemberOrFunctionOrValue list)
+                (errors: _ list)
+                =
+                let fieldsWithError = errors |> List.map (fun (_, fieldName, _) -> fieldName) |> Set.ofList
+                interfaceMembers
+                |> List.filter (fun m -> fieldsWithError |> Set.contains (m.DisplayName) |> not)
+
             // TODO: Check also if there are extra fields in the record not present in the interface?
-            (Ok (), getAllInterfaceMembers interface_ |> Seq.filter (fun memb -> memb.IsPropertyGetterMethod))
-            ||> Seq.fold (fun res memb ->
-                match res with
-                | Error _ -> res
-                | Ok _ ->
-                    let expectedType = memb.ReturnParameter.Type |> makeType Map.empty
-                    Array.tryFindIndex ((=) memb.DisplayName) fieldNames
-                    |> function
-                        | None ->
-                            match expectedType with
-                            | Fable.Option _ -> Ok () // Optional fields can be missing
-                            | _ -> sprintf "Object doesn't contain field '%s'" memb.DisplayName |> Error
-                        | Some i ->
-                            let e = List.item i argExprs
-                            match expectedType, e.Type with
-                            | Fable.Any, _ -> true
-                            | Fable.Option t1, Fable.Option t2
-                            | Fable.Option t1, t2
-                            | t1, t2 -> typeEquals false t1 t2
-                            |> function
-                                | true -> Ok ()
-                                | false ->
-                                    let typeName = getTypeFullName true expectedType
-                                    sprintf "Expecting type '%s' for field '%s'" typeName memb.DisplayName |> Error)
-        | _ -> Ok () // TODO: Error instead if we cannot check the interface?
+            let fieldErrors = fitsInterfaceMembers (Set.empty)
+            let indexerErrors =
+                fitsInterfaceIndexers
+                    // don't check already errored fields
+                    (fieldErrors |> List.map (fun (_, fieldName, _) -> fieldName) |> Set.ofList)
 
-
+            List.append fieldErrors indexerErrors
+            |> List.map (fun (r,_,m) -> (r,m))
+               // sort errors by their appearance in code
+            |> List.sortBy fst
+            |> function
+               | [] -> Ok ()
+               | errors -> Error errors
+        | _ ->
+            Ok () // TODO: Error instead if we cannot check the interface?
 
     let inline (|FableType|) _com (ctx: Context) t = makeType ctx.GenericArgs t
 

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -1249,12 +1249,14 @@ let fableCoreLib (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Exp
               [_; (_,DeclaredType(ent, []))] ->
                 let ent = com.GetEntity(ent)
                 if ent.IsInterface then
-                    FSharp2Fable.TypeHelpers.fitsAnonRecordInInterface com exprs fieldNames ent
+                    FSharp2Fable.TypeHelpers.fitsAnonRecordInInterface com exprs fieldNames ent r
                     |> function
-                        | Error errMsg ->
-                            addWarning com ctx.InlinePath r errMsg
+                       | Error errors ->
+                            errors
+                            |> List.iter (fun (range, error) -> addWarning com ctx.InlinePath range error)
                             Some arg
-                        | Ok () -> Some arg
+                       | Ok () ->
+                            Some arg
                 else Some arg
             | _ -> Some arg
         | "op_Dynamic", [left; memb] ->

--- a/tests/Compiler/AnonRecordInInterfaceTests.fs
+++ b/tests/Compiler/AnonRecordInInterfaceTests.fs
@@ -1,0 +1,815 @@
+module Fable.Tests.Compiler.AnonRecordInInterface
+
+open System
+open Fable.Tests.Util.Testing
+open Fable.Tests.Compiler.Util
+open Fable.Tests.Compiler.Util.Compiler
+
+module private Source =
+  let nl = Environment.NewLine
+  let indent = (+) "  "
+  let q = sprintf "\"%s\""
+  let concat = String.concat nl
+  let print source =
+    printfn "%s" source
+    source
+
+  type Property =
+    | ReadOnly of Name: string * Type: string
+    | ReadWrite of Name: string * Type: string
+    | Indexer of Name: string * IndexType: string * Type: string
+    | ReadWriteIndexer of Name: string * IndexType: string * Type: string
+  module Property =
+    let format =
+      function
+      | ReadOnly (name, ty) ->
+          sprintf "abstract %s: %s" name ty
+          |> List.singleton
+      | ReadWrite (name, ty) ->
+          sprintf "abstract %s: %s with get,set" name ty
+          |> List.singleton
+      | Indexer (name, index, ty) ->
+          [
+            "[<EmitIndexer>]"
+            sprintf "abstract %s:index: %s -> %s" name index ty
+          ]
+      | ReadWriteIndexer (name, index, ty) ->
+          [
+            "[<EmitIndexer>]"
+            sprintf "abstract %s:index: %s -> %s with get,set" name index ty
+          ]
+
+  type Interface = {
+    Name: string
+    Properties: Property list
+  }
+  module Interface =
+    let format i =
+      [
+        yield sprintf "type %s =" i.Name
+
+        yield!
+          i.Properties
+          |> List.collect Property.format
+          |> List.map indent
+      ]
+
+  type Case = {
+    Name: string
+    Fields: string list // no names, just types
+  }
+  module Case =
+    let format c =
+      match c.Fields with
+      | [] -> sprintf "| %s" c.Name
+      | fields ->
+          fields
+          |> String.concat " * "
+          |> sprintf "| %s of %s" c.Name
+      |> List.singleton
+  type DiscriminatedUnion = {
+    Name: string
+    Erase: bool
+    Cases: Case list
+  }
+  module DiscriminatedUnion =
+    let format du =
+      [
+        if du.Erase then
+          yield "[<Erase>]"
+        yield sprintf "type %s =" du.Name
+
+        yield!
+          du.Cases
+          |> List.collect Case.format
+          |> List.map indent
+      ]
+
+  let assign (name: string) (ty: string) (value: string) =
+    sprintf "let %s: %s = %s" name ty value
+
+  /// name of variabe is `v`
+  let assignAnonRecord (i: Interface) (anonRecordFields: (string * string) list) =
+    assert(anonRecordFields |> List.isEmpty |> not)
+
+    anonRecordFields
+    |> List.map (fun (name, value) -> sprintf "%s = %s" name value)
+    |> String.concat "; "
+    |> sprintf "!!{| %s |}"
+    |> assign "v" i.Name
+
+  let interfaceAndAssignments (i: Interface) (assignments: string list) =
+    [
+      yield! i |> Interface.format
+      yield! assignments
+    ]
+    |> concat
+
+  let interfaceAndAnonRecordAssignment (i: Interface) (anonRecordFields: (string * string) list) =
+    assignAnonRecord i anonRecordFields
+    |> List.singleton
+    |> interfaceAndAssignments i
+
+open Source
+
+let settings: Compiler.Settings =
+  let s = Compiler.Settings.standard
+  { s with
+      Opens =
+        [
+          yield! s.Opens
+          yield "Fable.Core"
+          yield "Fable.Core.JsInterop"
+        ]
+  }
+let compile = Compiler.Cached.compile settings
+let private testCase msg test = testCase msg (test >> ignore)
+
+module Error =
+
+  let missingField = "FABLE: Object doesn't contain field"
+  let unexpectedType = "FABLE: Expected type"
+  let unexpectedTypeMulti = "FABLE: Expected any type of"
+  let unexpectedIndexerType = "FABLE: Expected type"
+  let unexpectedIndexerTypeMulti = "FABLE: Expected any type of"
+
+  type private Rx = System.Text.RegularExpressions.Regex
+  /// Note: names cannot contain `'` (or `"`)
+  type Regex private () =
+    static let orNameRegex = Option.defaultValue "([^'\"]+)"
+    static let orNamesRegex =
+      Option.map (fun ns ->
+        ns
+        |> List.map (sprintf "'%s'")
+        |> String.concat "; "
+        |> sprintf "(\\[%s\\])"
+      )
+      >> Option.defaultValue "\\[\\s*(('[^'\"]+');?\\s*)+\\]"
+    static member MissingField (?interfaceName: string, ?fieldName: string, ?expectedType: string) =
+      let interfaceName = interfaceName |> orNameRegex
+      let fieldName = fieldName |> orNameRegex
+      let expectedType = expectedType |> orNameRegex
+      $"FABLE: Object doesn't contain field '{fieldName}' of type '{expectedType}' required by interface '{interfaceName}'"
+      |> Rx
+    static member UnexpectedType (?interfaceName: string, ?fieldName: string, ?expectedType: string, ?actualType: string) =
+      let interfaceName = interfaceName |> orNameRegex
+      let fieldName = fieldName |> orNameRegex
+      let expectedType = expectedType |> orNameRegex
+      let actualType = actualType |> orNameRegex
+      $"FABLE: Expected type '{expectedType}' for field '{fieldName}' in interface '{interfaceName}', but is '{actualType}'"
+      |> Rx
+    static member UnexpectedTypeMulti (?interfaceName: string, ?fieldName: string, ?expectedTypes: string list, ?actualType: string) =
+      let interfaceName = interfaceName |> orNameRegex
+      let fieldName = fieldName |> orNameRegex
+      let expectedTypes = expectedTypes |> orNamesRegex
+      let actualType = actualType |> orNameRegex
+      $"FABLE: Expected any type of {expectedTypes} for field '{fieldName}' in interface '{interfaceName}', but is '{actualType}'"
+      |> Rx
+    static member UnexpectedIndexerType (?interfaceName: string, ?indexerName: string, ?fieldName: string, ?expectedType: string, ?actualType: string) =
+      let interfaceName = interfaceName |> orNameRegex
+      let indexerName = indexerName |> orNameRegex
+      let fieldName = fieldName |> orNameRegex
+      let expectedType = expectedType |> orNameRegex
+      let actualType = actualType |> orNameRegex
+      $"FABLE: Expected type '{expectedType}' for field '{fieldName}' because of Indexer '{indexerName}' in interface '{interfaceName}', but is '{actualType}'"
+      |> Rx
+    static member UnexpectedIndexerTypeMulti (?interfaceName: string, ?indexerName: string, ?fieldName: string, ?expectedTypes: string list, ?actualType: string) =
+      let interfaceName = interfaceName |> orNameRegex
+      let indexerName = indexerName |> orNameRegex
+      let fieldName = fieldName |> orNameRegex
+      let expectedTypes = expectedTypes |> orNamesRegex
+      let actualType = actualType |> orNameRegex
+      $"FABLE: Expected any type of {expectedTypes} for field '{fieldName}' because of Indexer '{indexerName}' in interface '{interfaceName}', but is '{actualType}'"
+      |> Rx
+
+module private Ty =
+  let string = "System.String"
+  let int = "System.Int32"
+  let float = "System.Double"
+
+// Currently 'errors` are compiler warnings
+let tests =
+  testList "Cast Anonymous Record to interface (with `!!`)" [
+    testList "Tests for Compiler Messages Tests" [
+      let i = { Name = "Field1"; Properties = [ ReadOnly ("Value", "string") ] }
+      testCase "missing field" <| fun _ ->
+        interfaceAndAnonRecordAssignment i [("Foo", q "foo")]
+        |> compile
+        |> Assert.Is.Single.errorOrWarning
+        |> Assert.Exists.errorOrWarningMatching (Error.Regex.MissingField ())
+        |> Assert.Exists.errorOrWarningMatching (Error.Regex.MissingField (interfaceName = i.Name))
+        |> Assert.Exists.errorOrWarningMatching (Error.Regex.MissingField (fieldName = "Value"))
+        |> Assert.Exists.errorOrWarningMatching (Error.Regex.MissingField (expectedType = Ty.string))
+        |> Assert.Exists.errorOrWarningMatching (Error.Regex.MissingField (interfaceName = i.Name, fieldName = "Value", expectedType = Ty.string))
+      testCase "unexpected type" <| fun _ ->
+        interfaceAndAnonRecordAssignment i [("Value", string 42)]
+        |> compile
+        |> Assert.Is.Single.errorOrWarning
+        |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedType ())
+        |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedType (interfaceName = i.Name))
+        |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedType (fieldName = "Value"))
+        |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedType (expectedType = Ty.string))
+        |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedType (actualType = Ty.int))
+        |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedType (interfaceName = i.Name, fieldName = "Value", expectedType = Ty.string, actualType = Ty.int))
+
+      let i = { Name = "Field2"; Properties = [ ReadOnly ("Value", "U2<string,int>") ] }
+      testCase "unexpected type Multi" <| fun _ ->
+        interfaceAndAnonRecordAssignment i [("Value", string 3.14)]
+        |> compile
+        |> Assert.Is.Single.errorOrWarning
+        |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedTypeMulti ())
+        |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedTypeMulti (interfaceName = i.Name))
+        |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedTypeMulti (fieldName = "Value"))
+        |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedTypeMulti (expectedTypes = [Ty.string; Ty.int]))
+        |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedTypeMulti (actualType = Ty.float))
+        |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedTypeMulti (interfaceName = i.Name, fieldName = "Value", expectedTypes = [Ty.string; Ty.int], actualType = Ty.float))
+
+      let i = { Name = "Indexer1"; Properties = [ Indexer ("Item", "string", "string") ] }
+      testCase "unexpected indexer type" <| fun _ ->
+        interfaceAndAnonRecordAssignment i [("Value", string 42)]
+        |> compile
+        |> Assert.Is.Single.errorOrWarning
+        |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedIndexerType ())
+        |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedIndexerType (interfaceName = i.Name))
+        |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedIndexerType (indexerName = "Item"))
+        |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedIndexerType (fieldName = "Value"))
+        |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedIndexerType (expectedType = Ty.string))
+        |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedIndexerType (actualType = Ty.int))
+        |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedIndexerType (interfaceName = i.Name, indexerName = "Item", fieldName = "Value", expectedType = Ty.string, actualType = Ty.int))
+
+      let i = { Name = "Indexer2"; Properties = [ Indexer ("Item", "string", "U2<string,int>") ] }
+      testCase "unexpected indexer type Multi" <| fun _ ->
+        interfaceAndAnonRecordAssignment i [("Value", string 3.14)]
+        |> compile
+        |> Assert.Is.Single.errorOrWarning
+        |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedIndexerTypeMulti ())
+        |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedIndexerTypeMulti (interfaceName = i.Name))
+        |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedIndexerTypeMulti (indexerName = "Item"))
+        |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedIndexerTypeMulti (fieldName = "Value"))
+        |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedIndexerTypeMulti (expectedTypes = [Ty.string; Ty.int]))
+        |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedIndexerTypeMulti (actualType = Ty.float))
+        |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedIndexerTypeMulti (interfaceName = i.Name, indexerName = "Item", fieldName = "Value", expectedTypes = [Ty.string; Ty.int], actualType = Ty.float))
+    ]
+
+    testList "Interface with fields" [
+      testList "Interface with single readonly field" [
+        let i = { Name = "Field1"; Properties = [ ReadOnly ("Value", "string") ] }
+        testCase "no error for existing field with correct type" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", q "foo")]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "error for existing field with wrong type" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", string 42)]
+          |> compile
+          |> Assert.Is.Single.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedType (interfaceName = i.Name, fieldName = "Value"))
+        testCase "error for missing field" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Answer", string 42)]
+          |> compile
+          |> Assert.Is.Single.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.MissingField (interfaceName = i.Name, fieldName = "Value"))
+        testCase "error for missing field because of lower case typo" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("value", q "foo")]
+          |> compile
+          |> Assert.Is.Single.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.MissingField (interfaceName = i.Name, fieldName = "Value"))
+      ]
+      testList "interface with single readwrite field" [
+        let i = { Name = "Field1"; Properties = [ ReadWrite ("Value", "string") ] }
+        testCase "no error for existing field with correct type" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", q "foo")]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "error for existing field with wrong type" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", string 42)]
+          |> compile
+          |> Assert.Is.Single.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedType (interfaceName = i.Name, fieldName = "Value"))
+        testCase "error for missing field" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Answer", string 42)]
+          |> compile
+          |> Assert.Is.Single.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.MissingField (interfaceName = i.Name, fieldName = "Value"))
+        testCase "error for missing field because of lower case typo" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("value", q "foo")]
+          |> compile
+          |> Assert.Is.Single.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.MissingField (interfaceName = i.Name, fieldName = "Value"))
+
+      ]
+      testList "interface with two fields" [
+        let i = { Name = "Field2"; Properties = [ ReadOnly ("Value1", "string"); ReadOnly ("Value2", "int") ] }
+
+        testCase "no error fir existing fields with correct types" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value1", q "foo"); ("Value2", string 42)]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "error for existing field with wrong type" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value1", q "foo"); ("Value2", q "bar")]
+          |> compile
+          |> Assert.Is.Single.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedType (interfaceName = i.Name, fieldName = "Value2"))
+        testCase "error for missing field" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value2", string 42)]
+          |> compile
+          |> Assert.Is.Single.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.MissingField (interfaceName = i.Name, fieldName = "Value1"))
+        testCase "two errors for two missing field" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("SomeValue", string 42)]
+          |> compile
+          |> Assert.Are.errorsOrWarnings 2
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.MissingField (interfaceName = i.Name, fieldName = "Value1"))
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.MissingField (interfaceName = i.Name, fieldName = "Value2"))
+        testCase "two errors for missing field and wrong type" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value1", string 42)]
+          |> compile
+          |> Assert.Are.errorsOrWarnings 2
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedType (interfaceName = i.Name, fieldName = "Value1"))
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.MissingField (interfaceName = i.Name, fieldName = "Value2"))
+      ]
+      testList "interface with U2 field" [
+        // Ux receive special treatment: containing types (here string & int) are extracted and both types are accepted
+        let ty = "U2<string,int>"
+        let i = { Name = "Field3"; Properties = [ ReadOnly ("Value", ty) ] }
+
+        testCase "no error for existing field with string" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", q "foo")]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "no error for existing field with int" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", string 42)]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "error for existing field with float" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", string 3.14)]
+          |> compile
+          |> Assert.Is.Single.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedTypeMulti (interfaceName = i.Name, fieldName = "Value"))
+        testCase "no error for existing field with U2<string,int>" <| fun _ ->
+          interfaceAndAssignments i [
+            assign "a" ty "U2.Case2 42"
+            assignAnonRecord i [("Value", "a")]
+          ]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "Ideally: error because of missmatching type U3" <| fun _ ->
+          // Erased Union is reduced to type `Any` -> cannot distinguish between correct U2<string,int> and other Erased Unions (or even just `obj`)
+          interfaceAndAssignments i [
+            assign "a" "U3<string,int,float>" "U3.Case3 3.14"
+            assignAnonRecord i [("Value", "a")]
+          ]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "Ideally: error because of missmatching type obj" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", "obj()")]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "Probably: no error because of double-bangs" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", "!!3.14")]
+          |> compile
+          |> Assert.Is.errorOrWarning
+      ]
+      testList "interface with U3<int, string, float>" [
+        let ty = "U3<string,int, float>"
+        let i = { Name = "Field3"; Properties = [ ReadOnly ("Value", ty) ] }
+
+        testCase "no error for existing field with string" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", q "foo")]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "no error for existing field with int" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", string 42)]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "no error for existing field with float" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", string 3.14)]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "error for existing field with char" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", "\'c\'")]
+          |> compile
+          |> Assert.Is.Single.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedTypeMulti (interfaceName = i.Name, fieldName = "Value"))
+      ]
+      testList "interface with Union field" [
+        let du = { Name = "Union1"; Erase = false; Cases = [ { Name = "SomeInt"; Fields = ["int"] } ]}
+        let i = { Name = "Field4"; Properties = [ ReadOnly ("Value", du.Name) ] }
+
+        testCase "no error for existing field with correct type" <| fun _ ->
+          [
+            yield! du |> DiscriminatedUnion.format
+            yield! i |> Interface.format
+
+            yield assignAnonRecord i [("Value", "SomeInt 42")]
+          ]
+          |> concat
+          |> compile
+          |> Assert.Is.strictSuccess
+
+        testCase "error for existing field with wrong type" <| fun _ ->
+          [
+            yield! du |> DiscriminatedUnion.format
+            yield! i |> Interface.format
+
+            yield assignAnonRecord i [("Value", string 42)]
+          ]
+          |> concat
+          |> compile
+          |> Assert.Is.Single.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedType (interfaceName = i.Name, fieldName = "Value"))
+      ]
+      testList "interface with Erased Union field" [
+        let du = { Name = "ErasedUnion1"; Erase = true; Cases = [ { Name = "SomeInt"; Fields = ["int"] } ]}
+        let i = { Name = "Field5"; Properties = [ ReadOnly ("Value", du.Name) ] }
+
+        testCase "no error for existing field with correct type" <| fun _ ->
+          [
+            yield! du |> DiscriminatedUnion.format
+            yield! i |> Interface.format
+
+            yield assignAnonRecord i [("Value", "SomeInt 42")]
+          ]
+          |> concat
+          |> compile
+          |> Assert.Is.strictSuccess
+
+        testCase "Ideally: error for existing field with wrong int type" <| fun _ ->
+          // Erased Union gets reduced to `Any` -> `Any` accepts everything
+          [
+            yield! du |> DiscriminatedUnion.format
+            yield! i |> Interface.format
+
+            yield assignAnonRecord i [("Value", string 42)]
+          ]
+          |> concat
+          |> compile
+          // |> Assert.Is.Single.errorOrWarning
+          // |> Assert.Exists.errorOrWarningWith (Error.incorrectType "Tmp.ErasedUnion1" "Value")
+          |> Assert.Is.strictSuccess
+
+        testCase "Ideally: error for existing field with wrong obj type" <| fun _ ->
+          [
+            yield! du |> DiscriminatedUnion.format
+            yield! i |> Interface.format
+
+            yield assignAnonRecord i [("Value", "obj ()")]
+          ]
+          |> concat
+          |> compile
+          |> Assert.Is.strictSuccess
+      ]
+
+      testList "interface with field with option type" [
+        let i = { Name = "Field6"; Properties = [ ReadOnly ("Value", "string option"); ReadOnly ("Required", "string") ] }
+
+        testCase "no error for field with string option" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", "Some \"foo\""); ("Required", q "bar")]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "no error for field with string" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", q "foo"); ("Required", q "bar")]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "no error for missing optional field" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Required", q "bar")]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "error for field with int option" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", "Some 42"); ("Required", q "bar")]
+          |> compile
+          |> Assert.Is.Single.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedType (interfaceName = i.Name, fieldName = "Value"))
+        testCase "error for field with int" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", string 42); ("Required", q "bar")]
+          |> compile
+          |> Assert.Is.Single.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedType (interfaceName = i.Name, fieldName = "Value"))
+        testCase "error for missing required field" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", q "foo")]
+          |> compile
+          |> Assert.Is.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.MissingField (interfaceName = i.Name, fieldName = "Required"))
+      ]
+      testList "interface with field with option U2 type" [
+        let i = { Name = "Field7"; Properties = [ ReadOnly ("Value", "U2<string, int> option"); ReadOnly ("Required", "string") ] }
+
+        testCase "no error for field with string option" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", "Some \"foo\""); ("Required", q "bar")]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "no error for field with string" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", q "foo"); ("Required", q "bar")]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "no error for field with int option" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", "Some \"foo\""); ("Required", q "bar")]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "no error for field with int" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", q "foo"); ("Required", q "bar")]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "no error for missing optional field" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Required", q "bar")]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "error for field with float option" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", "Some 3.14"); ("Required", q "bar")]
+          |> compile
+          |> Assert.Is.Single.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedTypeMulti (interfaceName = i.Name, fieldName = "Value"))
+        testCase "error for field with float" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", string 3.14); ("Required", q "bar")]
+          |> compile
+          |> Assert.Is.Single.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedTypeMulti (interfaceName = i.Name, fieldName = "Value"))
+        testCase "error for missing required field" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", q "foo")]
+          |> compile
+          |> Assert.Is.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.MissingField (interfaceName = i.Name, fieldName = "Required"))
+      ]
+    ]
+
+    testList "Interface with EmitIndexer" [
+      testList "interface with single indexer of type string" [
+        let i = { Name = "Indexer1"; Properties = [ Indexer ("Item", "string", "string") ] }
+
+        testCase "no error for single string field" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", q "foo")]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "error for single int field" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", string 42)]
+          |> compile
+          |> Assert.Is.Single.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedIndexerType (interfaceName = i.Name, indexerName = "Item", fieldName = "Value"))
+        testCase "no errror for multiple string fields" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("V1", q "a"); ("V2", q "b"); ("V3", q "c"); ("V4", q "d"); ("V5", q "e")]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "error for two int fields" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("V1", q "a"); ("V2", string 42); ("V3", q "c"); ("V4", string 42); ("V5", q "e")]
+          |> compile
+          |> Assert.Are.errorsOrWarnings 2
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedIndexerType (interfaceName = i.Name, indexerName = "Item", fieldName = "V2"))
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedIndexerType (interfaceName = i.Name, indexerName = "Item", fieldName = "V4"))
+        testCase "error for field with function" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("F", "fun (x: string) -> x.ToLower()")]
+          |> compile
+          |> Assert.Is.Single.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedIndexerType (interfaceName = i.Name, indexerName = "Item", fieldName = "F"))
+        testCase "error for field with partial applied function" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("F", "sprintf \"Hello %s\"")]
+          |> compile
+          |> Assert.Is.Single.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedIndexerType (interfaceName = i.Name, indexerName = "Item", fieldName = "F"))
+      ]
+      testList "interface with single indexer of type U2<string, int>" [
+        let ty = "U2<string, int>"
+        let i = { Name = "Indexer2"; Properties = [ Indexer ("Item", "string", ty) ] }
+
+        testCase "no error for single string field" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", q "foo")]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "no error for single int field" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", string 42)]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "error for single float field" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", string 3.14)]
+          |> compile
+          |> Assert.Is.Single.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedIndexerTypeMulti (interfaceName = i.Name, indexerName = "Item", fieldName = "Value"))
+        testCase "no error for single U2<string,int> field" <| fun _ ->
+          [
+            yield! i |> Interface.format
+            yield assign "a" ty "U2.Case2 42"
+
+            yield assignAnonRecord i [("Value", "a")]
+          ]
+          |> concat
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "Ideally: error for missmatching type U3" <| fun _ ->
+          [
+            yield! i |> Interface.format
+            yield assign "a" "U3<string,int,float>" "U3.Case3 3.14"
+
+            yield assignAnonRecord i [("Value", "a")]
+          ]
+          |> concat
+          |> compile
+          |> Assert.Is.strictSuccess
+      ]
+      testList "interface with two indexers U<string,int> and int" [
+        // in TS: number indexer must be subset of string indexer
+        let ty = "U2<string, int>"
+        let i = { Name = "Indexer3"; Properties = [ Indexer ("Item", "string", ty); Indexer ("Item", "int", "int") ] }
+
+        testCase "no error for single string field" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", q "foo")]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "no error for single int field" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", string 42)]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "error for single float field" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", string 3.14)]
+          |> compile
+          |> Assert.Is.Single.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedIndexerTypeMulti (interfaceName = i.Name, indexerName = "Item", fieldName = "Value"))
+      ]
+      testList "indexer with other name than `Item`" [
+        let i = { Name = "Indexer4"; Properties = [ Indexer ("MyIndexer", "string", "string") ] }
+
+        testCase "no error for single string field" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", q "foo")]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "error for single int field" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", string 42)]
+          |> compile
+          |> Assert.Is.Single.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedIndexerType (interfaceName = i.Name, indexerName = "MyIndexer", fieldName = "Value"))
+      ]
+      testList "indexer with string indexer and get,set" [
+        let i = { Name = "Indexer5"; Properties = [ ReadWriteIndexer ("Item", "string", "string") ] }
+
+        testCase "no error for single string field" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", q "foo")]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "error for single int field" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", string 42)]
+          |> compile
+          |> Assert.Is.Single.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedIndexerType (interfaceName = i.Name, indexerName = "Item", fieldName = "Value"))
+      ]
+
+      testList "indexer with string option" [
+        let i = { Name = "Indexer6"; Properties = [ Indexer ("Item", "string", "string option") ] }
+
+        testCase "no error for field with string option" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", "Some \"foo\"")]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "no error for field with string" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", q "foo")]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "error for field with int option" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", "Some 42")]
+          |> compile
+          |> Assert.Is.Single.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedIndexerType (interfaceName = i.Name, fieldName = "Value"))
+        testCase "error for field with int" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", string 42)]
+          |> compile
+          |> Assert.Is.Single.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedIndexerType (interfaceName = i.Name, fieldName = "Value"))
+      ]
+      testList "indexer with U2<string,int> option" [
+        let ty = "U2<string, int> option"   // same as `U2<string option, string option>`
+        let i = { Name = "Indexer7"; Properties = [ Indexer ("Item", "string", ty) ] }
+
+        testCase "no error for field with string option" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", "Some \"foo\"")]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "no error for field with string" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", q "foo")]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "no error for field with int option" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", "Some \"foo\"")]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "no error for field with int" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", q "foo")]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "error for field with float option" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", "Some 3.14")]
+          |> compile
+          |> Assert.Is.Single.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedIndexerTypeMulti (interfaceName = i.Name, fieldName = "Value"))
+        testCase "error for field with float" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", string 3.14)]
+          |> compile
+          |> Assert.Is.Single.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedIndexerTypeMulti (interfaceName = i.Name, fieldName = "Value"))
+      ]
+    ]
+
+    testList "Interface fields and indexer" [
+      testList "Indexer and single field with string type" [
+        let i = { Name = "FieldAndIndexer1"; Properties = [
+            ReadOnly ("Name", "string")
+            Indexer ("Item", "string", "string")
+          ]}
+
+        testCase "No error for Name field and no `Item` field" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Name", q "John")]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "no error for Name field and additional string fields" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Name", q "John"); ("Value1", q "foo"); ("Value2", q "bar"); ("Value3", q "baz")]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "error for missing name field" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", q "foo")]
+          |> compile
+          |> Assert.Is.Single.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.MissingField (interfaceName = i.Name, fieldName = "Name"))
+        testCase "error for Name field with wrong type" <| fun _ ->
+          // NOTE: only ONE error, NOT two (one for interface field, one for indexer)
+          interfaceAndAnonRecordAssignment i [("Name", string 42)]
+          |> compile
+          |> Assert.Is.Single.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedType (interfaceName = i.Name, fieldName = "Name"))
+        testCase "two errors for missing name field AND additional int field" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Value", string 42)]
+          |> compile
+          |> Assert.Are.errorsOrWarnings 2
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedIndexerType (interfaceName = i.Name, fieldName = "Value"))
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.MissingField (interfaceName = i.Name, fieldName = "Name"))
+      ]
+      testList "Indexer U2<string,int> and string field Name" [
+        let ty = "U2<string,int>"
+        let i = { Name = "FieldAndIndexer2"; Properties = [
+            ReadOnly ("Name", "string")
+            Indexer ("Item", "string", ty)
+          ]}
+
+        testCase "no error for Name field" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Name", q "John")]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "error for int Name field" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Name", string 42)]
+          |> compile
+          |> Assert.Is.Single.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedType (interfaceName = i.Name, fieldName = "Name"))
+        testCase "error for float Name field" <| fun _ ->
+          //Note: just ONE error
+          interfaceAndAnonRecordAssignment i [("Name", string 3.14)]
+          |> compile
+          |> Assert.Is.Single.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedType (interfaceName = i.Name, fieldName = "Name"))
+        testCase "no error for string Name field and additional string fields" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Name", q "John"); ("Value1", q "foo"); ("Value2", q "bar"); ("Value3", q "baz")]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "no error for string Name field and additional int fields" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Name", q "John"); ("Value1", string 1); ("Value2", string 2); ("Value3", string 3)]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "no error for string Name field and additional string & int fields" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Name", q "John"); ("Value1", q "foo"); ("Value2", q "bar"); ("Value3", string 3); ("Value4", string 4); ("Value5", q "baz")]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "error for additional float field" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Name", q "John"); ("Value", string 3.14)]
+          |> compile
+          |> Assert.Is.Single.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedIndexerTypeMulti (interfaceName = i.Name, indexerName = "Item", fieldName = "Value"))
+        testCase "error for one float field among several valid fields" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Name", q "John"); ("Value1", q "foo"); ("Value2", q "bar"); ("Value3", string 3.14); ("Value4", string 4); ("Value5", q "baz")]
+          |> compile
+          |> Assert.Is.Single.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedIndexerTypeMulti (interfaceName = i.Name, indexerName = "Item", fieldName = "Value3"))
+      ]
+      testList "any Indexer and string field" [
+        let i = { Name = "FieldAndIndexer3"; Properties = [
+            ReadOnly ("Name", "string")
+            Indexer ("Item", "string", "obj")
+          ]}
+
+        testCase "no error for string Name field" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Name", q "John")]
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "error for int Name field" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [("Name", string 42)]
+          |> compile
+          |> Assert.Is.Single.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedType (interfaceName = i.Name, fieldName = "Name"))
+        testCase "no error for string Name field and several additional fields of various types" <| fun _ ->
+          interfaceAndAnonRecordAssignment i [
+            ("Name", q "John")
+            ("Value1", q "foo")
+            ("Value2", string 42)
+            ("Value3", "obj ()")
+            ("Value4", string 3.14)
+            ("Value5", "[1;2;3;4]")
+            ("Value6", "(1, 3.14)")
+            ("Value7", "{| Value = 42 |}")
+          ]
+          |> compile
+          |> Assert.Is.strictSuccess
+      ]
+    ]
+  ]

--- a/tests/Compiler/Compiler.fsproj
+++ b/tests/Compiler/Compiler.fsproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5</TargetFramework>
+    <RollForward>Major</RollForward>
+    <DefineConstants>$(DefineConstants);DOTNET_FILE_SYSTEM</DefineConstants>
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Expecto" Version="5.1.2" />
+    <PackageReference Include="FSharp.Core" Version="5.0.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Fable.Cli\Fable.Cli.fsproj" />
+    <ProjectReference Include="../../src/Fable.Core/Fable.Core.fsproj" />
+    <ProjectReference Include="..\..\src\fable-standalone\src\Fable.Standalone.fsproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="../Main/Util/Util.fs" />
+    <Compile Include="..\..\src\fable-standalone\test\bench\Platform.fs" />
+    <Compile Include="Util/Compiler.fs" />
+    <Compile Include="CompilerMessagesTests.fs" />
+    <Compile Include="AnonRecordInInterfaceTests.fs" />
+    <Compile Include="Main.fs" />
+  </ItemGroup>
+</Project>

--- a/tests/Compiler/CompilerMessagesTests.fs
+++ b/tests/Compiler/CompilerMessagesTests.fs
@@ -1,0 +1,46 @@
+module Fable.Tests.Compiler.CompilerMessages
+
+open Fable.Core
+open Fable.Tests.Util.Testing
+open Fable.Tests.Compiler.Util
+open Fable.Tests.Compiler.Util.Compiler
+
+let private compile = Compiler.Cached.compile Compiler.Settings.standard
+
+let tests =
+  testList "Compiler Messages" [
+    testCase "Compile Console.WriteLine" <| fun _ ->
+      let source = "Console.WriteLine(\"Hello World\")"
+      compile source
+      |> Assert.Is.success
+      |> ignore
+    testCase "Compile printfn" <| fun _ ->
+      let source = "printfn \"Hello %s\" \"World\""
+      compile source
+      |> Assert.Is.success
+      |> ignore
+
+    testCase "Compiling printfn with %s placeholder and int argument results in error" <| fun _ ->
+      let source = "printfn \"Hello %s\" 42"
+      compile source
+      |> Assert.Is.Single.error
+      |> ignore
+    testCase "Compiling incomplete pattern match results in warning" <| fun _ ->
+      let source = "match None with | Some n -> 42 |> ignore" // without `ignore`: Warning: Result of Expression is implicitly ignored
+      compile source
+      |> Assert.Is.Single.warning
+      |> ignore
+
+    testCase "Compiling printfn with %s placeholder and int argument results in specific error" <| fun _ ->
+      let source = "printfn \"Hello %s\" 42"
+      compile source
+      |> Assert.Exists.errorWith "This expression was expected to have type"
+      |> ignore
+    testCase "Compiling incomplete pattern match results in specific warning" <| fun _ ->
+      let source = "match None with | Some n -> 42"
+      compile source
+      |> Assert.Is.success
+      |> Assert.Exists.warningWith "Incomplete pattern matches on this expression"
+      |> Assert.Exists.warningWith "The result of this expression has type 'int' and is implicitly ignored."
+      |> ignore
+  ]

--- a/tests/Compiler/Main.fs
+++ b/tests/Compiler/Main.fs
@@ -1,0 +1,19 @@
+module Fable.Tests.Compiler.Main
+
+open Fable.Tests.Compiler
+open Expecto
+
+let allTests =
+    [
+        CompilerMessages.tests
+        AnonRecordInInterface.tests
+    ]
+
+
+[<EntryPoint>]
+let main args =
+    let config = { defaultConfig with ``parallel`` = false }
+
+    allTests
+    |> testList "All"
+    |> runTestsWithArgs config args

--- a/tests/Compiler/Util/Compiler.fs
+++ b/tests/Compiler/Util/Compiler.fs
@@ -1,0 +1,230 @@
+namespace Fable.Tests.Compiler.Util
+
+open System
+open Fable.Standalone
+
+type Compiler = IFableManager * IChecker
+module Compiler =
+
+  type Result = Error list
+  module Result =
+    let errors = List.filter (fun m -> not m.IsWarning)
+    let warnings = List.filter (fun m -> m.IsWarning)
+    let wasFailure = errors >> List.isEmpty >> not
+
+  type Settings = {
+    Opens: string list
+  }
+  module Settings =
+    let standard = {
+      Opens = [
+        "System"
+      ]
+    }
+
+  let private references =
+    Fable.Metadata.coreAssemblies
+  let private metadataPath = "../../src/fable-metadata/lib/"
+
+  let init (): Compiler =
+    let fable = Fable.Standalone.Main.init ()
+
+    let optimize = false
+    let optimizeFlag = "--optimize" + (if optimize then "+" else "-")
+    let otherOptions = [| optimizeFlag |]
+
+    let readAllBytes dllName = Bench.Platform.readAllBytes (metadataPath + dllName)
+    let checker = fable.CreateChecker (references, readAllBytes, otherOptions)
+
+    (fable, checker)
+
+  let clear ((fable, checker): Compiler) =
+    fable.ClearParseCaches checker
+
+  let compile ((fable, checker): Compiler) (settings: Settings) (source: string) =
+    let preamble =
+      [
+        yield! settings.Opens |> List.map (sprintf "open %s")
+
+        yield Environment.NewLine
+      ]
+      |> String.concat Environment.NewLine
+
+    let source = preamble + source
+
+    let projectFileName = "project.fsproj"
+    let fileName = "tmp.fs"
+    let parseFSharpScript () = fable.ParseFSharpFileInProject(checker, fileName, projectFileName, [|fileName|], [|source|])
+    let parseResult = parseFSharpScript ()
+    let babelResult = fable.CompileToBabelAst ("", parseResult, fileName)
+
+    (fable,checker) |> clear
+
+    let errors =
+      Seq.append parseResult.Errors babelResult.FableErrors
+      |> Seq.toList
+
+    errors
+
+  /// NOTE: NOT threadsafe
+  ///       -> don't use `parallel`
+  module Cached =
+    let private cached = lazy (init ())
+    let compiler () = cached.Force ()
+
+    let clear () =
+      compiler ()
+      |> clear
+
+    let compile settings (source: string): Result =
+      let compiler = compiler ()
+      compile compiler settings source
+
+
+  module Assert =
+    open Fable.Tests.Util.Testing
+
+    type private ExpectedMsg = ExpectedMsg of string
+      with
+        member this.Value =
+          let (ExpectedMsg msg) = this
+          msg
+
+    let private expected = ExpectedMsg ""
+    type ExpectedMsg with
+      member e.Append (txt: string) =
+        match e.Value with
+        | "" ->
+          if txt.Length >= 1 then
+            (txt.[0] |> Char.ToUpperInvariant |> string)
+            +
+            txt.[1..]
+          else
+            ""
+        | msg -> msg + " " + txt
+        |> ExpectedMsg
+      member e.Error = e.Append "Error"
+      member e.Warning = e.Append "Warning"
+      member e.Neither = e.Append "neither"
+      member e.Nor = e.Append "nor"
+      member e.Or = e.Append "or"
+      member e.Anything = e.Append "anything"
+      member e.With txt = e.Append (sprintf "with \"%s\"" txt)
+      member e.Matching txt = e.Append (sprintf "matching \"%s\"" txt)
+      member e.And = e.Append("and")
+      member e.No = e.Append "no"
+      member e.Single = e.Append "single"
+      member e.All = e.Append "all"
+      member e.Count (n: int) = e.Append (sprintf "%i" n)
+
+    let private fail (ExpectedMsg expected) actual =
+      equal (box expected) (box actual)
+    let private orFail expected test (actual: Result) : Result =
+      if not <| test actual then
+        fail expected actual
+      actual
+
+    module private Test =
+      module Is =
+        let error msg = not msg.IsWarning
+        let warning msg = msg.IsWarning
+        let single = function | [_] -> true | _ -> false
+        let zero = List.isEmpty
+        let count n = List.length >> (=) n
+      module All =
+        let error = List.forall Is.error
+        let warning = List.forall Is.warning
+        let neither = List.isEmpty
+      module Exists =
+        let error = List.exists Is.error
+        let warning = List.exists Is.warning
+        let neither = List.isEmpty
+        let either: Result -> bool = List.isEmpty >> not
+        let errorOrWarning: Result -> bool = List.isEmpty >> not
+        let matching = List.exists
+        let withMsg (txt: string) = List.exists (fun m -> m.Message.Contains txt)
+      module Text =
+        let contains (txt: string) msg = msg.Message.Contains(txt, StringComparison.InvariantCultureIgnoreCase)
+        let isMatch (regex: System.Text.RegularExpressions.Regex) msg =
+          regex.IsMatch msg.Message
+    let private (>&>) a b = fun actual -> a actual && b actual
+
+    module Is =
+      /// Neither error nor warning
+      let strictSuccess =
+        Test.All.neither
+        |> orFail expected.Neither.Error.Nor.Warning
+      let error =
+        Test.Exists.error
+        |> orFail expected.Error
+      let warning =
+        Test.Exists.warning >&> (not << Test.Exists.error)
+        |> orFail expected.Warning
+      let errorOrWarning =
+        Test.Exists.errorOrWarning
+        |> orFail expected.Error.Or.Warning
+      module No =
+        let error =
+          (not << Test.Exists.error)
+          |> orFail expected.No.Error
+        /// Same as `strictSuccess`
+        let errorOrWarning =
+          strictSuccess
+
+      /// No error; Warning is allowed
+      ///
+      /// Same as `No.error`
+      let success =
+        No.error
+
+      module Single =
+        let error =
+          Test.Is.single >&> Test.All.error
+          |> orFail expected.Single.Error
+        let warning =
+          Test.Is.single >&> Test.All.warning
+          |> orFail expected.Single.Warning
+        let errorOrWarning =
+          Test.Is.single
+          |> orFail expected.Single.Error.Or.Warning
+
+    module Are =
+      let errorsOrWarnings n =
+        Test.Is.count n
+        |> orFail (expected.Count(n).Error.Or.Warning)
+      let errors n =
+        Test.Is.count n >&> Test.All.error
+        |> orFail (expected.Count(n).Error)
+      let warnings n =
+        Test.Is.count n >&> Test.All.warning
+        |> orFail (expected.Count(n).Warning)
+
+    module All =
+      let error =
+        Test.All.error
+        |> orFail expected.All.Error
+      let warning =
+        Test.All.warning
+        |> orFail expected.All.Warning
+
+    module Exists =
+      let errorWith (txt: string) =
+        Test.Exists.matching (Test.Is.error >&> Test.Text.contains txt)
+        |> orFail (expected.Error.With txt)
+      let warningWith (txt: string) =
+        Test.Exists.matching (Test.Is.warning >&> Test.Text.contains txt)
+        |> orFail (expected.Error.With txt)
+      let errorOrWarningWith (txt: string) =
+        Test.Exists.matching (Test.Text.contains txt)
+        |> orFail (expected.Error.Or.Warning.With txt)
+
+      open System.Text.RegularExpressions
+      let errorMatching (regex: Regex) =
+        Test.Exists.matching (Test.Is.error >&> Test.Text.isMatch regex)
+        |> orFail (expected.Error.Matching (regex.ToString()))
+      let warningMatching (regex: Regex) =
+        Test.Exists.matching (Test.Is.warning >&> Test.Text.isMatch regex)
+        |> orFail (expected.Warning.Matching (regex.ToString()))
+      let errorOrWarningMatching (regex: Regex) =
+        Test.Exists.matching (Test.Text.isMatch regex)
+        |> orFail (expected.Error.Or.Warning.Matching (regex.ToString()))


### PR DESCRIPTION
Checks assignment of Anonymous Records to an interface (with `!!`) when interface contains `[<EmitIndexer>]`, see https://github.com/fable-compiler/ts2fable/issues/415#issuecomment-836084087 . (There's already a check for normal members in Interface)

-> Checks stuff like:
```fsharp
type MyInterface =
  [<EmitIndexer>]
  abstract Item: key:string -> string

let v: MyInterface = !!{| Value = "foo"; AnotherValue = 42 |}
```
-> Warning for `AnotherValue`:
> FABLE: Expected type 'System.String' for field 'AnotherValue' because of Indexer 'Item' in interface 'MyInterface', but is 'System.Int32'

<br/>
<br/>

A couple of caveats & issues:
* Errors are just Compiler Warnings, not compiler errors. Same behaviour as already existing checks for interface members.
* Previously there was only one error/warning per anon record displayed; now there's one error/warning for every incorrect Field (either missing or incorrect type)
* Handles `[<EmitIndexer>]` (-> 'index signature' in TS), NOT F# indexer. (Though in most cases they are probably the same member)
* Currently it's just assumed a Member with `[<EmitIndexer>]` is valid. In TS: string and/or int input, and some return type. That's not checked.  
  Might be reasonable for another PR, but not here. Location to check would probably be https://github.com/fable-compiler/Fable/blob/155bd5e0e446a11ad010d4869a04ca59785f183a/src/Fable.Transforms/FSharp2Fable.Util.fs#L1416
* Erased Unions are reduced in Fable to Type `Any` (https://github.com/fable-compiler/Fable/blob/155bd5e0e446a11ad010d4869a04ca59785f183a/src/Fable.Transforms/FSharp2Fable.Util.fs#L856) -> quite a lot checks involve `Any` either on interface member side (lhs) or anon record field side (rhs), like:
  ```fsharp
  [<Erase>] type E = E of string
  type I1 =
    [<EmitIndexer>]
    abstract Item: string -> E
    //                       ^ Any

  let i1: I1 = !! {| Value = 42 |}
  //                 ^^^^^^^^^^
  //                 `int` fits into `Any` -> no error
  ```
  There's one special case that's handled: `Ux<...>` in interface:
  ```fsharp
  type I1 =
    [<EmitIndexer>]
    abstract Item: string -> U2<string,int>

  let i1: I1 =
      !! {|
          V1 = 42
          //   ^^ int -> ok
          V2 = "foo"
          //   ^^^^^ string -> ok
          V3 = 3.14
          //   ^^^^ float -> error
      |}
  ```
  But because there are valid values on the rhs that are reduced to `Any`, those cases have to be accepted too:
  ```fsharp
  let i1: I1 =
      !! {|
          V5 = U2.Case2 42  // valid: type `U2<string,int>`
          //   ^^ Any -> Don't know if correct type -> accepted
          V5 = obj ()       // invalid: type `obj`
          //   ^^^ Any -> don't know if correct type -> accepted
          V6 =              // invalid: type `U3<string,int,float>`
              let v: U3<string, int, float> = U3.Case3 3.14
              v
          //  ^ Any -> don't know if correct type -> accepted
      |}
  ```
  Reason lhs (interface) can be handled, but rhs (actual value) cannot: For interface its F# type is available, while the rhs is already reduced to its Fable Type (and `Type.ErasedUnion` was removed some time ago (#2112))  
  Additional:
  * `Ux<...>` behaviour was added to normal interface member check too
  * `Ux<...> option` received special treatment too (`U2<string,int> option = U2<string option, int option>`). `option` behaviour is same as normal interface member check (`int option` => both allowed: `Some 42` and just `42`)
* There were no tests for compiler messages -> Added test project `tests/Compiler`
  * Uses `Fable.Standalone` for compiling. 
  * Creating Checker takes some time -> running tests seems like it's doing nothing for some time...
  * Run tests:
    * `dotnet fsi build.fsx test-compiler`
    * in `test/Compiler`: `dotnet run`
    * executed as part of all `test`s (`dotnet fsi build.fsx test`)
