### PR TITLE
Python fixes #2

### DIFF
--- a/src/fable-library-py/fable/types.py
+++ b/src/fable-library-py/fable/types.py
@@ -116,7 +116,7 @@ class Record(IComparable):
     def toJSON(self) -> str:
         return recordToJSON(this)
 
-    def toString(self) -> str:
+    def __str__(self) -> str:
         return recordToString(self)
 
     def GetHashCode(self) -> int:
@@ -188,7 +188,7 @@ class FSharpException(Exception, IComparable):
     def toJSON(self):
         return recordToJSON(self)
 
-    def toString(self):
+    def __str__(self):
         return recordToString(self)
 
     def GetHashCode(self):


### PR DESCRIPTION
- Use Python `__str__` instead `ToString`. Use Python string protocol instead of `ToString()` members. I.e members are named `__str__` instead of `ToString`. That way we can string any object using `str(obj)`. This is the same as we do with iterators being named `__iter__`. 
- Fix Python entry point by adding `if __name__ == "__main__":` before calling entry point function with `sys.args[1:]`