### PR TITLE
Add ParamObject attribute

### DIFF
--- a/src/Fable.Cli/Entry.fs
+++ b/src/Fable.Cli/Entry.fs
@@ -65,7 +65,7 @@ Arguments:
   --runFast         The command after the argument will be executed BEFORE compilation
   --runWatch        Like run, but will execute after each watch compilation
   --runScript       Runs the generated script for last file with node
-                    (Requires `"type": "module"` in package.json and at minimum Node.js 12.20, 14.14, or 16.0.)
+                    (Requires `"type": "module"` in package.json and at minimum Node.js 12.20, 14.14, or 16.0.0)
 
   --yes             Automatically reply 'yes' (e.g. with `clean` command)
   --noRestore       Skip `dotnet restore`

--- a/src/Fable.Core/Fable.Core.Types.fs
+++ b/src/Fable.Core/Fable.Core.Types.fs
@@ -91,6 +91,12 @@ type ParamListAttribute() =
 
 type ParamSeqAttribute = ParamListAttribute
 
+/// Used to convert arguments from specified index into an object
+[<AttributeUsage(AttributeTargets.Constructor ||| AttributeTargets.Method)>]
+type ParamObjectAttribute(int: int) =
+    inherit Attribute()
+    new () = ParamObjectAttribute(0)
+
 /// Experimental: Currently only intended for some specific libraries
 [<AttributeUsage(AttributeTargets.Parameter)>]
 type InjectAttribute() =

--- a/src/Fable.Core/Fable.Core.Types.fs
+++ b/src/Fable.Core/Fable.Core.Types.fs
@@ -91,9 +91,10 @@ type ParamListAttribute() =
 
 type ParamSeqAttribute = ParamListAttribute
 
-/// Used to convert arguments from specified index into an object
+/// Converts arguments from the specified index on (0 by default) into an object.
+/// IMPORTANT: This should be used only with native bindings.
 [<AttributeUsage(AttributeTargets.Constructor ||| AttributeTargets.Method)>]
-type ParamObjectAttribute(int: int) =
+type ParamObjectAttribute(fromIndex: int) =
     inherit Attribute()
     new () = ParamObjectAttribute(0)
 

--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -519,7 +519,7 @@ module Helpers =
         let hasParamSeq (memb: FSharpMemberOrFunctionOrValue) =
             Seq.tryLast memb.CurriedParameterGroups
             |> Option.bind Seq.tryLast
-            |> Option.map (fun lastParam -> hasAttribute "Fable.Core.ParamListAttribute" lastParam.Attributes)
+            |> Option.map (fun lastParam -> hasAttribute Atts.paramList lastParam.Attributes)
             |> Option.defaultValue false
 
         hasParamArray memb || hasParamSeq memb

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -23,6 +23,8 @@ module Atts =
     let [<Literal>] erase = "Fable.Core.EraseAttribute" // typeof<Fable.Core.EraseAttribute>.FullName
     let [<Literal>] stringEnum = "Fable.Core.StringEnumAttribute" // typeof<Fable.Core.StringEnumAttribute>.FullName
     let [<Literal>] inject = "Fable.Core.InjectAttribute" // typeof<Fable.Core.InjectAttribute>.FullName
+    let [<Literal>] paramList = "Fable.Core.ParamListAttribute"// typeof<Fable.Core.ParamListAttribute>.FullName
+    let [<Literal>] paramObject = "Fable.Core.ParamObjectAttribute"// typeof<Fable.Core.ParamObjectAttribute>.FullName
     let [<Literal>] decorator = "Fable.Core.JS.DecoratorAttribute" // typeof<Fable.Core.JS.DecoratorAttribute>.FullName
     let [<Literal>] reflectedDecorator = "Fable.Core.JS.ReflectedDecoratorAttribute" // typeof<Fable.Core.JS.ReflectedDecoratorAttribute>.FullName
 

--- a/src/quicktest/QuickTest.fs
+++ b/src/quicktest/QuickTest.fs
@@ -67,12 +67,3 @@ let measureTime (f: unit -> unit) = emitJsStatement () """
 // to Fable.Tests project. For example:
 // testCase "Addition works" <| fun () ->
 //     2 + 2 |> equal 4
-
-[<Global>]
-type MyJsClass [<ParamObject>] (?foo: int, ?bar: string, ?baz: float) =
-    [<ParamObject(2)>]
-    member _.Foo(foo: int, bar: string, ?baz: float) = jsNative
-
-let test() =
-    let c = MyJsClass(4, baz=56.)
-    c.Foo(5, baz=4., bar="b")

--- a/src/quicktest/QuickTest.fs
+++ b/src/quicktest/QuickTest.fs
@@ -67,3 +67,12 @@ let measureTime (f: unit -> unit) = emitJsStatement () """
 // to Fable.Tests project. For example:
 // testCase "Addition works" <| fun () ->
 //     2 + 2 |> equal 4
+
+[<Global>]
+type MyJsClass [<ParamObject>] (?foo: int, ?bar: string, ?baz: float) =
+    [<ParamObject(2)>]
+    member _.Foo(foo: int, bar: string, ?baz: float) = jsNative
+
+let test() =
+    let c = MyJsClass(4, baz=56.)
+    c.Foo(5, baz=4., bar="b")

--- a/tests/Main/ImportTests.fs
+++ b/tests/Main/ImportTests.fs
@@ -22,6 +22,14 @@ type MyClass() =
     static member foo(): string = jsNative
     static member foo(i: int): int = jsNative
 
+[<ImportMember("./js/1foo.js")>]
+type MyJsClassWithOptionArgs
+    [<ParamObject>]
+    (?foo: int, ?bar: string, ?baz: float) =
+    [<ParamObject(2)>]
+    member _.method(foo: int, bar: string, baz: float, ?lol: int) = jsNative
+    member _.value: string = jsNative
+
 type FooOptional =
     abstract Foo1: x: int * ?y: string -> int
     abstract Foo2: x: int * y: string option -> int
@@ -99,6 +107,15 @@ let tests =
 
     testCase "Static members of imported classes work" <| fun () ->
         MyJsClass.fuzzyMultiply(5, 4) |> equal 15
+
+    testCase "ParamObject works with constructors" <| fun () ->
+        let c = MyJsClassWithOptionArgs(4, baz=5.6)
+        c.value |> equal "4undefined5.6"
+
+    testCase "ParamObject works with fromIndex arg" <| fun () ->
+        let c = MyJsClassWithOptionArgs()
+        c.method(5, baz=4., lol=10, bar="b")
+        |> equal "5b410"
     #endif
 
     testCase "Import with relative paths from project subdirectory works" <| fun () ->

--- a/tests/Main/js/1foo.js
+++ b/tests/Main/js/1foo.js
@@ -83,3 +83,12 @@ export function handleClass(constructor) {
     x.Times = 2;
     return x.SaySomethingTo("Narumi");
 }
+
+export class MyJsClassWithOptionArgs {
+    constructor(opts) {
+        this.value = String(opts.foo) + String(opts.bar) + String(opts.baz);
+    }
+    method(foo, bar, opts) {
+        return String(foo) + String(bar) + String(opts.baz) + String(opts.lol);
+    }
+}


### PR DESCRIPTION
Very often we have to write bindings for JS methods accepting an object argument and the current solution (instantiate options with `jsOptions` or cast an anonymous record with `!!`) are not nice.

This allows you to add `[<ParamObject>]` attribute to the method with an optional index argument to say where the object arguments start. Optional arguments set to None are omitted. For example, this F# code:

```fsharp
[<Global>]
type MyJsClass [<ParamObject>] (?foo: int, ?bar: string, ?baz: float) =
    [<ParamObject(2)>]
    member _.Foo(foo: int, bar: string, ?baz: float) = jsNative

let test() =
    let c = MyJsClass(4, baz=56.)
    c.Foo(5, baz=4., bar="b")
```

Becomes:

```js
function test() {
    const c = new MyJsClass({
        foo: 4,
        baz: 56,
    });
    return c.Foo(5, "b", {
        baz: 4,
    });
}
```