### PR TITLE
Language specific FABLE_COMPILER defines

### DIFF
--- a/src/Fable.Cli/Entry.fs
+++ b/src/Fable.Cli/Entry.fs
@@ -228,19 +228,14 @@ type Runner =
             "FABLE_COMPILER"
             "FABLE_COMPILER_3_OR_GREATER"
             "FABLE_COMPILER_4"
+            "FABLE_COMPILER_4_OR_GREATER"
             match language with
             | Php -> "FABLE_COMPILER_PHP"
             | Rust -> "FABLE_COMPILER_RUST"
             | Dart -> "FABLE_COMPILER_DART"
-            | Python -> yield! [
-                "FABLE_COMPILER_PY"
-                "FABLE_COMPILER_PYTHON" ]
-            | TypeScript -> yield! [
-                "FABLE_COMPILER_TS"
-                "FABLE_COMPILER_TYPESCRIPT" ]
-            | JavaScript -> yield! [
-                "FABLE_COMPILER_JS"
-                "FABLE_COMPILER_JAVASCRIPT" ]
+            | Python -> "FABLE_COMPILER_PYTHON"
+            | TypeScript -> "FABLE_COMPILER_TYPESCRIPT"
+            | JavaScript -> "FABLE_COMPILER_JAVASCRIPT"
         ]
         |> List.distinct
 

--- a/src/Fable.Cli/Entry.fs
+++ b/src/Fable.Cli/Entry.fs
@@ -227,6 +227,12 @@ type Runner =
         |> List.append [
             "FABLE_COMPILER"
             "FABLE_COMPILER_3"
+            match language with
+            | Php -> "FABLE_COMPILER_PHP"
+            | Rust -> "FABLE_COMPILER_RUST"
+            | Dart -> "FABLE_COMPILER_DART"
+            | Python -> "FABLE_COMPILER_PY"
+            | JavaScript -> "FABLE_COMPILER_JS"
         ]
         |> List.distinct
 

--- a/src/Fable.Cli/Entry.fs
+++ b/src/Fable.Cli/Entry.fs
@@ -226,13 +226,21 @@ type Runner =
         args.Values "--define"
         |> List.append [
             "FABLE_COMPILER"
-            "FABLE_COMPILER_3"
+            "FABLE_COMPILER_3_OR_GREATER"
+            "FABLE_COMPILER_4"
             match language with
             | Php -> "FABLE_COMPILER_PHP"
             | Rust -> "FABLE_COMPILER_RUST"
             | Dart -> "FABLE_COMPILER_DART"
-            | Python -> "FABLE_COMPILER_PY"
-            | JavaScript -> "FABLE_COMPILER_JS"
+            | Python -> yield! [
+                "FABLE_COMPILER_PY"
+                "FABLE_COMPILER_PYTHON" ]
+            | TypeScript -> yield! [
+                "FABLE_COMPILER_TS"
+                "FABLE_COMPILER_TYPESCRIPT" ]
+            | JavaScript -> yield! [
+                "FABLE_COMPILER_JS"
+                "FABLE_COMPILER_JAVASCRIPT" ]
         ]
         |> List.distinct
 

--- a/src/Fable.Cli/Entry.fs
+++ b/src/Fable.Cli/Entry.fs
@@ -226,7 +226,6 @@ type Runner =
         args.Values "--define"
         |> List.append [
             "FABLE_COMPILER"
-            "FABLE_COMPILER_3_OR_GREATER"
             "FABLE_COMPILER_4"
             "FABLE_COMPILER_4_OR_GREATER"
             match language with

--- a/src/Fable.Transforms/Global/Compiler.fs
+++ b/src/Fable.Transforms/Global/Compiler.fs
@@ -1,7 +1,7 @@
 namespace Fable
 
 module Literals =
-    let [<Literal>] VERSION = "3.6.3"
+    let [<Literal>] VERSION = "4.0.0"
 
 type CompilerOptionsHelper =
     static member DefaultExtension = ".fs.js"

--- a/src/fable-compiler-js/src/ProjectParser.fs
+++ b/src/fable-compiler-js/src/ProjectParser.fs
@@ -93,7 +93,7 @@ let parseCompilerOptions projectXml =
         projectXml
         |> getXmlTagContents "DefineConstants"
         |> Seq.collect (fun s -> s.Split(';'))
-        |> Seq.append ["FABLE_COMPILER"; "FABLE_COMPILER_3"; "FABLE_COMPILER_JS"]
+        |> Seq.append ["FABLE_COMPILER"; "FABLE_COMPILER_3_OR_GREATER"; "FABLE_COMPILER_4"; "FABLE_COMPILER_JAVASCRIPT"]
         |> Seq.map (fun s -> s.Trim())
         |> Seq.distinct
         |> Seq.except ["$(DefineConstants)"; ""]
@@ -168,7 +168,7 @@ let parseProjectScript projectFilePath =
             | _ -> dllRefs, srcFiles)
     let projectRefs = [||]
     let sourceFiles = Array.append srcFiles [| Path.GetFileName projectFilePath |]
-    let otherOptions = [| "--define:FABLE_COMPILER"; "--define:FABLE_COMPILER_3"; "--define:FABLE_COMPILER_JS" |]
+    let otherOptions = [| "--define:FABLE_COMPILER"; "--define:FABLE_COMPILER_4"; "--define:FABLE_COMPILER_JAVASCRIPT" |]
     (projectRefs, dllRefs, sourceFiles, otherOptions)
 
 let parseProjectFile projectFilePath =

--- a/src/fable-compiler-js/src/ProjectParser.fs
+++ b/src/fable-compiler-js/src/ProjectParser.fs
@@ -93,7 +93,7 @@ let parseCompilerOptions projectXml =
         projectXml
         |> getXmlTagContents "DefineConstants"
         |> Seq.collect (fun s -> s.Split(';'))
-        |> Seq.append ["FABLE_COMPILER"; "FABLE_COMPILER_3_OR_GREATER"; "FABLE_COMPILER_4"; "FABLE_COMPILER_JAVASCRIPT"]
+        |> Seq.append ["FABLE_COMPILER"; "FABLE_COMPILER_4"; "FABLE_COMPILER_4_OR_GREATER"; "FABLE_COMPILER_JAVASCRIPT"]
         |> Seq.map (fun s -> s.Trim())
         |> Seq.distinct
         |> Seq.except ["$(DefineConstants)"; ""]

--- a/src/fable-standalone/test/bench-compiler/ProjectParser.fs
+++ b/src/fable-standalone/test/bench-compiler/ProjectParser.fs
@@ -93,7 +93,7 @@ let parseCompilerOptions projectXml =
         projectXml
         |> getXmlTagContents "DefineConstants"
         |> Seq.collect (fun s -> s.Split(';'))
-        |> Seq.append ["FABLE_COMPILER"; "FABLE_COMPILER_3"; "FABLE_COMPILER_JS"]
+        |> Seq.append ["FABLE_COMPILER"; "FABLE_COMPILER_3"; "FABLE_COMPILER_JAVASCRIPT"]
         |> Seq.map (fun s -> s.Trim())
         |> Seq.distinct
         |> Seq.except ["$(DefineConstants)"; ""]
@@ -168,7 +168,7 @@ let parseProjectScript projectFilePath =
             | _ -> dllRefs, srcFiles)
     let projectRefs = [||]
     let sourceFiles = Array.append srcFiles [| Path.GetFileName projectFilePath |]
-    let otherOptions = [| "--define:FABLE_COMPILER"; "--define:FABLE_COMPILER_3"; "--define:FABLE_COMPILER_JS" |]
+    let otherOptions = [| "--define:FABLE_COMPILER"; "--define:FABLE_COMPILER_3_OR_GREATER"; "--define:FABLE_COMPILER_4"; "--define:FABLE_COMPILER_JAVASCRIPT" |]
     (projectRefs, dllRefs, sourceFiles, otherOptions)
 
 let parseProjectFile projectFilePath =

--- a/src/fable-standalone/test/bench-compiler/ProjectParser.fs
+++ b/src/fable-standalone/test/bench-compiler/ProjectParser.fs
@@ -93,7 +93,7 @@ let parseCompilerOptions projectXml =
         projectXml
         |> getXmlTagContents "DefineConstants"
         |> Seq.collect (fun s -> s.Split(';'))
-        |> Seq.append ["FABLE_COMPILER"; "FABLE_COMPILER_3"; "FABLE_COMPILER_JAVASCRIPT"]
+        |> Seq.append ["FABLE_COMPILER"; "FABLE_COMPILER_4"; "FABLE_COMPILER_4_OR_GREATER"; "FABLE_COMPILER_JAVASCRIPT"]
         |> Seq.map (fun s -> s.Trim())
         |> Seq.distinct
         |> Seq.except ["$(DefineConstants)"; ""]
@@ -168,7 +168,7 @@ let parseProjectScript projectFilePath =
             | _ -> dllRefs, srcFiles)
     let projectRefs = [||]
     let sourceFiles = Array.append srcFiles [| Path.GetFileName projectFilePath |]
-    let otherOptions = [| "--define:FABLE_COMPILER"; "--define:FABLE_COMPILER_3_OR_GREATER"; "--define:FABLE_COMPILER_4"; "--define:FABLE_COMPILER_JAVASCRIPT" |]
+    let otherOptions = [| "--define:FABLE_COMPILER"; "--define:FABLE_COMPILER_4"; "--define:FABLE_COMPILER_4_OR_GREATER"; "--define:FABLE_COMPILER_JAVASCRIPT" |]
     (projectRefs, dllRefs, sourceFiles, otherOptions)
 
 let parseProjectFile projectFilePath =

--- a/src/fcs-fable/test/ProjectParser.fs
+++ b/src/fcs-fable/test/ProjectParser.fs
@@ -93,7 +93,7 @@ let parseCompilerOptions projectXml =
         projectXml
         |> getXmlTagContents "DefineConstants"
         |> Seq.collect (fun s -> s.Split(';'))
-        |> Seq.append ["FABLE_COMPILER"; "FABLE_COMPILER_JS"]
+        |> Seq.append ["FABLE_COMPILER"; "FABLE_COMPILER_JAVASCRIPT"]
         |> Seq.map (fun s -> s.Trim())
         |> Seq.distinct
         |> Seq.except ["$(DefineConstants)"; ""]
@@ -168,7 +168,7 @@ let parseProjectScript projectFilePath =
             | _ -> dllRefs, srcFiles)
     let projectRefs = [||]
     let sourceFiles = Array.append srcFiles [| Path.GetFileName projectFilePath |]
-    let otherOptions = [| "--define:FABLE_COMPILER"; "--define:FABLE_COMPILER_JS" |]
+    let otherOptions = [| "--define:FABLE_COMPILER"; "--define:FABLE_COMPILER_JAVASCRIPT" |]
     (projectRefs, dllRefs, sourceFiles, otherOptions)
 
 let parseProjectFile projectFilePath =

--- a/tests/Main/MiscTests.fs
+++ b/tests/Main/MiscTests.fs
@@ -447,7 +447,7 @@ type Order =
         quantity : int<kg>
     }
 
-#if !FABLE_COMPILER_JS
+#if !FABLE_COMPILER_JAVASCRIPT
 type LiteralJson = Fable.JsonProvider.Generator<LITERAL_JSON>
 #endif
 
@@ -460,7 +460,7 @@ let tests =
   testList "Miscellaneous" [
 
 #if FABLE_COMPILER
-#if !FABLE_COMPILER_JS
+#if !FABLE_COMPILER_JAVASCRIPT
     testCase "Fable.JsonProvider works" <| fun _ ->
         let parsed = LiteralJson(ANOTHER_JSON)
         parsed.widget.debug |> equal false
@@ -482,15 +482,18 @@ let tests =
         x <- x + 2
         #endif
         #if FABLE_COMPILER_3_OR_GREATER
-        x <- x + 3
-        #endif
-        #if FABLE_COMPILER_4
         x <- x + 4
         #endif
-        #if FABLE_COMPILER_5
-        x <- x + 5
+        #if FABLE_COMPILER_4
+        x <- x + 8
         #endif
-        equal 8 x
+        #if FABLE_COMPILER_4_OR_GREATER
+        x <- x + 16
+        #endif
+        #if FABLE_COMPILER_5
+        x <- x + 32
+        #endif
+        equal 29 x
 
     testCase "Can check compiler version at runtime" <| fun _ ->
         Compiler.majorMinorVersion >=  4.0 |> equal true

--- a/tests/Main/MiscTests.fs
+++ b/tests/Main/MiscTests.fs
@@ -481,19 +481,16 @@ let tests =
         #if FABLE_COMPILER_3
         x <- x + 2
         #endif
-        #if FABLE_COMPILER_3_OR_GREATER
+        #if FABLE_COMPILER_4
         x <- x + 4
         #endif
-        #if FABLE_COMPILER_4
+        #if FABLE_COMPILER_4_OR_GREATER
         x <- x + 8
         #endif
-        #if FABLE_COMPILER_4_OR_GREATER
+        #if FABLE_COMPILER_5
         x <- x + 16
         #endif
-        #if FABLE_COMPILER_5
-        x <- x + 32
-        #endif
-        equal 29 x
+        equal 13 x
 
     testCase "Can check compiler version at runtime" <| fun _ ->
         Compiler.majorMinorVersion >=  4.0 |> equal true

--- a/tests/Main/MiscTests.fs
+++ b/tests/Main/MiscTests.fs
@@ -481,13 +481,19 @@ let tests =
         #if FABLE_COMPILER_3
         x <- x + 2
         #endif
-        #if FABLE_COMPILER_4
+        #if FABLE_COMPILER_3_OR_GREATER
         x <- x + 3
         #endif
-        equal 3 x
+        #if FABLE_COMPILER_4
+        x <- x + 4
+        #endif
+        #if FABLE_COMPILER_5
+        x <- x + 5
+        #endif
+        equal 8 x
 
     testCase "Can check compiler version at runtime" <| fun _ ->
-        Compiler.majorMinorVersion >=  3.0 |> equal true
+        Compiler.majorMinorVersion >=  4.0 |> equal true
         Text.RegularExpressions.Regex.IsMatch(Compiler.version, @"^\d+\.\d+") |> equal true
 
     testCase "Can access compiler options" <| fun _ ->


### PR DESCRIPTION
Add language specific defines for `FABLE_COMPILER`. In addition to `FABLE_COMPILER` and `FABLE_COMPILER_4` this PR will add one of the language specific below:

- `FABLE_COMPILER_PHP`
- `FABLE_COMPILER_RUST`
- `FABLE_COMPILER_DART`
- `FABLE_COMPILER_PYTHON`
- `FABLE_COMPILER_JAVASCRIPT`
- `FABLE_COMPILER_TYPESCRIPT`

it also adds

- `FABLE_COMPILER_4_OR_GREATER`

What do you think @alfonsogarciacaro @ncave. Would something like this be OK?