### PR TITLE
Python fixes #3

### DIFF
--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -2101,9 +2101,7 @@ module Util =
                     let localId = Identifier.identifier(localId)
                     match import.Selector with
                     | "*" -> ImportNamespaceSpecifier(localId)
-                    | "default" | "" ->
-                        printfn "LocalId: %A" localId
-                        ImportDefaultSpecifier(localId)
+                    | "default" | "" -> ImportDefaultSpecifier(localId)
                     | memb -> ImportMemberSpecifier(localId, Identifier.identifier(memb)))
             import.Path, specifier)
         |> Seq.groupBy fst
@@ -2113,9 +2111,7 @@ module Util =
                 ||> Seq.fold (fun (mems, defs, alls) x ->
                     match x with
                     | ImportNamespaceSpecifier(_) -> mems, defs, x::alls
-                    | ImportDefaultSpecifier(_) ->
-                        printfn "ImportDefaultSpecifier: %A" (x)
-                        mems, x::defs, alls
+                    | ImportDefaultSpecifier(_) -> mems, x::defs, alls
                     | _ -> x::mems, defs, alls)
             // We used to have trouble when mixing member, default and namespace imports,
             // issue an import statement for each kind just in case

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -2101,7 +2101,9 @@ module Util =
                     let localId = Identifier.identifier(localId)
                     match import.Selector with
                     | "*" -> ImportNamespaceSpecifier(localId)
-                    | "default" | "" -> ImportDefaultSpecifier(localId)
+                    | "default" | "" ->
+                        printfn "LocalId: %A" localId
+                        ImportDefaultSpecifier(localId)
                     | memb -> ImportMemberSpecifier(localId, Identifier.identifier(memb)))
             import.Path, specifier)
         |> Seq.groupBy fst
@@ -2111,7 +2113,9 @@ module Util =
                 ||> Seq.fold (fun (mems, defs, alls) x ->
                     match x with
                     | ImportNamespaceSpecifier(_) -> mems, defs, x::alls
-                    | ImportDefaultSpecifier(_) -> mems, x::defs, alls
+                    | ImportDefaultSpecifier(_) ->
+                        printfn "ImportDefaultSpecifier: %A" (x)
+                        mems, x::defs, alls
                     | _ -> x::mems, defs, alls)
             // We used to have trouble when mixing member, default and namespace imports,
             // issue an import statement for each kind just in case

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -37,7 +37,7 @@ type BoundVars =
       LocalScope: HashSet<string> }
 
     member this.EnterScope () =
-        // printfn "EnterScope"
+        // printfn "EnterScope: %A" this
         let enclosingScope = HashSet<string>()
         enclosingScope.UnionWith(this.EnclosingScope)
         enclosingScope.UnionWith(this.LocalScope)
@@ -62,6 +62,7 @@ type BoundVars =
                 else
                     this.Bind(name)
         ]
+
 type Context =
   { File: Fable.File
     UsedNames: UsedNames
@@ -794,9 +795,11 @@ module Util =
         FunctionDef.Create(name = name, args = args, body = body)
 
     let makeFunctionExpression (com: IPythonCompiler) ctx name (args, (body: Expression)) : Expression * Statement list=
+        let ctx = { ctx with BoundVars = ctx.BoundVars.EnterScope() }
+
         let name =
             name |> Option.map (fun name -> com.GetIdentifier(ctx, name))
-            |> Option.defaultValue (Helpers.getUniqueIdentifier "lifted")
+            |> Option.defaultValue (Helpers.getUniqueIdentifier "expr")
         let func = makeFunction name (args, body)
         Expression.name(name), [ func ]
 
@@ -1472,6 +1475,7 @@ module Util =
             com.TransformAsExpr(ctx, target)
 
     let exprAsStatement (ctx: Context) (expr: Expression) : Statement list =
+        // printfn "exprAsStatement: %A" expr
         match expr with
         | NamedExpr({Target=target; Value=value; Loc=loc }) ->
             let nonLocals =
@@ -1481,7 +1485,7 @@ module Util =
                     [ ctx.BoundVars.NonLocals([ id ]) |> Statement.nonLocal ]
                 | _ -> []
 
-            //printfn "Nonlocals: %A" nonLocals
+            // printfn "Nonlocals: %A" nonLocals
             nonLocals @ [ Statement.assign([target], value) ]
         | _ -> [ Statement.expr(expr) ]
 
@@ -1658,7 +1662,7 @@ module Util =
                 transformDecisionTreeWithTwoSwitches com ctx returnStrategy targets treeExpr
 
     let transformSequenceExpr (com: IPythonCompiler) ctx (exprs: Fable.Expr list) : Expression * Statement list =
-        //printfn "transformSequenceExpr"
+        // printfn "transformSequenceExpr1"
         let ctx = { ctx with BoundVars = ctx.BoundVars.EnterScope() }
         let body =
             exprs
@@ -1679,14 +1683,15 @@ module Util =
         // expr, []
         //printfn "transformSequenceExpr, body: %A" body
 
-        let name = Helpers.getUniqueIdentifier ("lifted")
+        let name = Helpers.getUniqueIdentifier ("expr")
         let func = FunctionDef.Create(name = name, args = Arguments.arguments [], body = body)
 
         let name = Expression.name (name)
         Expression.call (name), [ func ]
 
     let transformSequenceExpr' (com: IPythonCompiler) ctx (exprs: Expression list) (stmts: Statement list) : Expression * Statement list =
-        //printfn "transformSequenceExpr', exprs: %A" exprs.Length
+        // printfn "transformSequenceExpr2', exprs: %A" exprs.Length
+        // printfn "ctx: %A" ctx.BoundVars
         let ctx = { ctx with BoundVars = ctx.BoundVars.EnterScope() }
 
         let body =
@@ -1699,7 +1704,7 @@ module Util =
                     else
                         exprAsStatement ctx expr)
 
-        let name = Helpers.getUniqueIdentifier ("lifted")
+        let name = Helpers.getUniqueIdentifier ("expr")
         let func = FunctionDef.Create(name = name, args = Arguments.arguments [], body = body)
 
         let name = Expression.name (name)
@@ -1774,6 +1779,7 @@ module Util =
 
         | Fable.Set(expr, kind, typ, value, range) ->
             let expr', stmts = transformSet com ctx range expr typ value kind
+            //printfn "Fable.Set: %A" expr
             match expr' with
             | Expression.NamedExpr({ Target = target; Value = _; Loc=_ }) ->
                 let nonLocals =
@@ -1784,13 +1790,8 @@ module Util =
             | _ -> expr', stmts
 
         | Fable.Let(ident, value, body) ->
-            //printfn "Fable.Let: %A" (ident, value, body)
-            if ctx.HoistVars [ident] then
-                let assignment, stmts = transformBindingAsExpr com ctx ident value
-                let bodyExpr, stmts' = com.TransformAsExpr(ctx, body)
-                let expr, stmts'' = transformSequenceExpr' com ctx [ assignment; bodyExpr ] (stmts @ stmts')
-                expr, stmts''
-            else iife com ctx expr
+            // printfn "Fable.Let: %A" (ident, value, body)
+            iife com ctx expr
 
         | Fable.LetRec(bindings, body) ->
             if ctx.HoistVars(List.map fst bindings) then
@@ -1894,6 +1895,7 @@ module Util =
 
         | Fable.Set(expr, kind, typ, value, range) ->
             let expr', stmts = transformSet com ctx range expr typ value kind
+            // printfn "Fable.Set: %A" (expr', value)
             match expr' with
             | Expression.NamedExpr({ Target = target; Value = value; Loc=loc }) ->
                 let nonLocals =
@@ -1997,11 +1999,11 @@ module Util =
                 args', Statement.while'(Expression.constant(true), body)
                 |> List.singleton
             | _ -> args |> List.map (ident com ctx), body
-        let body =
-            if declaredVars.Count = 0 then body
-            else
-                let varDeclStatement = multiVarDeclaration ctx [for v in declaredVars -> ident com ctx v, None]
-                varDeclStatement @ body
+        // let body =
+        //     if declaredVars.Count = 0 then body
+        //     else
+        //         let varDeclStatement = multiVarDeclaration ctx [for v in declaredVars -> ident com ctx v, None]
+        //         varDeclStatement @ body
         //printfn "Args: %A" (args, body)
         let args = Arguments.arguments(args |> List.map Arg.arg)
         args, body
@@ -2115,7 +2117,7 @@ module Util =
             getMemberArgsAndBody com ctx (NonAttached membName) info.HasSpread args body
 
         //printfn "Arsg: %A" args
-        let name = com.GetIdentifier(ctx, membName) //Helpers.getUniqueIdentifier "lifted"
+        let name = com.GetIdentifier(ctx, membName)
         let stmt = FunctionDef.Create(name = name, args = args, body = body)
         let expr = Expression.name (name)
         info.Attributes
@@ -2438,7 +2440,7 @@ module Compiler =
             for decl in file.Declarations do
                 hs.UnionWith(decl.UsedNames)
             hs
-        //printfn "File: %A" file.Declarations
+
         let ctx =
           { File = file
             UsedNames = { RootScope = HashSet file.UsedNamesInRootScope

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -590,6 +590,7 @@ module Util =
         // printfn "MemberName: %A" memberName
         match memberName with
         | "ToString" -> Expression.identifier("__str__")
+        | "Equals" -> Expression.identifier("__eq__")
         | n when n.StartsWith("Symbol.iterator") ->
             let name = Identifier "__iter__"
             Expression.name(name)
@@ -1739,6 +1740,11 @@ module Util =
             let func = Expression.name("str")
             let left, stmts = com.TransformAsExpr(ctx, expr)
             Expression.call (func, [ left ]), stmts
+
+        | Fable.Call(Fable.Get(expr, Fable.FieldGet(fieldName="Equals"), _, _), info, _, range) ->
+            let right, stmts = com.TransformAsExpr(ctx, info.Args.Head)
+            let left, stmts' = com.TransformAsExpr(ctx, expr)
+            Expression.compare (left, [Eq], [right]), stmts @ stmts'
 
         | Fable.Call(Fable.Get(expr, Fable.FieldGet(fieldName="split"), _, _), { Args=[Fable.Value(kind=Fable.StringConstant(""))]}, _, range) ->
             let func = Expression.name("list")

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -780,8 +780,13 @@ module Util =
         stmts @ [ Statement.return'(e) ]
 
     let makeArrowFunctionExpression (args: Arguments) (body: Statement list) : Expression * Statement list =
-        let name = Helpers.getUniqueIdentifier "lifted"
-        let func = FunctionDef.Create(name = name, args = args, body = body)
+        // Need to be able to receive unit for arrow expressions
+        let arguments =
+            match args.Args with
+            | [] -> Arguments.arguments [ Arg.arg (Python.Identifier("_"), Expression.name (Python.Identifier("None"))) ]
+            | _ -> args
+        let name = Helpers.getUniqueIdentifier "arrow"
+        let func = FunctionDef.Create(name = name, args = arguments, body = body)
         Expression.name (name), [ func ]
 
     let makeFunction name (args, (body: Expression)) : Statement =

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -412,9 +412,9 @@ module Helpers =
             name |> String.map(fun c -> if List.contains c ['.'; '$'; '`'; '*'; ' '] then '_' else c)
 
     let rewriteFableImport moduleName =
-        //printfn "ModuleName: %s" moduleName
+        // printfn "ModuleName: %s" moduleName
         let _reFableLib =
-            Regex(".*(\/fable-library.*)?\/(?<module>[^\/]*)\.(js|fs)", RegexOptions.Compiled)
+            Regex(".*(\/fable-library.*)\/(?<module>[^\/]*)\.(js|fs)", RegexOptions.Compiled)
 
         let m = _reFableLib.Match(moduleName)
         let dashify = applyCaseRule CaseRules.SnakeCase
@@ -427,18 +427,21 @@ module Helpers =
 
             let moduleName = String.concat "." [ "fable"; pymodule ]
 
-            //printfn "-> Module: %A" moduleName
+            // printfn "-> Module: %A" moduleName
             moduleName
-        else
+        elif moduleName.Contains(".fs") then
             // Modules should have short, all-lowercase names.
             let moduleName =
                 let name =
-                    moduleName.Replace("/", "")
+                    Path.GetFileNameWithoutExtension(moduleName)
                     |> dashify
-                string(name.[0]) + name.[1..]
+                    |> clean
+                $".{name}"
 
             // printfn "-> Module: %A" moduleName
             moduleName
+        else
+            moduleName |> dashify |> clean
 
     let unzipArgs (args: (Python.Expression * Python.Statement list) list): Python.Expression list * Python.Statement list =
         let stmts = args |> List.map snd |> List.collect id

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -582,14 +582,15 @@ module Util =
     let ofString (s: string) =
        Expression.constant(s)
 
-    let memberFromName (com: IPythonCompiler) (ctx: Context) (memberName: string): Expression * Statement list =
+    let memberFromName (com: IPythonCompiler) (ctx: Context) (memberName: string): Expression =
+        // printfn "MemberName: %A" memberName
         match memberName with
-        | "ToString" -> Expression.identifier("toString"), []
+        | "ToString" -> Expression.identifier("__str__")
         | n when n.StartsWith("Symbol.iterator") ->
             let name = Identifier "__iter__"
-            Expression.name(name), []
-        | n when Naming.hasIdentForbiddenChars n -> Expression.constant(n), []
-        | n -> com.GetIdentifierAsExpr(ctx, n), []
+            Expression.name(name)
+        | n when Naming.hasIdentForbiddenChars n -> Expression.constant(n)
+        | n -> com.GetIdentifierAsExpr(ctx, n)
 
     let get (com: IPythonCompiler) ctx r left memberName subscript =
         // printfn "get: %A" (left, memberName)
@@ -963,7 +964,7 @@ module Util =
         let members =
             members |> List.collect (fun memb ->
                 let info = memb.Info
-                let prop, computed = memberFromName com ctx memb.Name
+                let prop = memberFromName com ctx memb.Name
                 // If compileAsClass is false, it means getters don't have side effects
                 // and can be compiled as object fields (see condition above)
                 if info.IsValue || (not compileAsClass && info.IsGetter) then
@@ -2068,7 +2069,7 @@ module Util =
         else
             ent.FSharpFields
             |> Seq.map (fun field ->
-                let prop, computed = memberFromName com ctx field.Name
+                let prop = memberFromName com ctx field.Name
                 prop)
             |> Seq.toArray
 
@@ -2127,23 +2128,35 @@ module Util =
         //else
         statements
 
+    let nameFromKey (com: IPythonCompiler) (ctx: Context) key =
+        match key with
+        | Expression.Name({Id=ident}) -> ident
+        | Expression.Constant(value=value) ->
+            match value with
+            | :? string as name  -> com.GetIdentifier(ctx, name)
+            | _ -> failwith $"Not a valid value: {value}"
+        | name -> failwith $"Not a valid name: {name}"
+
     let transformAttachedProperty (com: IPythonCompiler) ctx (memb: Fable.MemberDecl) =
         let isStatic = not memb.Info.IsInstance
         //let kind = if memb.Info.IsGetter then ClassGetter else ClassSetter
         let args, body =
             getMemberArgsAndBody com ctx (Attached isStatic) false memb.Args memb.Body
-        let key, computed = memberFromName com ctx memb.Name
+        let key =
+            memberFromName com ctx memb.Name
+            |> nameFromKey com ctx
+
         let self = Arg.arg("self")
         let arguments = { args with Args = self::args.Args }
-        FunctionDef.Create(com.GetIdentifier(ctx, memb.Name), arguments, body = body)
+        FunctionDef.Create(key, arguments, body = body)
         |> List.singleton
 
     let transformAttachedMethod (com: IPythonCompiler) ctx (memb: Fable.MemberDecl) =
         // printfn "transformAttachedMethod"
         let isStatic = not memb.Info.IsInstance
         let makeMethod name args body =
-            let key, computed = memberFromName com ctx name
-            FunctionDef.Create(com.GetIdentifier(ctx,  name), args, body = body)
+            let key = memberFromName com ctx name |> nameFromKey com ctx
+            FunctionDef.Create(key, args, body = body)
         let args, body =
             getMemberArgsAndBody com ctx (Attached isStatic) memb.Info.HasSpread memb.Args memb.Body
         let self = Arg.arg("self")

--- a/src/fable-library-py/fable/decimal.py
+++ b/src/fable-library-py/fable/decimal.py
@@ -12,12 +12,13 @@ get_MinValue = MIN_EMIN
 
 
 def fromParts(low: int, mid: int, high: int, isNegative: bool, scale: int):
-    print("low: ", low)
-    print("mid: ", mid)
-    print("high: ", high)
-    print("scale: ", scale)
-    negative = -1 if isNegative else 1
-    return Decimal(low * negative) / Decimal(pow(10, scale))
+    sign = Decimal(-1) if isNegative else Decimal(1)
+    dlow = Decimal(low)
+    dmid = Decimal(mid << 32)
+    dhigh = Decimal(high << 64)
+    dscale = Decimal(pow(10, scale))
+
+    return (dlow + dmid + dhigh) / dscale * sign
 
 
 def op_Addition(x: Decimal, y: Decimal):

--- a/src/fable-library-py/fable/decimal.py
+++ b/src/fable-library-py/fable/decimal.py
@@ -1,0 +1,23 @@
+from decimal import Decimal, MAX_EMAX, MIN_EMIN
+
+get_Zero = Decimal(0)
+
+get_One = Decimal(1)
+
+get_MinusOne = Decimal(-1)
+
+get_MaxValue = MAX_EMAX
+
+get_MinValue = MIN_EMIN
+
+
+def fromParts(low: int, mid: int, high: int, isNegative: bool, scale: int):
+    print("low: ", low)
+    print("mid: ", mid)
+    print("high: ", high)
+    print("scale: ", scale)
+    return Decimal()
+
+
+def op_Addition(x: Decimal, y: Decimal):
+    return x + y

--- a/src/fable-library-py/fable/decimal.py
+++ b/src/fable-library-py/fable/decimal.py
@@ -16,7 +16,8 @@ def fromParts(low: int, mid: int, high: int, isNegative: bool, scale: int):
     print("mid: ", mid)
     print("high: ", high)
     print("scale: ", scale)
-    return Decimal()
+    negative = -1 if isNegative else 1
+    return Decimal(low * negative) / Decimal(pow(10, scale))
 
 
 def op_Addition(x: Decimal, y: Decimal):

--- a/src/fable-library-py/fable/long.py
+++ b/src/fable-library-py/fable/long.py
@@ -36,6 +36,3 @@ def parse(string: str, style: int, unsigned: bool, _bitsize: int, radix: Optiona
     #         return LongLib.fromString(str, unsigned, res.radix);
 
     # raise Exception("Input string was not in a correct format.");
-
-
-str = str  # FIXME: remove str imports in the compiler.

--- a/src/fable-library-py/fable/long.py
+++ b/src/fable-library-py/fable/long.py
@@ -20,6 +20,7 @@ def op_Multiply(a, b):
 def op_UnaryNegation(value):
     return -value
 
+
 def parse(string: str, style: int, unsigned: bool, _bitsize: int, radix: Optional[int] = None):
     return int(string)
     # res = isValid(str, style, radix)

--- a/src/fable-library-py/fable/long.py
+++ b/src/fable-library-py/fable/long.py
@@ -13,6 +13,13 @@ def op_LeftShift(self, numBits):
     return self << numBits
 
 
+def op_Multiply(a, b):
+    return a * b
+
+
+def op_UnaryNegation(value):
+    return -value
+
 def parse(string: str, style: int, unsigned: bool, _bitsize: int, radix: Optional[int] = None):
     return int(string)
     # res = isValid(str, style, radix)

--- a/src/fable-library-py/fable/reflection.py
+++ b/src/fable-library-py/fable/reflection.py
@@ -30,7 +30,10 @@ class TypeInfo:
     enum_cases: Optional[List[EnumCase]] = None
 
     def __str__(self) -> str:
-        return full_name(self)
+        return fullName(self)
+
+    def __eq__(self, other) -> bool:
+        return self.fullname == other.fullname and self.generics == other.generics
 
 
 def class_type(
@@ -132,7 +135,7 @@ def name(info):
 def fullName(t):
     gen = t.generics if t.generics is not None and not isinstance(t, list) else []
     if len(gen):
-        gen = ",".join([ fullName(x) for x in gen])
+        gen = ",".join([fullName(x) for x in gen])
         return f"${t.fullname}[{gen}]"
 
     else:

--- a/src/fable-library-py/fable/types.py
+++ b/src/fable-library-py/fable/types.py
@@ -116,7 +116,7 @@ class Record(IComparable):
     def toJSON(self) -> str:
         return recordToJSON(this)
 
-    def toString(self) -> str:
+    def __str__(self) -> str:
         return recordToString(self)
 
     def GetHashCode(self) -> int:
@@ -188,7 +188,7 @@ class FSharpException(Exception, IComparable):
     def toJSON(self):
         return recordToJSON(self)
 
-    def toString(self):
+    def __str__(self):
         return recordToString(self)
 
     def GetHashCode(self):

--- a/src/fable-library-py/fable/types.py
+++ b/src/fable-library-py/fable/types.py
@@ -180,7 +180,6 @@ def toString(x, callStack=0):
     return str(x)
 
 
-str = str
 Exception = Exception
 
 

--- a/src/fable-library-py/fable/util.py
+++ b/src/fable-library-py/fable/util.py
@@ -60,8 +60,8 @@ class IEquatable(ABC):
     def GetHashCode(self):
         return hash(self)
 
-    def Equals(self, other):
-        return self.Equals(other)
+    # def Equals(self, other):
+    #     return self.Equals(other)
 
     @abstractmethod
     def __eq__(self, other):
@@ -298,7 +298,7 @@ def isDisposable(x):
 
 
 def toIterator(en):
-    print("toIterator: ", en)
+    #print("toIterator: ", en)
 
     class Iterator:
         def __iter__(self):

--- a/src/fable-library-py/fable/util.py
+++ b/src/fable-library-py/fable/util.py
@@ -89,10 +89,6 @@ def equals(a, b):
     return a == b
 
 
-def equal(a, b):
-    return a == b
-
-
 def compare(a, b):
     if a == b:
         return 0

--- a/tests/Python/Fable.Tests.fsproj
+++ b/tests/Python/Fable.Tests.fsproj
@@ -33,6 +33,7 @@
     <Compile Include="TestLoops.fs" />
     <Compile Include="TestAsync.fs" />
     <Compile Include="TestMap.fs" />
+    <Compile Include="TestArithmetic.fs" />
     <!-- <Compile Include="TestSudoku.fs" /> -->
     <Compile Include="Main.fs" />
   </ItemGroup>

--- a/tests/Python/TestArithmetic.fs
+++ b/tests/Python/TestArithmetic.fs
@@ -1,0 +1,149 @@
+module Fable.Tests.Arithmetic
+
+open System
+open Util.Testing
+
+let [<Literal>] aLiteral = 5
+let notALiteral = 5
+let [<Literal>] literalNegativeValue = -345
+
+let checkTo3dp (expected: float) actual =
+    floor (actual * 1000.) |> equal expected
+
+let positiveInfinity = System.Double.PositiveInfinity
+let negativeInfinity = System.Double.NegativeInfinity
+let isNaN = fun x -> System.Double.IsNaN(x)
+
+let equals (x:'a) (y:'a) = x = y
+let compareTo (x:'a) (y:'a) = compare x y
+
+let decimalOne = 1M
+let decimalTwo = 2M
+
+[<Fact>]
+let ``test Infix add can be generated`` () =
+    4 + 2 |> equal 6
+
+[<Fact>]
+let ``test Int32 literal addition is optimized`` () =
+    aLiteral + 7 |> equal 12
+    notALiteral + 7 |> equal 12
+
+[<Fact>]
+let ``test Unary negation with negative literal values works`` () =
+    -literalNegativeValue |> equal 345
+
+[<Fact>]
+let ``test Unary negation with integer MinValue works`` () =
+    -(-128y) |> equal System.SByte.MinValue
+    -(-32768s) |> equal System.Int16.MinValue
+    -(-2147483648) |> equal System.Int32.MinValue
+    -(-9223372036854775808L) |> equal System.Int64.MinValue
+
+[<Fact>]
+let ``test Infix subtract can be generated`` () =
+    4 - 2 |> equal 2
+
+[<Fact>]
+let ``test Infix multiply can be generated`` () =
+    4 * 2 |> equal 8
+
+[<Fact>]
+let ``test Infix divide can be generated`` () =
+    4 / 2 |> equal 2
+
+[<Fact>]
+let ``test Integer division doesn't produce floats`` () =
+    5. / 2. |> equal 2.5
+    5 / 2 |> equal 2
+    5 / 3 |> equal 1
+
+[<Fact>]
+let ``test Infix modulo can be generated`` () =
+    4 % 3 |> equal 1
+
+[<Fact>]
+let ``test Evaluation order is preserved by generated code`` () =
+    (4 - 2) * 2 + 1 |> equal 5
+
+[<Fact>]
+let ``test Bitwise and can be generated`` () =
+    6 &&& 2 |> equal 2
+
+[<Fact>]
+let ``test Bitwise or can be generated`` () =
+    4 ||| 2 |> equal 6
+
+[<Fact>]
+let ``test Bitwise shift left can be generated`` () =
+    4 <<< 2 |> equal 16
+
+[<Fact>]
+let ``test Bitwise shift left with unsigned integer works`` () =
+    1u <<< 31 |> equal 2147483648u
+
+[<Fact>]
+let ``test Bitwise OR on large unsigned integer works`` () =
+    0x80000000u ||| 0u |> equal (0x80000000u ||| 0u >>> 0)
+
+[<Fact>]
+let ``test Bitwise AND on large unsigned integer works`` () =
+    0x80000000u &&& 0xffffffffu |> equal (0x80000000u &&& 0xffffffffu >>> 0)
+
+[<Fact>]
+let ``test Bitwise XOR on large unsigned integer works`` () =
+    0x80000000u ^^^ 0u |> equal (0x80000000u ^^^ 0u >>> 0)
+
+[<Fact>]
+let ``test Bitwise Invert on large unsigned integer works`` () =
+    (~~~0x80000000u >>> 0) |> equal ~~~0x80000000u
+
+[<Fact>]
+let ``test Bitwise shift right can be generated`` () =
+    4 >>> 2 |> equal 1
+
+[<Fact>]
+let ``test Zero fill shift right (>>>) for uint32`` () =
+    0x80000000 >>> 1 |> equal -1073741824
+    0x80000000u >>> 1 |> equal 1073741824u
+
+[<Fact>]
+let ``test UInt64 multiplication with 0 returns uint``() =
+    0x0UL * 0x1UL |> equal 0x0UL
+
+[<Fact>]
+let ``test Decimal literals can be generated`` () =
+    0M |> equal System.Decimal.Zero
+    1M |> equal System.Decimal.One
+    -1M |> equal System.Decimal.MinusOne
+    79228162514264337593543950335M |> equal System.Decimal.MaxValue
+    -79228162514264337593543950335M |> equal System.Decimal.MinValue
+
+[<Fact>]
+let ``test Decimal.ToString works`` () =
+    string 001.23456M |> equal "1.23456"
+    string 1.23456M |> equal "1.23456"
+    string 0.12345M |> equal "0.12345"
+    string 0.01234M |> equal "0.01234"
+    string 0.00123M |> equal "0.00123"
+    string 0.00012M |> equal "0.00012"
+    string 0.00001M |> equal "0.00001"
+    string 0.00000M |> equal "0.00000"
+    string 0.12300M |> equal "0.12300"
+    string 0.0M |> equal "0.0"
+    string 0M |> equal "0"
+    string 1M |> equal "1"
+    string -1M |> equal "-1"
+    string 00000000000000000000000000000.M |> equal "0"
+    string 0.0000000000000000000000000000M |> equal "0.0000000000000000000000000000"
+    string 79228162514264337593543950335M |> equal "79228162514264337593543950335"
+    string -79228162514264337593543950335M |> equal "-79228162514264337593543950335"
+
+[<Fact>]
+let ``test Decimal precision is kept`` () =
+    let items = [ 290.8M
+                  290.8M
+                  337.12M
+                  6.08M
+                  -924.8M ]
+    List.sum items |> equal 0M

--- a/tests/Python/TestSeq.fs
+++ b/tests/Python/TestSeq.fs
@@ -5,7 +5,6 @@ open Util.Testing
 let sumFirstTwo (zs: seq<float>) =
     let second = Seq.skip 1 zs |> Seq.head
     let first = Seq.head zs
-    printfn "sumFirstTwo: %A" (first, second)
     first + second
 
 let rec sumFirstSeq (zs: seq<float>) (n: int): float =


### PR DESCRIPTION
- Fix better support and testing for arithmetics
- Compact imports, handle multiple imports from the same module on the same line
- Fix default imports.
- Handle unit arguments to arrow expressions
- Avoid sequence expressions if possible