### PR TITLE
Multiple sources

### DIFF
--- a/src/fable-standalone/src/Worker/Shared.fs
+++ b/src/fable-standalone/src/Worker/Shared.fs
@@ -15,11 +15,15 @@ type WorkerRequest =
     /// * refsExtraSuffix: e.g. add .txt extension to enable gzipping in Github Pages
     | CreateChecker of refsDirUrl: string * extraRefs: string[] * refsExtraSuffix: string option * otherFSharpOptions: string[]
     | ParseCode of fsharpCode: string * otherFSharpOptions: string[]
+    | ParseFile of file : string * fsharpCode: FSharpCodeFile[] * otherFSharpOptions: string[]
     | CompileCode of fsharpCode: string * otherFSharpOptions: string[]
-    | CompileCodeArray of fsharpCode: FSharpCodeFile[] * otherFSharpOptions: string[]
+    | CompileFiles of fsharpCode: FSharpCodeFile[] * otherFSharpOptions: string[]
     | GetTooltip of id: Guid * line: int * column: int * lineText: string
     | GetCompletions of id: Guid * line: int * column: int * lineText: string
     | GetDeclarationLocation of id: Guid * line: int * column: int * lineText: string
+    | GetTooltipForFile of id: Guid * file: string * line: int * column: int * lineText: string
+    | GetCompletionsForFile of id: Guid * file: string * line: int * column: int * lineText: string
+    | GetDeclarationLocationForFile of id: Guid * file: string * line: int * column: int * lineText: string
     static member Decoder =
         Decode.Auto.generateDecoder<WorkerRequest>()
 

--- a/src/fable-standalone/src/Worker/Shared.fs
+++ b/src/fable-standalone/src/Worker/Shared.fs
@@ -6,11 +6,17 @@ open Fable.Core
 open Fable.Core.JsInterop
 open Thoth.Json
 
+type FSharpCodeFile = {
+        Name : string
+        Content : string
+    }
+
 type WorkerRequest =
     /// * refsExtraSuffix: e.g. add .txt extension to enable gzipping in Github Pages
     | CreateChecker of refsDirUrl: string * extraRefs: string[] * refsExtraSuffix: string option * otherFSharpOptions: string[]
     | ParseCode of fsharpCode: string * otherFSharpOptions: string[]
     | CompileCode of fsharpCode: string * otherFSharpOptions: string[]
+    | CompileCodeArray of fsharpCode: FSharpCodeFile[] * otherFSharpOptions: string[]
     | GetTooltip of id: Guid * line: int * column: int * lineText: string
     | GetCompletions of id: Guid * line: int * column: int * lineText: string
     | GetDeclarationLocation of id: Guid * line: int * column: int * lineText: string
@@ -26,7 +32,7 @@ type WorkerAnswer =
     | Loaded of version: string
     | LoadFailed
     | ParsedCode of errors: Fable.Standalone.Error[]
-    | CompilationFinished of jsCode: string * errors: Fable.Standalone.Error[] * stats: CompileStats
+    | CompilationFinished of jsCode: string[] * errors: Fable.Standalone.Error[] * stats: CompileStats
     | CompilerCrashed of message: string
     | FoundTooltip of id: Guid * lines: string[]
     | FoundCompletions of id: Guid * Fable.Standalone.Completion[]

--- a/src/fable-standalone/src/Worker/Shared.fs
+++ b/src/fable-standalone/src/Worker/Shared.fs
@@ -36,7 +36,8 @@ type WorkerAnswer =
     | Loaded of version: string
     | LoadFailed
     | ParsedCode of errors: Fable.Standalone.Error[]
-    | CompilationFinished of jsCode: string[] * errors: Fable.Standalone.Error[] * stats: CompileStats
+    | CompilationFinished of jsCode: string * errors: Fable.Standalone.Error[] * stats: CompileStats
+    | CompilationsFinished of jsCode: string[] * errors: Fable.Standalone.Error[] * stats: CompileStats
     | CompilerCrashed of message: string
     | FoundTooltip of id: Guid * lines: string[]
     | FoundCompletions of id: Guid * Fable.Standalone.Completion[]

--- a/src/fable-standalone/src/Worker/Worker.fs
+++ b/src/fable-standalone/src/Worker/Worker.fs
@@ -206,7 +206,7 @@ let rec loop (box: MailboxProcessor<WorkerRequest>) (state: State) = async {
     | Some fable, CompileCode(fsharpCode, otherFSharpOptions) ->
         try
             let! (jsCode,errors,stats) = compileCode fable FILE_NAME ([| FILE_NAME |])  ([| fsharpCode |]) otherFSharpOptions
-            CompilationFinished ([| jsCode |], errors, stats) |> state.Worker.Post
+            CompilationFinished (jsCode, errors, stats) |> state.Worker.Post
         with er ->
             JS.console.error er
             CompilerCrashed er.Message |> state.Worker.Post
@@ -233,7 +233,7 @@ let rec loop (box: MailboxProcessor<WorkerRequest>) (state: State) = async {
                         combineStats c f  // Stats
                     )
 
-            CompilationFinished combinedResults |> state.Worker.Post
+            CompilationsFinished combinedResults |> state.Worker.Post
         with er ->
             JS.console.error er
             CompilerCrashed er.Message |> state.Worker.Post


### PR DESCRIPTION
This PR provides additional support for REPL "projects" of multiple source FS files (as used by the Sutil REPL - a separate PR will be created against the main REPL for multiple file support).

Accepting this PR should not affect the main Fable REPL (this has been tested against a local build of the main REPL). The affected build files are worker.min.js (and possibly bundle.min.js).

This PR defines the following additional `WorkerRequest` messages:

```
    | ParseFile of file : string * fsharpCode: FSharpCodeFile[] * otherFSharpOptions: string[]
    | CompileFiles of fsharpCode: FSharpCodeFile[] * otherFSharpOptions: string[]
    | GetTooltipForFile of id: Guid * file: string * line: int * column: int * lineText: string
    | GetCompletionsForFile of id: Guid * file: string * line: int * column: int * lineText: string
    | GetDeclarationLocationForFile of id: Guid * file: string * line: int * column: int * lineText: string
```

and one additional `WorkerAnswer` message:

```
    | CompilationsFinished of jsCode: string[] * errors: Fable.Standalone.Error[] * stats: CompileStats
```

Existing messages are not changed; this means that the resulting worker.min.js will work with the existing Fable REPL (this has been tested).
