### PR TITLE
Python import handling

### DIFF
--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -1124,7 +1124,7 @@ let fableCoreLib (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Exp
     match i.DeclaringEntityFullName, i.CompiledName with
     | _, "op_ErasedCast" -> List.tryHead args
     | _, ".ctor" -> typedObjExpr t [] |> Some
-    | _, ("jsNative"|"nativeOnly") ->
+    | _, ("pyNative"|"nativeOnly") ->
         // TODO: Fail at compile time?
         addWarning com ctx.InlinePath r $"{i.CompiledName} is being compiled without replacement, this will fail at runtime."
         let runtimeMsg =

--- a/src/fable-library-py/fable/types.py
+++ b/src/fable-library-py/fable/types.py
@@ -92,11 +92,10 @@ def recordEquals(self, other):
     if self is other:
         return True
 
-    for name in self.__dict__.keys():
-        if not equals(self.__dict__[name], other.__dict__[name]):
-            return False
+    a = self.__dict__ if hasattr(self, "__dict__") else self
+    b = other.__dict__ if hasattr(other, "__dict__") else other
 
-    return True
+    return a == b
 
 
 def recordCompareTo(self, other):


### PR DESCRIPTION
Fix python import handling. Use `ImportAll` to import the module, and not for `*` which should not be used.