### PR TITLE
Python fixes #5

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -194,6 +194,7 @@ let buildLibraryPy() =
     copyFile (buildDirPy </> "fable/system.text.py") (buildDirPy </> "fable/system_text.py")
     copyFile (buildDirPy </> "fable/fsharp.core.py") (buildDirPy </> "fable/fsharp_core.py")
     copyFile (buildDirPy </> "fable/fsharp.collections.py") (buildDirPy </> "fable/fsharp_collections.py")
+    copyFile (buildDirPy </> "fable/system.collections.generic.py") (buildDirPy </> "fable/system_collections_generic.py")
     //copyFile (buildDirPy </> "fable/async.py") (buildDirPy </> "fable/async_.py")
     removeFile (buildDirPy </> "fable/system.text.py")
 

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -1166,6 +1166,7 @@ module Util =
 
         match callee, callInfo.ThisArg with
         | Fable.Get(expr, Fable.FieldGet(fieldName="set"), _, _), _ ->
+            // printfn "Type: %A" expr.Type
             let right, stmts = com.TransformAsExpr(ctx, callInfo.Args.Head)
             let arg, stmts' = com.TransformAsExpr(ctx, callInfo.Args.Tail.Head)
             let value, stmts'' = com.TransformAsExpr(ctx, expr)
@@ -1300,6 +1301,10 @@ module Util =
             Expression.attribute (value = value, attr = attr, ctx = Load), stmts
         | Fable.FieldGet(fieldName="toLocaleLowerCase") ->
             let attr = Python.Identifier("lower")
+            let value, stmts = com.TransformAsExpr(ctx, fableExpr)
+            Expression.attribute (value = value, attr = attr, ctx = Load), stmts
+        | Fable.FieldGet(fieldName="findIndex") ->
+            let attr = Python.Identifier("index")
             let value, stmts = com.TransformAsExpr(ctx, fableExpr)
             Expression.attribute (value = value, attr = attr, ctx = Load), stmts
         | Fable.FieldGet(fieldName="indexOf") ->

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -1163,12 +1163,15 @@ module Util =
         // printfn "transformCall: %A" callee
         let callee', stmts = com.TransformAsExpr(ctx, callee)
         let args, stmts' = transformCallArgs com ctx callInfo.HasSpread callInfo.Args
+
         match callee, callInfo.ThisArg with
         | Fable.Get(expr, Fable.FieldGet(fieldName="set"), _, _), _ ->
             let right, stmts = com.TransformAsExpr(ctx, callInfo.Args.Head)
             let arg, stmts' = com.TransformAsExpr(ctx, callInfo.Args.Tail.Head)
             let value, stmts'' = com.TransformAsExpr(ctx, expr)
             Expression.none(), Statement.assign([Expression.subscript (value, right)], arg) :: stmts @ stmts' @ stmts''
+        | Fable.Get(expr, Fable.FieldGet(fieldName="sort"), _, _), _ ->
+            callFunction range callee' [], stmts @ stmts'
 
         | _, Some(TransformExpr com ctx (thisArg, stmts'')) -> callFunction range callee' (thisArg::args), stmts @ stmts' @ stmts''
         | _, None when callInfo.IsConstructor -> Expression.call(callee', args, ?loc=range), stmts @ stmts'

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -1791,6 +1791,7 @@ module Util =
             let args, stmts' = info.Args |> List.map (fun arg -> com.TransformAsExpr(ctx, arg)) |> List.unzip |> (fun (e, s) -> (e, List.collect id s))
             let slice =
                 match args with
+                | [] ->  Expression.slice()
                 | [ lower ] -> Expression.slice(lower=lower)
                 | [ Expression.Name({Id=Identifier("None")}); upper ] -> Expression.slice(upper=upper)
                 | [ lower; upper ] -> Expression.slice(lower=lower, upper=upper)

--- a/src/fable-library-py/fable/Fable.Library.fsproj
+++ b/src/fable-library-py/fable/Fable.Library.fsproj
@@ -21,8 +21,8 @@
     <Compile Include="../../fable-library/FSharp.Collections.fs" />
     <Compile Include="../../fable-library/FSharp.Core.fs" />
     <Compile Include="Native.fs" />
-    <!-- <Compile Include="MutableMap.fs" /> -->
-    <!-- <Compile Include="MutableSet.fs" /> -->
+    <Compile Include="../../fable-library/MutableMap.fs" />
+    <Compile Include="../../fable-library/MutableSet.fs" />
     <Compile Include="../../fable-library/Choice.fs" />
     <Compile Include="../../fable-library/Array.fs" />
     <Compile Include="../../fable-library/List.fs" />

--- a/src/fable-library-py/fable/Native.fs
+++ b/src/fable-library-py/fable/Native.fs
@@ -10,7 +10,7 @@ open Fable.Import
 
 [<AllowNullLiteral>]
 type Cons<'T> =
-    [<Emit("$0($1)")>]
+    [<Emit("$0([0]*$1)")>]
     abstract Allocate : len: int -> 'T []
 
 module Helpers =

--- a/src/fable-library-py/fable/Native.fs
+++ b/src/fable-library-py/fable/Native.fs
@@ -36,9 +36,10 @@ module Helpers =
     [<Emit("$0+$1")>]
     let concatImpl (array1: 'T []) (arrays: 'T [] seq) : 'T [] = nativeOnly
 
-    [<Emit("$0[:$2]+([$1]*$3)")>]
-    let fillImpl (array: 'T []) (value: 'T) (start: int) (count: int) : 'T [] = nativeOnly
-
+    let fillImpl (array: 'T []) (value: 'T) (start: int) (count: int) : 'T [] =
+        for i = 0 to count - 1 do
+            array.[i+start] <- value
+        array
 
     [<Emit("functools.reduce($0, $2, $1)")>]
     let foldImpl (folder: 'State -> 'T -> 'State) (state: 'State) (array: 'T []) : 'State = nativeOnly
@@ -53,7 +54,7 @@ module Helpers =
         !! array?reduceRight (System.Func<'State, 'T, int, 'State>(folder), state)
 
     // Typed arrays not supported, only dynamic ones do
-    let inline pushImpl (array: 'T []) (item: 'T) : int = !! array?push (item)
+    let inline pushImpl (array: 'T []) (item: 'T) : int = !! array?append (item)
 
     // Typed arrays not supported, only dynamic ones do
     let inline insertImpl (array: 'T []) (index: int) (item: 'T) : 'T [] = !! array?splice (index, 0, item)
@@ -95,8 +96,8 @@ module Helpers =
     let inline reduceBackImpl (reduction: 'T -> 'T -> 'T) (array: 'T []) : 'T = !! array?reduceRight (reduction)
 
     // Inlining in combination with dynamic application may cause problems with uncurrying
-    // Using Emit keeps the argument signature
-    [<Emit("$1.sort($0)")>]
+    // Using Emit keeps the argument signature. Note: Python cannot take an argument here.
+    [<Emit("$1.sort()")>]
     let sortInPlaceWithImpl (comparer: 'T -> 'T -> int) (array: 'T []) : unit = nativeOnly //!!array?sort(comparer)
 
     [<Emit("$2.set($0.subarray($1, $1 + $4), $3)")>]

--- a/src/fable-library-py/fable/big_int.py
+++ b/src/fable-library-py/fable/big_int.py
@@ -2,5 +2,21 @@ def fromZero():
     return 0
 
 
+def fromOne():
+    return 1
+
+
+def fromInt32(x):
+    return x
+
+
+def fromInt64(x):
+    return x
+
+
+def fromString(x):
+    return int(x)
+
+
 def op_Addition(a, b):
     return a + b

--- a/src/fable-library-py/fable/long.py
+++ b/src/fable-library-py/fable/long.py
@@ -8,6 +8,8 @@ def fromBits(lowBits: int, highBits: int, unsigned: bool):
 
     return ret
 
+def fromInt(x):
+    return x
 
 def op_LeftShift(self, numBits):
     return self << numBits

--- a/src/fable-library-py/fable/map_util.py
+++ b/src/fable-library-py/fable/map_util.py
@@ -5,7 +5,7 @@ V = TypeVar("V")
 
 
 def addToSet(v, set):
-    if set.has(v):
+    if v in set:
         return False
 
     set.add(v)
@@ -17,3 +17,19 @@ def addToDict(dict: Dict[K, V], k: K, v: V):
         raise Exception("An item with the same key has already been added. Key: " + str(k))
 
     dict[k] = v
+
+
+def tryGetValue(map, key, defaultValue):
+    print("tryGetValue", (map, key))
+    if key in map:
+        defaultValue.contents = map.get(key)
+        return True
+
+    return False
+
+
+def getItemFromDict(map, key):
+    if key in map:
+        return map.get(key)
+    else:
+        raise Exception(f"The given key '${key}' was not present in the dictionary.")

--- a/src/fable-library-py/fable/map_util.py
+++ b/src/fable-library-py/fable/map_util.py
@@ -20,7 +20,7 @@ def addToDict(dict: Dict[K, V], k: K, v: V):
 
 
 def tryGetValue(map, key, defaultValue):
-    print("tryGetValue", (map, key))
+    # print("tryGetValue", (map, key))
     if key in map:
         defaultValue.contents = map.get(key)
         return True

--- a/src/fable-library-py/fable/map_util.py
+++ b/src/fable-library-py/fable/map_util.py
@@ -1,9 +1,3 @@
-from typing import Dict, TypeVar
-
-K = TypeVar("K")
-V = TypeVar("V")
-
-
 def addToSet(v, set):
     if v in set:
         return False
@@ -12,11 +6,11 @@ def addToSet(v, set):
     return True
 
 
-def addToDict(dict: Dict[K, V], k: K, v: V):
+def addToDict(dict, k, v):
     if k in dict:
         raise Exception("An item with the same key has already been added. Key: " + str(k))
 
-    dict[k] = v
+    dict.set(k, v)
 
 
 def tryGetValue(map, key, defaultValue):

--- a/src/fable-library-py/fable/option.py
+++ b/src/fable-library-py/fable/option.py
@@ -5,6 +5,24 @@ class Some:
     def __init__(self, value):
         self.value = value
 
+    def __eq__(self, other):
+        if self is other:
+            return True
+
+        if other is None:
+            return False
+
+        if self.value == other.value:
+            return True
+
+        return False
+
+    def __str__(self):
+        return f"Some {self.value}"
+
+    def __repr__(self):
+        return str(self)
+
 
 def defaultArg(value, default_value):
     return option.default_arg(option.of_optional(value), default_value)

--- a/src/fable-library-py/fable/types.py
+++ b/src/fable-library-py/fable/types.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from abc import abstractstaticmethod
 from typing import Any, Generic, Iterable, List, TypeVar, Union as Union_, Callable, Optional, cast
+from .util import equals
 
 from .util import IComparable
 
@@ -91,7 +92,11 @@ def recordEquals(self, other):
     if self is other:
         return True
 
-    return False
+    for name in self.__dict__.keys():
+        if not equals(self.__dict__[name], other.__dict__[name]):
+            return False
+
+    return True
 
 
 def recordCompareTo(self, other):
@@ -106,6 +111,10 @@ def recordCompareTo(self, other):
                 return 1
 
         return 0
+
+
+def recordToString(self):
+    return "{ " + "\n  ".join(map(lambda kv: kv[0] + " = " + str(kv[1]), self.__dict__.items())) + " }"
 
 
 def recordGetHashCode(self):

--- a/src/fable-library-py/fable/util.py
+++ b/src/fable-library-py/fable/util.py
@@ -319,8 +319,6 @@ def isDisposable(x):
 
 
 def toIterator(en):
-    #print("toIterator: ", en)
-
     class Iterator:
         def __iter__(self):
             return self
@@ -332,6 +330,10 @@ def toIterator(en):
             return getattr(en, "System_Collections_IEnumerator_get_Current")()
 
     return Iterator()
+
+
+def safeHash(x):
+    return hash(x)
 
 
 def stringHash(s):

--- a/src/fable-library-py/fable/util.py
+++ b/src/fable-library-py/fable/util.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+import functools
 from threading import RLock
 from typing import Callable, Iterable, List, TypeVar, Optional
 
@@ -95,6 +96,22 @@ def compare(a, b):
     if a < b:
         return -1
     return 1
+
+
+def equalArraysWith(x, y, eq):
+    if x is None:
+        return y is None
+    if y is None:
+        return False
+
+    if len(x) != len(y):
+        return False
+
+    return eq(x, y)
+
+
+def equalArrays(x, y):
+    return equalArraysWith(x, y, equals)
 
 
 def comparePrimitives(x, y) -> int:
@@ -325,8 +342,23 @@ def numberHash(x):
     return x * 2654435761 | 0
 
 
+def combineHashCodes(hashes):
+    if not hashes:
+        return 0
+
+    return functools.reduce(lambda h1, h2: ((h1 << 5) + h1) ^ h2, hashes)
+
+
 def structuralHash(x):
     return hash(x)
+
+
+def arrayHash(xs):
+    hashes = []
+    for i, x in enumerate(xs):
+        hashes.append(structuralHash(x))
+
+    return combineHashCodes(hashes)
 
 
 def physicalHash(x):

--- a/src/fable-library-py/fable/util.py
+++ b/src/fable-library-py/fable/util.py
@@ -98,6 +98,10 @@ def compare(a, b):
     return 1
 
 
+def compareArrays(a, b):
+    return compare(a, b)
+
+
 def equalArraysWith(x, y, eq):
     if x is None:
         return y is None

--- a/src/fable-library-py/setup.py
+++ b/src/fable-library-py/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 setuptools.setup(
     name="fable-library",
-    version="0.1.0",
+    version="0.2.0",
     description="Fable library for Python",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/Python/Fable.Tests.fsproj
+++ b/tests/Python/Fable.Tests.fsproj
@@ -20,7 +20,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Util.fs" />
+    <Compile Include="TestComparison.fs" />
     <Compile Include="TestSeq.fs" />
+    <Compile Include="TestSeqExpression.fs" />
     <Compile Include="TestList.fs" />
     <Compile Include="TestMath.fs" />
     <Compile Include="TestFn.fs" />
@@ -29,11 +31,14 @@
     <Compile Include="TestReflection.fs" />
     <Compile Include="TestSet.fs" />
     <Compile Include="TestOption.fs" />
+    <Compile Include="TestResult.fs" />
+    <Compile Include="TestTupleType.fs" />
     <Compile Include="TestUnionType.fs" />
     <Compile Include="TestLoops.fs" />
     <Compile Include="TestAsync.fs" />
     <Compile Include="TestMap.fs" />
     <Compile Include="TestArray.fs" />
+    <!-- <Compile Include="TestResizeArray.fs" /> -->
     <Compile Include="TestArithmetic.fs" />
     <Compile Include="TestSudoku.fs" />
     <Compile Include="Main.fs" />

--- a/tests/Python/TestArray.fs
+++ b/tests/Python/TestArray.fs
@@ -217,3 +217,74 @@ let ``test Array.distinctBy works`` () =
     let ys = xs |> Array.distinctBy (fun x -> x % 2)
     ys |> Array.length |> equal 2
     ys |> Array.head >= 4 |> equal true
+
+[<Fact>]
+let ``test Array.distinctBy with tuples works`` () =
+      let xs = [| 4,1; 4,2; 4,3; 6,4; 6,5; 5,6; 5,7 |]
+      let ys = xs |> Array.distinctBy (fun (x,_) -> x % 2)
+      ys |> Array.length |> equal 2
+      ys |> Array.head |> fst >= 4 |> equal true
+
+// FIXME: this test currently hangs
+// [<Fact>]
+// let ``test Array distinctBy works on large array`` () =
+//     let xs = [| 0 .. 50000 |]
+//     let ys =
+//         Array.append xs xs
+//         |> Array.distinctBy(fun x -> x.ToString())
+//     ys |> equal xs
+
+[<Fact>]
+let ``test Array.sub works`` () =
+    let xs = [|0..99|]
+    let ys = Array.sub xs 5 10    // [|5; 6; 7; 8; 9; 10; 11; 12; 13; 14|]
+    ys |> Array.sum |> equal 95
+
+[<Fact>]
+let ``test Array.fill works`` () =
+    let xs = Array.zeroCreate 4   // [|0; 0; 0; 0|]
+    Array.fill xs 1 2 3           // [|0; 3; 3; 0|]
+    xs |> Array.sum |> equal 6
+
+[<Fact>]
+let ``test Array.empty works`` () =
+    let xs = Array.empty<int>
+    xs.Length |> equal 0
+
+[<Fact>]
+let ``test Array.append works`` () =
+    let xs1 = [|1; 2; 3; 4|]
+    let zs1 = Array.append [|0|] xs1
+    zs1.[0] + zs1.[1] |> equal 1
+    let xs2 = [|"a"; "b"; "c"|]
+    let zs2 = Array.append [|"x";"y"|] xs2
+    zs2.[1] + zs2.[3] |> equal "yb"
+
+[<Fact>]
+let ``test Array.average works`` () =
+    let xs = [|1.; 2.; 3.; 4.|]
+    Array.average xs
+    |> equal 2.5
+
+[<Fact>]
+let ``test Array.averageBy works`` () =
+    let xs = [|1.; 2.; 3.; 4.|]
+    Array.averageBy (fun x -> x * 2.) xs
+    |> equal 5.
+
+[<Fact>]
+let ``test Array.average works with custom types`` () =
+    [|MyNumber 1; MyNumber 2; MyNumber 3|] |> Array.average |> equal (MyNumber 2)
+
+[<Fact>]
+let ``test Array.averageBy works with custom types`` () =
+    [|{ MyNumber = MyNumber 5 }; { MyNumber = MyNumber 4 }; { MyNumber = MyNumber 3 }|]
+    |> Array.averageBy (fun x -> x.MyNumber) |> equal (MyNumber 4)
+
+[<Fact>]
+let ``test Array.choose with ints works`` () =
+    let xs = [| 1; 2; 3; 4; 5; 6; 7; 8; 9; 10 |]
+    let result = xs |> Array.choose (fun i ->
+        if i % 2 = 1 then Some i
+        else None)
+    result.Length |> equal 5

--- a/tests/Python/TestArray.fs
+++ b/tests/Python/TestArray.fs
@@ -124,3 +124,96 @@ let ``test Array slice with non-numeric arrays work`` () =
     xs.[1..2] <- [|"X";"X";"X";"X"|]
     equal xs.[2] "X"
     equal xs.[3] "D"
+
+[<Fact>]
+let ``test Array literals work`` () =
+    let x = [| 1; 2; 3; 4; 5 |]
+    equal 5 x.Length
+
+[<Fact>]
+let ``test Array indexer getter works`` () =
+    let x = [| 1.; 2.; 3.; 4.; 5. |]
+    x.[2] |> equal 3.
+
+[<Fact>]
+let ``test Array indexer setter works`` () =
+    let x = [| 1.; 2.; 3.; 4.; 5. |]
+    x.[3] <- 10.
+    equal 10. x.[3]
+
+[<Fact>]
+let ``test Array getter works`` () =
+    let x = [| 1.; 2.; 3.; 4.; 5. |]
+    Array.get x 2 |> equal 3.
+
+[<Fact>]
+let ``test Array setter works`` () =
+    let x = [| 1.; 2.; 3.; 4.; 5. |]
+    Array.set x 3 10.
+    equal 10. x.[3]
+
+[<Fact>]
+let ``test Array.Length works`` () =
+    let xs = [| 1.; 2.; 3.; 4. |]
+    xs.Length |> equal 4
+
+[<Fact>]
+let ``test Array.zeroCreate works`` () =
+    let xs = Array.zeroCreate 2
+    equal 2 xs.Length
+    equal 0 xs.[1]
+
+// See https://github.com/fable-compiler/repl/issues/96
+[<Fact>]
+let ``test Array.zeroCreate works with KeyValuePair`` () =
+    let a = Array.zeroCreate<System.Collections.Generic.KeyValuePair<float,bool>> 3
+    equal 0. a.[1].Key
+    equal false a.[2].Value
+
+[<Fact>]
+let ``test Array.create works`` () =
+    let xs = Array.create 2 5
+    equal 2 xs.Length
+    Array.sum xs |> equal 10
+
+[<Fact>]
+let ``test Array.blit works`` () =
+    let xs = [| 1..10 |]
+    let ys = Array.zeroCreate 20
+    Array.blit xs 3 ys 5 4        // [|0; 0; 0; 0; 0; 4; 5; 6; 7; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0|]
+    ys.[5] + ys.[6] + ys.[7] + ys.[8] |> equal 22
+
+[<Fact>]
+let ``test Array.blit works with non typed arrays`` () =
+    let xs = [| 'a'..'h' |] |> Array.map string
+    let ys = Array.zeroCreate 20
+    Array.blit xs 3 ys 5 4
+    ys.[5] + ys.[6] + ys.[7] + ys.[8] |> equal "defg"
+
+[<Fact>]
+let ``test Array.copy works`` () =
+    let xs = [| 1; 2; 3; 4 |]
+    let ys = Array.copy xs
+    xs.[0] <- 0                   // Ensure a deep copy
+    ys |> Array.sum |> equal 10
+
+[<Fact>]
+let ``test Array.distinct works`` () =
+    let xs = [| 1; 1; 1; 2; 2; 3; 3 |]
+    let ys = xs |> Array.distinct
+    ys |> Array.length |> equal 3
+    ys |> Array.sum |> equal 6
+
+[<Fact>]
+let ``test Array.distinct with tuples works`` () =
+    let xs = [|(1, 2); (2, 3); (1, 2)|]
+    let ys = xs |> Array.distinct
+    ys |> Array.length |> equal 2
+    ys |> Array.sumBy fst |> equal 3
+
+[<Fact>]
+let ``test Array.distinctBy works`` () =
+    let xs = [| 4; 4; 4; 6; 6; 5; 5 |]
+    let ys = xs |> Array.distinctBy (fun x -> x % 2)
+    ys |> Array.length |> equal 2
+    ys |> Array.head >= 4 |> equal true

--- a/tests/Python/TestComparison.fs
+++ b/tests/Python/TestComparison.fs
@@ -1,0 +1,309 @@
+module Fable.Tests.Comparison
+
+open System
+open Util.Testing
+open Fable.Tests.Util
+open Fable.Core.PyInterop
+open System.Collections.Generic
+open FSharp.Data.UnitSystems.SI.UnitSymbols
+
+
+type UTest = A of int | B of int
+type RTest = { a: int; b: int }
+type STest = struct val A: int; new(a: int) = { A = a }; end
+type OTest(a) = member val A = a with get, set
+
+[<CustomEquality; CustomComparison>]
+type UTest2 =
+    | String of string
+    override x.GetHashCode() = x.GetHashCode()
+    override x.Equals(yobj) =
+       match yobj with
+         | :? UTest2 as y ->
+            match x, y with
+            | String s1, String s2 -> (s1 + s1) = s2
+         | _ -> false
+    interface System.IEquatable<UTest2> with
+        member x.Equals(y) =
+            match x, y with
+            | String s1, String s2 -> (s1 + s1) = s2
+    interface System.IComparable with
+        member x.CompareTo(yobj) =
+            match yobj with
+            | :? UTest2 as y ->
+                match x, y with
+                | String s1, String s2 -> compare (s1 + s1) s2
+            | _ -> invalidArg "yobj" "cannot compare values of different types"
+
+
+exception Ex of int
+
+type MyTest(i: int) =
+    member x.Value = i
+    override x.GetHashCode() = i
+    override x.Equals(yobj) =
+       match yobj with
+         | :? MyTest as y -> y.Value + 1 = x.Value
+         | _ -> false
+    interface System.IComparable with
+        member x.CompareTo(yobj) =
+            match yobj with
+            | :? MyTest as y -> compare (y.Value + 1) x.Value
+            | _ -> invalidArg "yobj" "cannot compare values of different types"
+            // | _ -> -1
+
+    interface System.IEquatable<MyTest> with
+        member x.Equals(y) =
+            y.Value + 1 = x.Value
+
+type Status =
+| CreateScenePicture
+| ReadingOldDevice
+| CreateOldMeterReadingPicture
+| SelectingNewDevice
+| ReadingNewDevice
+| CreateNewMeterReadingPicture
+| GetSignature
+| Done
+
+type MyClass(v) =
+    member val Value: int = v with get, set
+
+[<Fact>]
+let ``test Typed array equality works`` () =
+    let xs1 = [| 1; 2; 3 |]
+    let xs2 = [| 1; 2; 3 |]
+    let xs3 = [| 1; 2; 4 |]
+    let xs4 = [| 1; 2 |]
+    equal true (xs1 = xs2)
+    equal false (xs1 = xs3)
+    equal true (xs1 <> xs3)
+    equal false (xs1 <> xs2)
+    equal true (xs1 <> xs4)
+
+[<Fact>]
+let ``test Array equality works`` () =
+    let xs1 = [| "1"; "2"; "3" |]
+    let xs2 = [| "1"; "2"; "3" |]
+    let xs3 = [| "1"; "2"; "4" |]
+    let xs4 = [| "1"; "2" |]
+    equal true (xs1 = xs2)
+    equal false (xs1 = xs3)
+    equal true (xs1 <> xs3)
+    equal false (xs1 <> xs2)
+    equal true (xs1 <> xs4)
+
+[<Fact>]
+let ``test Tuple equality works`` () =
+    let xs1 = ( 1, 2, 3 )
+    let xs2 = ( 1, 2, 3 )
+    let xs3 = ( 1, 2, 4 )
+    equal true (xs1 = xs2)
+    equal false (xs1 = xs3)
+    equal true (xs1 <> xs3)
+    equal false (xs1 <> xs2)
+
+[<Fact>]
+let ``test List equality works`` () =
+    let xs1 = [ 1; 2; 3 ]
+    let xs2 = [ 1; 2; 3 ]
+    let xs3 = [ 1; 2; 4 ]
+    equal true (xs1 = xs2)
+    equal false (xs1 = xs3)
+    equal true (xs1 <> xs3)
+    equal false (xs1 <> xs2)
+
+[<Fact>]
+let ``test Set equality works`` () =
+    let xs1 = Set [ 1; 2; 3 ]
+    let xs2 = Set [ 1; 2; 3 ]
+    let xs3 = Set [ 1; 2; 4 ]
+    let xs4 = Set [ 3; 2; 1 ]
+    let xs5 = Set [ 1; 2; 3; 1 ]
+    equal true (xs1 = xs2)
+    equal false (xs1 = xs3)
+    equal true (xs1 <> xs3)
+    equal false (xs1 <> xs2)
+    equal true (xs1 = xs4)
+    equal false (xs1 <> xs5)
+
+[<Fact>]
+let ``test Map equality works`` () =
+    let xs1 = Map [ ("a", 1); ("b", 2); ("c", 3) ]
+    let xs2 = Map [ ("a", 1); ("b", 2); ("c", 3) ]
+    let xs3 = Map [ ("a", 1); ("b", 2); ("c", 4) ]
+    let xs4 = Map [ ("c", 3); ("b", 2); ("a", 1) ]
+    equal true (xs1 = xs2)
+    equal false (xs1 = xs3)
+    equal true (xs1 <> xs3)
+    equal false (xs1 <> xs2)
+    equal true (xs1 = xs4)
+
+[<Fact>]
+let ``test Union equality works`` () =
+    let u1 = A 2
+    let u2 = A 2
+    let u3 = A 4
+    let u4 = B 2
+    equal true (u1 = u2)
+    equal false (u1 = u3)
+    equal true (u1 <> u3)
+    equal false (u1 <> u2)
+    equal false (u1 = u4)
+    Object.ReferenceEquals(u1, u1) |> equal true
+    Object.ReferenceEquals(u1, u2) |> equal false
+
+// FIXME:
+// [<Fact>]
+// let ``test Union custom equality works`` () =
+//     let u1 = String "A"
+//     let u2 = String "A"
+//     let u3 = String "AA"
+//     equal false (u1 = u2)
+//     equal true (u1 = u3)
+
+[<Fact>]
+let ``test Record equality works`` () =
+    let r1 = { a = 1; b = 2 }
+    let r2 = { a = 1; b = 2 }
+    let r3 = { a = 1; b = 4 }
+    equal true (r1 = r2)
+    equal false (r1 = r3)
+    equal true (r1 <> r3)
+    equal false (r1 <> r2)
+    Object.ReferenceEquals(r1, r1) |> equal true
+    Object.ReferenceEquals(r1, r2) |> equal false
+
+// FIXME:
+// [<Fact>]
+// let ``test Exception equality works`` () =
+//     equal true ((Ex 1) = (Ex 1))
+//     equal false ((Ex 1) = (Ex 2))
+
+[<Fact>]
+let ``test Equality with objects implementing IEquatable works`` () =
+    let c1 = MyTest(5)
+    let c2 = MyTest(4)
+    let c3 = MyTest(5)
+    equal true (c1 = c2)
+    equal false (c1 = c3)
+    equal true (c1 <> c3)
+    equal false (c1 <> c2)
+    Object.ReferenceEquals(c1, c1) |> equal true
+    Object.ReferenceEquals(c1, c2) |> equal false
+
+[<Fact>]
+let ``test Typed array comparison works`` () =
+    let xs1 = [| 1; 2; 3 |]
+    let xs2 = [| 1; 2; 3 |]
+    let xs3 = [| 1; 2; 4 |]
+    let xs4 = [| 1; 2; 2 |]
+    let xs5 = [| 1; 2 |]
+    let xs6 = [| 1; 2; 3; 1 |]
+    equal 0 (compare xs1 xs2)
+    equal -1 (compare xs1 xs3)
+    equal true (xs1 < xs3)
+    equal 1 (compare xs1 xs4)
+    equal false (xs1 < xs4)
+    equal 1 (compare xs1 xs5)
+    equal true (xs1 > xs5)
+    equal -1 (compare xs1 xs6)
+    equal false (xs1 > xs6)
+
+[<Fact>]
+let ``test Array comparison works`` () =
+    let xs1 = [| "1"; "2"; "3" |]
+    let xs2 = [| "1"; "2"; "3" |]
+    let xs3 = [| "1"; "2"; "4" |]
+    let xs4 = [| "1"; "2"; "2" |]
+    let xs5 = [| "1"; "2" |]
+    let xs6 = [| "1"; "2"; "3"; "1" |]
+    equal 0 (compare xs1 xs2)
+    equal -1 (compare xs1 xs3)
+    equal true (xs1 < xs3)
+    equal 1 (compare xs1 xs4)
+    equal false (xs1 < xs4)
+    equal 1 (compare xs1 xs5)
+    equal true (xs1 > xs5)
+    equal -1 (compare xs1 xs6)
+    equal false (xs1 > xs6)
+
+[<Fact>]
+let ``test Tuple comparison works`` () =
+    let xs1 = ( 1, 2, 3 )
+    let xs2 = ( 1, 2, 3 )
+    let xs3 = ( 1, 2, 4 )
+    let xs4 = ( 1, 2, 2 )
+    equal 0 (compare xs1 xs2)
+    equal -1 (compare xs1 xs3)
+    equal true (xs1 < xs3)
+    equal 1 (compare xs1 xs4)
+    equal false (xs1 < xs4)
+
+[<Fact>]
+let ``test List comparison works`` () =
+    let xs1 = [ 1; 2; 3 ]
+    let xs2 = [ 1; 2; 3 ]
+    let xs3 = [ 1; 2; 4 ]
+    let xs4 = [ 1; 2; 2 ]
+    let xs5 = [ 1; 2 ]
+    let xs6 = [ 1; 2; 3; 1 ]
+    equal 0 (compare xs1 xs2)
+    equal -1 (compare xs1 xs3)
+    equal true (xs1 < xs3)
+    equal 1 (compare xs1 xs4)
+    equal false (xs1 < xs4)
+    equal 1 (compare xs1 xs5)
+    equal true (xs1 > xs5)
+    equal -1 (compare xs1 xs6)
+    equal false (xs1 > xs6)
+
+// FIXME
+// [<Fact>]
+// let ``test Set comparison works`` () =
+//     let xs1 = Set [ 1; 2; 3 ]
+//     let xs2 = Set [ 1; 2; 3 ]
+//     let xs3 = Set [ 1; 2; 4 ]
+//     let xs4 = Set [ 1; 2; 2 ]
+//     let xs5 = Set [ 1; 2 ]
+//     let xs6 = Set [ 1; 2; 3; 1 ]
+//     equal 0 (compare xs1 xs2)
+//     equal -1 (compare xs1 xs3)
+//     equal true (xs1 < xs3)
+//     equal 1 (compare xs1 xs4)
+//     equal false (xs1 < xs4)
+//     equal 1 (compare xs1 xs5)
+//     equal true (xs1 > xs5)
+//     equal 0 (compare xs1 xs6)
+
+// [<Fact>]
+// let ``test Map comparison works`` () =
+//     let xs1 = Map [ ("a", 1); ("b", 2); ("c", 3) ]
+//     let xs2 = Map [ ("a", 1); ("b", 2); ("c", 3) ]
+//     let xs3 = Map [ ("a", 1); ("b", 2); ("c", 4) ]
+//     let xs4 = Map [ ("a", 1); ("b", 2); ("c", 2) ]
+//     let xs5 = Map [ ("a", 1); ("b", 2) ]
+//     let xs6 = Map [ ("a", 1); ("b", 2); ("c", 3); ("d", 1) ]
+//     equal 0 (compare xs1 xs2)
+//     equal -1 (compare xs1 xs3)
+//     equal true (xs1 < xs3)
+//     equal 1 (compare xs1 xs4)
+//     equal false (xs1 < xs4)
+//     equal 1 (compare xs1 xs5)
+//     equal true (xs1 > xs5)
+//     equal -1 (compare xs1 xs6)
+//     equal false (xs1 > xs6)
+
+[<Fact>]
+let ``test Union comparison works`` () =
+    let u1 = A 2
+    let u2 = A 2
+    let u3 = A 4
+    let u4 = A 1
+    let u5 = B 2
+    equal 0 (compare u1 u2)
+    equal -1 (compare u1 u3)
+    equal true (u1 < u3)
+    equal 1 (compare u1 u4)
+    equal false (u1 < u4)
+    (compare u1 u5) = 0 |> equal false

--- a/tests/Python/TestList.fs
+++ b/tests/Python/TestList.fs
@@ -1,6 +1,28 @@
 module Fable.Tests.List
 
 open Util.Testing
+let rec sumFirstList (zs: float list) (n: int): float =
+    match n with
+    | 0 -> 0.
+    | 1 -> zs.Head
+    | _ -> zs.Head + sumFirstList zs.Tail (n-1)
+
+type Point =
+    { x: int; y: int }
+    static member Zero = { x=0; y=0 }
+    static member Neg(p: Point) = { x = -p.x; y = -p.y }
+    static member (+) (p1, p2) = { x= p1.x + p2.x; y = p1.y + p2.y }
+
+type MyNumber =
+    | MyNumber of int
+    static member Zero = MyNumber 0
+    static member (+) (MyNumber x, MyNumber y) =
+        MyNumber(x + y)
+    static member DivideByInt (MyNumber x, i: int) =
+        MyNumber(x / i)
+
+type MyNumberWrapper =
+    { MyNumber: MyNumber }
 
 [<Fact>]
 let ``test Some [] works`` () =
@@ -298,11 +320,247 @@ let ``test List.length works II`` () =
 
 
 [<Fact>]
-let ``test List.map works`` () =
+let ``test List.item works`` () =
+    [1; 2] |> List.item 1 |> equal 2
+
+[<Fact>]
+let``test "List.map works`` () =
+    let xs = [1;2;3]
+    let ys = xs |> List.map ((*) 2)
+    equal 4 ys.Tail.Head
+
+[<Fact>]
+let ``test List.mapi works`` () =
+    let xs = [1]
+    let ys = xs |> List.mapi (fun i x -> i * x)
+    equal 0 ys.Head
+
+[<Fact>]
+let ``test List.map2 works`` () =
+    let xs = [1;2]
+    let ys = [2;3]
+    let zs = List.map2 (fun x y -> x - y) xs ys
+    equal -1 zs.Head
+
+[<Fact>]
+let ``test List.ofArray works`` () =
+    let xs = [|1; 2|]
+    let ys = List.ofArray xs
+    ys.Head |> equal 1
+
+    let xs1 = [|1.; 2.; 3.; 4.|]
+    let ys1 = List.ofArray xs1
+    sumFirstList ys1 3 |> equal 6.
+
+[<Fact>]
+let ``test List.ofSeq works`` () =
+    // let xs = [|1; 2|] :> _ seq
+    let ys = List.ofSeq <| seq { yield 1; yield 2 }
+    ys.Head |> equal 1
+    ys.Length |> equal 2
+
+[<Fact>]
+let ``test List.pick works`` () =
+    let xs = [1; 2]
+    xs |> List.pick (fun x ->
+        match x with
+        | 2 -> Some x
+        | _ -> None)
+    |> equal 2
+
+[<Fact>]
+let ``test List.reduce works`` () =
+    let xs = [1; 2]
+    xs |> List.reduce (+)
+    |> equal 3
+
+// [<Fact>]
+// let ``test List.reduceBack works`` () =
+//         let xs = [1; 2]
+//         xs |> List.reduceBack (+)
+//         |> equal 3
+
+[<Fact>]
+let ``test List.replicate works`` () =
+    List.replicate 3 3
+    |> List.sum |> equal 9
+
+[<Fact>]
+let ``test List.rev works`` () =
+    let xs = [1; 2; 3]
+    let ys = xs |> List.rev
+    equal 3 ys.Head
+
+[<Fact>]
+let ``test List.scan works`` () =
     let xs = [1; 2; 3; 4]
-    xs
-    |> List.map string
-    |> equal ["1"; "2"; "3"; "4"]
+    let ys = (0, xs) ||> List.scan (fun acc x -> acc - x)
+    ys.[3] + ys.[4]
+    |> equal -16
+
+[<Fact>]
+let ``test List.scanBack works`` () =
+    let xs = [1; 2; 3]
+    let ys = List.scanBack (fun x acc -> acc - x) xs 0
+    ys.Head + ys.Tail.Head
+    |> equal -11
+
+[<Fact>]
+let ``test List.sort works`` () =
+    let xs = [3; 4; 1; -3; 2; 10]
+    let ys = ["a"; "c"; "B"; "d"]
+    xs |> List.sort |> List.take 3 |> List.sum |> equal 0
+    ys |> List.sort |> List.item 1 |> equal "a"
+
+[<Fact>]
+let ``test List.sort with tuples works`` () =
+    let xs = [3; 1; 1; -3]
+    let ys = ["a"; "c"; "B"; "d"]
+    (xs, ys) ||> List.zip |> List.sort |> List.item 1 |> equal (1, "B")
+
+// TODO: Python sort cannot take arguments
+// [<Fact>]
+// let ``test List.sortBy works`` () =
+//     let xs = [3; 1; 4; 2]
+//     let ys = xs |> List.sortBy (fun x -> -x)
+//     ys.Head + ys.Tail.Head
+//     |> equal 7
+
+[<Fact>]
+let ``test List.sortWith works`` () =
+    let xs = [3; 4; 1; 2]
+    let ys = xs |> List.sortWith (fun x y -> int(x - y))
+    ys.Head + ys.Tail.Head
+    |> equal 3
+
+// FIXME:
+// [<Fact>]
+// let ``test List.sortDescending works`` () =
+//     let xs = [3; 4; 1; -3; 2; 10]
+//     xs |> List.sortDescending |> List.take 3 |> List.sum |> equal 17
+//     let ys = ["a"; "c"; "B"; "d"]
+//     ys |> List.sortDescending |> List.item 1 |> equal "c"
+
+[<Fact>]
+let ``test List.sortByDescending works`` () =
+    let xs = [3; 1; 4; 2]
+    let ys = xs |> List.sortByDescending (fun x -> -x)
+    ys.Head + ys.Tail.Head
+    |> equal 3
+
+[<Fact>]
+let ``test List.max works`` () =
+    let xs = [1; 2]
+    xs |> List.max
+    |> equal 2
+
+[<Fact>]
+let ``test List.maxBy works`` () =
+    let xs = [1; 2]
+    xs |> List.maxBy (fun x -> -x)
+    |> equal 1
+
+[<Fact>]
+let ``test List.min works`` () =
+    let xs = [1; 2]
+    xs |> List.min
+    |> equal 1
+
+[<Fact>]
+let ``test List.minBy works`` () =
+    let xs = [1; 2]
+    xs |> List.minBy (fun x -> -x)
+    |> equal 2
+
+[<Fact>]
+let ``test List.sum works`` () =
+    [1; 2] |> List.sum
+    |> equal 3
+
+[<Fact>]
+let ``test List.sumBy works`` () =
+    [1; 2] |> List.sumBy (fun x -> x*2)
+    |> equal 6
+
+[<Fact>]
+let ``test List.sum with non numeric types works`` () =
+  let p1 = {x=1; y=10}
+  let p2 = {x=2; y=20}
+  [p1; p2] |> List.sum |> (=) {x=3;y=30} |> equal true
+
+[<Fact>]
+let ``test List.sumBy with non numeric types works`` () =
+  let p1 = {x=1; y=10}
+  let p2 = {x=2; y=20}
+  [p1; p2] |> List.sumBy Point.Neg |> (=) {x = -3; y = -30} |> equal true
+
+[<Fact>]
+let ``test List.sumBy with numeric projection works`` () =
+  let p1 = {x=1; y=10}
+  let p2 = {x=2; y=20}
+  [p1; p2] |> List.sumBy (fun p -> p.y) |> equal 30
+
+[<Fact>]
+let ``test List.sum with non numeric types works II`` () =
+    [MyNumber 1; MyNumber 2; MyNumber 3] |> List.sum |> equal (MyNumber 6)
+
+[<Fact>]
+let ``test List.sumBy with non numeric types works II`` () =
+    [{ MyNumber = MyNumber 5 }; { MyNumber = MyNumber 4 }; { MyNumber = MyNumber 3 }]
+    |> List.sumBy (fun x -> x.MyNumber) |> equal (MyNumber 12)
+
+[<Fact>]
+let ``test List.skip works`` () =
+    let xs = [1.; 2.; 3.; 4.; 5.]
+    let ys = xs |> List.skip 1
+    ys |> List.head
+    |> equal 2.
+
+[<Fact>]
+let ``test List.skipWhile works`` () =
+    let xs = [1.; 2.; 3.; 4.; 5.]
+    xs |> List.skipWhile (fun i -> i <= 3.)
+    |> List.head
+    |> equal 4.
+
+[<Fact>]
+let ``test List.take works`` () =
+    let xs = [1.; 2.; 3.; 4.; 5.]
+    xs |> List.take 2
+    |> List.last
+    |> equal 2.
+    // List.take should throw an exception if there're not enough elements
+    try xs |> List.take 20 |> List.length with _ -> -1
+    |> equal -1
+
+[<Fact>]
+let ``test List.takeWhile works`` () =
+    let xs = [1.; 2.; 3.; 4.; 5.]
+    xs |> List.takeWhile (fun i -> i < 3.)
+    |> List.last
+    |> equal 2.
+
+[<Fact>]
+let ``test List.tail works`` () =
+    let xs = [1; 2]
+    let ys = xs |> List.tail
+    equal 1 ys.Length
+
+[<Fact>]
+let ``test List.toArray works`` () =
+    let ys = List.toArray [1; 2]
+    ys.[0] + ys.[1] |> equal 3
+    let xs = [1; 1]
+    let ys2 = List.toArray (2::xs)
+    ys2.[0] + ys2.[1] + ys2.[2] |> equal 4
+
+[<Fact>]
+let ``test List.toSeq works`` () =
+    [1; 2]
+    |> List.toSeq
+    |> Seq.tail |> Seq.head
+    |> equal 2
+
 
 
 [<Fact>]

--- a/tests/Python/TestResizeArray.fs
+++ b/tests/Python/TestResizeArray.fs
@@ -1,0 +1,304 @@
+module Fable.Tests.ResizeArrays
+
+open Util.Testing
+
+[<Fact>]
+let ``test ResizeArray zero creation works`` () =
+    let li = ResizeArray<float>()
+    equal 0 li.Count
+
+[<Fact>]
+let ``test ResizeArray zero creation with size works`` () =
+    let li = ResizeArray<string>(5)
+    equal 0 li.Count
+
+[<Fact>]
+let ``test ResizeArray creation with seq works`` () =
+    let li = ResizeArray<_>(seq{1..5})
+    Seq.sum li
+    |> equal 15
+
+[<Fact>]
+let ``test ResizeArray creation with literal array works`` () =
+    let li = ResizeArray<_> [|1;2;3;4;5|]
+    Seq.sum li
+    |> equal 15
+
+[<Fact>]
+let ``test ResizeArray creation with literal list works`` () =
+    let li = ResizeArray<_> [1;2;3;4;5]
+    Seq.sum li
+    |> equal 15
+
+[<Fact>]
+let ``test ResizeArray casting to seq works`` () =
+    let xs = ResizeArray<_>(seq{1..5}) :> seq<_>
+    Seq.sum xs
+    |> equal 15
+
+[<Fact>]
+let ``test ResizeArray iteration works`` () =
+    let li = ResizeArray<_>()
+    li.Add(1.); li.Add(2.); li.Add(3.); li.Add(4.); li.Add(5.)
+    let acc = ref 0.
+    for i in li do
+       acc := !acc + i
+    equal 15. !acc
+
+[<Fact>]
+let ``test ResizeArray iteration with index works`` () =
+    let li = ResizeArray<_>()
+    for i = 1 to 4 do
+       li.Add(i)
+    let mutable x = 0
+    for i = 0 to li.Count - 1 do
+       x <- x + li.[i]
+    equal 10 x
+
+[<Fact>]
+let ``test ResizeArray folding works`` () =
+    let li = ResizeArray<_>()
+    li.Add(1.); li.Add(2.); li.Add(3.); li.Add(4.); li.Add(5.)
+    li |> Seq.fold (fun acc item -> acc + item) 0.
+    |> equal 15.
+
+[<Fact>]
+let ``test ResizeArray.Count works`` () =
+    let li = ResizeArray<_>()
+    li.Add(1.); li.Add(2.); li.Add(3.); li.Add(4.); li.Add(5.)
+    equal 5 li.Count
+
+[<Fact>]
+let ``test ResizeArray.Find works`` () =
+    let li = ResizeArray<_>()
+    li.Add(1.); li.Add(2.); li.Add(3.); li.Add(4.); li.Add(5.)
+    System.Predicate<_> (fun x -> x = 1.)  |> li.Find |> equal 1.
+    System.Predicate<_> (fun x -> x = -1.) |> li.Find |> equal 0.
+
+[<Fact>]
+let ``test ResizeArray.Find with option works`` () =
+    let li = ResizeArray<_>()
+    li.Add(Some 1); li.Add(None);
+    System.Predicate<_> (fun _ -> true)  |> li.Find |> equal (Some 1)
+    System.Predicate<_> (fun _ -> false)  |> li.Find |> equal None
+    System.Predicate<_> Option.isNone  |> li.Find |> equal None
+    System.Predicate<_> Option.isSome  |> li.Find |> equal (Some 1)
+
+[<Fact>]
+let ``test ResizeArray.FindAll works`` () =
+    let xs = ResizeArray<_> [1.; 2.; 3.; 4.]
+    System.Predicate<_> (fun x -> x <= 3.) |> xs.FindAll |> (fun l -> l.Count) |> equal 3
+    System.Predicate<_> (fun x -> x = 5.) |> xs.FindAll |> (fun l -> l.Count) |> equal 0
+
+[<Fact>]
+let ``test ResizeArray.FindLast works`` () =
+    let li = ResizeArray<_>()
+    li.Add(1.,0.); li.Add(2.,0.); li.Add(3.,0.); li.Add(4.,0.); li.Add(5.,0.); li.Add(1.,1.)
+    System.Predicate<_> (fun (x, _) -> x = 1.)  |> li.FindLast |> snd |> equal 1.
+
+[<Fact>]
+let ``test ResizeArray.FindLast with option works`` () =
+    let li = ResizeArray<_>()
+    li.Add(Some 1); li.Add(None);
+    System.Predicate<_> (fun _ -> true)  |> li.FindLast |> equal None
+    System.Predicate<_> (fun _ -> false)  |> li.FindLast |> equal None
+    System.Predicate<_> Option.isSome  |> li.FindLast |> equal (Some 1)
+
+[<Fact>]
+let ``test ResizeArray.FindIndex works`` () =
+    let li = ResizeArray<_>()
+    li.Add(1.); li.Add(2.); li.Add(3.); li.Add(2.); li.Add(5.)
+    System.Predicate<_> (fun x -> x = 2.) |> li.FindIndex |> equal 1
+    System.Predicate<_> (fun x -> x = 0.) |> li.FindIndex |> equal -1
+
+[<Fact>]
+let ``test ResizeArray.FindLastIndex works`` () =
+    let li = ResizeArray<_>()
+    li.Add(1.); li.Add(2.); li.Add(3.); li.Add(2.); li.Add(5.)
+    System.Predicate<_> (fun x -> x = 2.) |> li.FindLastIndex |> equal 3
+    System.Predicate<_> (fun x -> x = 0.) |> li.FindLastIndex |> equal -1
+
+[<Fact>]
+let ``test ResizeArray.ForEach works`` () =
+    let li = ResizeArray<_>()
+    let mutable sum = 0
+    li.Add(1); li.Add(2); li.Add(3); li.Add(4); li.Add(5)
+    System.Action<_> (fun x -> sum <- sum + x) |> li.ForEach
+    sum |> equal 15
+
+[<Fact>]
+let ``test ResizeArray indexer getter works`` () =
+    let li = ResizeArray<_>()
+    li.Add(1.); li.Add(2.); li.Add(3.); li.Add(4.); li.Add(5.)
+    equal 2. li.[1]
+
+[<Fact>]
+let ``test ResizeArray indexer setter works`` () =
+    let li = ResizeArray<_>()
+    li.Add(1.); li.Add(2.); li.Add(3.); li.Add(4.); li.Add(5.)
+    li.[3] <- 10.
+    equal 10. li.[3]
+
+[<Fact>]
+let ``test ResizeArray.Clear works`` () =
+    let li = ResizeArray<_>()
+    li.Add(1.); li.Add(2.); li.Add(3.); li.Add(4.); li.Add(5.)
+    li.Clear()
+    equal 0 li.Count
+
+[<Fact>]
+let ``test ResizeArray.Add works`` () =
+    let li = ResizeArray<_>()
+    li.Add(1.); li.Add(2.); li.Add(3.); li.Add(4.); li.Add(5.)
+    li.Add(6.)
+    equal 6 li.Count
+
+[<Fact>]
+let ``test ResizeArray.AddRange works`` () =
+    let li = ResizeArray<_>()
+    li.AddRange [1;2;3]
+    equal 3 li.Count
+
+[<Fact>]
+let ``test ResizeArray.InsertRange works`` () =
+    let li = ResizeArray<_>()
+    let mutable sum = 0
+    li.Add(1); li.Add(2); li.Add(5)
+    li.InsertRange(2, [3;4])
+    Seq.toList li |> equal [1;2;3;4;5]
+
+[<Fact>]
+let ``test ResizeArray.GetRange works`` () =
+    let li = ResizeArray<_>()
+    li.AddRange [1;2;3]
+    let sub = li.GetRange(1, 2)
+    sub.Count |> equal 2
+    sub.Contains(1) |> equal false
+
+[<Fact>]
+let ``test ResizeArray.Contains works`` () =
+    let li = ResizeArray<_>()
+    li.Add("ab")
+    li.Add("ch")
+    li.Contains("ab") |> equal true
+    li.Contains("cd") |> equal false
+
+[<Fact>]
+let ``test ResizeArray.IndexOf works`` () =
+    let li = ResizeArray<_>()
+    li.Add("ch")
+    li.Add("ab")
+    li.IndexOf("ab") |> equal 1
+    li.IndexOf("cd") |> equal -1
+
+[<Fact>]
+let ``test ResizeArray.Remove works`` () =
+    let li = ResizeArray<_>()
+    li.Add("ab")
+    li.Add("ch")
+    li.Remove("ab") |> equal true
+    li.Remove("cd") |> equal false
+
+[<Fact>]
+let ``test ResizeArray.RemoveAll works`` () =
+    let li = ResizeArray<_>()
+    li.Add("ab")
+    li.Add("ch")
+    li.Add("ab")
+    System.Predicate<_> (fun x -> x = "ab") |> li.RemoveAll |> equal 2
+    System.Predicate<_> (fun x -> x = "ab") |> li.RemoveAll |> equal 0
+    li.[0] |> equal "ch"
+
+[<Fact>]
+let ``test ResizeArray.RemoveRange works`` () =
+    let xs = ResizeArray<int>()
+    for x in [1 .. 5] do xs.Add(x)
+    xs.RemoveRange(1, 2) // [1;2;3;4;5] -> [1;4;5]
+    equal 1 xs.[0]
+    equal 4 xs.[1]
+    equal 5 xs.[2]
+
+[<Fact>]
+let ``test ResizeArray.Exists works`` () =
+    let xs = ResizeArray<int>()
+    for x in [1 .. 5] do xs.Add(x)
+    xs.Exists (fun a -> a > 5) |> equal false
+    xs.Exists (fun a -> a = 5) |> equal true
+    xs.Exists (fun a -> a > 1) |> equal true
+    xs.Exists (fun a -> a = 1) |> equal true
+    xs.Exists (fun a -> a < 1) |> equal false
+    xs.Exists (fun a -> a = 3) |> equal true
+
+[<Fact>]
+let ``test ResizeArray.RemoveAt works`` () =
+    let li = ResizeArray<_>()
+    li.Add(1.); li.Add(2.); li.Add(3.); li.Add(4.); li.Add(5.)
+    li.RemoveAt(2)
+    equal 4. li.[2]
+
+[<Fact>]
+let ``test ResizeArray.Insert works`` () =
+    let li = ResizeArray<_>()
+    li.Add(1.); li.Add(2.); li.Add(3.); li.Add(4.); li.Add(5.)
+    li.Insert(2, 8.)
+    equal 8. li.[2]
+
+[<Fact>]
+let ``test ResizeArray.ReverseInPlace works`` () =
+    let li = ResizeArray<_>()
+    li.Add(1.); li.Add(2.); li.Add(3.); li.Add(4.); li.Add(5.)
+    li.Reverse()
+    equal 2. li.[3]
+
+[<Fact>]
+let ``test ResizeArray.SortInPlace works`` () =
+    let li = ResizeArray<_>()
+    li.Add("Ana"); li.Add("Pedro"); li.Add("Lucía"); li.Add("Paco")
+    li.Sort()
+    equal "Paco" li.[2]
+    let li2 = ResizeArray [1;3;10;2]
+    li2.Sort()
+    equal 2 li2.[1]
+
+[<Fact>]
+let ``test ResizeArray.SortInPlaceWith works`` () =
+    let li = ResizeArray<_>()
+    li.Add(3.); li.Add(6.); li.Add(5.); li.Add(4.); li.Add(8.)
+    li.Sort(fun x y -> if x > y then -1 elif x < y then 1 else 0)
+    equal 4. li.[3]
+
+[<Fact>]
+let ``test ResizeArray.SortInPlaceWith works with custom comparison function`` () =
+    let ns = ResizeArray<int> [1;3;2]
+    ns.Sort(fun x y -> if x < y then 1 else -1)
+    Seq.toList ns |> equal [3; 2; 1]
+    ns.Sort(compare)
+    Seq.toList ns |> equal [1;2;3]
+
+[<Fact>]
+let ``test ResizeArray.SortInPlaceWith works with custom comparer`` () =
+    let ns = ResizeArray<int> [1;3;2]
+    let comparer = System.Collections.Generic.Comparer<int>.Default
+    ns.Sort(comparer)
+    Seq.toList ns |> equal [1;2;3]
+
+[<Fact>]
+let ``test ResizeArray.ToArray works`` () =
+    let li = ResizeArray<_>()
+    li.Add(3.); li.Add(6.); li.Add(5.); li.Add(4.); li.Add(8.)
+    equal 5 li.Count
+    let ar = li.ToArray()
+    Array.length ar |> equal li.Count
+    ar.[0] <- 2.
+    equal 3. li.[0]
+    equal 2. ar.[0]
+
+[<Fact>]
+let ``test ResizeArray.Item is undefined when index is out of range`` () =
+    let xs = ResizeArray [0]
+    #if FABLE_COMPILER
+    isNull <| box (xs.Item 1)
+    #else
+    try (xs.Item 1) |> ignore; false with _ -> true
+    #endif
+    |> equal true

--- a/tests/Python/TestResult.fs
+++ b/tests/Python/TestResult.fs
@@ -1,0 +1,53 @@
+module Fable.Tests.Result
+
+open Util.Testing
+
+type Foo =
+    | Foo of Result<int, string>
+
+let foo (a: Foo): bool =
+    match a with
+    | Foo(Ok(_)) -> true
+    | _ -> false
+
+[<Fact>]
+let ``test constructors can be generated`` () =
+    let ok = Ok 10
+    Ok 10 |> equal ok
+
+    let error = Error 10
+    Error 10 |> equal error
+
+[<Fact>]
+let ``test pattern matching works`` () =
+    let ok = Ok "foo"
+    match ok with
+    | Ok x -> Some x
+    | Error _ -> None
+    |> equal (Some "foo")
+
+    let error = Error 10
+    match Error 10 with
+    | Ok _ -> None
+    | Error y -> Some y
+    |> equal (Some 10)
+
+[<Fact>]
+let ``test map function can be generated`` () =
+    let f = (+) 1
+    Ok 9 |> Result.map f |> equal (Ok 10)
+
+[<Fact>]
+let ``test mapError function can be generated`` () =
+    let f = (+) 1
+    Error 9 |> Result.mapError f |> equal (Error 10)
+
+[<Fact>]
+let ``test bind function can be generated`` () =
+    let f = Error
+    Ok 10 |> Result.bind f |> equal (Error 10)
+
+[<Fact>]
+let ``test Nesting Result in pattern matching works`` () =
+    Ok 5 |> Foo |> foo |> equal true
+    Error "error" |> Foo |> foo |> equal false

--- a/tests/Python/TestSeq.fs
+++ b/tests/Python/TestSeq.fs
@@ -13,6 +13,23 @@ let rec sumFirstSeq (zs: seq<float>) (n: int): float =
    | 1 -> Seq.head zs
    | _ -> (Seq.head zs) + sumFirstSeq (Seq.skip 1 zs) (n-1)
 
+type Point =
+    { x: int; y: int }
+    static member Zero = { x=0; y=0 }
+    static member Neg(p: Point) = { x = -p.x; y = -p.y }
+    static member (+) (p1, p2) = { x= p1.x + p2.x; y = p1.y + p2.y }
+
+type MyNumber =
+    | MyNumber of int
+    static member Zero = MyNumber 0
+    static member (+) (MyNumber x, MyNumber y) =
+        MyNumber(x + y)
+    static member DivideByInt (MyNumber x, i: int) =
+        MyNumber(x / i)
+
+type MyNumberWrapper =
+    { MyNumber: MyNumber }
+
 [<Fact>]
 let ``test Seq.empty works`` () =
     let xs = Seq.empty<int>
@@ -79,3 +96,679 @@ let ``test Seq.collect works with Options`` () =
     }
     |> Seq.length
     |> equal 4
+
+[<Fact>]
+let ``test Seq.chunkBySize works`` () =
+    seq {1..8} |> Seq.chunkBySize 4 |> Seq.toList |> equal [ [|1..4|]; [|5..8|] ]
+    seq {1..10} |> Seq.chunkBySize 4 |> Seq.toList |> equal [ [|1..4|]; [|5..8|]; [|9..10|] ]
+
+[<Fact>]
+let ``test Seq.exists works`` () =
+    let xs = [1.; 2.; 3.; 4.]
+    xs |> Seq.exists (fun x -> x = 2.)
+    |> equal true
+
+[<Fact>]
+let ``test Seq.exists2 works`` () =
+    let xs = [1.; 2.; 3.; 4.]
+    let ys = [1.; 2.; 3.; 4.]
+    Seq.exists2 (fun x y -> x * y = 16.) xs ys
+    |> equal true
+
+[<Fact>]
+let ``test Seq.filter works`` () =
+    let xs = [1.; 2.; 3.; 4.]
+    let ys = xs |> Seq.filter (fun x -> x > 5.)
+    ys |> Seq.isEmpty
+    |> equal true
+
+[<Fact>]
+let ``test Seq.find works`` () =
+    let xs = [1.; 2.; 3.; 4.]
+    xs |> Seq.find ((=) 2.)
+    |> equal 2.
+
+[<Fact>]
+let ``test Seq.findIndex works`` () =
+    let xs = [1.; 2.; 3.; 4.]
+    xs |> Seq.findIndex ((=) 2.)
+
+[<Fact>]
+let ``test Seq.findBack works`` () =
+    let xs = [1.; 2.; 3.; 4.]
+    xs |> Seq.find ((>) 4.) |> equal 1.
+    xs |> Seq.findBack ((>) 4.) |> equal 3.
+
+[<Fact>]
+let ``test Seq.findBack with option works`` () =
+    let xs = [Some 1.; None]
+    xs |> Seq.find Option.isSome |> equal (Some(1.))
+    xs |> Seq.find Option.isSome |> (fun v -> v.Value) |> equal 1.
+    xs |> Seq.findBack Option.isNone |> equal None
+
+[<Fact>]
+let ``test Seq.findIndexBack works`` () =
+    let xs = [1.; 2.; 3.; 4.]
+    xs |> Seq.findIndex ((>) 4.) |> equal 0
+    xs |> Seq.findIndexBack ((>) 4.) |> equal 2
+
+[<Fact>]
+let ``test Seq.tryFindBack works`` () =
+    let xs = [1.; 2.; 3.; 4.]
+    xs |> Seq.tryFind ((>) 4.) |> equal (Some 1.)
+    xs |> Seq.tryFindBack ((>) 4.) |> equal (Some 3.)
+    xs |> Seq.tryFindBack ((=) 5.) |> equal None
+
+[<Fact>]
+let ``test Seq.tryFindBack with option works`` () =
+    let xs = [Some 1.; None]
+    xs |> Seq.tryFind Option.isSome |> equal (Some(Some 1.))
+    xs |> Seq.tryFind Option.isSome |> (fun v -> v.Value.Value) |> equal 1.
+    xs |> Seq.tryFindBack Option.isNone |> equal (Some None)
+    xs |> Seq.tryFindBack Option.isNone |> (fun v -> v.Value) |>  equal None
+    xs |> Seq.tryFindBack (fun v -> match v with Some v -> v = 2. | _ -> false) |> equal None
+
+[<Fact>]
+let ``test Seq.tryFindIndexBack works`` () =
+    let xs = [1.; 2.; 3.; 4.]
+    xs |> Seq.tryFindIndex ((>) 4.) |> equal (Some 0)
+    xs |> Seq.tryFindIndexBack ((>) 4.) |> equal (Some 2)
+    xs |> Seq.tryFindIndexBack ((=) 5.) |> equal None
+
+[<Fact>]
+let ``test Seq.fold works`` () =
+    let xs = [1.; 2.; 3.; 4.]
+    let total = xs |> Seq.fold (+) 0.
+    total |> equal 10.
+
+[<Fact>]
+let ``test Seq.fold with tupled arguments works`` () =
+    let a, b =
+        ((1, 5), [1;2;3;4])
+        ||> Seq.fold (fun (a, b) i ->
+            a * i, b + i)
+    equal 24 a
+    equal 15 b
+
+[<Fact>]
+let ``test Seq.forall works`` () =
+    let xs = [1.; 2.; 3.; 4.]
+    Seq.forall (fun x -> x < 5.) xs
+    |> equal true
+
+[<Fact>]
+let ``test Seq.forall2 works`` () =
+    let xs = [1.; 2.; 3.; 4.]
+    let ys = [1.; 2.; 3.; 4.]
+    Seq.forall2 (=) xs ys
+    |> equal true
+
+[<Fact>]
+let ``test Seq.forall is lazy`` () =
+    let mutable x = ""
+    let one() = x <- "one"; false
+    let two() = x <- "two"; true
+    let ok =
+        [one; two]
+        |> Seq.map (fun c -> c())
+        |> Seq.forall id
+    ok |> equal false
+    x |> equal "one"
+
+[<Fact>]
+let ``test Seq.head works`` () =
+    let xs = [1.; 2.; 3.; 4.]
+    Seq.head xs
+    |> equal 1.
+
+[<Fact>]
+let ``test Seq.head with option works`` () =
+    let xs = [Some 1.; None]
+    Seq.head xs |> equal (Some 1.)
+    Seq.head xs |> (fun v -> v.Value) |> equal 1.
+    let xs = [None; Some 1.]
+    Seq.head xs |> equal None
+
+[<Fact>]
+let ``test Seq.tryHead works`` () =
+    let xs = [1.; 2.; 3.; 4.]
+    Seq.tryHead xs |> equal (Some 1.)
+    Seq.tryHead [] |> equal None
+
+[<Fact>]
+let ``test Seq.tryHead with option works`` () =
+    let xs = [Some 1.; None]
+    Seq.tryHead xs |> equal (Some(Some 1.))
+    Seq.tryHead xs |> (fun v -> v.Value.Value) |> equal 1.
+    let xs = [None; Some 1.]
+    Seq.tryHead xs |> equal (Some(None))
+    Seq.tryHead xs |> (fun v -> v.Value) |> equal None
+
+[<Fact>]
+let ``test Seq.tail works`` () =
+    let xs = [1.; 2.; 3.; 4.]
+    Seq.tail xs |> Seq.length |> equal 3
+
+[<Fact>]
+let ``test Seq.init works`` () =
+    let xs = Seq.init 4 float
+    sumFirstTwo xs
+    |> equal 1.
+
+[<Fact>]
+let ``test Seq.isEmpty works`` () =
+    let xs = [1]
+    Seq.isEmpty xs |> equal false
+    Seq.isEmpty [] |> equal true
+
+[<Fact>]
+let ``test Seq.iter works`` () =
+    let xs = [1.; 2.; 3.; 4.]
+    let total = ref 0.
+    xs |> Seq.iter (fun x ->
+       total := !total + x
+    )
+    !total |> equal 10.
+
+[<Fact>]
+let ``test Seq.iter2 works`` () =
+    let xs = [1.; 2.; 3.; 4.]
+    let total = ref 0.
+    Seq.iter2 (fun x y ->
+       total := !total + x + y
+    ) xs xs
+    !total |> equal 20.
+
+[<Fact>]
+let ``test Seq.iteri works`` () =
+    let xs = [1.; 2.; 3.; 4.]
+    let total = ref 0.
+    xs |> Seq.iteri (fun i x ->
+       total := !total + (float i) * x
+    )
+    !total |> equal 20.
+
+[<Fact>]
+let ``test Seq.map works II`` () =
+    let xs = [1.]
+    let ys = xs |> Seq.map ((*) 2.)
+    ys |> Seq.head
+    |> equal 2.
+
+[<Fact>]
+let ``test Seq.map2 works`` () =
+    let xs = [1.]
+    let ys = [2.]
+    let zs = Seq.map2 (*) xs ys
+    zs |> Seq.head
+    |> equal 2.
+
+[<Fact>]
+let ``test Seq.mapi works`` () =
+    let xs = [1.]
+    let ys = xs |> Seq.mapi (fun i x -> float i + x)
+    ys |> Seq.head
+    |> equal 1.
+
+[<Fact>]
+let ``test Seq.indexed works`` () =
+    let xs = seq { "a"; "b"; "c" } |> Seq.indexed
+    let x = xs |> Seq.tail |> Seq.head
+    fst x |> equal 1
+    snd x |> equal "b"
+
+[<Fact>]
+let ``test Seq.mapFold works`` () =
+    let xs = [1y; 2y; 3y; 4y]
+    let result = xs |> Seq.mapFold (fun acc x -> (x * 2y, acc + x)) 0y
+    fst result |> Seq.sum |> equal 20y
+    snd result |> equal 10y
+
+[<Fact>]
+let ``test Seq.mapFoldBack works`` () =
+    let xs = [1.; 2.; 3.; 4.]
+    let result = Seq.mapFoldBack (fun x acc -> (x * -2., acc - x)) xs 0.
+    fst result |> Seq.sum |> equal -20.
+    snd result |> equal -10.
+
+[<Fact>]
+let ``test Seq.max works`` () =
+    let xs = [1.; 2.]
+    xs |> Seq.max
+    |> equal 2.
+
+[<Fact>]
+let ``test Seq.maxBy works`` () =
+    let xs = [1.; 2.]
+    xs |> Seq.maxBy (fun x -> -x)
+    |> equal 1.
+
+[<Fact>]
+let ``test Seq.min works`` () =
+    let xs = [1.; 2.]
+    xs |> Seq.min
+    |> equal 1.
+
+[<Fact>]
+let ``test Seq.minBy works`` () =
+    let xs = [1.; 2.]
+    xs |> Seq.minBy (fun x -> -x)
+    |> equal 2.
+
+[<Fact>]
+let ``test Seq.max with non numeric types works`` () =
+    let p1 = {x=1; y=1}
+    let p2 = {x=2; y=2}
+    [p1; p2] |> Seq.max |> equal p2
+
+[<Fact>]
+let ``test Seq.maxBy with non numeric types works`` () =
+    let p1 = {x=1; y=1}
+    let p2 = {x=2; y=2}
+    [p1; p2] |> Seq.maxBy Point.Neg |> equal p1
+
+[<Fact>]
+let ``test Seq.min with non numeric types works`` () =
+    let p1 = {x=1; y=1}
+    let p2 = {x=2; y=2}
+    [p1; p2] |> Seq.min |> equal p1
+
+[<Fact>]
+let ``test Seq.minBy with non numeric types works`` () =
+    let p1 = {x=1; y=1}
+    let p2 = {x=2; y=2}
+    [p1; p2] |> Seq.minBy Point.Neg |> equal p2
+
+[<Fact>]
+let ``test Seq.maxBy with numeric projection works`` () =
+    let p1 = {x=1; y=2}
+    let p2 = {x=2; y=1}
+    [p1; p2] |> Seq.maxBy (fun p -> p.y) |> equal p1
+
+[<Fact>]
+let ``test Seq.minBy with numeric projection works`` () =
+    let p1 = {x=1; y=2}
+    let p2 = {x=2; y=1}
+    [p1; p2] |> Seq.minBy (fun p -> p.y) |> equal p2
+
+[<Fact>]
+let ``test Seq.sum works`` () =
+    let xs = [1.; 2.]
+    xs |> Seq.sum
+    |> equal 3.
+
+[<Fact>]
+let ``test Seq.sumBy works`` () =
+    let xs = [1.; 2.]
+    xs |> Seq.sumBy ((*) 2.)
+    |> equal 6.
+
+[<Fact>]
+let ``test Seq.sum with non numeric types works`` () =
+    let p1 = {x=1; y=10}
+    let p2 = {x=2; y=20}
+    [p1; p2] |> Seq.sum |> (=) {x=3;y=30} |> equal true
+
+[<Fact>]
+let ``test Seq.sumBy with non numeric types works`` () =
+    let p1 = {x=1; y=10}
+    let p2 = {x=2; y=20}
+    [p1; p2] |> Seq.sumBy Point.Neg |> (=) {x = -3; y = -30} |> equal true
+
+[<Fact>]
+let ``test Seq.sumBy with numeric projection works`` () =
+    let p1 = {x=1; y=10}
+    let p2 = {x=2; y=20}
+    [p1; p2] |> Seq.sumBy (fun p -> p.y) |> equal 30
+
+[<Fact>]
+let ``test Seq.sum with non numeric types works II`` () =
+    seq {MyNumber 1; MyNumber 2; MyNumber 3}
+    |> Seq.sum |> equal (MyNumber 6)
+
+[<Fact>]
+let ``test Seq.sumBy with non numeric types works II`` () =
+    seq {{ MyNumber = MyNumber 5 }; { MyNumber = MyNumber 4 }; { MyNumber = MyNumber 3 }}
+    |> Seq.sumBy (fun x -> x.MyNumber) |> equal (MyNumber 12)
+
+[<Fact>]
+let ``test Seq.item works`` () =
+    let xs = [1.; 2.]
+    Seq.item 1 xs
+    |> equal 2.
+
+[<Fact>]
+let ``test Seq.tryItem works`` () =
+    let xs = [1.; 2.; 3.; 4.]
+    Seq.tryItem 3 xs |> equal (Some 4.)
+    Seq.tryItem 4 xs |> equal None
+    Seq.tryItem -1 xs |> equal None
+
+[<Fact>]
+let ``test Seq.ofArray works`` () =
+    let xs = [|1.; 2.|]
+    let ys = Seq.ofArray xs
+    ys |> Seq.head
+    |> equal 1.
+
+[<Fact>]
+let ``test Seq.ofList works`` () =
+    let xs = [1.; 2.]
+    let ys = Seq.ofList xs
+    ys |> Seq.head
+    |> equal 1.
+
+[<Fact>]
+let ``test Seq.pick works`` () =
+    let xs = [1.; 2.]
+    xs |> Seq.pick (fun x ->
+       match x with
+       | 2. -> Some x
+       | _ -> None)
+    |> equal 2.
+
+[<Fact>]
+let ``test Seq.range works`` () =
+    seq{1..5}
+    |> Seq.reduce (+)
+    |> equal 15
+
+    seq{1. .. 5.}
+    |> Seq.reduce (+)
+    |> equal 15.
+
+[<Fact>]
+let ``test Seq.range step works`` () =
+    seq{0..2..9}
+    |> Seq.reduce (+)
+    |> equal 20
+
+    seq{0. .. 2. .. 9.}
+    |> Seq.reduce (+)
+    |> equal 20.
+
+    seq{9 .. -2 .. 0}
+    |> Seq.reduce (+)
+    |> equal 25
+
+[<Fact>]
+let ``test Seq.range works with chars`` () =
+    seq{'a' .. 'f'}
+    |> Seq.toArray
+    |> System.String
+    |> equal "abcdef"
+
+    seq{'z' .. 'a'}
+    |> Seq.length
+    |> equal 0
+
+[<Fact>]
+let ``test Seq.range works with long`` () =
+    seq{1L..5L}
+    |> Seq.reduce (+)
+    |> equal 15L
+
+    seq{1UL .. 5UL}
+    |> Seq.reduce (+)
+    |> equal 15UL
+
+[<Fact>]
+let ``test Seq.range step works with long`` () =
+    seq{0L..2L..9L}
+    |> Seq.reduce (+)
+    |> equal 20L
+
+    seq{0UL..2UL..9UL}
+    |> Seq.reduce (+)
+    |> equal 20UL
+
+[<Fact>]
+let ``test Seq.range works with decimal`` () =
+    seq{1M .. 50M}
+    |> Seq.reduce (+)
+    |> equal 1275M
+
+[<Fact>]
+let ``test Seq.range step works with decimal`` () =
+    seq {-3M .. -0.4359698987M .. -50M}
+    |> Seq.reduce (+)
+    |> equal -2843.0340746886M
+
+[<Fact>]
+let ``test Seq.range works with bigint`` () =
+    seq{1I..2000I}
+    |> Seq.reduce (+)
+    |> equal 2001000I
+
+[<Fact>]
+let ``test Seq.range step works with bigint`` () =
+    seq {1I .. 10000000000000I .. 20000000000000000I}
+    |> Seq.reduce (+)
+    |> equal 19990000000000002000I
+
+[<Fact>]
+let ``test Seq.reduce works`` () =
+    let xs = [1.; 2.]
+    xs |> Seq.reduce (+)
+    |> equal 3.
+
+[<Fact>]
+let ``test Seq.scan works`` () =
+    let xs = [1.; 2.; 3.; 4.]
+    let ys = xs |> Seq.scan (+) 0.
+    sumFirstTwo ys |> equal 1.
+
+[<Fact>]
+let ``test Seq.scan works with empty input`` () =
+    let xs = Seq.empty
+    let ys = xs |> Seq.scan (+) 3
+    Seq.head ys |> equal 3
+    Seq.length ys |> equal 1
+
+[<Fact>]
+let ``test Seq.sort works`` () =
+    let xs = [3.; 4.; 1.; -3.; 2.; 10.] |> List.toSeq
+    let ys = ["a"; "c"; "B"; "d"] |> List.toSeq
+    xs |> Seq.sort |> Seq.take 3 |> Seq.sum |> equal 0.
+    ys |> Seq.sort |> Seq.item 1 |> equal "a"
+
+[<Fact>]
+let ``test Seq.sort with tuples works`` () =
+    let xs = seq {3; 1; 1; -3}
+    let ys = seq {"a"; "c"; "B"; "d"}
+    (xs, ys) ||> Seq.zip |> Seq.sort |> Seq.item 1 |> equal (1, "B")
+
+// FIXME:
+//[<Fact>]
+// let ``test Seq.sortDescending works`` () =
+//     let xs = [3.; 4.; 1.; -3.; 2.; 10.] |> List.toSeq
+//     xs |> Seq.sortDescending |> Seq.take 3 |> Seq.sum |> equal 17.
+//     let ys = ["a"; "c"; "B"; "d"] |> List.toSeq
+//     ys |> Seq.sortDescending |> Seq.item 1 |> equal "c"
+
+// FIXME:
+// [<Fact>]
+// let ``test Seq.sortBy works`` () =
+//     let xs = [3.; 1.; 4.; 2.]
+//     let ys = xs |> Seq.sortBy (fun x -> -x)
+//     sumFirstTwo ys
+//     |> equal 7.
+
+[<Fact>]
+let ``test Seq.sortByDescending works`` () =
+    let xs = [3.; 1.; 4.; 2.]
+    let ys = xs |> Seq.sortByDescending (fun x -> -x)
+    sumFirstTwo ys
+    |> equal 3.
+
+[<Fact>]
+let ``test Seq.skip works`` () =
+    let xs = [1.; 2.; 3.]
+    let ys = xs |> Seq.skip 1
+    ys |> Seq.head
+    |> equal 2.
+
+[<Fact>]
+let ``test Seq.skip fails when there're not enough elements`` () =
+    let error, xs = ref false, [|1;2;3;4;5|]
+    try
+        Seq.skip 5 xs |> Seq.length |> equal 0
+    with _ -> error := true
+    equal false !error
+    try
+        Seq.skip 6 xs |> Seq.length |> equal 0
+    with _ -> error := true
+    equal true !error
+
+[<Fact>]
+let ``test Seq.toArray works`` () =
+    let xs = [1.; 2.; 3.]
+    let ys = xs |> Seq.toArray
+    ys.[0] + ys.[1]
+    |> equal 3.
+
+[<Fact>]
+let ``test Seq.toList works`` () =
+    let xs = [1.; 2.; 3.]
+    let ys = xs |> Seq.toList
+    ys.Head + ys.Tail.Head
+    |> equal 3.
+
+[<Fact>]
+let ``test Seq.tryFind works`` () =
+    [1.; 2.]
+    |> Seq.tryFind ((=) 1.)
+    |> Option.isSome
+    |> equal true
+    [1.; 2.] |> Seq.tryFind ((=) 5.) |> equal None
+
+[<Fact>]
+let ``test Seq.tryFindIndex works`` () =
+    [1.; 2.]
+    |> Seq.tryFindIndex ((=) 2.)
+    |> Option.get
+    |> equal 1
+    [1.; 2.] |> Seq.tryFindIndex ((=) 5.) |> equal None
+
+[<Fact>]
+let ``test Seq.tryPick works`` () =
+    let xs = [1.; 2.]
+    let r = xs |> Seq.tryPick (fun x ->
+       match x with
+       | 2. -> Some x
+       | _ -> None)
+    match r with
+    | Some x -> x
+    | None -> 0.
+    |> equal 2.
+
+[<Fact>]
+let ``test Seq.zip works`` () =
+    let xs = [1.; 2.; 3.]
+    let ys = [1.; 2.; 3.]
+    let zs = Seq.zip xs ys
+    let x, y = zs |> Seq.head
+    x + y
+    |> equal 2.
+
+[<Fact>]
+let ``test Seq.zip3 works`` () =
+    let xs = [1.; 2.; 3.]
+    let ys = [1.; 2.; 3.]
+    let zs = [1.; 2.; 3.]
+    let ks = Seq.zip3 xs ys zs
+    let x, y, z = ks |> Seq.head
+    x + y + z
+    |> equal 3.
+
+[<Fact>]
+let ``test Seq.cache works`` () =
+     let count = ref 0
+     let xs =
+        1 |> Seq.unfold(fun i ->
+           count := !count + 1
+           if i <= 10 then Some(i, i+1)
+           else None)
+           |> Seq.cache
+     xs |> Seq.length |> ignore
+     xs |> Seq.length |> ignore
+     !count
+     |> equal 11
+
+[<Fact>]
+let ``test Seq.cast works`` () =
+    let xs = [box 1; box 2; box 3]
+    let ys = Seq.cast<int> xs
+    ys |> Seq.head |> equal 1
+
+[<Fact>]
+let ``test Seq.compareWith works`` () =
+    let xs = [1; 2; 3; 4]
+    let ys = [1; 2; 3; 5]
+    let zs = [1; 2; 3; 3]
+    Seq.compareWith (-) xs xs |> equal 0
+    Seq.compareWith (-) xs ys |> equal -1
+    Seq.compareWith (-) xs zs |> equal 1
+
+// FIXME:
+//[<Fact>]
+// let ``test Seq.countBy works`` () =
+//     let xs = [1; 2; 3; 4]
+//     let ys = xs |> Seq.countBy (fun x -> x % 2)
+//     ys |> Seq.length |> equal 2
+
+[<Fact>]
+let ``test Seq.distinct works`` () =
+    let xs = [1; 1; 1; 2; 2; 3; 3]
+    let ys = xs |> Seq.distinct
+    ys |> Seq.length |> equal 3
+    ys |> Seq.sum |> equal 6
+
+[<Fact>]
+let ``test Seq.distinct with tuples works`` () =
+    let xs = [(1, 2); (2, 3); (1, 2)]
+    let ys = xs |> Seq.distinct
+    ys |> Seq.length |> equal 2
+    ys |> Seq.sumBy fst |> equal 3
+
+[<Fact>]
+let ``test Seq.distinctBy works`` () =
+    let xs = [4; 4; 4; 6; 6; 5; 5]
+    let ys = xs |> Seq.distinctBy (fun x -> x % 2)
+    ys |> Seq.length |> equal 2
+    ys |> Seq.head >= 4 |> equal true
+
+[<Fact>]
+let ``test Seq.distinctBy with tuples works`` () =
+    let xs = [4,1; 4,2; 4,3; 6,4; 6,5; 5,6; 5,7]
+    let ys = xs |> Seq.distinctBy (fun (x,_) -> x % 2)
+    ys |> Seq.length |> equal 2
+    ys |> Seq.head |> fst >= 4 |> equal true
+
+[<Fact>]
+let ``test Seq.distinct works on infinite sequences`` () =
+    let rec numbersFrom n =
+      seq { yield n; yield n; yield! numbersFrom (n + 1) }
+    let xs =
+        numbersFrom 1
+        |> Seq.distinct
+        |> Seq.take 5
+    xs |> Seq.toList |> equal [1; 2; 3; 4; 5]
+
+[<Fact>]
+let ``test Seq.distinctBy works on infinite sequences`` () =
+    let rec numbersFrom n =
+      seq { yield n; yield n; yield! numbersFrom (n + 1) }
+    let xs =
+        numbersFrom 1
+        |> Seq.distinctBy (fun x -> x / 5)
+        |> Seq.take 5
+    xs |> Seq.toList |> equal [1; 5; 10; 15; 20]
+
+// [<Fact>]
+// let ``test Seq.groupBy works`` () =
+//     let xs = [1; 2; 3; 4]
+//     let ys = xs |> Seq.groupBy (fun x -> x % 2)
+//     ys |> Seq.length |> equal 2
+//     ys |> Seq.iter (fun (k,v) ->
+//         v |> Seq.exists (fun x -> x % 2 <> k) |> equal false)

--- a/tests/Python/TestSeqExpression.fs
+++ b/tests/Python/TestSeqExpression.fs
@@ -1,0 +1,119 @@
+module Fable.Tests.SeqExpressions
+
+open System
+open Util.Testing
+
+type 'a Tree =
+    | Leaf
+    | Node of 'a Tree * 'a * 'a Tree
+
+type DisposableAction(f) =
+    interface IDisposable with
+        member __.Dispose() = f()
+
+[<Fact>]
+let ``test empty seq expressions work`` () =
+    seq { do () }
+    |> Seq.length |> float |> equal 0.
+
+[<Fact>]
+let ``test yield in seq expressions works`` () =
+    seq { yield 1 }
+    |> Seq.length |> equal 1
+
+[<Fact>]
+let ``test yield from in seq expressions works`` () =
+    let ys = seq { yield 1 }
+    seq { yield! ys }
+    |> Seq.length |> equal 1
+
+[<Fact>]
+let ``test infinite seq expressions work`` () =
+    let rec green () = seq {
+        yield "green"
+        yield! yellow() }
+    and yellow () = seq {
+        yield "yellow"
+        yield! red() }
+    and red () = seq {
+        yield "red"
+        yield! green() }
+    green() |> Seq.item 12 |> equal "green"
+
+[<Fact>]
+let ``test combine in seq expressions works`` () =
+    seq { yield 1; yield 2 }
+    |> Seq.length |> equal 2
+
+[<Fact>]
+let ``test multiple yields in seq expressions work`` () =
+    let upTo n = seq {
+        for i = 1 to n do yield n
+    }
+    let numbers () = seq {
+        yield 8
+        yield! upTo 5
+        yield 4
+        yield! upTo 3
+        yield 2
+    }
+    numbers() |> Seq.sum |> equal 48
+
+[<Fact>]
+let ``test for in seq expressions works`` () =
+    seq { for x in 1 .. 10 do yield x }
+    |> Seq.length |> equal 10
+
+[<Fact>]
+let ``test while in seq expressions works`` () =
+    let mutable n = 0
+    seq {
+        while n < 10 do
+            n <- n + 1
+            yield n
+    } |> Seq.sum |> equal 55
+
+[<Fact>]
+let ``test recursive seq expressions work`` () =
+    let rec traverse t = seq {
+        match t with
+        | Leaf -> ()
+        | Node(xs, y, zs) ->
+            yield y
+            yield! traverse xs
+            yield! traverse zs |> Seq.map (fun x -> 2 * x)
+    }
+    let t = Node(Node(Leaf, 1, Leaf), 2, Node(Leaf, 3, Leaf))
+    traverse t |> Seq.sum |> equal 9
+
+[<Fact>]
+let ``test try...finally in seq expressions works`` () =
+    let mutable n = 0
+    try seq {
+        try
+            raise (exn "My message")
+        finally
+            n <- n + 1
+        } |> Seq.iter ignore
+    with _ -> ()
+    equal 1 n
+
+[<Fact>]
+let ``test use in seq expressions works`` () =
+    let mutable n = 0
+    seq {
+        use x = new DisposableAction(fun () ->
+            n <- n + 1)
+        ignore x
+    } |> Seq.iter ignore
+    equal 1 n
+
+[<Fact>]
+let ``test array expressions work`` () =
+    [| for x in 1 .. 10 do yield x |]
+    |> Array.length |> equal 10
+
+[<Fact>]
+let ``test list expressions work`` () =
+    [ for x in 1 .. 10 do yield x ]
+    |> List.length |> equal 10

--- a/tests/Python/TestTupleType.fs
+++ b/tests/Python/TestTupleType.fs
@@ -1,0 +1,52 @@
+module Fable.Tests.TupleTypes
+
+open System
+open Util.Testing
+
+[<Fact>]
+let ``test Tuple dereferencing can be generated`` () =
+    let x = 10, true
+    let y, z = x
+    equal 10 y
+    equal true z
+
+[<Fact>]
+let ``test fst function can be generated`` () =
+    let xy = 10., true
+    fst xy |> equal 10.
+
+[<Fact>]
+let ``test snd function can be generated`` () =
+    let xy = 10., true
+    snd xy |> equal true
+
+[<Fact>]
+let ``test Tuple constructor works`` () =
+    let t2 = Tuple<_,_>(2, 3)
+    let t3 = Tuple.Create("a", 14, "c")
+    equal (2, 3) t2
+    equal ("a", 14, "c") t3
+
+[<Fact>]
+let ``test ValueTuple constructor works`` () =
+    let t2 = ValueTuple<_,_>(2, 3)
+    let t3 = ValueTuple.Create("a", 14, "c")
+    equal (struct (2, 3)) t2
+    equal (struct ("a", 14, "c")) t3
+
+[<Fact>]
+let ``test Can transform ref tuple to value tuple`` () =
+    let t2 = (2, 3)
+    t2.ToValueTuple() |> equal (struct (2, 3))
+
+[<Fact>]
+let ``test Can transform value tuple to ref tuple`` () =
+    let t3 = (struct (2, 3, "c"))
+    t3.ToTuple() |> equal (2, 3, "c")
+
+[<Fact>]
+let ``test Can create tuples of single element`` () =
+    let t1 = Tuple<_> 4
+    let t1b = Tuple.Create "b"
+    t1.Item1 |> equal 4
+    t1b.Item1 |> equal "b"


### PR DESCRIPTION
- Translate `a.set(x, y)` to `a[x] = y`
- Translate `x.has(y)` to `y in x`
- Add MutableMap
- Add MutableSet
- Remove break-statements from transformed switches