### PR TITLE
Fix #2505 - String.Split(null)

### DIFF
--- a/src/fable-library/String.ts
+++ b/src/fable-library/String.ts
@@ -469,7 +469,7 @@ export function split(str: string, splitters: string[], count?: number, removeEm
       splitters[key - 1] = arguments[key];
     }
   }
-  splitters = splitters.map((x) => escape(x));
+  splitters = splitters.map((x) => escape(x ?? " "));
   splitters = splitters.length > 0 ? splitters : [" "];
   let i = 0;
   const splits: string[] = [];

--- a/tests/Main/StringTests.fs
+++ b/tests/Main/StringTests.fs
@@ -515,6 +515,8 @@ let tests =
             |> (=) [|"a";"b";"c";"";"d"|] |> equal true
             "a b c  d ".Split()
             |> (=) [|"a";"b";"c";"";"d";""|] |> equal true
+            "a b c  d".Split(null)
+            |> (=) [|"a";"b";"c";"";"d"|] |> equal true
             let array = "a;b,c".Split(',', ';')
             "abc" = array.[0] + array.[1] + array.[2]
             |> equal true


### PR DESCRIPTION
Fixes #2505.

``"foo bar".Split(null)`` should behave the same as ``"foo bar".Split()``, as it does in .NET.