### PR TITLE
Allow import with a single argument

### DIFF
--- a/src/Fable.Core/Fable.Core.Types.fs
+++ b/src/Fable.Core/Fable.Core.Types.fs
@@ -43,6 +43,9 @@ type GlobalAttribute() =
 type ImportAttribute(selector: string, from: string) =
     inherit Attribute()
 
+    /// Same as `Import("default", "my-package")`
+    new (from: string) = ImportAttribute ("default", from)
+
 /// Takes the member name from the value it decorates
 type ImportMemberAttribute(from: string) =
     inherit Attribute()

--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -1472,6 +1472,8 @@ module Util =
                     ImportAtt("default", path.Trim()) |> Some
                 | Atts.importMember, [(:? string as path)] ->
                     ImportAtt(Naming.placeholder, path.Trim()) |> Some
+                | _, [(:? string as path)] ->
+                    ImportAtt("default", path.Trim()) |> Some
                 | _, [(:? string as selector); (:? string as path)] ->
                     ImportAtt(selector.Trim(), path.Trim()) |> Some
                 | _ -> None


### PR DESCRIPTION
Allow import with only the package. Selector defaults to "default" so `Import("my-package")` is the same as `Import("default", "my-package")`.  This is so we can import single modules in Python and looks much better than `ImportDefault("json")` since Python does not have the concept of a default import, and still make sense for JS as well.

Adding you to the PR since it touches outside the Python code. What do you think?

With this PR I can write much better looking Python bindings. e.g:

```fs
type IExports =
    abstract dumps : obj: obj -> string
    abstract loads : string -> obj

[<Import("json")>]
let json: IExports = nativeOnly
```

Full source for example: https://github.com/dbrattli/Fable.Python/blob/main/src/Json.fs