### PR TITLE
Make String.Split split on all whitespaces by default to mirror .NET

### DIFF
--- a/src/fable-library/String.ts
+++ b/src/fable-library/String.ts
@@ -469,8 +469,8 @@ export function split(str: string, splitters: string[], count?: number, removeEm
       splitters[key - 1] = arguments[key];
     }
   }
-  splitters = splitters.map((x) => escape(x ?? " "));
-  splitters = splitters.length > 0 ? splitters : [" "];
+  splitters = splitters.map((x) => (x == null) ? "\\s" : escape(x));
+  splitters = splitters.length > 0 ? splitters : ["\\s"];
   let i = 0;
   const splits: string[] = [];
   const reg = new RegExp(splitters.join("|"), "g");

--- a/tests/Main/StringTests.fs
+++ b/tests/Main/StringTests.fs
@@ -515,8 +515,20 @@ let tests =
             |> (=) [|"a";"b";"c";"";"d"|] |> equal true
             "a b c  d ".Split()
             |> (=) [|"a";"b";"c";"";"d";""|] |> equal true
+            "a\tb".Split()
+            |> (=) [|"a";"b"|] |> equal true
+            "a\nb".Split()
+            |> (=) [|"a";"b"|] |> equal true
+            "a\rb".Split()
+            |> (=) [|"a";"b"|] |> equal true
+            "a\u2003b".Split() // em space
+            |> (=) [|"a";"b"|] |> equal true
             "a b c  d".Split(null)
             |> (=) [|"a";"b";"c";"";"d"|] |> equal true
+            "a\tb".Split(null)
+            |> (=) [|"a";"b"|] |> equal true
+            "a\u2003b".Split() // em space
+            |> (=) [|"a";"b"|] |> equal true
             let array = "a;b,c".Split(',', ';')
             "abc" = array.[0] + array.[1] + array.[2]
             |> equal true


### PR DESCRIPTION
``String.Split()`` and ``String.Split(null)`` are supposed to split on *any* unicode whitespace character (\s, \t, \r, \n, EM space, etc) according to the .NET implementation.

See https://github.com/fable-compiler/Fable/pull/2516#issuecomment-905198074