### PR TITLE
[Python] Fixes 11

### DIFF
--- a/src/Fable.Transforms/Python/Python.fs
+++ b/src/Fable.Transforms/Python/Python.fs
@@ -91,6 +91,7 @@ type Statement =
     | For of For
     | Try of Try
     | Expr of Expr
+    | With of With
     | While of While
     | Raise of Raise
     | Import of Import
@@ -141,6 +142,19 @@ type Try =
       OrElse: Statement list
       FinalBody: Statement list
       Loc: SourceLocation option }
+
+/// A single context manager in a with block. context_expr is the context manager, often a Call node. optional_vars is a
+/// Name, Tuple or List for the as foo part, or None if that isn’t used.
+type WithItem =
+  { ContextExpr: Expression
+    OptionalVars: Expression option }
+
+/// A with block. items is a list of withitem nodes representing the context managers, and body is the indented block
+/// inside the context.
+type With =
+  { Items: WithItem list
+    Body: Statement list
+    TypeComment: string option }
 
 /// A single argument in a list. arg is a raw string of the argument name, annotation is its annotation, such as a Str
 /// or Name node.
@@ -804,6 +818,7 @@ type AST =
     | Keyword of Keyword
     | Arg of Arg
     | Identifier of Identifier
+    | WithItem of WithItem
 
 [<AutoOpen>]
 module PythonExtensions =
@@ -817,6 +832,12 @@ module PythonExtensions =
         static member try'(body, ?handlers, ?orElse, ?finalBody, ?loc) : Statement =
             Try.try' (body, ?handlers = handlers, ?orElse = orElse, ?finalBody = finalBody, ?loc = loc)
             |> Try
+
+        static member with'(items, ?body, ?typeComment) : Statement =
+             { Items=items
+               Body=defaultArg body []
+               TypeComment=typeComment }
+            |> With
 
         static member classDef(name, ?bases, ?keywords, ?body, ?decoratorList, ?loc) : Statement =
             { Name = name

--- a/src/Fable.Transforms/Python/Python.fs
+++ b/src/Fable.Transforms/Python/Python.fs
@@ -1028,6 +1028,10 @@ module PythonExtensions =
     type Alias with
 
         static member alias(name, ?asname) = { Name = name; AsName = asname }
+    type WithItem with
+        static member withItem(contextExpr, ?optinalVars) =
+            { ContextExpr=contextExpr
+              OptionalVars = optinalVars }
 
     type Try with
 

--- a/src/Fable.Transforms/Python/PythonPrinter.fs
+++ b/src/Fable.Transforms/Python/PythonPrinter.fs
@@ -109,6 +109,7 @@ module PrinterExtensions =
             | While (wh) -> printer.Print(wh)
             | Raise (st) -> printer.Print(st)
             | Expr (st) -> printer.Print(st)
+            | With (wi) -> printer.Print(wi)
             | For (st) -> printer.Print(st)
             | Try (st) -> printer.Print(st)
             | If (st) -> printer.Print(st)
@@ -169,6 +170,22 @@ module PrinterExtensions =
                 printer.Print(", *")
                 printer.Print(vararg)
             | _ -> ()
+
+        member printer.Print(wi: With) =
+            printer.Print("with ")
+            printer.PrintCommaSeparatedList(wi.Items)
+            printer.Print(":")
+            printer.PushIndentation()
+            printer.PrintStatements(wi.Body)
+            printer.PopIndentation()
+
+        member printer.Print(wi: WithItem) =
+            printer.Print(wi.ContextExpr)
+            match wi.OptionalVars with
+            | Some vars ->
+                printer.Print(" as ")
+                printer.Print(vars)
+            | None -> ()
 
         member printer.Print(assign: Assign) =
             //printer.PrintOperation(targets.[0], "=", value, None)
@@ -629,6 +646,7 @@ module PrinterExtensions =
             | AST.Arg (arg) -> printer.Print(arg)
             | AST.Statement (st) -> printer.Print(st)
             | AST.Identifier (id) -> printer.Print(id)
+            | AST.WithItem (wi) -> printer.Print(wi)
 
         member printer.PrintBlock
             (
@@ -723,7 +741,8 @@ module PrinterExtensions =
             printer.PrintCommaSeparatedList(nodes |> List.map AST.Alias)
         member printer.PrintCommaSeparatedList(nodes: Identifier list) =
             printer.PrintCommaSeparatedList(nodes |> List.map AST.Identifier)
-
+        member printer.PrintCommaSeparatedList(nodes: WithItem list) =
+            printer.PrintCommaSeparatedList(nodes |> List.map AST.WithItem)
 
         member printer.PrintFunction
             (

--- a/src/Fable.Transforms/Python/PythonPrinter.fs
+++ b/src/Fable.Transforms/Python/PythonPrinter.fs
@@ -175,6 +175,7 @@ module PrinterExtensions =
             printer.Print("with ")
             printer.PrintCommaSeparatedList(wi.Items)
             printer.Print(":")
+            printer.PrintNewLine()
             printer.PushIndentation()
             printer.PrintStatements(wi.Body)
             printer.PopIndentation()

--- a/src/Fable.Transforms/Python/README.md
+++ b/src/Fable.Transforms/Python/README.md
@@ -54,14 +54,14 @@ and https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/basic-type
 
 ## Interfaces and Protocols
 
-| .NET          |       Python       | Comment                                                                                           |
-|---------------|:------------------:|---------------------------------------------------------------------------------------------------|
-| `IEquatable`  |      `__eq__`      | for determining equality of instances with method `Equals`                                        |
-| `IEnumerator` |     `__next__`     |                                                                                                   |
-| `IEnumerable` |     `__iter__`     |                                                                                                   |
-| `IComparable` | `__lt__`+ `__eq__` | Method `CompareTo` returns 0, 1 or -1 and is implemented for types that can be ordered or sorted. |
-| `IDisposable` |     `__exit__`     |                                                                                                   |
-| `ToString`    |     `__str__`      | Calls to `x.ToString` will be translated to `str(x)`.                                             |
+| .NET          |         Python          | Comment                                                                                           |
+|---------------|:-----------------------:|---------------------------------------------------------------------------------------------------|
+| `IEquatable`  |        `__eq__`         | for determining equality of instances with method `Equals`                                        |
+| `IEnumerator` |       `__next__`        |                                                                                                   |
+| `IEnumerable` |       `__iter__`        |                                                                                                   |
+| `IComparable` |   `__lt__`+ `__eq__`    | Method `CompareTo` returns 0, 1 or -1 and is implemented for types that can be ordered or sorted. |
+| `IDisposable` | `__exit__` + `__exit__` | Every IDisposable will (and should) also implement a resource manager.                            |
+| `ToString`    |        `__str__`        | Calls to `x.ToString` will be translated to `str(x)`.                                             |
 
 ## Arrow Functions
 

--- a/src/Fable.Transforms/Python/README.md
+++ b/src/Fable.Transforms/Python/README.md
@@ -60,6 +60,7 @@ and https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/basic-type
 | `IEnumerator` |     `__next__`     |                                                                                                   |
 | `IEnumerable` |     `__iter__`     |                                                                                                   |
 | `IComparable` | `__lt__`+ `__eq__` | Method `CompareTo` returns 0, 1 or -1 and is implemented for types that can be ordered or sorted. |
+| `IDisposable` |     `__exit__`     |                                                                                                   |
 | `ToString`    |     `__str__`      | Calls to `x.ToString` will be translated to `str(x)`.                                             |
 
 ## Arrow Functions

--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -1940,7 +1940,7 @@ let arrays (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (thisArg: E
     | "Copy", None, [_source; _sourceIndex; _target; _targetIndex; _count] -> copyToArray com r t i args
     | "Copy", None, [source; target; count] -> copyToArray com r t i [source; makeIntConst 0; target; makeIntConst 0; count]
     | "IndexOf", None, args ->
-        Helper.LibCall(com, "array", "indexOf", t, args, i.SignatureArgTypes, ?loc=r) |> Some
+        Helper.LibCall(com, "array", "index_of", t, args, i.SignatureArgTypes, ?loc=r) |> Some
     | "GetEnumerator", Some arg, _ -> getEnumerator com r t arg |> Some
     | _ -> None
 

--- a/src/fable-library-py/fable_library/async_builder.py
+++ b/src/fable-library-py/fable_library/async_builder.py
@@ -87,8 +87,10 @@ class IAsyncContext:
     def create(on_success, on_error, on_cancel, trampoline, cancel_token):
         return AnonymousAsyncContext(on_success, on_error, on_cancel, trampoline, cancel_token)
 
+
 def empty_continuation(x=None):
     pass
+
 
 class AnonymousAsyncContext:
     def __init__(self, on_success=None, on_error=None, on_cancel=None, trampoline=None, cancel_token=None):

--- a/src/fable-library-py/fable_library/util.py
+++ b/src/fable-library-py/fable_library/util.py
@@ -134,16 +134,21 @@ def compare_arrays(a, b):
     return compare(a, b)
 
 
-def equal_arrays_with(x, y, eq) -> bool:
-    if x is None:
-        return y is None
-    if y is None:
+def equal_arrays_with(xs: List[T], ys: List[T], eq: Callable[[T, T], bool]) -> bool:
+    if xs is None:
+        return ys is None
+
+    if ys is None:
         return False
 
-    if len(x) != len(y):
+    if len(xs) != len(ys):
         return False
 
-    return eq(x, y)
+    for i, x in enumerate(xs):
+        if not eq(x, ys[i]):
+            return False
+
+    return True
 
 
 def equal_arrays(x, y):
@@ -275,10 +280,6 @@ class IEnumerator(Generic[T], IDisposable):
 
     @abstractmethod
     def Reset(self) -> None:
-        ...
-
-    @abstractmethod
-    def Dispose(self):
         ...
 
     def __getattr__(self, name: str):
@@ -535,23 +536,6 @@ def physical_hash(x):
         return hash(x)
 
     return number_hash(ObjectRef.id(x))
-
-
-def equal_arrays_with(xs: List[T], ys: List[T], eq: Callable[[T, T], bool]) -> bool:
-    if xs is None:
-        return ys is None
-
-    if ys is None:
-        return False
-
-    if len(xs) != len(ys):
-        return False
-
-    for i, x in enumerate(xs):
-        if not eq(x, ys[i]):
-            return False
-
-    return True
 
 
 def round(value, digits=0):


### PR DESCRIPTION
- Fix disposable of context managers
- Add With-statement to Python AST
- Use Python `with` for F# `use` bindings
  -  Except for TC optimized functions (where looping will escape and dispose the resource)