### PR TITLE
Fix isSubclassOf to walk up the inheritance chain

### DIFF
--- a/src/fable-library/Reflection.ts
+++ b/src/fable-library/Reflection.ts
@@ -187,7 +187,7 @@ export function isEnum(t: TypeInfo) {
 }
 
 export function isSubclassOf(t1: TypeInfo, t2: TypeInfo) {
-  return t1.parent?.Equals(t2) ?? false;
+  return t1.parent != null && (t1.parent.Equals(t2) || isSubclassOf(t1.parent, t2));
 }
 
 /**

--- a/src/fable-library/Reflection.ts
+++ b/src/fable-library/Reflection.ts
@@ -186,7 +186,7 @@ export function isEnum(t: TypeInfo) {
   return t.enumCases != null && t.enumCases.length > 0;
 }
 
-export function isSubclassOf(t1: TypeInfo, t2: TypeInfo) {
+export function isSubclassOf(t1: TypeInfo, t2: TypeInfo): Boolean {
   return t1.parent != null && (t1.parent.Equals(t2) || isSubclassOf(t1.parent, t2));
 }
 


### PR DESCRIPTION
This fixes `Type.IsSubclassOf` to work the same way as .NET. To repro the issue, run this snippet on [Fable REPL](https://fable.io/repl/#?code=C4TwDgpgBAYg9nAFASigXigYwDYEMDO+UEAdgCYBQokUAQrgE4rpQCWJAFhA68LAiirho9AF7MM7Ljz70myChTA8SwAGYkoAIjlsi+AK4AjHASJw1-OAH4oAUiNaoiahAsAeOQD4AdAEl8AGVjU0IAeTUXYQ94OC9kBWV2dU0dXFE9KEMTPEIoCytbBycoyA8xXwDgnLMI0rc1d1j45CA&html=Q&css=Q) and in FSI:

```fsharp
type Foo() = class end
type Bar() = inherit Foo()
type Baz() = inherit Bar()

printfn "Bar is subclass of Foo? %b" (typeof<Bar>.IsSubclassOf(typeof<Foo>))
printfn "Baz is subclass of Foo? %b" (typeof<Baz>.IsSubclassOf(typeof<Foo>))
```

FSI output:

```
Bar is subclass of Foo? true
Baz is subclass of Foo? true
```

Fable output:

```
Bar is subclass of Foo? true
Baz is subclass of Foo? false
```
