### PR TITLE
Initial support for FormattableString

### DIFF
--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -1720,6 +1720,15 @@ let stringModule (com: ICompiler) (ctx: Context) r t (i: CallInfo) (_: Expr opti
     | meth, args ->
         Helper.LibCall(com, "String", Naming.lowerFirst meth, t, args, i.SignatureArgTypes, ?loc=r) |> Some
 
+let formattableString (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (thisArg: Expr option) (args: Expr list) =
+    match i.CompiledName, thisArg, args with
+    | "Create", None, [str; args] -> objExpr ["str", str; "args", args] |> Some
+    | "get_Format", Some x, _ -> get r t x "str" |> Some
+    | "get_ArgumentCount", Some x, _ -> get r t (getSimple x "args") "length" |> Some
+    | "GetArgument", Some x, [idx] -> getExpr r t (getSimple x "args") idx |> Some
+    | "GetArguments", Some x, [] -> get r t x "args" |> Some
+    | _ -> None
+
 let seqModule (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (thisArg: Expr option) (args: Expr list) =
     match i.CompiledName, args with
     | "Cast", [arg] -> Some arg // Erase
@@ -3075,6 +3084,8 @@ let private replacedModules =
     Types.char, chars
     Types.string, strings
     "Microsoft.FSharp.Core.StringModule", stringModule
+    "System.FormattableString", formattableString
+    "System.Runtime.CompilerServices.FormattableStringFactory", formattableString
     "System.Text.StringBuilder", bclType
     Types.array, arrays
     Types.list, lists

--- a/tests/Main/StringTests.fs
+++ b/tests/Main/StringTests.fs
@@ -894,4 +894,13 @@ let tests =
 
       testCase "interpolated string with double % should be unescaped" <| fun () ->
             $"{100}%%" |> equal "100%"
+
+      testCase "Can create FormattableString" <| fun () ->
+          let orderAmount = 100
+          let convert (s: FormattableString) = s
+          let s = convert $"You owe: {orderAmount:N5} {3} {5 = 5}"
+          s.Format |> equal "You owe: {0:N5} {1} {2}"
+          s.ArgumentCount |> equal 3
+          s.GetArgument(2) |> equal (box true)
+          s.GetArguments() |> equal [|100; 3; true|]
   ]


### PR DESCRIPTION
Fixes #1973

This PR adds support for:

- `FormattableString.Format`
- `FormattableString.ArgumentCount`
- `FormattableString.GetArgument()`
- `FormattableString.GetArguments(index)`
- `FormattableStringFactory.Create`: this happens when assigning an interpolated string to a variable of `FormattableString` or passing it to a function that accepts `FormattableString` as argument.

```fsharp
let s: FormattableString = $"You owe: {orderAmount:N5} {3} {5 = 5}"

let convert (s: FormattableString) = s
let s = convert $"You owe: {orderAmount:N5} {3} {5 = 5}"
```

