### PR TITLE
Fix dropped DEBUG constant

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -352,8 +352,28 @@ let testMocha() =
 
     runMocha buildDir
 
+let testDefineConstants() =
+    [ "tests/DefineConstants/DebugWithExtraDefines", "Debug"
+      "tests/DefineConstants/CustomConfiguration", "Test"
+      "tests/DefineConstants/ReleaseNoExtraDefines", String.Empty ]
+    |> List.iter (fun (projectDir, configuration) ->
+        let buildDir = "build/"+ projectDir
+
+        cleanDirs [ buildDir ]
+        runFableWithArgs projectDir [
+            "--outDir " + buildDir
+            "--exclude Fable.Core"
+            if not(String.IsNullOrEmpty configuration) then
+                "--configuration " + configuration
+        ]
+
+        runMocha buildDir
+    )
+
 let test() =
     buildLibraryIfNotExists()
+
+    testDefineConstants()
 
     testMocha()
 
@@ -520,6 +540,7 @@ match argsLower with
 // | "coverage"::_ -> coverage()
 | "test"::_ -> test()
 | "test-mocha"::_ -> testMocha()
+| "test-define-constants"::_ -> testDefineConstants()
 | "test-js"::_ -> testJs(minify)
 | "test-js-fast"::_ -> testJsFast()
 | "test-react"::_ -> testReact()

--- a/src/Fable.Cli/Entry.fs
+++ b/src/Fable.Cli/Entry.fs
@@ -151,18 +151,16 @@ type Runner =
 
         let configuration =
             let defaultConfiguration = if watch then "Debug" else "Release"
-            let configurationArg = argValue "--configuration" args |> Option.defaultValue defaultConfiguration
-            if String.IsNullOrWhiteSpace configurationArg then
-                defaultConfiguration
-            else
-                configurationArg
+            match argValue "--configuration" args with
+            | None -> defaultConfiguration
+            | Some c when String.IsNullOrWhiteSpace c -> defaultConfiguration
+            | Some configurationArg -> configurationArg
 
         let define =
             argValues "--define" args
             |> List.append [
                 "FABLE_COMPILER"
                 "FABLE_COMPILER_3"
-                configuration.ToUpperInvariant()
             ]
             |> List.distinct
 

--- a/src/Fable.Cli/ProjectCracker.fs
+++ b/src/Fable.Cli/ProjectCracker.fs
@@ -270,18 +270,13 @@ let getSourcesFromFsproj (projFile: string) =
         | path -> [ path ])
 
 let private isUsefulOption (opt : string) =
-    match opt with
-    // We manage DEBUG (and maybe later TRACE) through CLI
-    | "--define:DEBUG"
-    | "--define:TRACE" -> false
-    | _ ->
-        [ "--define"
-          "--nowarn"
-          "--warnon"
-        //   "--warnaserror" // Disable for now to prevent unexpected errors, see #2288
-        //   "--langversion" // See getBasicCompilerArgs
-        ]
-        |> List.exists opt.StartsWith
+    [ "--define"
+      "--nowarn"
+      "--warnon"
+    //   "--warnaserror" // Disable for now to prevent unexpected errors, see #2288
+    //   "--langversion" // See getBasicCompilerArgs
+    ]
+    |> List.exists opt.StartsWith
 
 let excludeProjRef (opts: CrackerOptions) (dllRefs: IDictionary<string,string>) (projRef: string) =
     let projName = Path.GetFileNameWithoutExtension(projRef)

--- a/tests/DefineConstants/CustomConfiguration/Fable.Tests.DefineConstants.CustomConfiguration.fsproj
+++ b/tests/DefineConstants/CustomConfiguration/Fable.Tests.DefineConstants.CustomConfiguration.fsproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+    <RollForward>Major</RollForward>
+    <OtherFlags>$(OtherFlags) --crossoptimize-</OtherFlags>
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Test' ">
+    <DefineConstants>DEBUG;FOOBAR</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="FSharp.Core" Version="5.0.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../../src/Fable.Core/Fable.Core.fsproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Main.fs" />
+  </ItemGroup>
+</Project>

--- a/tests/DefineConstants/CustomConfiguration/Main.fs
+++ b/tests/DefineConstants/CustomConfiguration/Main.fs
@@ -1,0 +1,41 @@
+﻿module Fable.Tests.DefineConstants.CustomConfiguration
+
+open Fable.Core
+open Fable.Core.JsInterop
+open Fable.Core.Testing
+
+let [<Global>] describe (name: string) (f: unit->unit) : unit = jsNative
+let [<Global>] it (msg: string) (f: unit->unit) : unit = jsNative
+let equals expected actual = Assert.AreEqual(actual, expected)
+
+describe "CustomConfiguration" (fun () ->
+    let isDefined = "is defined"
+    let notDefined = "not defined"
+
+    it "should define DEBUG" (fun () ->
+        #if DEBUG
+        isDefined
+        #else
+        notDefined
+        #endif
+        |> equals isDefined
+    )
+
+    it "should define TEST" (fun () ->
+        #if TEST
+        isDefined
+        #else
+        notDefined
+        #endif
+        |> equals isDefined
+    )
+
+    it "should define FOOBAR" (fun () ->
+        #if FOOBAR
+        isDefined
+        #else
+        notDefined
+        #endif
+        |> equals isDefined
+    )
+)

--- a/tests/DefineConstants/DebugWithExtraDefines/Fable.Tests.DefineConstants.DebugWithExtraDefines.fsproj
+++ b/tests/DefineConstants/DebugWithExtraDefines/Fable.Tests.DefineConstants.DebugWithExtraDefines.fsproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+    <RollForward>Major</RollForward>
+    <OtherFlags>$(OtherFlags) --crossoptimize-</OtherFlags>
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DefineConstants>FOOBAR</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="FSharp.Core" Version="5.0.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../../src/Fable.Core/Fable.Core.fsproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Main.fs" />
+  </ItemGroup>
+</Project>

--- a/tests/DefineConstants/DebugWithExtraDefines/Main.fs
+++ b/tests/DefineConstants/DebugWithExtraDefines/Main.fs
@@ -1,0 +1,32 @@
+﻿module Fable.Tests.DefineConstants.DebugWithExtraDefines
+
+open Fable.Core
+open Fable.Core.JsInterop
+open Fable.Core.Testing
+
+let [<Global>] describe (name: string) (f: unit->unit) : unit = jsNative
+let [<Global>] it (msg: string) (f: unit->unit) : unit = jsNative
+let equals expected actual = Assert.AreEqual(actual, expected)
+
+describe "DebugWithExtraDefines" (fun () ->
+    let isDefined = "is defined"
+    let notDefined = "not defined"
+
+    it "should define DEBUG" (fun () ->
+        #if DEBUG
+        isDefined
+        #else
+        notDefined
+        #endif
+        |> equals isDefined
+    )
+
+    it "should define FOOBAR" (fun () ->
+        #if FOOBAR
+        isDefined
+        #else
+        notDefined
+        #endif
+        |> equals isDefined
+    )
+)

--- a/tests/DefineConstants/ReleaseNoExtraDefines/Fable.Tests.DefineConstants.ReleaseNoExtraDefines.fsproj
+++ b/tests/DefineConstants/ReleaseNoExtraDefines/Fable.Tests.DefineConstants.ReleaseNoExtraDefines.fsproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+    <RollForward>Major</RollForward>
+    <OtherFlags>$(OtherFlags) --crossoptimize-</OtherFlags>
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="FSharp.Core" Version="5.0.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../../src/Fable.Core/Fable.Core.fsproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Main.fs" />
+  </ItemGroup>
+</Project>

--- a/tests/DefineConstants/ReleaseNoExtraDefines/Main.fs
+++ b/tests/DefineConstants/ReleaseNoExtraDefines/Main.fs
@@ -1,0 +1,32 @@
+﻿module Fable.Tests.DefineConstants.CustomConfiguration
+
+open Fable.Core
+open Fable.Core.JsInterop
+open Fable.Core.Testing
+
+let [<Global>] describe (name: string) (f: unit->unit) : unit = jsNative
+let [<Global>] it (msg: string) (f: unit->unit) : unit = jsNative
+let equals expected actual = Assert.AreEqual(actual, expected)
+
+describe "ReleaseNoExtraDefines" (fun () ->
+    let isDefined = "is defined"
+    let notDefined = "not defined"
+
+    it "should NOT define DEBUG" (fun () ->
+        #if DEBUG
+        isDefined
+        #else
+        notDefined
+        #endif
+        |> equals notDefined
+    )
+
+    it "should define RELEASE" (fun () ->
+        #if RELEASE
+        isDefined
+        #else
+        notDefined
+        #endif
+        |> equals isDefined
+    )
+)


### PR DESCRIPTION
- don't strip DEBUG and TRACE
- don't define the configuration ourselves
- rely on Dotnet.ProjInfo to return constants based on configuration
- add tests:
  - Debug with extra constants
  - custom configuration "Test"
  - Release without extra constants

Fixes #2477