### PR TITLE
issue-2229-datetime-tryparse-inconsistent-tuple

### DIFF
--- a/src/fable-library/Date.ts
+++ b/src/fable-library/Date.ts
@@ -219,7 +219,12 @@ export function parseRaw(input: string) {
     } else {
       throw new Error("The string is not a valid Date.");
     }
+
+    if (isNaN(date.getTime())) {
+      throw new Error("The string is not a valid Date.");
+    }
   }
+
   return date;
 }
 


### PR DESCRIPTION
This is a _partial_ fix for https://github.com/fable-compiler/Fable/issues/2229. 

There are two issue raised there: 

 1. Fable date-time parser does not accepts dates that .NET does (e.g. `"31.10.2020"`) 
 2. Fable `DateTime.TryParse` sometimes returns `(true, new Date("Invalid date"))` for invalid dates

This PR fixes (2) by adding an additional safety check to `parseRaw`. 