### PR TITLE
Pass only dirty files to FCS

### DIFF
--- a/src/Fable.AST/Plugins.fs
+++ b/src/Fable.AST/Plugins.fs
@@ -21,6 +21,7 @@ type CompilerOptions =
         Define: string list
         DebugMode: bool
         OptimizeFSharpAst: bool
+        // TODO: Rename this to TrimRootModule in beyond branch
         RootModule: bool
         Verbosity: Verbosity
         FileExtension: string

--- a/src/Fable.Cli/Entry.fs
+++ b/src/Fable.Cli/Entry.fs
@@ -73,7 +73,7 @@ let knownCliArgs() = [
 
   // Hidden args
   ["--typescript"], []
-  ["--rootModule"], []
+  ["--trimRootModule"], []
   ["--fableLib"], []
   ["--replace"], []
 ]
@@ -220,7 +220,7 @@ type Runner =
                                    define = define,
                                    debugMode = (configuration = "Debug"),
                                    optimizeFSharpAst = args.FlagEnabled "--optimize",
-                                   rootModule = (args.FlagOr("--rootModule", true)),
+                                   trimRootModule = (args.FlagOr("--trimRootModule", true)),
                                    verbosity = verbosity)
 
     let cliArgs =

--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -90,8 +90,8 @@ module private Util =
             | Some r -> $"%s{file}(%i{r.start.line},%i{r.start.column}): (%i{r.``end``.line},%i{r.``end``.column}) %s{severity} %s{log.Tag}: %s{log.Message}"
             | None -> $"%s{file}(1,1): %s{severity} %s{log.Tag}: %s{log.Message}"
 
-    let getFSharpErrorLogs (proj: Project) =
-        proj.Errors
+    let getFSharpErrorLogs (errors: FSharpDiagnostic array) =
+        errors
         |> Array.map (fun er ->
             let severity =
                 match er.Severity with
@@ -109,12 +109,6 @@ module private Util =
 
             Log.Make(severity, msg, fileName=er.FileName, range=range, tag="FSHARP")
         )
-
-    let hasWatchDependency (path: string) (dirtyFiles: Set<string>) watchDependencies =
-        match Map.tryFind path watchDependencies with
-        | None -> false
-        | Some watchDependencies ->
-            watchDependencies |> Array.exists (fun p -> Set.contains p dirtyFiles)
 
     let changeFsExtension isInFableHiddenDir filePath fileExt =
         let fileExt =
@@ -329,47 +323,69 @@ type ProjectCracked(projFile: string,
         let sourceFiles = getSourceFiles result.ProjectOptions
         ProjectCracked(cliArgs.ProjectFile, sourceFiles, cliArgs, result)
 
-type ProjectChecked(project: Project, checker: FSharpChecker) =
-
-    static let checkProject (config: ProjectCracked) (checker: FSharpChecker) = async {
-        Log.always $"Compiling {IO.Path.GetRelativePath(config.CliArgs.RootDir, config.ProjectOptions.ProjectFileName)}..."
-        let! result, ms = measureTimeAsync <| fun () ->
-            checker.ParseAndCheckProject(config.ProjectOptions)
-        Log.always $"F# compilation finished in %i{ms}ms\n"
-        return result
-    }
+type ProjectChecked(project: Project, checker: FSharpChecker, errors: FSharpDiagnostic array) =
 
     member _.Project = project
     member _.Checker = checker
+    member _.Errors = errors
 
     static member Init(config: ProjectCracked) = async {
-        let checker = FSharpChecker.Create(
-                        keepAssemblyContents=true,
-                        keepAllBackgroundResolutions=false,
-                        keepAllBackgroundSymbolUses=false)
+        let checker =
+            FSharpChecker.Create(
+                keepAssemblyContents=true,
+                keepAllBackgroundResolutions=false,
+                keepAllBackgroundSymbolUses=false)
 
-        let! checkResults = checkProject config checker
-        let proj = Project(config.ProjectFile,
-                           checkResults,
-                           getPlugin = loadType config.CliArgs,
-                           optimizeFSharpAst = config.FableOptions.OptimizeFSharpAst,
-                           rootModule = config.FableOptions.RootModule)
-        return ProjectChecked(proj, checker)
+        Log.always $"Compiling {IO.Path.GetRelativePath(config.CliArgs.RootDir, config.ProjectOptions.ProjectFileName)}..."
+        let! checkResults, ms = measureTimeAsync <| fun () ->
+            checker.ParseAndCheckProject(config.ProjectOptions)
+        Log.always $"F# compilation finished in %i{ms}ms\n"
+
+        let proj =
+            Project.From(
+                config.ProjectFile,
+                (if config.FableOptions.OptimizeFSharpAst then
+                    checkResults.GetOptimizedAssemblyContents().ImplementationFiles
+                else
+                    checkResults.AssemblyContents.ImplementationFiles),
+                checkResults.ProjectContext.GetReferencedAssemblies(),
+                getPlugin = loadType config.CliArgs,
+                rootModule = config.FableOptions.RootModule
+            )
+        return ProjectChecked(proj, checker, checkResults.Diagnostics)
     }
 
-    // TODO: Check if update can be faster by cheking only dirty files
-    member this.Update(config: ProjectCracked) = async {
-        let! checkResults = checkProject config this.Checker
-        let proj = this.Project.Update(checkResults)
-        return ProjectChecked(proj, checker)
+    member this.Update(config: ProjectCracked, files: string array) = async {
+
+        Log.always $"Compiling {IO.Path.GetRelativePath(config.CliArgs.RootDir, config.ProjectOptions.ProjectFileName)}..."
+        let! results, ms = measureTimeAsync <| fun () ->
+            files
+            |> Array.map (fun file -> async {
+                let! sourceText = File.readAllTextNonBlocking file
+                let sourceText = FSharp.Compiler.Text.SourceText.ofString sourceText
+                // `fileVersion` parameter doesn't seem to be used, it ends up discarded here:
+                // https://github.com/dotnet/fsharp/blob/38fd59027e4b8bb42a72c4d896cb3ef4e345f743/src/fsharp/service/service.fs#L452
+                let! _parseResult, checkResult = checker.ParseAndCheckFileInProject(file, 0, sourceText, config.ProjectOptions)
+                return
+                    match checkResult with
+                    | FSharpCheckFileAnswer.Succeeded result -> Some result
+                    | FSharpCheckFileAnswer.Aborted ->
+                        Log.always $"Aborted: {IO.Path.GetRelativePath(config.CliArgs.RootDir, file)}"
+                        None
+            })
+            |> Async.Parallel
+        Log.always $"F# compilation finished in %i{ms}ms\n"
+
+        let results = results |> Array.choose id
+        let proj = results |> Array.choose (fun r -> r.ImplementationFile) |> Array.toList |> this.Project.Update
+        return ProjectChecked(proj, checker, results |> Array.collect (fun r -> r.Diagnostics))
     }
 
 type State =
     { CliArgs: CliArgs
       ProjectCrackedAndChecked: (ProjectCracked * ProjectChecked) option
       WatchDependencies: Map<string, string[]>
-      PendingFilesToCompile: string[]
-      ErroredFiles: Set<string>
+      PendingFiles: string[]
       DeduplicateDic: Collections.Concurrent.ConcurrentDictionary<string, string>
       Watcher: FsWatcher option
       HasCompiledOnce: bool }
@@ -396,8 +412,7 @@ type State =
           WatchDependencies = Map.empty
           Watcher = watchDelay |> Option.map FsWatcher
           DeduplicateDic = Collections.Concurrent.ConcurrentDictionary()
-          PendingFilesToCompile = [||]
-          ErroredFiles = Set.empty
+          PendingFiles = [||]
           HasCompiledOnce = false }
 
 let rec startCompilation (changes: ISet<string>) (state: State) = async {
@@ -416,38 +431,31 @@ let rec startCompilation (changes: ISet<string>) (state: State) = async {
     let! projCracked, projChecked, filesToCompile = async {
         match state.ProjectCrackedAndChecked with
         | Some(projCracked, projChecked) ->
-            let fsprojChanged, oldFiles, projCracked =
+            let fsprojChanged, projCracked =
                 // For performance reasons, don't crack .fsx scripts for every change
                 if changes |> Seq.exists (fun c -> c.EndsWith(".fsproj")) then
-                    true, Set projCracked.SourceFiles, ProjectCracked.Init(state.CliArgs)
-                else false, Set.empty, projCracked
+                    true, ProjectCracked.Init(state.CliArgs)
+                else false, projCracked
 
-            let dirtyFiles =
-                // If Fable compilation didn't happen yet (because of errors) just compile all files
-                if not state.HasCompiledOnce then
-                    projCracked.SourceFiles
-                else
-                    projCracked.SourceFiles
-                    |> Array.choose (fun path ->
-                        if changes.Contains(path)
-                            || (fsprojChanged && not(Set.contains path oldFiles))
-                            then Some path
-                        else None)
-
-            if Array.isEmpty dirtyFiles then
-                return projCracked, projChecked, [||]
+            if fsprojChanged then
+                let! projChecked = ProjectChecked.Init(projCracked)
+                return projCracked, projChecked, projCracked.SourceFiles
             else
-                let dirtyFiles = set dirtyFiles
-                let! projChecked =
-                    if fsprojChanged then ProjectChecked.Init(projCracked)
-                    else projChecked.Update(projCracked)
+                let hasWatchDependency (path: string) =
+                    match Map.tryFind path state.WatchDependencies with
+                    | None -> false
+                    | Some watchDependencies -> watchDependencies |> Array.exists changes.Contains
+
                 let filesToCompile =
                     projCracked.SourceFiles
-                    |> Array.choose (fun path ->
-                        if Set.contains path dirtyFiles
-                            || hasWatchDependency path dirtyFiles state.WatchDependencies then Some path
-                        else None)
+                    |> Array.filter (fun path ->
+                        changes.Contains path || hasWatchDependency path)
+                    |> Array.append state.PendingFiles
+                    |> Array.distinct
+
+                let! projChecked = projChecked.Update(projCracked, filesToCompile)
                 return projCracked, projChecked, filesToCompile
+
         | None ->
             let projCracked = ProjectCracked.Init(state.CliArgs)
             let! projChecked = ProjectChecked.Init(projCracked)
@@ -469,25 +477,17 @@ let rec startCompilation (changes: ISet<string>) (state: State) = async {
             return projCracked, projChecked, filesToCompile
         }
 
-    let filesToCompile =
-        filesToCompile
-        |> Array.filter (fun file -> file.EndsWith(".fs") || file.EndsWith(".fsx"))
-        |> Array.append (Set.toArray state.ErroredFiles)
-        |> Array.append state.PendingFilesToCompile
-        |> Array.distinct
-
-    let logs = getFSharpErrorLogs projChecked.Project
+    let logs = getFSharpErrorLogs projChecked.Errors
     let hasFSharpError = logs |> Array.exists (fun l -> l.Severity = Severity.Error)
 
     let! logs, state = async {
-        // Skip Fable compilation if there are F# errors
-        if hasFSharpError then
-            return
-                if not state.HasCompiledOnce then logs, state
-                else logs, { state with PendingFilesToCompile = filesToCompile }
+        // Skip Fable recompilation if there are F# errors, this prevents bundlers, dev servers, tests... from being triggered
+        if hasFSharpError && state.HasCompiledOnce then
+            return logs, { state with PendingFiles = filesToCompile }
         else
             let! results, ms = measureTimeAsync <| fun () ->
                 filesToCompile
+                |> Array.filter (fun file -> file.EndsWith(".fs") || file.EndsWith(".fsx"))
                 |> Array.map (fun file ->
                     projCracked.MakeCompiler(file, projChecked.Project, state.CliArgs.OutDir)
                     |> compileFile state.HasCompiledOnce state.CliArgs state.GetOrAddDeduplicateTargetDir)
@@ -508,7 +508,7 @@ let rec startCompilation (changes: ISet<string>) (state: State) = async {
                         Array.append logs [|log|], deps)
 
             return logs, { state with HasCompiledOnce = true
-                                      PendingFilesToCompile = [||]
+                                      PendingFiles = [||]
                                       WatchDependencies = watchDependencies }
     }
 
@@ -528,17 +528,15 @@ let rec startCompilation (changes: ISet<string>) (state: State) = async {
         | _ -> false)
     |> Array.iter (formatLog state.CliArgs >> Log.warning)
 
-    let newErrors =
-        (Set.empty, logs) ||> Array.fold (fun errors log ->
+    let erroredFiles =
+        logs |> Array.choose (fun log ->
             if log.Severity = Severity.Error then
                 Log.error(formatLog state.CliArgs log)
-                match log.FileName with
-                | Some file -> Set.add file errors
-                | None -> errors
-            else errors)
+                log.FileName
+            else None)
 
     let errorMsg =
-        if Set.isEmpty newErrors then None
+        if Array.isEmpty erroredFiles then None
         else Some "Compilation failed"
 
     let errorMsg, state =
@@ -573,10 +571,6 @@ let rec startCompilation (changes: ISet<string>) (state: State) = async {
 
     match state.Watcher with
     | Some watcher ->
-        let oldErrors =
-            state.ErroredFiles
-            |> Set.filter (fun file -> not(Array.contains file filesToCompile))
-
         let! changes =
             watcher.Observe [
                 projCracked.ProjectOptions.ProjectFileName
@@ -590,7 +584,7 @@ let rec startCompilation (changes: ISet<string>) (state: State) = async {
 
         return!
             { state with ProjectCrackedAndChecked = Some(projCracked, projChecked)
-                         ErroredFiles = Set.union oldErrors newErrors }
+                         PendingFiles = erroredFiles }
             |> startCompilation changes
 
     | None ->

--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -350,7 +350,7 @@ type ProjectChecked(project: Project, checker: FSharpChecker, errors: FSharpDiag
                     checkResults.AssemblyContents.ImplementationFiles),
                 checkResults.ProjectContext.GetReferencedAssemblies(),
                 getPlugin = loadType config.CliArgs,
-                rootModule = config.FableOptions.RootModule
+                trimRootModule = config.FableOptions.RootModule
             )
         return ProjectChecked(proj, checker, checkResults.Diagnostics)
     }
@@ -446,12 +446,11 @@ let rec startCompilation (changes: ISet<string>) (state: State) = async {
                     | None -> false
                     | Some watchDependencies -> watchDependencies |> Array.exists changes.Contains
 
+                let pendingFiles = set state.PendingFiles
+
                 let filesToCompile =
-                    projCracked.SourceFiles
-                    |> Array.filter (fun path ->
-                        changes.Contains path || hasWatchDependency path)
-                    |> Array.append state.PendingFiles
-                    |> Array.distinct
+                    projCracked.SourceFiles |> Array.filter (fun path ->
+                        changes.Contains path || pendingFiles.Contains path || hasWatchDependency path)
 
                 let! projChecked = projChecked.Update(projCracked, filesToCompile)
                 return projCracked, projChecked, filesToCompile

--- a/src/Fable.Cli/Util.fs
+++ b/src/Fable.Cli/Util.fs
@@ -93,14 +93,16 @@ module File =
     open System.IO
 
     /// File.ReadAllText fails with locked files. See https://stackoverflow.com/a/1389172
-    let readAllTextNonBlocking (path: string) =
+    let readAllTextNonBlocking (path: string) = async {
         if File.Exists(path) then
             use fileStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)
             use textReader = new StreamReader(fileStream)
-            textReader.ReadToEnd()
+            let! text = textReader.ReadToEndAsync() |> Async.AwaitTask
+            return text
         else
             Log.always("File does not exist: " + path)
-            ""
+            return ""
+    }
 
     let rec tryFindPackageJsonDir dir =
         if File.Exists(Path.Combine(dir, "package.json")) then Some dir

--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -309,43 +309,47 @@ module Helpers =
         then [||] :> IList<_>
         else (nonAbbreviatedType t).GenericArguments
 
-    let private getEntityMangledName (com: Compiler) trimRootModule (ent: Fable.EntityRef) =
+    type TrimRootModule =
+        | TrimRootModule of Compiler
+        | NoTrimRootModule
+
+    let private getEntityMangledName trimRootModule (ent: Fable.EntityRef) =
         let fullName = ent.FullName
         match trimRootModule, ent.Path with
-        | true, Fable.SourcePath sourcePath ->
+        | TrimRootModule com, Fable.SourcePath sourcePath ->
             let rootMod = com.GetRootModule(sourcePath)
             if fullName.StartsWith(rootMod) then
                 fullName.Substring(rootMod.Length).TrimStart('.')
             else fullName
         // Ignore Precompiled libs and other entities for which we don't have implementation file data
-        | true, (Fable.PrecompiledLib _ | Fable.AssemblyPath _ | Fable.CoreAssemblyName _)
-        | false, _ -> fullName
+        | TrimRootModule _, (Fable.PrecompiledLib _ | Fable.AssemblyPath _ | Fable.CoreAssemblyName _)
+        | NoTrimRootModule, _ -> fullName
 
     let cleanNameAsJsIdentifier (name: string) =
         if name = ".ctor" then "$ctor"
         else name.Replace('.','_').Replace('`','$')
 
     let getEntityDeclarationName (com: Compiler) (ent: Fable.EntityRef) =
-        let entityName = getEntityMangledName com true ent |> cleanNameAsJsIdentifier
+        let entityName = getEntityMangledName (TrimRootModule com) ent |> cleanNameAsJsIdentifier
         (entityName, Naming.NoMemberPart)
         ||> Naming.sanitizeIdent (fun _ -> false)
 
-    let private getMemberMangledName (com: Compiler) trimRootModule (memb: FSharpMemberOrFunctionOrValue) =
+    let private getMemberMangledName trimRootModule (memb: FSharpMemberOrFunctionOrValue) =
         if memb.IsExtensionMember then
             let overloadSuffix = OverloadSuffix.getExtensionHash memb
-            let entName = FsEnt.Ref memb.ApparentEnclosingEntity |> getEntityMangledName com false
+            let entName = FsEnt.Ref memb.ApparentEnclosingEntity |> getEntityMangledName NoTrimRootModule
             entName, Naming.InstanceMemberPart(memb.CompiledName, overloadSuffix)
         else
             match memb.DeclaringEntity with
             | Some ent ->
                 let entFullName = FsEnt.Ref ent
                 if ent.IsFSharpModule then
-                    match getEntityMangledName com trimRootModule entFullName with
+                    match getEntityMangledName trimRootModule entFullName with
                     | "" -> memb.CompiledName, Naming.NoMemberPart
                     | moduleName -> moduleName, Naming.StaticMemberPart(memb.CompiledName, "")
                 else
                     let overloadSuffix = OverloadSuffix.getHash ent memb
-                    let entName = getEntityMangledName com trimRootModule entFullName
+                    let entName = getEntityMangledName trimRootModule entFullName
                     if memb.IsInstanceMember
                     then entName, Naming.InstanceMemberPart(memb.CompiledName, overloadSuffix)
                     else entName, Naming.StaticMemberPart(memb.CompiledName, overloadSuffix)
@@ -353,15 +357,15 @@ module Helpers =
 
     /// Returns the sanitized name for the member declaration and whether it has an overload suffix
     let getMemberDeclarationName (com: Compiler) (memb: FSharpMemberOrFunctionOrValue) =
-        let name, part = getMemberMangledName com true memb
+        let name, part = getMemberMangledName (TrimRootModule com) memb
         let name = cleanNameAsJsIdentifier name
         let part = part.Replace(cleanNameAsJsIdentifier)
         let sanitizedName = Naming.sanitizeIdent (fun _ -> false) name part
         sanitizedName, not(String.IsNullOrEmpty(part.OverloadSuffix))
 
     /// Used to identify members uniquely in the inline expressions dictionary
-    let getMemberUniqueName (com: Compiler) (memb: FSharpMemberOrFunctionOrValue): string =
-        getMemberMangledName com false memb
+    let getMemberUniqueName (memb: FSharpMemberOrFunctionOrValue): string =
+        getMemberMangledName NoTrimRootModule memb
         ||> Naming.buildNameWithoutSanitation
 
     let getMemberDisplayName (memb: FSharpMemberOrFunctionOrValue) =

--- a/src/Fable.Transforms/FSharp2Fable.fs
+++ b/src/Fable.Transforms/FSharp2Fable.fs
@@ -1260,10 +1260,6 @@ let private transformMemberDecl (com: FableCompiler) (ctx: Context) (memb: FShar
             |> addError com [] None
         []
     elif isInline memb then
-        let inlineExpr = { Args = List.concat args
-                           Body = body
-                           FileName = (com :> Compiler).CurrentFile }
-        com.AddInlineExpr(memb, inlineExpr)
         []
     elif memb.IsImplicitConstructor then
         transformImplicitConstructor com ctx memb args body
@@ -1395,30 +1391,24 @@ let getRootModule (file: FSharpImplementationFileContents) =
         | _, None -> ""
     getRootModuleInner None file.Declarations
 
-let private tryGetMemberArgsAndBody (com: Compiler) fileName entityFullName memberUniqueName =
-    let rec tryGetMemberArgsAndBodyInner (entityFullName: string) (memberUniqueName: string) = function
-        | FSharpImplementationFileDeclaration.Entity (e, decls) ->
-            let entityFullName2 = FsEnt.FullName e
-            if entityFullName.StartsWith(entityFullName2)
-            then List.tryPick (tryGetMemberArgsAndBodyInner entityFullName memberUniqueName) decls
-            else None
-        | FSharpImplementationFileDeclaration.MemberOrFunctionOrValue (memb2, args, body) ->
-            if getMemberUniqueName com memb2 = memberUniqueName
-            then Some(args, body)
-            else None
-        | FSharpImplementationFileDeclaration.InitAction _ -> None
-    let file = com.GetImplementationFile(fileName)
-    file.Declarations |> List.tryPick (tryGetMemberArgsAndBodyInner entityFullName memberUniqueName)
+let getInlineExprs (file: FSharpImplementationFileContents) =
+    let rec getInlineExprsInner decls =
+        decls |> List.collect (function
+            | FSharpImplementationFileDeclaration.InitAction _ -> []
+            | FSharpImplementationFileDeclaration.Entity(_, decls) -> getInlineExprsInner decls
+            | FSharpImplementationFileDeclaration.MemberOrFunctionOrValue (memb, args, body) ->
+                if isInline memb then
+                    let key = getMemberUniqueName memb
+                    let inlineExpr = { Args = List.concat args; Body = body; FileName = file.FileName }
+                    [key, inlineExpr]
+                else [])
+    getInlineExprsInner file.Declarations
 
 type FableCompiler(com: Compiler) =
     let attachedMembers = Dictionary<string, _>()
     let onlyOnceWarnings = HashSet<string>()
 
     member __.Options = com.Options
-
-    member _.AddInlineExpr(memb, inlineExpr: InlineExpr) =
-        let fullName = getMemberUniqueName com memb
-        com.GetOrAddInlineExpr(fullName, fun () -> inlineExpr) |> ignore
 
     member _.ReplaceAttachedMembers(entityFullName, f) =
         if attachedMembers.ContainsKey(entityFullName) then
@@ -1467,7 +1457,7 @@ type FableCompiler(com: Compiler) =
             Inject.injectArg this ctx r genArgs parameter
 
         member _.GetInlineExpr(memb) =
-            let membUniqueName = getMemberUniqueName com memb
+            let membUniqueName = getMemberUniqueName memb
             match memb.DeclaringEntity with
             | None -> failwith ("Unexpected inlined member without declaring entity. Please report: " + membUniqueName)
             | Some ent ->
@@ -1477,13 +1467,7 @@ type FableCompiler(com: Compiler) =
                 | None -> failwith ("Cannot access source path of " + entRef.FullName)
                 | Some fileName ->
                     com.AddWatchDependency(fileName)
-                    com.GetOrAddInlineExpr(membUniqueName, fun () ->
-                        match tryGetMemberArgsAndBody com fileName entRef.FullName membUniqueName with
-                        | Some(args, body) ->
-                            { Args = List.concat args
-                              Body = body
-                              FileName = fileName }
-                        | None -> failwith ("Cannot find inline member. Please report: " + membUniqueName))
+                    com.GetInlineExpr(membUniqueName)
 
     interface Compiler with
         member _.Options = com.Options
@@ -1496,7 +1480,7 @@ type FableCompiler(com: Compiler) =
         member _.GetRootModule(fileName) = com.GetRootModule(fileName)
         member _.GetEntity(fullName) = com.GetEntity(fullName)
         member _.TryGetNonCoreAssemblyEntity(fullName) = com.TryGetNonCoreAssemblyEntity(fullName)
-        member _.GetOrAddInlineExpr(fullName, generate) = com.GetOrAddInlineExpr(fullName, generate)
+        member _.GetInlineExpr(fullName) = com.GetInlineExpr(fullName)
         member _.AddWatchDependency(fileName) = com.AddWatchDependency(fileName)
         member _.AddLog(msg, severity, ?range, ?fileName:string, ?tag: string) =
             com.AddLog(msg, severity, ?range=range, ?fileName=fileName, ?tag=tag)

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -2253,7 +2253,7 @@ module Compiler =
             member _.TryGetNonCoreAssemblyEntity(fullName) = com.TryGetNonCoreAssemblyEntity(fullName)
             member _.GetImplementationFile(fileName) = com.GetImplementationFile(fileName)
             member _.GetRootModule(fileName) = com.GetRootModule(fileName)
-            member _.GetOrAddInlineExpr(fullName, generate) = com.GetOrAddInlineExpr(fullName, generate)
+            member _.GetInlineExpr(fullName) = com.GetInlineExpr(fullName)
             member _.AddWatchDependency(fileName) = com.AddWatchDependency(fileName)
             member _.AddLog(msg, severity, ?range, ?fileName:string, ?tag: string) =
                 com.AddLog(msg, severity, ?range=range, ?fileName=fileName, ?tag=tag)

--- a/src/Fable.Transforms/Global/Compiler.fs
+++ b/src/Fable.Transforms/Global/Compiler.fs
@@ -13,14 +13,14 @@ type CompilerOptionsHelper =
                        ?verbosity,
                        ?fileExtension,
                        ?clampByteArrays,
-                       ?rootModule) =
+                       ?trimRootModule) =
         {
             CompilerOptions.Define = defaultArg define []
             DebugMode = defaultArg debugMode true
             Language = defaultArg language JavaScript
             TypedArrays = defaultArg typedArrays true
             OptimizeFSharpAst = defaultArg optimizeFSharpAst false
-            RootModule = defaultArg rootModule false
+            RootModule = defaultArg trimRootModule false
             Verbosity = defaultArg verbosity Verbosity.Normal
             FileExtension = defaultArg fileExtension CompilerOptionsHelper.DefaultExtension
             ClampByteArrays = defaultArg clampByteArrays false

--- a/src/Fable.Transforms/Global/Compiler.fs
+++ b/src/Fable.Transforms/Global/Compiler.fs
@@ -54,7 +54,7 @@ type Compiler =
     abstract GetRootModule: fileName: string -> string
     abstract GetEntity: Fable.EntityRef -> Fable.Entity
     abstract TryGetNonCoreAssemblyEntity: Fable.EntityRef -> Fable.Entity option
-    abstract GetOrAddInlineExpr: string * (unit->InlineExpr) -> InlineExpr
+    abstract GetInlineExpr: string -> InlineExpr
     abstract AddWatchDependency: file: string -> unit
     abstract AddLog: msg:string * severity: Severity * ?range: SourceLocation
                         * ?fileName:string * ?tag: string -> unit

--- a/src/Fable.Transforms/State.fs
+++ b/src/Fable.Transforms/State.fs
@@ -10,30 +10,6 @@ open FSharp.Compiler.Symbols
 open FSharp.Compiler.SourceCodeServices
 #endif
 
-#if FABLE_COMPILER
-type Dictionary<'TKey, 'TValue> with
-    member x.GetOrAdd (key, valueFactory) =
-        match x.TryGetValue key with
-        | true, v -> v
-        | false, _ -> let v = valueFactory(key) in x.Add(key, v); v
-    member x.AddOrUpdate (key, valueFactory, updateFactory) =
-        if x.ContainsKey(key)
-        then let v = updateFactory key x.[key] in x.[key] <- v; v
-        else let v = valueFactory(key) in x.Add(key, v); v
-    static member From<'K, 'V when 'K : equality>(kvs: KeyValuePair<'K, 'V> seq) =
-        let d = Dictionary()
-        for kv in kvs do
-            d.Add(kv.Key, kv.Value)
-        d
-
-type ConcurrentDictionary<'TKey, 'TValue> = Dictionary<'TKey, 'TValue>
-#else
-open System.Collections.Concurrent
-type ConcurrentDictionary<'TKey, 'TValue> with
-    static member From(kvs: KeyValuePair<'TKey, 'TValue> seq) =
-        ConcurrentDictionary(kvs)
-#endif
-
 type IDictionary<'Key, 'Value> with
     member this.TryValue(key: 'Key) =
         match this.TryGetValue(key) with
@@ -58,7 +34,7 @@ type PluginRef =
     { DllPath: string
       TypeFullName: string }
 
-type Assemblies(getPlugin, checkResults: FSharpCheckProjectResults) =
+type Assemblies(getPlugin, fsharpAssemblies: FSharpAssembly list) =
     let assemblies = Dictionary()
     let coreAssemblies = Dictionary()
 
@@ -66,7 +42,7 @@ type Assemblies(getPlugin, checkResults: FSharpCheckProjectResults) =
         let plugins = Dictionary<Fable.EntityRef, System.Type>()
         let coreAssemblyNames = HashSet Metadata.coreAssemblies
 
-        for asm in checkResults.ProjectContext.GetReferencedAssemblies() do
+        for asm in fsharpAssemblies do
             match asm.FileName with
             | Some path ->
                 let path = Path.normalizePath path
@@ -104,9 +80,7 @@ type Assemblies(getPlugin, checkResults: FSharpCheckProjectResults) =
         | None -> failwithf "Cannot find assembly %s" asmPathOrName
 
     member _.GetEntityByAssemblyPath(asmPath, entityRef) =
-        match assemblies.TryGetValue(asmPath) with
-        | true, asm -> Some asm
-        | false, _ -> None
+        assemblies.TryValue(asmPath)
         |> findEntityByPath asmPath entityRef
 
     member _.TryGetEntityByAssemblyPath(asmPath, entityRef: Fable.EntityRef) =
@@ -117,9 +91,7 @@ type Assemblies(getPlugin, checkResults: FSharpCheckProjectResults) =
         |> Option.map (fun e -> FSharp2Fable.FsEnt e :> Fable.Entity)
 
     member _.GetEntityByCoreAssemblyName(asmName, entityRef: Fable.EntityRef) =
-        match coreAssemblies.TryGetValue(asmName) with
-        | true, asm -> Some asm
-        | false, _ -> None
+        coreAssemblies.TryValue(asmName)
         |> findEntityByPath asmName entityRef
 
     member _.Plugins = plugins
@@ -129,59 +101,67 @@ type ImplFile =
         Ast: FSharpImplementationFileContents
         RootModule: string
         Entities: IReadOnlyDictionary<string, Fable.Entity>
+        InlineExprs: (string * InlineExpr) list
     }
+    static member From(file: FSharpImplementationFileContents, rootModule) =
+        let entities = Dictionary()
+        let rec loop (ents: FSharpEntity seq) =
+            for e in ents do
+                if e.IsFSharpAbbreviation then ()
+                else
+                    let fableEnt = FSharp2Fable.FsEnt e :> Fable.Entity
+                    entities.Add(fableEnt.FullName, fableEnt)
+                    loop e.NestedEntities
 
-// TODO: Pass implementation files (and FSharpAssemblies) instead of the check results
-// in case we want to check files individually
+        FSharp2Fable.Compiler.getRootFSharpEntities file |> loop
+        {
+            Ast = file
+            Entities = entities
+            RootModule = if rootModule then FSharp2Fable.Compiler.getRootModule file else ""
+            InlineExprs = FSharp2Fable.Compiler.getInlineExprs file
+        }
+
 type Project(projFile: string,
-             checkResults: FSharpCheckProjectResults,
-             ?getPlugin: PluginRef -> System.Type,
-             ?optimizeFSharpAst,
-             ?assemblies,
-             ?rootModule) =
+             implFiles: Map<string, ImplFile>,
+             assemblies: Assemblies,
+             rootModule: bool) =
 
-    let rootModule = defaultArg rootModule true
-    let optimizeFSharpAst = defaultArg optimizeFSharpAst false
-    let getPlugin = defaultArg getPlugin (fun _ -> failwith "Plugins are not supported")
-    let assemblies =
-        match assemblies with
-        | Some assemblies -> assemblies
-        | None -> Assemblies(getPlugin, checkResults)
-//    do printfn "MEMORY %i" (System.GC.GetTotalMemory(true))
+    let inlineExprs = implFiles |> Seq.collect (fun kv -> kv.Value.InlineExprs) |> dict
 
-    let inlineExprs = ConcurrentDictionary<string, InlineExpr>()
+    static member From(projFile,
+                       fsharpFiles: FSharpImplementationFileContents list,
+                       fsharpAssemblies: FSharpAssembly list,
+                       ?getPlugin: PluginRef -> System.Type,
+                       ?rootModule) =
 
-    let implFiles =
-        (if optimizeFSharpAst then checkResults.GetOptimizedAssemblyContents().ImplementationFiles
-         else checkResults.AssemblyContents.ImplementationFiles)
-        |> Seq.map (fun file ->
-            let entities = Dictionary()
-            let rec loop (ents: FSharpEntity seq) =
-                for e in ents do
-                    if e.IsFSharpAbbreviation then ()
-                    else
-                        let fableEnt = FSharp2Fable.FsEnt e :> Fable.Entity
-                        entities.Add(fableEnt.FullName, fableEnt)
-                        loop e.NestedEntities
-            FSharp2Fable.Compiler.getRootFSharpEntities file |> loop
-            let key = Path.normalizePathAndEnsureFsExtension file.FileName
-            let rootModule = if rootModule then FSharp2Fable.Compiler.getRootModule file else ""
-            // TODO: If we also get the inlined functions here we don't need the concurrent dictionary
-            key, { Ast = file; RootModule = rootModule; Entities = entities })
-        |> dict
+        let rootModule = defaultArg rootModule true
+        let getPlugin = defaultArg getPlugin (fun _ -> failwith "Plugins are not supported")
+        let assemblies = Assemblies(getPlugin, fsharpAssemblies)
 
-    // TODO: pass a list of files so we don't need to update all the calculated implementation files
-    member this.Update(checkResults: FSharpCheckProjectResults) =
-        Project(this.ProjectFile, checkResults,
-                optimizeFSharpAst=optimizeFSharpAst,
-                rootModule=rootModule,
-                assemblies=assemblies)
+        let implFiles =
+            fsharpFiles
+            |> List.map (fun file ->
+                let key = Path.normalizePathAndEnsureFsExtension file.FileName
+                key, ImplFile.From(file, rootModule))
+            |> Map
+
+        Project(projFile, implFiles, assemblies, rootModule)
+
+    member this.Update(fsharpFiles: FSharpImplementationFileContents list) =
+
+        let implFiles =
+            (this.ImplementationFiles, fsharpFiles) ||> List.fold (fun implFiles file ->
+                let key = Path.normalizePathAndEnsureFsExtension file.FileName
+                let file = ImplFile.From(file, this.RootModule)
+                Map.add key file implFiles)
+
+        Project(this.ProjectFile, implFiles, this.Assemblies, this.RootModule)
 
     member _.ProjectFile = projFile
     member _.ImplementationFiles = implFiles
     member _.Assemblies = assemblies
     member _.InlineExprs = inlineExprs
-    member _.Errors = checkResults.Diagnostics
+    member _.RootModule = rootModule
 
 type Log =
     { Message: string
@@ -222,15 +202,15 @@ type CompilerImpl(currentFile, project: Project, options, fableLibraryDir: strin
 
         member _.GetImplementationFile(fileName) =
             let fileName = Path.normalizePathAndEnsureFsExtension fileName
-            match project.ImplementationFiles.TryGetValue(fileName) with
-            | true, file -> file.Ast
-            | false, _ -> failwith ("Cannot find implementation file " + fileName)
+            match Map.tryFind fileName project.ImplementationFiles with
+            | Some file -> file.Ast
+            | None -> failwith ("Cannot find implementation file " + fileName)
 
         member this.GetRootModule(fileName) =
             let fileName = Path.normalizePathAndEnsureFsExtension fileName
-            match project.ImplementationFiles.TryGetValue(fileName) with
-            | true, file -> file.RootModule
-            | false, _ ->
+            match project.ImplementationFiles.TryValue(fileName) with
+            | Some file -> file.RootModule
+            | None ->
                 let msg = $"Cannot find root module for {fileName}. If this belongs to a package, make sure it includes the source files."
                 (this :> Compiler).AddLog(msg, Severity.Warning, fileName=currentFile)
                 "" // failwith msg
@@ -242,12 +222,12 @@ type CompilerImpl(currentFile, project: Project, options, fableLibraryDir: strin
             | Fable.AssemblyPath path -> project.Assemblies.GetEntityByAssemblyPath(path, entityRef)
             | Fable.SourcePath fileName ->
                 // let fileName = Path.normalizePathAndEnsureFsExtension fileName
-                match project.ImplementationFiles.TryGetValue(fileName) with
-                | true, file ->
-                    match file.Entities.TryGetValue(entityRef.FullName) with
-                    | true, e -> e
-                    | false, _ -> failwithf "Cannot find entity %s in %s" entityRef.FullName fileName
-                | false, _ -> failwith ("Cannot find implementation file " + fileName)
+                match project.ImplementationFiles.TryValue(fileName) with
+                | Some file ->
+                    match file.Entities.TryValue(entityRef.FullName) with
+                    | Some e -> e
+                    | None -> failwithf "Cannot find entity %s in %s" entityRef.FullName fileName
+                | None -> failwith ("Cannot find implementation file " + fileName)
 
         member _.TryGetNonCoreAssemblyEntity(entityRef: Fable.EntityRef) =
             match entityRef.Path with
@@ -259,8 +239,10 @@ type CompilerImpl(currentFile, project: Project, options, fableLibraryDir: strin
                 project.ImplementationFiles.TryValue(fileName)
                 |> Option.bind (fun file -> file.Entities.TryValue(entityRef.FullName))
 
-        member _.GetOrAddInlineExpr(fullName, generate) =
-            project.InlineExprs.GetOrAdd(fullName, fun _ -> generate())
+        member _.GetInlineExpr(memberUniqueName) =
+            match project.InlineExprs.TryValue(memberUniqueName) with
+            | Some e -> e
+            | None -> failwith ("Cannot find inline member: " + memberUniqueName)
 
         member _.AddWatchDependency(file) =
             if file <> currentFile then

--- a/src/fable-compiler-js/src/app.fs
+++ b/src/fable-compiler-js/src/app.fs
@@ -145,7 +145,7 @@ let parseFiles projectFileName options =
     printfn "InteractiveChecker created in %d ms" ms0
 
     // parse F# files to AST
-    let parseFSharpProject () = fable.ParseFSharpProject(checker, projectFileName, fileNames, sources)
+    let parseFSharpProject () = fable.ParseAndCheckProject(checker, projectFileName, fileNames, sources)
     let parseRes, ms1 = measureTime parseFSharpProject ()
     printfn "Project: %s, FCS time: %d ms" projectFileName ms1
     printfn "--------------------------------------------"
@@ -157,7 +157,7 @@ let parseFiles projectFileName options =
 
     // clear cache to lower memory usage
     // if not options.watch then
-    fable.ClearParseCaches(checker)
+    fable.ClearCache(checker)
 
     // exclude signature files
     let fileNames = fileNames |> Array.filter (fun x -> not (x.EndsWith(".fsi")))

--- a/src/fable-standalone/src/Interfaces.fs
+++ b/src/fable-standalone/src/Interfaces.fs
@@ -42,7 +42,7 @@ type SourceMapping =
 type IChecker =
     interface end
 
-type IParseResults =
+type IParseAndCheckResults =
     abstract OtherFSharpOptions: string[]
     abstract Errors: Error[]
 
@@ -59,15 +59,15 @@ type IWriter =
 type IFableManager =
     abstract Version: string
     abstract CreateChecker: references: string[] * readAllBytes: (string -> byte[]) * otherOptions: string[] -> IChecker
-    abstract ClearParseCaches: checker: IChecker -> unit
-    abstract ParseFSharpProject: checker: IChecker * projectFileName: string * fileNames: string[] * sources: string[] * ?otherFSharpOptions: string[] -> IParseResults
-    abstract ParseFSharpFileInProject: checker: IChecker * fileName: string * projectFileName: string * fileNames: string[] * sources: string[] * ?otherFSharpOptions: string[] -> IParseResults
-    abstract GetParseErrors: parseResults: IParseResults -> Error[]
-    abstract GetDeclarationLocation: parseResults: IParseResults * line: int * col: int * lineText: string -> Range option
-    abstract GetToolTipText: parseResults: IParseResults * line: int * col: int * lineText: string -> string[]
-    abstract GetCompletionsAtLocation: parseResults: IParseResults * line: int * col: int * lineText: string -> Completion[]
-    abstract CompileToBabelAst: fableLibrary: string * parseResults: IParseResults * fileName: string
+    abstract ClearCache: checker: IChecker -> unit
+    abstract ParseAndCheckProject: checker: IChecker * projectFileName: string * fileNames: string[] * sources: string[] * ?otherFSharpOptions: string[] -> IParseAndCheckResults
+    abstract ParseAndCheckFileInProject: checker: IChecker * fileName: string * projectFileName: string * fileNames: string[] * sources: string[] * ?otherFSharpOptions: string[] -> IParseAndCheckResults
+    abstract GetErrors: parseResults: IParseAndCheckResults -> Error[]
+    abstract GetDeclarationLocation: parseResults: IParseAndCheckResults * line: int * col: int * lineText: string -> Range option
+    abstract GetToolTipText: parseResults: IParseAndCheckResults * line: int * col: int * lineText: string -> string[]
+    abstract GetCompletionsAtLocation: parseResults: IParseAndCheckResults * line: int * col: int * lineText: string -> Completion[]
+    abstract CompileToBabelAst: fableLibrary: string * parseResults: IParseAndCheckResults * fileName: string
                                 * ?typedArrays: bool
                                 * ?typescript: bool -> IBabelResult
     abstract PrintBabelAst: babelResult: IBabelResult * IWriter -> Async<unit>
-    abstract FSharpAstToString: parseResults: IParseResults * fileName: string -> string
+    abstract FSharpAstToString: parseResults: IParseAndCheckResults * fileName: string -> string

--- a/src/fable-standalone/src/Main.fs
+++ b/src/fable-standalone/src/Main.fs
@@ -13,7 +13,7 @@ open FSharp.Compiler.SourceCodeServices
 open FSharp.Compiler.Symbols
 
 type CheckerImpl(checker: InteractiveChecker) =
-    member __.Checker = checker
+    member _.Checker = checker
     interface IChecker
 
 let mapError (error: FSharpDiagnostic) =
@@ -32,20 +32,21 @@ let mapError (error: FSharpDiagnostic) =
             | FSharpDiagnosticSeverity.Error -> false
     }
 
-type ParseResults (project: Lazy<Project>,
+type ParseAndCheckResults
+                  (project: Lazy<Project>,
                    parseFileResultsOpt: FSharpParseFileResults option,
                    checkFileResultsOpt: FSharpCheckFileResults option,
                    checkProjectResults: FSharpCheckProjectResults,
                    otherFSharpOptions: string[]) =
 
-    member __.GetProject () = project.Force()
-    member __.ParseFileResultsOpt = parseFileResultsOpt
-    member __.CheckFileResultsOpt = checkFileResultsOpt
-    member __.CheckProjectResults = checkProjectResults
+    member _.GetProject () = project.Force()
+    member _.ParseFileResultsOpt = parseFileResultsOpt
+    member _.CheckFileResultsOpt = checkFileResultsOpt
+    member _.CheckProjectResults = checkProjectResults
 
-    interface IParseResults with
-        member __.OtherFSharpOptions = otherFSharpOptions
-        member __.Errors = checkProjectResults.Diagnostics |> Array.map mapError
+    interface IParseAndCheckResults with
+        member _.OtherFSharpOptions = otherFSharpOptions
+        member _.Errors = checkProjectResults.Diagnostics |> Array.map mapError
 
 let inline private tryGetLexerSymbolIslands (sym: Lexer.LexerSymbol) =
   match sym.Text with
@@ -123,23 +124,27 @@ let makeProjOptions projectFileName fileNames otherFSharpOptions =
         Stamp = None }
     projOptions
 
-let makeProject (projectOptions: FSharpProjectOptions) (projectResults: FSharpCheckProjectResults) =
+let makeProject (projectOptions: FSharpProjectOptions) (checkResults: FSharpCheckProjectResults) =
     // let errors = com.GetFormattedLogs() |> Map.tryFind "error"
     // if errors.IsSome then failwith (errors.Value |> String.concat "\n")
     let optimize = projectOptions.OtherOptions |> Array.exists ((=) "--optimize+")
-    Project(projectOptions.ProjectFileName, projectResults, optimizeFSharpAst=optimize)
+    Project.From(
+        projectOptions.ProjectFileName,
+        (if optimize then checkResults.GetOptimizedAssemblyContents().ImplementationFiles
+        else checkResults.AssemblyContents.ImplementationFiles),
+        checkResults.ProjectContext.GetReferencedAssemblies())
 
-let parseFSharpProject (checker: InteractiveChecker) projectFileName fileNames sources otherFSharpOptions =
-    let projectResults = checker.ParseAndCheckProject (projectFileName, fileNames, sources)
+let parseAndCheckProject (checker: InteractiveChecker) projectFileName fileNames sources otherFSharpOptions =
+    let checkResults = checker.ParseAndCheckProject (projectFileName, fileNames, sources)
+    let projectOptions = makeProjOptions projectFileName fileNames otherFSharpOptions
+    let project = lazy (makeProject projectOptions checkResults)
+    ParseAndCheckResults (project, None, None, checkResults, otherFSharpOptions)
+
+let parseAndCheckFileInProject (checker: InteractiveChecker) fileName projectFileName fileNames sources otherFSharpOptions =
+    let results, checkResults, projectResults = checker.ParseAndCheckFileInProject (fileName, projectFileName, fileNames, sources)
     let projectOptions = makeProjOptions projectFileName fileNames otherFSharpOptions
     let project = lazy (makeProject projectOptions projectResults)
-    ParseResults (project, None, None, projectResults, otherFSharpOptions)
-
-let parseFSharpFileInProject (checker: InteractiveChecker) fileName projectFileName fileNames sources otherFSharpOptions =
-    let parseResults, checkResults, projectResults = checker.ParseAndCheckFileInProject (fileName, projectFileName, fileNames, sources)
-    let projectOptions = makeProjOptions projectFileName fileNames otherFSharpOptions
-    let project = lazy (makeProject projectOptions projectResults)
-    ParseResults (project, Some parseResults, Some checkResults, projectResults, otherFSharpOptions)
+    ParseAndCheckResults (project, Some results, Some checkResults, projectResults, otherFSharpOptions)
 
 let tooltipToString (el: ToolTipElement): string[] =
     let dataToString (data: ToolTipElementData) =
@@ -166,8 +171,8 @@ let tooltipToString (el: ToolTipElement): string[] =
     | ToolTipElement.CompositionError err -> [|err|]
 
 /// Get tool tip at the specified location
-let getDeclarationLocation (parseResults: ParseResults) line col lineText =
-    match parseResults.CheckFileResultsOpt with
+let getDeclarationLocation (results: ParseAndCheckResults) line col lineText =
+    match results.CheckFileResultsOpt with
     | Some checkFile ->
         match findLongIdents(col - 1, lineText) with
         | None -> None
@@ -186,8 +191,8 @@ let getDeclarationLocation (parseResults: ParseResults) line col lineText =
     | None -> None
 
 /// Get tool tip at the specified location
-let getToolTipAtLocation (parseResults: ParseResults) line col lineText =
-    match parseResults.CheckFileResultsOpt with
+let getToolTipAtLocation (results: ParseAndCheckResults) line col lineText =
+    match results.CheckFileResultsOpt with
     | Some checkFile ->
         match findLongIdents(col - 1, lineText) with
         | None ->
@@ -200,22 +205,22 @@ let getToolTipAtLocation (parseResults: ParseResults) line col lineText =
     | None ->
         [||]
 
-let getCompletionsAtLocation (parseResults: ParseResults) (line: int) (col: int) lineText =
-   match parseResults.CheckFileResultsOpt with
+let getCompletionsAtLocation (results: ParseAndCheckResults) (line: int) (col: int) lineText =
+   match results.CheckFileResultsOpt with
     | Some checkFile ->
         let ln, residue = findLongIdentsAndResidue(col - 1, lineText)
         let longName = QuickParse.GetPartialLongNameEx(lineText, col - 1)
         let longName = { longName with QualifyingIdents = ln; PartialIdent = residue }
-        let decls = checkFile.GetDeclarationListInfo(parseResults.ParseFileResultsOpt, line, lineText, longName, fun () -> [])
+        let decls = checkFile.GetDeclarationListInfo(results.ParseFileResultsOpt, line, lineText, longName, fun () -> [])
         decls.Items |> Array.map (fun decl ->
             { Name = decl.Name; Glyph = convertGlyph decl.Glyph })
     | None ->
         [||]
 
-let compileToFableAst (parseResults: IParseResults) fileName fableLibrary typedArrays language =
-    let res = parseResults :?> ParseResults
+let compileToFableAst (results: IParseAndCheckResults) fileName fableLibrary typedArrays language =
+    let res = results :?> ParseAndCheckResults
     let project = res.GetProject()
-    let define = parseResults.OtherFSharpOptions |> Array.choose (fun x ->
+    let define = results.OtherFSharpOptions |> Array.choose (fun x ->
         if x.StartsWith("--define:") || x.StartsWith("-d:")
         then x.[(x.IndexOf(':') + 1)..] |> Some
         else None) |> Array.toList
@@ -252,46 +257,46 @@ type BabelResult(program: Babel.Program, errors) =
 
 let init () =
   { new IFableManager with
-        member __.Version = Fable.Literals.VERSION
+        member _.Version = Fable.Literals.VERSION
 
-        member __.CreateChecker(references, readAllBytes, otherOptions) =
+        member _.CreateChecker(references, readAllBytes, otherOptions) =
             InteractiveChecker.Create(references, readAllBytes, otherOptions)
             |> CheckerImpl :> IChecker
 
-        member __.ClearParseCaches(checker) =
+        member _.ClearCache(checker) =
             let c = checker :?> CheckerImpl
             c.Checker.ClearCache()
 
-        member __.ParseFSharpProject(checker, projectFileName, fileNames, sources, ?otherFSharpOptions) =
+        member _.ParseAndCheckProject(checker, projectFileName, fileNames, sources, ?otherFSharpOptions) =
             let c = checker :?> CheckerImpl
             let otherFSharpOptions = defaultArg otherFSharpOptions [||]
-            parseFSharpProject c.Checker projectFileName fileNames sources otherFSharpOptions :> IParseResults
+            parseAndCheckProject c.Checker projectFileName fileNames sources otherFSharpOptions :> IParseAndCheckResults
 
-        member __.ParseFSharpFileInProject(checker, fileName, projectFileName, fileNames, sources, ?otherFSharpOptions) =
+        member _.ParseAndCheckFileInProject(checker, fileName, projectFileName, fileNames, sources, ?otherFSharpOptions) =
             let c = checker :?> CheckerImpl
             let otherFSharpOptions = defaultArg otherFSharpOptions [||]
-            parseFSharpFileInProject c.Checker fileName projectFileName fileNames sources otherFSharpOptions :> IParseResults
+            parseAndCheckFileInProject c.Checker fileName projectFileName fileNames sources otherFSharpOptions :> IParseAndCheckResults
 
-        member __.GetParseErrors(parseResults:IParseResults) =
-            parseResults.Errors
+        member _.GetErrors(results:IParseAndCheckResults) =
+            results.Errors
 
-        member __.GetDeclarationLocation(parseResults:IParseResults, line:int, col:int, lineText:string) =
-            let res = parseResults :?> ParseResults
+        member _.GetDeclarationLocation(results:IParseAndCheckResults, line:int, col:int, lineText:string) =
+            let res = results :?> ParseAndCheckResults
             getDeclarationLocation res line col lineText
 
-        member __.GetToolTipText(parseResults:IParseResults, line:int, col:int, lineText:string) =
-            let res = parseResults :?> ParseResults
+        member _.GetToolTipText(results:IParseAndCheckResults, line:int, col:int, lineText:string) =
+            let res = results :?> ParseAndCheckResults
             getToolTipAtLocation res line col lineText
 
-        member __.GetCompletionsAtLocation(parseResults:IParseResults, line:int, col:int, lineText:string) =
-            let res = parseResults :?> ParseResults
+        member _.GetCompletionsAtLocation(results:IParseAndCheckResults, line:int, col:int, lineText:string) =
+            let res = results :?> ParseAndCheckResults
             getCompletionsAtLocation res line col lineText
 
-        member __.CompileToBabelAst(fableLibrary:string, parseResults:IParseResults, fileName:string,
+        member _.CompileToBabelAst(fableLibrary:string, results:IParseAndCheckResults, fileName:string,
                                     ?typedArrays, ?typescript) =
             let language = match typescript with | Some true -> TypeScript | _ -> JavaScript
             let com, fableAst, errors =
-                compileToFableAst parseResults fileName fableLibrary typedArrays language
+                compileToFableAst results fileName fableLibrary typedArrays language
             let babelAst =
                 fableAst |> Fable2Babel.Compiler.transformFile com
             upcast BabelResult(babelAst, errors)
@@ -311,8 +316,8 @@ let init () =
             | _ ->
                 failwith "Unexpected Babel result"
 
-        member __.FSharpAstToString(parseResults:IParseResults, fileName:string) =
-            let res = parseResults :?> ParseResults
+        member _.FSharpAstToString(results:IParseAndCheckResults, fileName:string) =
+            let res = results :?> ParseAndCheckResults
             let project = res.GetProject()
             let implFile = project.ImplementationFiles.Item(fileName)
             AstPrint.printFSharpDecls "" implFile.Ast.Declarations |> String.concat "\n"

--- a/src/fable-standalone/src/Worker/Worker.fs
+++ b/src/fable-standalone/src/Worker/Worker.fs
@@ -42,7 +42,7 @@ type FableStateConfig =
 type State =
     { Fable: FableState option
       Worker: ObservableWorker<WorkerRequest>
-      CurrentResults: Map<string,IParseResults> }
+      CurrentResults: Map<string, IParseAndCheckResults> }
 
 type SourceWriter(sourceMaps: bool) =
     let sb = System.Text.StringBuilder()
@@ -101,7 +101,7 @@ let private compileCode fable fileName fsharpNames fsharpCodes otherFSharpOption
         let! fable = makeFableState (Initialized fable) otherFSharpOptions
         let (parseResults, parsingTime) = measureTime (fun () ->
             // fable.Manager.ParseFSharpScript(fable.Checker, FILE_NAME, fsharpCode, otherFSharpOptions)) ()
-            fable.Manager.ParseFSharpFileInProject(fable.Checker, fileName, PROJECT_NAME, fsharpNames, fsharpCodes, otherFSharpOptions)) ()
+            fable.Manager.ParseAndCheckFileInProject(fable.Checker, fileName, PROJECT_NAME, fsharpNames, fsharpCodes, otherFSharpOptions)) ()
 
         let! jsCode, errors, fableTransformTime = async {
             if parseResults.Errors |> Array.exists (fun e -> not e.IsWarning) then
@@ -178,7 +178,7 @@ let rec loop (box: MailboxProcessor<WorkerRequest>) (state: State) = async {
         // Check if we need to recreate the FableState because otherFSharpOptions have changed
         let! fable = makeFableState (Initialized fable) otherFSharpOptions
         // let res = fable.Manager.ParseFSharpScript(fable.Checker, FILE_NAME, fsharpCode, otherFSharpOptions)
-        let res = fable.Manager.ParseFSharpFileInProject(fable.Checker, FILE_NAME, PROJECT_NAME, [|FILE_NAME|], [|fsharpCode|], otherFSharpOptions)
+        let res = fable.Manager.ParseAndCheckFileInProject(fable.Checker, FILE_NAME, PROJECT_NAME, [|FILE_NAME|], [|fsharpCode|], otherFSharpOptions)
 
         ParsedCode res.Errors |> state.Worker.Post
         return! loop box { state with CurrentResults = state.CurrentResults.Add(FILE_NAME,res) }
@@ -192,7 +192,7 @@ let rec loop (box: MailboxProcessor<WorkerRequest>) (state: State) = async {
 
             let names = fsharpCode |> Array.map (fun x -> x.Name)
             let contents = fsharpCode |> Array.map (fun x -> x.Content)
-            let res = fable.Manager.ParseFSharpFileInProject(fable.Checker, file, PROJECT_NAME, names, contents, otherFSharpOptions)
+            let res = fable.Manager.ParseAndCheckFileInProject(fable.Checker, file, PROJECT_NAME, names, contents, otherFSharpOptions)
 
             ParsedCode res.Errors |> state.Worker.Post
 

--- a/src/fable-standalone/test/bench-compiler/app.fs
+++ b/src/fable-standalone/test/bench-compiler/app.fs
@@ -129,7 +129,7 @@ let parseFiles projectFileName options =
     printfn "InteractiveChecker created in %d ms" ms0
 
     // parse F# files to AST
-    let parseFSharpProject () = fable.ParseFSharpProject(checker, projectFileName, fileNames, sources)
+    let parseFSharpProject () = fable.ParseAndCheckProject(checker, projectFileName, fileNames, sources)
     let parseRes, ms1 = measureTime parseFSharpProject ()
     printfn "Project: %s, FCS time: %d ms" projectFileName ms1
     printfn "--------------------------------------------"
@@ -141,7 +141,7 @@ let parseFiles projectFileName options =
 
     // clear cache to lower memory usage
     // if not options.watch then
-    fable.ClearParseCaches(checker)
+    fable.ClearCache(checker)
 
     // exclude signature files
     let fileNames = fileNames |> Array.filter (fun x -> not (x.EndsWith(".fsi")))

--- a/src/fable-standalone/test/bench/app.fs
+++ b/src/fable-standalone/test/bench/app.fs
@@ -41,12 +41,12 @@ let main argv =
         let checker, ms0 = measureTime createChecker ()
         printfn "InteractiveChecker created in %d ms" ms0
         // let parseFSharpScript () = fable.ParseFSharpScript(checker, fileName, source)
-        let parseFSharpScript () = fable.ParseFSharpFileInProject(checker, fileName, projectFileName, [|fileName|], [|source|])
+        let parseFSharpScript () = fable.ParseAndCheckFileInProject(checker, fileName, projectFileName, [|fileName|], [|source|])
         let fableLibraryDir = "fable-library"
         let parseFable (res, fileName) = fable.CompileToBabelAst(fableLibraryDir, res, fileName)
         let bench i =
             let parseRes, ms1 = measureTime parseFSharpScript ()
-            let errors = fable.GetParseErrors parseRes
+            let errors = fable.GetErrors parseRes
             errors |> Array.iter (printfn "Error: %A")
             if errors.Length > 0 then failwith "Too many errors."
             let babelAst, ms2 = measureTime parseFable (parseRes, fileName)

--- a/tests/Compiler/Compiler.fsproj
+++ b/tests/Compiler/Compiler.fsproj
@@ -6,7 +6,7 @@
     <DefineConstants>$(DefineConstants);DOTNET_FILE_SYSTEM</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Expecto" Version="5.1.2" />
+    <PackageReference Include="Expecto" Version="9.0.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Fable.Cli\Fable.Cli.fsproj" />

--- a/tests/Compiler/Main.fs
+++ b/tests/Compiler/Main.fs
@@ -12,7 +12,7 @@ let allTests =
 
 [<EntryPoint>]
 let main args =
-    let config = { defaultConfig with ``parallel`` = false }
+    let config = { defaultConfig with runInParallel = false }
 
     allTests
     |> testList "All"

--- a/tests/Compiler/Util/Compiler.fs
+++ b/tests/Compiler/Util/Compiler.fs
@@ -39,7 +39,7 @@ module Compiler =
     (fable, checker)
 
   let clear ((fable, checker): Compiler) =
-    fable.ClearParseCaches checker
+    fable.ClearCache checker
 
   let compile ((fable, checker): Compiler) (settings: Settings) (source: string) =
     let preamble =
@@ -54,7 +54,7 @@ module Compiler =
 
     let projectFileName = "project.fsproj"
     let fileName = "tmp.fs"
-    let parseFSharpScript () = fable.ParseFSharpFileInProject(checker, fileName, projectFileName, [|fileName|], [|source|])
+    let parseFSharpScript () = fable.ParseAndCheckFileInProject(checker, fileName, projectFileName, [|fileName|], [|source|])
     let parseResult = parseFSharpScript ()
     let babelResult = fable.CompileToBabelAst ("", parseResult, fileName)
 

--- a/tests/Integration/Fable.Tests.Integration.fsproj
+++ b/tests/Integration/Fable.Tests.Integration.fsproj
@@ -5,7 +5,7 @@
     <RollForward>Major</RollForward>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Expecto" Version="5.1.2" />
+    <PackageReference Include="Expecto" Version="9.0.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Fable.Cli\Fable.Cli.fsproj" />

--- a/tests/Main/Fable.Tests.fsproj
+++ b/tests/Main/Fable.Tests.fsproj
@@ -8,7 +8,7 @@
  </PropertyGroup>
 
  <ItemGroup>
-    <PackageReference Include="Expecto" Version="5.1.2" />
+    <PackageReference Include="Expecto" Version="9.0.4" />
     <PackageReference Include="AltCover" Version="5.3.675" />
     <PackageReference Include="Fable.JsonProvider" Version="1.0.1" />
     <PackageReference Include="FSharp.UMX" Version="1.0.0" />


### PR DESCRIPTION
So far, for recompilations we've just been calling `ParseAndCheckProject` on FCS, same as when compiling the whole project for the first time. This usually works fine when modifying files that are down the list of files because FCS caches the files on top, but for big projects, when editing a file on top of the list, FCS invalidates all the files below it, so the compilation can take a long time even if there are no other files depending on it.

In this PR, for watch compilations we call `ParseAndCheckFileInProject` instead so only "dirty" files are being recompiled which should help with the above case.

Note that I've touched the way files are recompiled to unify F# and Fable compilation, so we need to be sure watch compilations still work fine (for example, when changes cause errors in other files and then we fix the errors in a different iteration). It'd be great to have some integration tests about this.