### PR TITLE
Precompile inlined functions

### DIFF
--- a/Fable.sln
+++ b/Fable.sln
@@ -1,31 +1,33 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30114.105
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{C8CB96CF-68A8-4083-A0F8-319275CF8097}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fable.Core", "src\Fable.Core\Fable.Core.fsproj", "{287FF404-A34F-4385-95BE-C892BA0E3DCE}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Fable.Core", "src\Fable.Core\Fable.Core.fsproj", "{287FF404-A34F-4385-95BE-C892BA0E3DCE}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fable.Library", "src\fable-library\Fable.Library.fsproj", "{11C625B4-0E0E-49BD-977F-4A0FC9821B5B}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Fable.Library", "src\fable-library\Fable.Library.fsproj", "{11C625B4-0E0E-49BD-977F-4A0FC9821B5B}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fable.AST", "src\Fable.AST\Fable.AST.fsproj", "{893F6BC9-81D7-4154-88D8-0F0D4601E7AE}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Fable.AST", "src\Fable.AST\Fable.AST.fsproj", "{893F6BC9-81D7-4154-88D8-0F0D4601E7AE}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fable.Transforms", "src\Fable.Transforms\Fable.Transforms.fsproj", "{AC4FFF83-30BB-4DBA-9600-C19FA999E088}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Fable.Transforms", "src\Fable.Transforms\Fable.Transforms.fsproj", "{AC4FFF83-30BB-4DBA-9600-C19FA999E088}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fable.Cli", "src\Fable.Cli\Fable.Cli.fsproj", "{964B545D-0EB2-485A-9D74-693D75DB3EDE}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Fable.Cli", "src\Fable.Cli\Fable.Cli.fsproj", "{964B545D-0EB2-485A-9D74-693D75DB3EDE}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "QuickTest", "src\quicktest\QuickTest.fsproj", "{11F9359C-06BA-410A-AB1B-339B89222983}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "QuickTest", "src\quicktest\QuickTest.fsproj", "{11F9359C-06BA-410A-AB1B-339B89222983}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fable.PublishUtils", "src\Fable.PublishUtils\Fable.PublishUtils.fsproj", "{B6D5BB00-D2C2-404D-8CA2-A278784AF0CA}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Fable.PublishUtils", "src\Fable.PublishUtils\Fable.PublishUtils.fsproj", "{B6D5BB00-D2C2-404D-8CA2-A278784AF0CA}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1972E8A5-9DC3-40FA-87FD-FE25FC90132B}"
+	ProjectSection(SolutionItems) = preProject
+		build.fsx = build.fsx
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{287FF404-A34F-4385-95BE-C892BA0E3DCE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -57,6 +59,9 @@ Global
 		{B6D5BB00-D2C2-404D-8CA2-A278784AF0CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B6D5BB00-D2C2-404D-8CA2-A278784AF0CA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{287FF404-A34F-4385-95BE-C892BA0E3DCE} = {C8CB96CF-68A8-4083-A0F8-319275CF8097}
 		{11C625B4-0E0E-49BD-977F-4A0FC9821B5B} = {C8CB96CF-68A8-4083-A0F8-319275CF8097}
@@ -65,5 +70,8 @@ Global
 		{964B545D-0EB2-485A-9D74-693D75DB3EDE} = {C8CB96CF-68A8-4083-A0F8-319275CF8097}
 		{11F9359C-06BA-410A-AB1B-339B89222983} = {C8CB96CF-68A8-4083-A0F8-319275CF8097}
 		{B6D5BB00-D2C2-404D-8CA2-A278784AF0CA} = {C8CB96CF-68A8-4083-A0F8-319275CF8097}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {58DF9285-8523-4EAC-B598-BE5B02A76A00}
 	EndGlobalSection
 EndGlobal

--- a/src/Fable.AST/Fable.fs
+++ b/src/Fable.AST/Fable.fs
@@ -289,21 +289,33 @@ type TestKind =
     | ListTest of isCons: bool
     | UnionCaseTest of tag: int
 
+type MemberRefInfo =
+    {
+        Name: string
+        Path: string
+        IsMutable: bool
+        IsPublic: bool
+        HasOverloadSuffix: bool
+    }
+
 type UnresolvedExpr =
     // TODO: Add also MemberKind from the flags?
     | UnresolvedTraitCall of sourceTypes: Type list * traitName: string * isInstance: bool * argTypes: Type list * argExprs: Expr list * typ: Type * range: SourceLocation option
     | UnresolvedReplaceCall of thisArg: Expr option * args: Expr list * info: ReplaceCallInfo * attachedCall: Expr option * typ: Type * range: SourceLocation option
     | UnresolvedInlineCall of memberUniqueName: string * genArgs: (string * Type) list * callee: Expr option * info: CallInfo * typ: Type * range: SourceLocation option
+    | UnresolvedMemberRef of MemberRefInfo * typ: Type * range: SourceLocation option
     member this.Type =
         match this with
         | UnresolvedTraitCall(_,_,_,_,_,t,_)
         | UnresolvedReplaceCall(_,_,_,_,t,_)
-        | UnresolvedInlineCall(_,_,_,_,t,_) -> t
+        | UnresolvedInlineCall(_,_,_,_,t,_)
+        | UnresolvedMemberRef(_,t,_) -> t
     member this.Range =
         match this with
         | UnresolvedTraitCall(_,_,_,_,_,_,r)
         | UnresolvedReplaceCall(_,_,_,_,_,r)
-        | UnresolvedInlineCall(_,_,_,_,_,r) -> r
+        | UnresolvedInlineCall(_,_,_,_,_,r)
+        | UnresolvedMemberRef(_,_,r) -> r
 
 type Expr =
     // Values and Idents

--- a/src/Fable.AST/Fable.fs
+++ b/src/Fable.AST/Fable.fs
@@ -42,8 +42,8 @@ type GenericParam =
     abstract Name: string
 
 type Parameter =
-    abstract Name: string option
-    abstract Type: Type
+    { Name: string option
+      Type: Type }
 
 type MemberInfo =
     abstract Attributes: Attribute seq
@@ -265,8 +265,13 @@ type OperationKind =
     | Binary of BinaryOperator * left: Expr * right: Expr
     | Logical of LogicalOperator * left: Expr * right: Expr
 
+type FieldKey =
+    { Name: string
+      FieldType: Type
+      IsMutable: bool }
+
 type KeyKind =
-    | FieldKey of Field
+    | FieldKey of FieldKey
     | ExprKey of Expr
 
 type GetKind =

--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -306,8 +306,11 @@ type ProjectCracked(cliArgs: CliArgs, crackerResponse: CrackerResponse, sourceFi
     member _.SourceFiles = sourceFiles
     member _.SourceFilePaths = sourceFiles |> Array.map (fun f -> f.NormalizedFullPath)
 
-    member _.MakeCompiler(currentFile, project, triggeredByDependency) =
-        let opts = { cliArgs.CompilerOptions with TriggeredByDependency = triggeredByDependency }
+    member _.MakeCompiler(currentFile, project, ?triggeredByDependency) =
+        let opts =
+            match triggeredByDependency with
+            | Some t -> { cliArgs.CompilerOptions with TriggeredByDependency = t }
+            | None -> cliArgs.CompilerOptions
         let fableLibDir = Path.getRelativePath currentFile crackerResponse.FableLibDir
         CompilerImpl(currentFile, project, opts, fableLibDir, ?outDir=cliArgs.OutDir)
 
@@ -362,26 +365,27 @@ type ProjectChecked(checker: InteractiveChecker, errors: FSharpDiagnostic array,
     member _.Checker = checker
     member _.Errors = errors
 
-    static member Init(config: ProjectCracked) = async {
-        let checker = InteractiveChecker.Create(config.ProjectOptions)
-        let! implFiles, errors, assemblies = checkProject config checker None
+    static member Init(projCracked: ProjectCracked) = async {
+        let checker = InteractiveChecker.Create(projCracked.ProjectOptions)
+        let! implFiles, errors, assemblies = checkProject projCracked checker None
 
         return ProjectChecked(checker, errors, Project.From(
-                                config.ProjectFile,
+                                projCracked.ProjectFile,
                                 implFiles,
                                 assemblies.Value,
-                                getPlugin = loadType config.CliArgs,
-                                trimRootModule = config.FableOptions.RootModule))
+                                mkCompiler = (fun p f -> projCracked.MakeCompiler(f, p)),
+                                getPlugin = loadType projCracked.CliArgs,
+                                trimRootModule = projCracked.FableOptions.RootModule))
     }
 
-    member this.Update(config: ProjectCracked, filesToCompile) = async {
+    member this.Update(projCracked: ProjectCracked, filesToCompile) = async {
         let! implFiles, errors, _ =
             Some(Array.last filesToCompile)
-            |> checkProject config this.Checker
+            |> checkProject projCracked this.Checker
 
         let filesToCompile = set filesToCompile
         let implFiles = implFiles |> List.filter (fun f -> filesToCompile.Contains(f.FileName))
-        return ProjectChecked(checker, errors, this.Project.Update(implFiles))
+        return ProjectChecked(checker, errors, this.Project.Update(implFiles, mkCompiler = (fun p f -> projCracked.MakeCompiler(f, p))))
     }
 
 type Watcher =

--- a/src/Fable.Cli/Properties/launchSettings.json
+++ b/src/Fable.Cli/Properties/launchSettings.json
@@ -1,0 +1,9 @@
+{
+  "profiles": {
+    "Fable.Cli": {
+      "commandName": "Project",
+      "commandLineArgs": "watch src/Quicktest --noCache --exclude Fable.Core",
+      "workingDirectory": "C:\\Users\\alfon\\repos\\Fable"
+    }
+  }
+}

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -1625,7 +1625,7 @@ module Util =
 
     let rec transformAsExpr (com: IBabelCompiler) ctx (expr: Fable.Expr): Expression =
         match expr with
-        | Fable.Unresolved _ -> addErrorAndReturnNull com None "Unexpected unresolved expression"
+        | Fable.Unresolved e -> addErrorAndReturnNull com e.Range "Unexpected unresolved expression"
 
         | Fable.TypeCast(e,t,tag) -> transformCast com ctx t tag e
 
@@ -1706,8 +1706,8 @@ module Util =
     let rec transformAsStatements (com: IBabelCompiler) ctx returnStrategy
                                     (expr: Fable.Expr): Statement array =
         match expr with
-        | Fable.Unresolved _ ->
-            addError com [] None "Unexpected unresolved expression"
+        | Fable.Unresolved e ->
+            addError com [] e.Range "Unexpected unresolved expression"
             [||]
 
         | Fable.TypeCast(e, t, tag) ->

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -226,7 +226,7 @@ module Reflection =
             | _ ->
                 let ent = com.GetEntity(entRef)
                 let generics = generics |> List.map (transformTypeInfo com ctx r genMap) |> List.toArray
-                /// Check if the entity is actually declared in JS code
+                // Check if the entity is actually declared in JS code
                 if ent.IsInterface
                     || FSharp2Fable.Util.isErasedOrStringEnumEntity ent
                     || FSharp2Fable.Util.isGlobalOrImportedEntity ent
@@ -362,7 +362,7 @@ module Annotation =
 
     let mergeTypeParamDecls (decl1: TypeParameterDeclaration option) (decl2: TypeParameterDeclaration option) =
         match decl1, decl2 with
-        | Some (TypeParameterDeclaration(``params``=p1)), Some (TypeParameterDeclaration(``params``=p2)) ->
+        | Some (TypeParameterDeclaration(parameters=p1)), Some (TypeParameterDeclaration(parameters=p2)) ->
             Array.append
                 (p1 |> Array.map (fun (TypeParameter(name=name)) -> name))
                 (p2 |> Array.map (fun (TypeParameter(name=name)) -> name))
@@ -599,11 +599,12 @@ module Util =
 
     let getDecisionTarget (ctx: Context) targetIndex =
         match List.tryItem targetIndex ctx.DecisionTargets with
-        | None -> failwithf "Cannot find DecisionTree target %i" targetIndex
+        | None -> failwith $"Cannot find DecisionTree target %i{targetIndex}"
         | Some(idents, target) -> idents, target
 
     let rec isJsStatement ctx preferStatement (expr: Fable.Expr) =
         match expr with
+        | Fable.Unresolved _
         | Fable.Value _ | Fable.Import _  | Fable.IdentExpr _
         | Fable.Lambda _ | Fable.Delegate _ | Fable.ObjectExpr _
         | Fable.Call _ | Fable.CurriedApply _ | Fable.Curry _ | Fable.Operation _
@@ -1036,7 +1037,7 @@ module Util =
             // let baseExpr = (baseRefId |> typedIdent com ctx) :> Expression
             // Some (baseExpr, []) // default base constructor
             let range = baseCall |> Option.bind (fun x -> x.Range)
-            sprintf "Ignoring base call for %s" baseType.Entity.FullName |> addWarning com [] range
+            $"Ignoring base call for %s{baseType.Entity.FullName}" |> addWarning com [] range
             None
         | Some _, _ ->
             let range = baseCall |> Option.bind (fun x -> x.Range)
@@ -1088,13 +1089,13 @@ module Util =
                 members |> List.choose (function
                     | ObjectProperty(key, value, computed) ->
                         ClassMember.classProperty(key, value, computed_=computed) |> Some
-                    | ObjectMethod(kind, key, ``params``, body, computed, returnType, typeParameters, _) ->
+                    | ObjectMethod(kind, key, parameters, body, computed, returnType, typeParameters, _) ->
                         let kind =
                             match kind with
                             | "get" -> ClassGetter
                             | "set" -> ClassSetter
                             | _ -> ClassFunction
-                        ClassMember.classMethod(kind, key, ``params``, body, computed_=computed,
+                        ClassMember.classMethod(kind, key, parameters, body, computed_=computed,
                             ?returnType=returnType, ?typeParameters=typeParameters) |> Some)
 
             let baseExpr, classMembers =
@@ -1452,7 +1453,7 @@ module Util =
 
     let transformDecisionTreeSuccessAsStatements (com: IBabelCompiler) (ctx: Context) returnStrategy targetIndex boundValues: Statement[] =
         match returnStrategy with
-        | Some(Target targetId) as target ->
+        | Some(Target targetId) ->
             let idents, _ = getDecisionTarget ctx targetIndex
             let assignments =
                 matchTargetIdentAndValues idents boundValues
@@ -1624,6 +1625,8 @@ module Util =
 
     let rec transformAsExpr (com: IBabelCompiler) ctx (expr: Fable.Expr): Expression =
         match expr with
+        | Fable.Unresolved _ -> addErrorAndReturnNull com None "Unexpected unresolved expression"
+
         | Fable.TypeCast(e,t,tag) -> transformCast com ctx t tag e
 
         | Fable.Curry(e, arity, _, r) -> transformCurry com ctx r e arity
@@ -1703,6 +1706,10 @@ module Util =
     let rec transformAsStatements (com: IBabelCompiler) ctx returnStrategy
                                     (expr: Fable.Expr): Statement array =
         match expr with
+        | Fable.Unresolved _ ->
+            addError com [] None "Unexpected unresolved expression"
+            [||]
+
         | Fable.TypeCast(e, t, tag) ->
             [|transformCast com ctx t tag e |> resolveExpr t returnStrategy|]
 
@@ -1805,8 +1812,6 @@ module Util =
                 then BinaryOperator.BinaryLessOrEqual, UpdateOperator.UpdatePlus
                 else BinaryOperator.BinaryGreaterOrEqual, UpdateOperator.UpdateMinus
 
-            let a = start |> varDeclaration (typedIdent com ctx var |> Pattern.Identifier) true
-
             [|Statement.forStatement(
                 transformBlock com ctx None body,
                 start |> varDeclaration (typedIdent com ctx var |> Pattern.Identifier) true,
@@ -1870,7 +1875,7 @@ module Util =
         let membName = Identifier.identifier(membName)
         let decl: Declaration =
             match expr with
-            | ClassExpression(body, id, superClass, implements, superTypeParameters, typeParameters, loc) ->
+            | ClassExpression(body, _id, superClass, implements, superTypeParameters, typeParameters, _loc) ->
                 Declaration.classDeclaration(
                     body,
                     ?id = Some membName,
@@ -1878,9 +1883,9 @@ module Util =
                     ?superTypeParameters = superTypeParameters,
                     ?typeParameters = typeParameters,
                     ?implements = implements)
-            | FunctionExpression(_, ``params``, body, returnType, typeParameters, _) ->
+            | FunctionExpression(_, parameters, body, returnType, typeParameters, _) ->
                 Declaration.functionDeclaration(
-                    ``params``, body, membName,
+                    parameters, body, membName,
                     ?returnType = returnType,
                     ?typeParameters = typeParameters)
             | _ -> varDeclaration membName' isMutable expr |> Declaration.VariableDeclaration

--- a/src/Fable.Transforms/FableTransforms.fs
+++ b/src/Fable.Transforms/FableTransforms.fs
@@ -207,7 +207,7 @@ module private Transforms =
         | Delegate(args, body, name) -> Some(args, body, name)
         | _ -> None
 
-    let (|FieldType|) (fi: Field) = fi.FieldType
+    let (|FieldKeyType|) (fi: FieldKey) = fi.FieldType
 
     let (|ImmediatelyApplicable|_|) = function
         | Lambda(arg, body, _) -> Some(arg, body)
@@ -437,7 +437,7 @@ module private Transforms =
             let body = uncurryIdentsAndReplaceInBody args body
             Delegate(args, body, name)
         // Uncurry also values received from getters
-        | Get(callee, (ByKey(FieldKey(FieldType fieldType)) | UnionField(_,fieldType)), t, r) ->
+        | Get(callee, (ByKey(FieldKey(FieldKeyType fieldType)) | UnionField(_,fieldType)), t, r) ->
             match getLambdaTypeArity fieldType, callee.Type with
             // For anonymous records, if the lambda returns a generic the actual
             // arity may be higher than expected, so we need a runtime partial application

--- a/src/Fable.Transforms/Global/Babel.fs
+++ b/src/Fable.Transforms/Global/Babel.fs
@@ -68,13 +68,13 @@ type Expression =
     | NewExpression of callee: Expression * arguments: Expression array * typeArguments: TypeParameterInstantiation option * loc: SourceLocation option
     | FunctionExpression of
         id: Identifier option *
-        ``params``: Pattern array *
+        parameters: Pattern array *
         body: BlockStatement *
         returnType: TypeAnnotation option *
         typeParameters: TypeParameterDeclaration option *
         loc: SourceLocation option
     | ArrowFunctionExpression of
-        ``params``: Pattern array *
+        parameters: Pattern array *
         body: BlockStatement *
         returnType: TypeAnnotation option *
         typeParameters: TypeParameterDeclaration option *
@@ -125,7 +125,7 @@ type Declaration =
         loc: SourceLocation option
     | VariableDeclaration of VariableDeclaration
     | FunctionDeclaration of
-        ``params``: Pattern array *
+        parameters: Pattern array *
         body: BlockStatement *
         id: Identifier *
         returnType: TypeAnnotation option *
@@ -150,7 +150,7 @@ type ModuleDeclaration =
     | ImportDeclaration of specifiers: ImportSpecifier array * source: StringLiteral
     | ExportNamedReferences of specifiers: ExportSpecifier array * source: StringLiteral option
 
-    /// An export batch declaration, e.g., export * from "mod";.
+//    /// An export batch declaration, e.g., export * from "mod";.
 // Template Literals
 //type TemplateElement(value: string, tail, ?loc) =
 //    inherit Node("TemplateElement", ?loc = loc)
@@ -205,7 +205,7 @@ type BlockStatement =
 //    let directives = [||] // defaultArg directives_ [||]
 //    member _.Directives: Directive array = directives
 
-/// An empty statement, i.e., a solitary semicolon.
+// /// An empty statement, i.e., a solitary semicolon.
 //type EmptyStatement(?loc) =
 //    inherit Statement("EmptyStatement", ?loc = loc)
 //    member _.Print(_) = ()
@@ -239,8 +239,8 @@ type VariableDeclaration =
 //    member _.Body: BlockStatement = body
 //    member _.Test: Expression = test
 
-/// When passing a VariableDeclaration, the bound value must go through
-/// the `right` parameter instead of `init` property in VariableDeclarator
+// /// When passing a VariableDeclaration, the bound value must go through
+// /// the `right` parameter instead of `init` property in VariableDeclarator
 //type ForInStatement(left, right, body, ?loc) =
 //    inherit Statement("ForInStatement", ?loc = loc)
 //    member _.Body: BlockStatement = body
@@ -307,7 +307,7 @@ type ObjectMember =
     | ObjectMethod of
         kind: string *
         key: Expression *
-        ``params``: Pattern array *
+        parameters: Pattern array *
         body: BlockStatement *
         computed: bool *
         returnType: TypeAnnotation option *
@@ -346,7 +346,7 @@ type ClassMember =
     | ClassMethod of
         kind: string *
         key: Expression *
-        ``params``: Pattern array *
+        parameters: Pattern array *
         body: BlockStatement *
         computed: bool *
         ``static``: bool option *
@@ -421,7 +421,7 @@ type TypeAnnotationInfo =
     | ObjectTypeAnnotation of ObjectTypeAnnotation
     | GenericTypeAnnotation of id: Identifier * typeParameters: TypeParameterInstantiation option
     | FunctionTypeAnnotation of
-        ``params``: FunctionTypeParam array *
+        parameters: FunctionTypeParam array *
         returnType: TypeAnnotationInfo *
         typeParameters: TypeParameterDeclaration option *
         rest: FunctionTypeParam option
@@ -435,10 +435,10 @@ type TypeParameter =
     | TypeParameter of name: string * bound: TypeAnnotation option * ``default``: TypeAnnotationInfo option
 
 type TypeParameterDeclaration =
-    | TypeParameterDeclaration of ``params``: TypeParameter array
+    | TypeParameterDeclaration of parameters: TypeParameter array
 
 type TypeParameterInstantiation =
-    | TypeParameterInstantiation of ``params``: TypeAnnotationInfo array
+    | TypeParameterInstantiation of parameters: TypeAnnotationInfo array
 
 type FunctionTypeParam =
     | FunctionTypeParam of name: Identifier * typeAnnotation: TypeAnnotationInfo * optional: bool option
@@ -524,11 +524,11 @@ module Helpers =
         static member objectExpression(properties, ?loc) = ObjectExpression(properties, loc)
         static member newExpression(callee, arguments, ?typeArguments, ?loc) = NewExpression(callee, arguments, typeArguments, loc)
         /// A fat arrow function expression, e.g., let foo = (bar) => { /* body */ }.
-        static member arrowFunctionExpression(``params``, body: BlockStatement, ?returnType, ?typeParameters, ?loc) = //?async_, ?generator_,
-            ArrowFunctionExpression(``params``, body, returnType, typeParameters, loc)
-        static member arrowFunctionExpression(``params``, body: Expression, ?returnType, ?typeParameters, ?loc): Expression =
+        static member arrowFunctionExpression(parameters, body: BlockStatement, ?returnType, ?typeParameters, ?loc) = //?async_, ?generator_,
+            ArrowFunctionExpression(parameters, body, returnType, typeParameters, loc)
+        static member arrowFunctionExpression(parameters, body: Expression, ?returnType, ?typeParameters, ?loc): Expression =
             let body = BlockStatement [| Statement.returnStatement(body) |]
-            Expression.arrowFunctionExpression(``params``, body, ?returnType = returnType, ?typeParameters = typeParameters, ?loc = loc)
+            Expression.arrowFunctionExpression(parameters, body, ?returnType = returnType, ?typeParameters = typeParameters, ?loc = loc)
         /// If computed is true, the node corresponds to a computed (a[b]) member expression and property is an Expression.
         /// If computed is false, the node corresponds to a static (a.b) member expression and property is an Identifier.
         static member memberExpression(object, property, ?computed_, ?loc) =
@@ -538,8 +538,8 @@ module Helpers =
                 | Expression.Identifier(Identifier(name=name)) -> name
                 | _ -> ""
             MemberExpression(name, object, property, computed, loc)
-        static member functionExpression(``params``, body, ?id, ?returnType, ?typeParameters, ?loc) = //?generator_, ?async_
-            FunctionExpression(id, ``params``, body, returnType, typeParameters, loc)
+        static member functionExpression(parameters, body, ?id, ?returnType, ?typeParameters, ?loc) = //?generator_, ?async_
+            FunctionExpression(id, parameters, body, returnType, typeParameters, loc)
         static member classExpression(body, ?id, ?superClass, ?superTypeParameters, ?typeParameters, ?implements, ?loc) =
             ClassExpression(body, id, superClass, implements, superTypeParameters, typeParameters, loc)
         static member spreadElement(argument, ?loc) =
@@ -661,8 +661,8 @@ module Helpers =
                 [| VariableDeclarator(var, init) |],
                 ?loc = loc
             )
-        static member functionDeclaration(``params``, body, id, ?returnType, ?typeParameters, ?loc) =
-            FunctionDeclaration(``params``, body, id, returnType, typeParameters, loc)
+        static member functionDeclaration(parameters, body, id, ?returnType, ?typeParameters, ?loc) =
+            FunctionDeclaration(parameters, body, id, returnType, typeParameters, loc)
         static member classDeclaration(body, ?id, ?superClass, ?superTypeParameters, ?typeParameters, ?implements, ?loc) =
             ClassDeclaration(body, id, superClass, implements, superTypeParameters, typeParameters, loc)
         static member interfaceDeclaration(id, body, ?extends_, ?typeParameters, ?implements_): Declaration = // ?mixins_,
@@ -697,7 +697,7 @@ module Helpers =
             FunctionTypeParam(name, typeInfo, optional)
 
     type ClassMember with
-        static member classMethod(kind_, key, ``params``, body, ?computed_, ?``static``, ?``abstract``, ?returnType, ?typeParameters, ?loc) : ClassMember =
+        static member classMethod(kind_, key, parameters, body, ?computed_, ?``static``, ?``abstract``, ?returnType, ?typeParameters, ?loc) : ClassMember =
             let kind =
                 match kind_ with
                 | ClassImplicitConstructor -> "constructor"
@@ -705,7 +705,7 @@ module Helpers =
                 | ClassSetter -> "set"
                 | ClassFunction -> "method"
             let computed = defaultArg computed_ false
-            ClassMethod(kind, key, ``params``, body, computed, ``static``, ``abstract``, returnType, typeParameters, loc)
+            ClassMethod(kind, key, parameters, body, computed, ``static``, ``abstract``, returnType, typeParameters, loc)
         static member classProperty(key, ?value, ?computed_, ?``static``, ?optional, ?typeAnnotation, ?loc): ClassMember =
             let computed = defaultArg computed_ false
             ClassProperty(key, value, computed, defaultArg ``static`` false, defaultArg optional false, typeAnnotation, loc)
@@ -731,14 +731,14 @@ module Helpers =
         static member objectProperty(key, value, ?computed_) = // ?shorthand_,
             let computed = defaultArg computed_ false
             ObjectProperty(key, value, computed)
-        static member objectMethod(kind_, key, ``params``, body, ?computed_, ?returnType, ?typeParameters, ?loc) =
+        static member objectMethod(kind_, key, parameters, body, ?computed_, ?returnType, ?typeParameters, ?loc) =
             let kind =
                 match kind_ with
                 | ObjectGetter -> "get"
                 | ObjectSetter -> "set"
                 | ObjectMeth -> "method"
             let computed = defaultArg computed_ false
-            ObjectMethod(kind, key, ``params``, body, computed, returnType, typeParameters, loc)
+            ObjectMethod(kind, key, parameters, body, computed, returnType, typeParameters, loc)
 
     type ObjectTypeProperty with
         static member objectTypeProperty(key, value, ?computed_, ?kind, ?``static``, ?optional, ?proto, ?method) =
@@ -757,8 +757,8 @@ module Helpers =
     type TypeAnnotationInfo with
         static member genericTypeAnnotation(id, ?typeParameters) =
             GenericTypeAnnotation (id, typeParameters)
-        static member functionTypeAnnotation(``params``, returnType, ?typeParameters, ?rest): TypeAnnotationInfo =
-            FunctionTypeAnnotation(``params``,returnType, typeParameters, rest)
+        static member functionTypeAnnotation(parameters, returnType, ?typeParameters, ?rest): TypeAnnotationInfo =
+            FunctionTypeAnnotation(parameters,returnType, typeParameters, rest)
 
     type ObjectTypeAnnotation with
         static member objectTypeAnnotation(properties, ?indexers_, ?callProperties_, ?internalSlots_, ?exact_) =

--- a/src/Fable.Transforms/Global/Compiler.fs
+++ b/src/Fable.Transforms/Global/Compiler.fs
@@ -37,9 +37,10 @@ open FSharp.Compiler.Symbols
 open Fable.AST
 
 type InlineExpr =
-    { Args: FSharpMemberOrFunctionOrValue list
-      Body: FSharpExpr
-      FileName: string }
+    { Args: Fable.Ident list
+      Body: Fable.Expr
+      FileName: string
+      ScopeIdents: Set<string> }
 
 type CompilerPlugins =
     { MemberDeclarationPlugins: Map<Fable.EntityRef, System.Type> }

--- a/src/Fable.Transforms/Global/Fable.Core.fs
+++ b/src/Fable.Transforms/Global/Fable.Core.fs
@@ -19,3 +19,7 @@ type CaseRules =
 type StringEnumAttribute() =
    inherit Attribute()
    new (caseRules: CaseRules) = StringEnumAttribute()
+
+[<AttributeUsage(AttributeTargets.Interface)>]
+type MangleAttribute() =
+    inherit Attribute()

--- a/src/Fable.Transforms/Inject.fs
+++ b/src/Fable.Transforms/Inject.fs
@@ -8,6 +8,7 @@ open Fable.Transforms
 open FSharp2Fable.Helpers
 open FSharp2Fable.Patterns
 open FSharp2Fable.TypeHelpers
+open Fable.Transforms.FSharp2Fable
 
 let private resolveParamGeneric (genArg: Lazy<(string * Fable.Type) list>)= function
     | Fable.GenericParam genParamName ->
@@ -42,7 +43,7 @@ let (|GeneratedInterface|_|) com ctx r t =
         | _ -> None
     | _ -> None
 
-let injectArg com ctx r (genArgs: (string * Fable.Type) list) (par: FSharpParameter): Fable.Expr =
+let injectArg com (ctx: IContext) r (genArgs: (string * Fable.Type) list) (par: FSharpParameter): Fable.Expr =
     let parType = nonAbbreviatedType par.Type
     let typ =
         // The type of the parameter must be an option

--- a/src/Fable.Transforms/Inject.fs
+++ b/src/Fable.Transforms/Inject.fs
@@ -43,7 +43,7 @@ let (|GeneratedInterface|_|) com ctx r t =
         | _ -> None
     | _ -> None
 
-let injectArg com (ctx: IContext) r (genArgs: (string * Fable.Type) list) (par: FSharpParameter): Fable.Expr =
+let injectArg com (ctx: Context) r (genArgs: (string * Fable.Type) list) (par: FSharpParameter): Fable.Expr =
     let parType = nonAbbreviatedType par.Type
     let typ =
         // The type of the parameter must be an option

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -660,7 +660,7 @@ let (|ListSingleton|) x = [x]
 let rec findInScope scope identName =
     match scope with
     | [] -> None
-    | (_,ident2,expr)::prevScope ->
+    | (_, ident2: Ident, expr: Expr option)::prevScope ->
         if identName = ident2.Name then
             match expr with
             | Some(MaybeCasted(IdentExpr ident)) when not ident.IsMutable -> findInScope prevScope ident.Name

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -661,3 +661,95 @@ module AST =
             | None, None -> None
             | Some r1, Some r2 -> Some(r1 + r2)
         (None, locs) ||> Seq.fold addTwo
+
+    let visit f e =
+        match e with
+        | Unresolved _ -> e // Unresolved expressions must be matched explicitly
+        | IdentExpr _ -> e
+        | TypeCast(e, t, tag) -> TypeCast(f e, t, tag)
+        | Import(info, t, r) ->
+            Import({ info with Selector = info.Selector
+                               Path = info.Path }, t, r)
+        | Value(kind, r) ->
+            match kind with
+            | ThisValue _ | BaseValue _
+            | TypeInfo _ | Null _ | UnitConstant
+            | BoolConstant _ | CharConstant _ | StringConstant _
+            | NumberConstant _ | RegexConstant _ -> e
+            | EnumConstant(exp, ent) -> EnumConstant(f exp, ent) |> makeValue r
+            | NewOption(e, t) -> NewOption(Option.map f e, t) |> makeValue r
+            | NewTuple exprs -> NewTuple(List.map f exprs) |> makeValue r
+            | NewArray(exprs, t) -> NewArray(List.map f exprs, t) |> makeValue r
+            | NewArrayFrom(e, t) -> NewArrayFrom(f e, t) |> makeValue r
+            | NewList(ht, t) ->
+                let ht = ht |> Option.map (fun (h,t) -> f h, f t)
+                NewList(ht, t) |> makeValue r
+            | NewRecord(exprs, ent, genArgs) ->
+                NewRecord(List.map f exprs, ent, genArgs) |> makeValue r
+            | NewAnonymousRecord(exprs, ent, genArgs) ->
+                NewAnonymousRecord(List.map f exprs, ent, genArgs) |> makeValue r
+            | NewUnion(exprs, uci, ent, genArgs) ->
+                NewUnion(List.map f exprs, uci, ent, genArgs) |> makeValue r
+        | Test(e, kind, r) -> Test(f e, kind, r)
+        | Curry(e, arity, t, r) -> Curry(f e, arity, t, r)
+        | Lambda(arg, body, name) -> Lambda(arg, f body, name)
+        | Delegate(args, body, name) -> Delegate(args, f body, name)
+        | ObjectExpr(members, t, baseCall) ->
+            let baseCall = Option.map f baseCall
+            let members = members |> List.map (fun m -> { m with Body = f m.Body })
+            ObjectExpr(members, t, baseCall)
+        | CurriedApply(callee, args, t, r) ->
+            CurriedApply(f callee, List.map f args, t, r)
+        | Call(callee, info, t, r) ->
+            let info = { info with ThisArg = Option.map f info.ThisArg
+                                   Args = List.map f info.Args }
+            Call(f callee, info, t, r)
+        | Emit(info, t, r) ->
+            let callInfo =
+                { info.CallInfo with ThisArg = Option.map f info.CallInfo.ThisArg
+                                     Args = List.map f info.CallInfo.Args }
+            Emit({ info with CallInfo = callInfo }, t, r)
+        | Operation(kind, t, r) ->
+            match kind with
+            | Unary(operator, operand) ->
+                Operation(Unary(operator, f operand), t, r)
+            | Binary(op, left, right) ->
+                Operation(Binary(op, f left, f right), t, r)
+            | Logical(op, left, right) ->
+                Operation(Logical(op, f left, f right), t, r)
+        | Get(e, kind, t, r) ->
+            match kind with
+            | ListHead | ListTail | OptionValue | TupleIndex _ | UnionTag
+            | UnionField _ | ByKey(FieldKey _) -> Get(f e, kind, t, r)
+            | ByKey(ExprKey e2) -> Get(f e, ByKey(ExprKey(f e2)), t, r)
+        | Sequential exprs -> Sequential(List.map f exprs)
+        | Let(ident, value, body) -> Let(ident, f value, f body)
+        | LetRec(bs, body) ->
+            let bs = bs |> List.map (fun (i,e) -> i, f e)
+            LetRec(bs, f body)
+        | IfThenElse(cond, thenExpr, elseExpr, r) ->
+            IfThenElse(f cond, f thenExpr, f elseExpr, r)
+        | Set(e, kind, v, r) ->
+            match kind with
+            | Some(ExprKey e2) ->
+                Set(f e, Some(ExprKey(f e2)), f v, r)
+            | Some(FieldKey _) | None -> Set(f e, kind, f v, r)
+        | WhileLoop(e1, e2, r) -> WhileLoop(f e1, f e2, r)
+        | ForLoop(i, e1, e2, e3, up, r) -> ForLoop(i, f e1, f e2, f e3, up, r)
+        | TryCatch(body, catch, finalizer, r) ->
+            TryCatch(f body,
+                     Option.map (fun (i, e) -> i, f e) catch,
+                     Option.map f finalizer, r)
+        | DecisionTree(expr, targets) ->
+            let targets = targets |> List.map (fun (idents, v) -> idents, f v)
+            DecisionTree(f expr, targets)
+        | DecisionTreeSuccess(idx, boundValues, t) ->
+            DecisionTreeSuccess(idx, List.map f boundValues, t)
+
+    let rec visitFromInsideOut f e =
+        visit (visitFromInsideOut f) e |> f
+
+    let rec visitFromOutsideIn (f: Expr->Expr option) e =
+        match f e with
+        | Some e -> e
+        | None -> visit (visitFromOutsideIn f) e

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -374,12 +374,7 @@ module AST =
         | _ -> false
 
     let makeFieldKey name isMutable typ =
-        FieldKey({ new Field with
-                    member _.Name = name
-                    member _.IsMutable = isMutable
-                    member _.IsStatic = false
-                    member _.FieldType = typ
-                    member _.LiteralValue = None })
+        FieldKey({ Name = name; FieldType = typ; IsMutable = isMutable })
 
     /// ATTENTION: Make sure the ident name is unique
     let makeTypedIdent typ name =


### PR DESCRIPTION
This PR precompiles inlined functions. This is something I wanted to do since v3 release and the goal is to be able to serialize them as Fable Exprs so we don't need to run the type checker against package sources every time as it happens now.

The main hurdle to precompile inlined functions is many operations in FSharp2Fable require compile-time resolution, like trait calls (SRTP). To work around this I'm introducing [unresolved expressions](https://github.com/fable-compiler/Fable/blob/12223a92fbd20daa95c12a5606443a3cea747ad9/src/Fable.AST/Fable.fs#L301-L306) that will be handled when [inlining the expression](https://github.com/fable-compiler/Fable/blob/12223a92fbd20daa95c12a5606443a3cea747ad9/src/Fable.Transforms/FSharp2Fable.fs#L1485-L1540) in the call site.

The next step will be to separate compilation of sources from packages and user projects (although we'll probably include also an option to precompile common projects).  What I'm thinking now is enabling a system-wide cache (e.g. `$HOME/.fable`) to keep compiled packages so they can be reused later. This should also make it easier to add libraries to the REPL.

@ncave @dbrattli After accepting the PR, I will merge with `beyond` right away to avoid divergence but hopefully it shouldn't affect you much. The AST now contains Unresolve expressions, but they only have to be dealt with when resolving inline expressions so you can just [ignore them](https://github.com/fable-compiler/Fable/blob/12223a92fbd20daa95c12a5606443a3cea747ad9/src/Fable.Transforms/Fable2Babel.fs#L1628) in later stages of the compilation.