### PR TITLE
Add support for StringSplitOptions.TrimEntries

### DIFF
--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -1758,7 +1758,7 @@ let strings (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr opt
     | "Split", Some c, _ ->
         match args with
         // Optimization
-        | [] -> Helper.InstanceCall(c, "split", t, [makeStrConst ""]) |> Some
+        | [] -> Helper.InstanceCall(c, "split", t, [makeStrConst " "]) |> Some
         | [Value(CharConstant _,_) as separator]
         | [StringConst _ as separator]
         | [Value(NewArray([separator],_),_)] ->
@@ -1770,8 +1770,12 @@ let strings (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr opt
                 | _ -> Value(NewArray([arg1], String), None)
             let args = [arg1; Value(Null Any, None); arg2]
             Helper.LibCall(com, "String", "split", t, c::args, ?loc=r) |> Some
-        | args ->
-            Helper.LibCall(com, "String", "split", t, args, i.SignatureArgTypes, ?thisArg=thisArg, ?loc=r) |> Some
+        | arg1::args ->
+            let arg1 =
+                match arg1.Type with
+                | Array _ -> arg1
+                | _ -> Value(NewArray([arg1], String), None)
+            Helper.LibCall(com, "String", "split", t, arg1::args, i.SignatureArgTypes, ?thisArg=thisArg, ?loc=r) |> Some
     | "Join", None, _ ->
         let methName =
             match i.SignatureArgTypes with

--- a/tests/Main/StringTests.fs
+++ b/tests/Main/StringTests.fs
@@ -513,32 +513,44 @@ let tests =
 
       testCase "String.Split works" <| fun () ->
             "a b c  d".Split(' ')
-            |> (=) [|"a";"b";"c";"";"d"|] |> equal true
+            |> equal [|"a";"b";"c";"";"d"|]
             "a b c  d ".Split()
-            |> (=) [|"a";"b";"c";"";"d";""|] |> equal true
+            |> equal [|"a";"b";"c";"";"d";""|]
+            "a-b-c".Split()
+            |> equal [|"a-b-c"|]
+            "a-b-c".Split("")
+            |> equal [|"a-b-c"|]
             "a\tb".Split()
-            |> (=) [|"a";"b"|] |> equal true
+            |> equal [|"a";"b"|]
             "a\nb".Split()
-            |> (=) [|"a";"b"|] |> equal true
+            |> equal [|"a";"b"|]
             "a\rb".Split()
-            |> (=) [|"a";"b"|] |> equal true
+            |> equal [|"a";"b"|]
             "a\u2003b".Split() // em space
-            |> (=) [|"a";"b"|] |> equal true
+            |> equal [|"a";"b"|]
             "a b c  d".Split(null)
-            |> (=) [|"a";"b";"c";"";"d"|] |> equal true
+            |> equal [|"a";"b";"c";"";"d"|]
             "a\tb".Split(null)
-            |> (=) [|"a";"b"|] |> equal true
+            |> equal [|"a";"b"|]
             "a\u2003b".Split(null) // em space
-            |> (=) [|"a";"b"|] |> equal true
+            |> equal [|"a";"b"|]
             let array = "a;b,c".Split(',', ';')
             "abc" = array.[0] + array.[1] + array.[2]
             |> equal true
             "a--b-c".Split([|"--"|], StringSplitOptions.None)
-            |> (=) [|"a";"b-c"|] |> equal true
-
+            |> equal [|"a";"b-c"|]
+            " a-- b- c ".Split('-', 2, StringSplitOptions.None)
+            |> equal [|" a"; "- b- c "|]
+            "---o---o---".Split("--", StringSplitOptions.None)
+            |> equal [|""; "-o"; "-o"; "-"|];
+            
       testCase "String.Split with remove empties works" <| fun () ->
             "a b c  d ".Split([|" "|], StringSplitOptions.RemoveEmptyEntries)
             |> (=) [|"a";"b";"c";"d"|] |> equal true
+            " a-- b- c ".Split("-", 2, StringSplitOptions.RemoveEmptyEntries)
+            |> (=) [|" a"; " b- c "|] |> equal true
+            "---o---o---".Split("--", StringSplitOptions.RemoveEmptyEntries)
+            |> (=) [|"-o"; "-o"; "-"|] |> equal true
             let array = ";,a;b,c".Split([|','; ';'|], StringSplitOptions.RemoveEmptyEntries)
             "abc" = array.[0] + array.[1] + array.[2]
             |> equal true
@@ -549,6 +561,34 @@ let tests =
             equal "b  c d" array.[1]
             "a;,b,c;d".Split([|','; ';'|], 3, StringSplitOptions.RemoveEmptyEntries)
             |> (=) [|"a";"b";"c;d"|] |> equal true
+            "a-b-c".Split("", System.Int32.MaxValue)
+            |> (=) [|"a-b-c"|] |> equal true
+
+      testCase "String.Split with empty works" <| fun () ->
+            let array = "a b cd".Split()
+            array |> equal [| "a"; "b"; "cd" |]
+
+      testCase "String.Split with trim entries works" <| fun () ->
+            " a-- b- c ".Split('-', 2, StringSplitOptions.TrimEntries)
+            |> (=) [|"a"; "- b- c"|] |> equal true
+            " a-- b- c ".Split('-', 3, StringSplitOptions.TrimEntries)
+            |> (=) [|"a"; ""; "b- c"|] |> equal true
+
+      testCase "String.Split with trim and remove entries works" <| fun () ->
+            " a-- b- c ".Split([| "-" |], 2, StringSplitOptions.RemoveEmptyEntries ||| StringSplitOptions.TrimEntries)
+            |> equal [|"a"; "b- c"|]
+            " a-- b- c ".Split([| '-' |], 3, StringSplitOptions.RemoveEmptyEntries ||| StringSplitOptions.TrimEntries)
+            |> equal  [|"a"; "b"; "c"|]
+
+      testCase "String.Split with consecutive separators works" <| fun () ->
+            "       ".Split(" ", 4,  StringSplitOptions.None)
+            |> equal [|"";"";"";"    "|]
+            "       ".Split(" ", 4,  StringSplitOptions.RemoveEmptyEntries)
+            |> equal [||]
+            "       ".Split(" ", 4,  StringSplitOptions.TrimEntries)
+            |> equal [|"";"";"";""|]
+            "       ".Split(" ", 4,  StringSplitOptions.RemoveEmptyEntries ||| StringSplitOptions.TrimEntries)
+            |> equal [||]
 
       testCase "String.Replace works" <| fun () ->
             "abc abc abc".Replace("abc", "d") |> equal "d d d"


### PR DESCRIPTION
This covers both aspects of issue #2569 
1. It adds support for TrimEntries
2. It fixes the existing implementation to deal with separators like "" and finding the correct locations to perform the split