### PR TITLE
Culture invariant tests

### DIFF
--- a/tests/Main/DateTimeTests.fs
+++ b/tests/Main/DateTimeTests.fs
@@ -3,6 +3,7 @@ module Fable.Tests.DateTime
 open System
 open Util.Testing
 open Fable.Tests
+open System.Globalization
 
 let toSigFigs nSigFigs x =
     let absX = abs x
@@ -20,7 +21,7 @@ let thatYearMilliseconds (dt: DateTime) =
 let tests =
   testList "DateTime" [
     testCase "DateTime.ToString with format works" <| fun () ->
-        DateTime(2014, 9, 11, 16, 37, 0).ToString("HH:mm", System.Globalization.CultureInfo.InvariantCulture)
+        DateTime(2014, 9, 11, 16, 37, 0).ToString("HH:mm", CultureInfo.InvariantCulture)
         |> equal "16:37"
 
     testCase "DateTime.ToString without separator works" <| fun () -> // See #1131
@@ -92,7 +93,7 @@ let tests =
         let dto = DateTimeOffset(d)
 
         // dto.ToString() |> equal "2014-10-09 13:23:30 +00:00"
-        dto.ToString("HH:mm:ss", System.Globalization.CultureInfo.InvariantCulture) |> equal "13:23:30"
+        dto.ToString("HH:mm:ss", CultureInfo.InvariantCulture) |> equal "13:23:30"
 
     testCase "DateTime.Hour works" <| fun () ->
         let d = DateTime(2014, 10, 9, 13, 23, 30, DateTimeKind.Local)
@@ -230,21 +231,21 @@ let tests =
         d > DateTime.MinValue |> equal true
 
     testCase "DateTime.Parse works" <| fun () ->
-        let d = DateTime.Parse("9/10/2014 1:50:34 PM")
+        let d = DateTime.Parse("9/10/2014 1:50:34 PM", CultureInfo.InvariantCulture)
         d.Year + d.Month + d.Day + d.Hour + d.Minute
         |> equal 2096
 
     testCase "DateTime.Parse with time-only string works" <| fun () -> // See #1045
-        let d = DateTime.Parse("13:50:34")
+        let d = DateTime.Parse("13:50:34", CultureInfo.InvariantCulture)
         d.Hour + d.Minute + d.Second |> equal 97
-        let d = DateTime.Parse("1:5:34 AM")
+        let d = DateTime.Parse("1:5:34 AM", CultureInfo.InvariantCulture)
         d.Hour + d.Minute + d.Second |> equal 40
-        let d = DateTime.Parse("1:5:34 PM")
+        let d = DateTime.Parse("1:5:34 PM", CultureInfo.InvariantCulture)
         d.Hour + d.Minute + d.Second |> equal 52
 
     testCase "DateTime.TryParse works" <| fun () ->
         let f (d: string) =
-            match DateTime.TryParse(d) with
+            match DateTime.TryParse(d, CultureInfo.InvariantCulture, DateTimeStyles.None) with
             | true, _ -> true
             | false, _ -> false
         f "foo" |> equal false
@@ -253,7 +254,7 @@ let tests =
 
     testCase "Parsing doesn't succeed for invalid dates" <| fun () ->
         let invalidAmericanDate = "13/1/2020"
-        let r, _date = DateTime.TryParse invalidAmericanDate
+        let r, _date = DateTime.TryParse(invalidAmericanDate, CultureInfo.InvariantCulture, DateTimeStyles.None)
         r |> equal false
 
     testCase "DateTime.Today works" <| fun () ->

--- a/tests/Main/StringTests.fs
+++ b/tests/Main/StringTests.fs
@@ -2,6 +2,8 @@ module Fable.Tests.Strings
 
 open System
 open Util.Testing
+open System.Globalization
+
 #if FABLE_COMPILER
 open Fable.Core
 open Fable.Core.JsInterop
@@ -83,7 +85,7 @@ let tests =
                               .Append(true)
                               .Append(5.2)
                               .Append(34)
-            equal "aaabcd/true5.234" (builder.ToString().ToLower())
+            equal "aaabcd/true5.234" (builder.ToString().Replace(",", ".").ToLower())
 
       testCase "kprintf works" <| fun () ->
             let f (s:string) = s + "XX"
@@ -288,9 +290,9 @@ let tests =
           |> equal "[ Hello][  Foo]"
 
       testCase "String.Format combining padding and zeroes pattern works" <| fun () ->
-          String.Format("{0:++0.00++}", -5000.5657) |> equal "-++5000.57++"
-          String.Format("{0:000.00}foo", 5) |> equal "005.00foo"
-          String.Format("{0,-8:000.00}foo", 12.456) |> equal "012.46  foo"
+          String.Format(CultureInfo.InvariantCulture, "{0:++0.00++}", -5000.5657) |> equal "-++5000.57++"
+          String.Format(CultureInfo.InvariantCulture, "{0:000.00}foo", 5) |> equal "005.00foo"
+          String.Format(CultureInfo.InvariantCulture, "{0,-8:000.00}foo", 12.456) |> equal "012.46  foo"
 
       testCase "String.Format {0:x} works" <| fun () ->
             //See above comment on expected values
@@ -312,7 +314,7 @@ let tests =
 
       testCase "ToString formatted works with decimals" <| fun () -> // See #2276
           let decimal = 78.6M
-          decimal.ToString("0.000") |> equal "78.600"
+          decimal.ToString("0.000").Replace(",", ".") |> equal "78.600"
 
       testCase "Printf works with generic argument" <| fun () ->
           spr "bar %s" "a" |> equal "bar a"
@@ -344,7 +346,7 @@ let tests =
       testCase "String.Format with extra formatting works" <| fun () ->
             let i = 0.5466788
             let dt = DateTime(2014, 9, 26).AddMinutes(19.)
-            String.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:F2} {0:P2} {1:yyyy-MM-dd HH:mm}", i, dt)
+            String.Format(CultureInfo.InvariantCulture, "{0:F2} {0:P2} {1:yyyy-MM-dd HH:mm}", i, dt)
                   .Replace(",", ".").Replace(" %", "%")
             |> equal "0.55 54.67% 2014-09-26 00:19"
 
@@ -362,10 +364,10 @@ let tests =
           sprintf "%+0-10i" -22  |> equal "-22       "
 
       testCase "Padding with String.Format works" <| fun () ->
-          String.Format("{0,10:F1}", 3.14).Replace(",", ".")  |> equal "       3.1"
-          String.Format("{0,-10:F1}", 3.14).Replace(",", ".") |> equal "3.1       "
-          String.Format("{0,10}", 22)                         |> equal "        22"
-          String.Format("{0,-10}", -22)                       |> equal "-22       "
+          String.Format(CultureInfo.InvariantCulture, "{0,10:F1}", 3.14)  |> equal "       3.1"
+          String.Format(CultureInfo.InvariantCulture, "{0,-10:F1}", 3.14) |> equal "3.1       "
+          String.Format(CultureInfo.InvariantCulture, "{0,10}", 22)       |> equal "        22"
+          String.Format(CultureInfo.InvariantCulture, "{0,-10}", -22)     |> equal "-22       "
 
       // Conversions
 

--- a/tests/Main/TypeTests.fs
+++ b/tests/Main/TypeTests.fs
@@ -885,7 +885,7 @@ let tests =
         let multiplyTwice x y = x * y * y
 
         foo.[3] <- 'W'
-        foo.Foo <- foo.Foo + foo.DoSomething(addPlus2, 3.).ToString("F2") + foo.[2].ToString()
+        foo.Foo <- foo.Foo + foo.DoSomething(addPlus2, 3.).ToString("F2").Replace(",", ".") + foo.[2].ToString()
         foo.Foo <- foo.Foo + foo.Sum("a", "bc", "d")
 
         foo.Foo |> equal "FoW19.20Wabcd"
@@ -904,7 +904,7 @@ let tests =
         let multiplyTwice x y = x * y * y
 
         bar.[3] <- 'Z'
-        bar.Bar <- bar.Bar + bar.DoSomething(multiplyTwice, 3.).ToString("F2") + bar.[2].ToString() + (sprintf "%b%b" bar.['B'] bar.['x'])
+        bar.Bar <- bar.Bar + bar.DoSomething(multiplyTwice, 3.).ToString("F2").Replace(",", ".") + bar.[2].ToString() + (sprintf "%b%b" bar.['B'] bar.['x'])
         bar.Bar <- bar.Bar + bar.Sum("a", "bc", "d")
 
         bar.Bar |> equal "Zar77.40rfalsefalsedbca"
@@ -915,7 +915,7 @@ let tests =
         let multiplyTwice x y = x * y * y
         let foo2 = FooClass("Foo") :> FooInterface
         foo2.[0] <- 'W'
-        foo2.Foo <- foo2.Foo + foo2.DoSomething(multiplyTwice, 3.).ToString("F2") + foo2.[2].ToString()
+        foo2.Foo <- foo2.Foo + foo2.DoSomething(multiplyTwice, 3.).ToString("F2").Replace(',', '.') + foo2.[2].ToString()
         foo2.Foo <- foo2.Foo + foo2.Sum("a", "bc", "d")
         foo2.Foo |> equal "Woo1020.00oabcabcdabcabcd"
 
@@ -925,7 +925,7 @@ let tests =
         let multiplyTwice x y = x * y * y
         let bar2 = BarClass("Bar") :> BarInterface
         bar2.[0] <- 'Z'
-        bar2.Bar <- bar2.Bar + bar2.DoSomething(addPlus2, 3.).ToString("F2") + bar2.[2].ToString() + (sprintf "%b%b" bar2.['B'] bar2.['x'])
+        bar2.Bar <- bar2.Bar + bar2.DoSomething(addPlus2, 3.).ToString("F2").Replace(",", ".") + bar2.[2].ToString() + (sprintf "%b%b" bar2.['B'] bar2.['x'])
         bar2.Bar <- bar2.Bar + bar2.Sum("a", "bc", "d")
         bar2.Bar |> equal "BZr9536.74rtruefalseaabcbcaabcbcdd"
 


### PR DESCRIPTION
Fixes #2597.

I used `Replace` in some places because with `InvariantCulture` Mocha tests started failing with `ToString` producing unexpected different results.