### PR TITLE
Set default language based on executable

### DIFF
--- a/src/Fable.AST/Plugins.fs
+++ b/src/Fable.AST/Plugins.fs
@@ -16,6 +16,14 @@ type Language =
     | Php
     | Dart
 
+    override this.ToString () =
+        match this with
+        | JavaScript -> "JS"
+        | TypeScript -> "TypeScript"
+        | Python -> "Python"
+        | Php -> "PHP"
+        | Dart -> "Dart"
+
 type CompilerOptions =
     {
         TypedArrays: bool

--- a/src/Fable.Cli/Entry.fs
+++ b/src/Fable.Cli/Entry.fs
@@ -145,10 +145,10 @@ let argLanguage (args: CliArgs) =
     |> Option.defaultWith (fun () ->
         // Set default language based on name of executing process (fable tool).
         let proc = System.Reflection.Assembly.GetEntryAssembly().Location
-        let fileName = Path.GetFileNameWithoutExtension(proc)
-        match fileName with
-        | "fable-py" -> "py"
-        | _ -> "js"
+        match Path.GetFileNameWithoutExtension(proc) with
+        | "fable-py" -> Python
+        | _ -> JavaScript
+        |> string
     )
     |> (function
     | "js" | "javascript" | "JavaScript" -> JavaScript

--- a/src/Fable.Cli/Entry.fs
+++ b/src/Fable.Cli/Entry.fs
@@ -190,15 +190,7 @@ type Runner =
             Ok fsprojPath
 
     let language = argLanguage args
-    let lang =
-        match language with
-        | JavaScript -> "JS"
-        | TypeScript -> "TypeScript"
-        | Python -> "Python"
-        | Php -> "PHP"
-        | Dart -> "Dart"
-
-    Log.always($"Fable: F# to {lang} compiler " + Literals.VERSION)
+    Log.always($"Fable: F# to {language} compiler " + Literals.VERSION)
     Log.always("Thanks to the contributor! @" + Contributors.getRandom() + "\n")
 
     let typedArrays = args.FlagOr("--typedArrays", true)

--- a/src/Fable.Cli/Entry.fs
+++ b/src/Fable.Cli/Entry.fs
@@ -142,19 +142,21 @@ let argLanguage (args: CliArgs) =
     args.Value("--lang", "--language")
     |> Option.orElseWith (fun () -> if args.FlagEnabled("--typescript") then Some "ts" else None) // Compatibility with "--typescript"
     |> Option.map (fun lang -> lang.ToLower())
-    |> Option.defaultValue "js"
+    |> Option.defaultWith (fun () ->
+        // Set default language based on name of executing process (fable tool).
+        let proc = System.Reflection.Assembly.GetEntryAssembly().Location
+        let fileName = Path.GetFileNameWithoutExtension(proc)
+        match fileName with
+        | "fable-py" -> "py"
+        | _ -> "js"
+    )
     |> (function
+    | "js" | "javascript" | "JavaScript" -> JavaScript
     | "ts" | "typescript" | "TypeScript" -> TypeScript
     | "py" | "python" | "Python" -> Python
     | "php" | "Php" | "PHP" -> Php
     | "dart" -> Dart
-    | _ ->
-        // Set language based on name of executing process (fable tool).
-        let proc = System.Reflection.Assembly.GetEntryAssembly().Location
-        let fileName = Path.GetFileNameWithoutExtension(proc)
-        match fileName with
-        | "fable-py" -> Python
-        | _ -> JavaScript)
+    | _ -> JavaScript)
 
 type Runner =
   static member Run(args: CliArgs, rootDir: string, runProc: RunProcess option, ?fsprojPath: string, ?watch) = result {
@@ -188,6 +190,17 @@ type Runner =
             Ok fsprojPath
 
     let language = argLanguage args
+    let lang =
+        match language with
+        | JavaScript -> "JS"
+        | TypeScript -> "TypeScript"
+        | Python -> "Python"
+        | Php -> "PHP"
+        | Dart -> "Dart"
+
+    Log.always($"Fable: F# to {lang} compiler " + Literals.VERSION)
+    Log.always("Thanks to the contributor! @" + Contributors.getRandom() + "\n")
+
     let typedArrays = args.FlagOr("--typedArrays", true)
     let outDir = args.Value("-o", "--outDir") |> Option.map normalizeAbsolutePath
     let outDirLast = outDir |> Option.bind (fun outDir -> outDir.TrimEnd('/').Split('/') |> Array.tryLast) |> Option.defaultValue ""
@@ -352,8 +365,6 @@ let main argv =
             match commands with
             | ["--version"] -> ()
             | _ ->
-                Log.always("Fable: F# to JS compiler " + Literals.VERSION)
-                Log.always("Thanks to the contributor! @" + Contributors.getRandom() + "\n")
                 if args.FlagEnabled "--verbose" then
                     Log.makeVerbose()
 

--- a/tests/Main/AsyncTests.fs
+++ b/tests/Main/AsyncTests.fs
@@ -200,7 +200,7 @@ let tests =
     //         do! Async.Sleep 75
     //         equal true !res
     //     }
-    
+
     testCaseAsync "Async.Parallel works" <| fun () ->
         async {
             let makeWork i =
@@ -263,7 +263,7 @@ let tests =
             let! result = Async.Sequential works
             let ``then`` = DateTimeOffset.Now
             let d = ``then`` - now
-            if d < TimeSpan.FromSeconds 1. then
+            if d <= TimeSpan.FromSeconds 1. then
                 failwithf "expected sequential operations to take longer than 1 second, but took %0.00f" d.TotalSeconds
             result |> equal [| 1 .. 5 |]
             result |> Seq.sum |> equal _aggregate


### PR DESCRIPTION
- Make it possible to select JavaScript as language (not just default)
- Use Python as default if executable is "fable-py"
- Make Async.Sequential test less flaky