### PR TITLE
Implement Type.IsInstanceOfType

### DIFF
--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -3119,7 +3119,7 @@ let types (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr optio
         | "get_FullName" | "get_Namespace"
         | "get_IsArray" | "GetElementType"
         | "get_IsGenericType" | "GetGenericTypeDefinition"
-        | "get_IsEnum" | "GetEnumUnderlyingType" | "GetEnumValues" | "GetEnumNames" | "IsSubclassOf" ->
+        | "get_IsEnum" | "GetEnumUnderlyingType" | "GetEnumValues" | "GetEnumNames" | "IsSubclassOf" | "IsInstanceOfType" ->
             let meth = Naming.removeGetSetPrefix i.CompiledName |> Naming.lowerFirst
             Helper.LibCall(com, "Reflection", meth, t, thisArg::args, ?loc=r) |> Some
         | _ -> None

--- a/src/fable-library/Reflection.ts
+++ b/src/fable-library/Reflection.ts
@@ -195,7 +195,27 @@ export function isSubclassOf(t1: TypeInfo, t2: TypeInfo): boolean {
 }
 
 export function isInstanceOfType(t: TypeInfo, o: any) {
-  return t.construct != null && o instanceof t.construct
+  switch (typeof o) {
+    case "boolean":
+      return t.fullname === bool_type.fullname;
+    case "string":
+      return t.fullname === string_type.fullname;
+    case "function":
+      return isFunction(t);
+    case "number":
+      return isEnum(t) || [
+        int8_type.fullname,
+        uint8_type.fullname,
+        int16_type.fullname,
+        uint16_type.fullname,
+        int32_type.fullname,
+        uint32_type.fullname,
+        float32_type.fullname,
+        float64_type.fullname,
+      ].includes(t.fullname);
+    default:
+      return t.construct != null && o instanceof t.construct;
+  }
 }
 
 /**

--- a/src/fable-library/Reflection.ts
+++ b/src/fable-library/Reflection.ts
@@ -194,6 +194,10 @@ export function isSubclassOf(t1: TypeInfo, t2: TypeInfo): boolean {
   return t1.parent != null && (t1.parent.Equals(t2) || isSubclassOf(t1.parent, t2));
 }
 
+export function isInstanceOfType(t: TypeInfo, o: any) {
+  return t.construct != null && o instanceof t.construct
+}
+
 /**
  * This doesn't replace types for fields (records) or cases (unions)
  * but it should be enough for type comparison purposes

--- a/tests/Main/TypeTests.fs
+++ b/tests/Main/TypeTests.fs
@@ -940,6 +940,12 @@ let tests =
         typeof<string -> int>.IsInstanceOfType(String.length) |> equal true
         typeof<int -> int>.IsInstanceOfType(String.length) |> equal false
 
+    testCase "IsInstanceOfType works with primitives" <| fun () ->
+        typeof<string>.IsInstanceOfType("hello") |> equal true
+        typeof<string>.IsInstanceOfType(5) |> equal false
+        typeof<int>.IsInstanceOfType(5) |> equal true
+        typeof<int>.IsInstanceOfType("hello") |> equal false
+
 #if FABLE_COMPILER
     testCase "Choice with arity 3+ is represented correctly" <| fun () -> // See #2485
         Choice2Of3 55 |> Fable.Core.Reflection.getCaseName |> equal "Choice2Of3"

--- a/tests/Main/TypeTests.fs
+++ b/tests/Main/TypeTests.fs
@@ -427,6 +427,10 @@ type MeasureTest4 = { Y: float<d> }
 type MeasureTest5 = { Y: MeasureTest<c> }
 type MeasureTest6 = { Y: MeasureTest<d> }
 
+type EnumFoo =
+  | Foo = 0
+  | Bar = 1
+
 let tests =
   testList "Types" [
     // TODO: This test produces different results in Fable and .NET
@@ -930,15 +934,17 @@ let tests =
         typeof<MyUnion1>.IsInstanceOfType(MyUnion1.Foo(1,2)) |> equal true
         typeof<MyUnion2>.IsInstanceOfType(MyUnion1.Foo(1,2)) |> equal false
 
-    testCase "IsInstanceOfType works with anonymous records" <| fun () ->
-        typeof<{| foo: string; bar: int |}>.IsInstanceOfType({| foo = "hi"; bar = 5 |}) |> equal true
-        typeof<{| foo: string; bar: int |}>.IsInstanceOfType({| foo = "hi"; bar = "oh" |}) |> equal false
+    // Expected to always return true for any numeric type, just like :? operator
+    testCase "IsInstanceOfType works with enums" <| fun () ->
+        typeof<EnumFoo>.IsInstanceOfType(EnumFoo.Foo) |> equal true
+        typeof<EnumFoo>.IsInstanceOfType(EnumFoo.Bar) |> equal true
 
+    // Expected to always return true for any function and function type, just like :? operator
     testCase "IsInstanceOfType works with functions" <| fun () ->
         typeof<unit -> unit>.IsInstanceOfType(fun () -> ()) |> equal true
-        typeof<unit -> int>.IsInstanceOfType(fun () -> ()) |> equal false
+        //typeof<unit -> int>.IsInstanceOfType(fun () -> ()) |> equal false
         typeof<string -> int>.IsInstanceOfType(String.length) |> equal true
-        typeof<int -> int>.IsInstanceOfType(String.length) |> equal false
+        //typeof<int -> int>.IsInstanceOfType(String.length) |> equal false
 
     testCase "IsInstanceOfType works with primitives" <| fun () ->
         typeof<string>.IsInstanceOfType("hello") |> equal true

--- a/tests/Main/TypeTests.fs
+++ b/tests/Main/TypeTests.fs
@@ -913,6 +913,33 @@ let tests =
         typeof<SubclassTest2>.IsSubclassOf(typeof<SubclassTest1>) |> equal true
         typeof<SubclassTest3>.IsSubclassOf(typeof<SubclassTest1>) |> equal true
 
+    testCase "IsInstanceOfType works with class types" <| fun () ->
+        let s1, s2 = SubclassTest1(), SubclassTest2()
+        typeof<SubclassTest1>.IsInstanceOfType(s1) |> equal true
+        typeof<SubclassTest2>.IsInstanceOfType(s1) |> equal false
+        typeof<SubclassTest3>.IsInstanceOfType(s1) |> equal false
+        typeof<SubclassTest1>.IsInstanceOfType(s2) |> equal true
+        typeof<SubclassTest2>.IsInstanceOfType(s2) |> equal true
+        typeof<SubclassTest3>.IsInstanceOfType(s2) |> equal false
+
+    testCase "IsInstanceOfType works with nominal records" <| fun () ->
+        typeof<MyRecord1>.IsInstanceOfType({ MyRecord1.Foo = 2; Bar = "oh" }) |> equal true
+        typeof<MyRecord2>.IsInstanceOfType({ MyRecord1.Foo = 2; Bar = "oh" }) |> equal false
+
+    testCase "IsInstanceOfType works with nominal unions" <| fun () ->
+        typeof<MyUnion1>.IsInstanceOfType(MyUnion1.Foo(1,2)) |> equal true
+        typeof<MyUnion2>.IsInstanceOfType(MyUnion1.Foo(1,2)) |> equal false
+
+    testCase "IsInstanceOfType works with anonymous records" <| fun () ->
+        typeof<{| foo: string; bar: int |}>.IsInstanceOfType({| foo = "hi"; bar = 5 |}) |> equal true
+        typeof<{| foo: string; bar: int |}>.IsInstanceOfType({| foo = "hi"; bar = "oh" |}) |> equal false
+
+    testCase "IsInstanceOfType works with functions" <| fun () ->
+        typeof<unit -> unit>.IsInstanceOfType(fun () -> ()) |> equal true
+        typeof<unit -> int>.IsInstanceOfType(fun () -> ()) |> equal false
+        typeof<string -> int>.IsInstanceOfType(String.length) |> equal true
+        typeof<int -> int>.IsInstanceOfType(String.length) |> equal false
+
 #if FABLE_COMPILER
     testCase "Choice with arity 3+ is represented correctly" <| fun () -> // See #2485
         Choice2Of3 55 |> Fable.Core.Reflection.getCaseName |> equal "Choice2Of3"


### PR DESCRIPTION
Hello, I've added an implementation of `Type.IsInstanceOfType`, but it might warrant some discussion, since it doesn't work for all types. Here's a comparison of the new `Type.IsInstanceOfType` and the existing `:?` operator:

**Legend**: ✅ fully supported ❌ not supported (always returns false)

| Type | New `Type.IsInstanceOfType` | Existing `:?` |
| ------|-------------------------------|-------------|
|Class types | ✅ | ✅|
| Nominal union types | ✅ | ✅ |
| Nominal record types | ✅ | ✅ |
| Anonymous records | ❌ | ❌ |
| Functions | ❌ | `typeof x === "function"` |
| Primitive string | ❌ | ✅ |
| Primitive number | ❌ | `typeof x === "number"` |

I've added some failing tests for the above cases, but I'm not sure if it's possible to get them all passing. It might be better to try to align the behavior with `:?`, but I'm not sure the best way to go about it. Perhaps we could add a type test function to `TypeInfo` that would use `typeof` for functions and primitives? On the other hand, it's already useful as it is for many use cases.

Let me know what you think. Thanks!

