### PR TITLE
Replace .fsproj with .fableproj in fable_modules

### DIFF
--- a/src/Fable.Transforms/Global/Prelude.fs
+++ b/src/Fable.Transforms/Global/Prelude.fs
@@ -129,6 +129,7 @@ module Naming =
     let [<Literal>] placeholder = "__PLACE-HOLDER__"
     let [<Literal>] dummyFile = "__DUMMY-FILE__.txt"
     let [<Literal>] fableHiddenDir = "fable_modules"
+    let [<Literal>] fableProjExt = ".fableproj"
     let [<Literal>] unknown = "UNKNOWN"
 
     let isInFableHiddenDir (file: string) =


### PR DESCRIPTION
This is to avoid conflicts with other F# tooling that scans the workspace for .fsproj files (Paket, Ionide), see https://github.com/fable-compiler/fable-react-native/issues/64#issuecomment-931304787