### PR TITLE
Python fixes 14

### DIFF
--- a/src/Fable.Cli/Pipeline.fs
+++ b/src/Fable.Cli/Pipeline.fs
@@ -72,7 +72,8 @@ module Python =
             |> Naming.applyCaseRule Core.CaseRules.SnakeCase
             |> Fable.PY.Naming.checkPyKeywords
         // Note that Python modules cannot contain dots or it will be impossible to import them
-        let targetPath = Path.Combine(targetDir, fileName + fileExt)
+        let targetPath = Path.Combine(targetDir, Path.replaceExtension fileExt fileName)
+
         let stream = new IO.StreamWriter(targetPath)
 
         interface PythonPrinter.Writer with

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -1291,10 +1291,9 @@ module Util =
         | Some(Target left) -> exprAsStatement ctx (assign None (left |> Expression.identifier) pyExpr)
 
     let transformOperation com ctx range opKind: Expression * Statement list =
-        // printfn "transformOperation: %A" opKind
         match opKind with
         | Fable.Unary(UnaryVoid, TransformExpr com ctx (expr, stmts)) ->
-            expr, stmts
+            Expression.none(), stmts
         | Fable.Unary(UnaryTypeof, TransformExpr com ctx (expr, stmts)) ->
             let func = Expression.name("type")
             let args = [ expr ]

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -539,7 +539,7 @@ module Helpers =
                 path.Replace("./", "").Replace("/", ".") + "."
 
         let moduleImport = $"{path}{moduleName}"
-        printfn "ModuleImport: %s" moduleImport
+        // printfn "ModuleImport: %s" moduleImport
         moduleImport
 
     let unzipArgs (args: (Expression * Statement list) list): Expression list * Python.Statement list =

--- a/src/Fable.Transforms/Python/Python.fs
+++ b/src/Fable.Transforms/Python/Python.fs
@@ -2,6 +2,7 @@
 namespace rec Fable.AST.Python
 
 open Fable.AST
+open Fable.AST.Python
 
 type Expression =
     | Attribute of Attribute
@@ -1001,8 +1002,8 @@ module PythonExtensions =
 
             Expression.binOp(left, op, right, ?loc=loc)
 
-        static member boolOp(op, values, ?loc) : Expression = { Values = values; Operator = op; Loc=loc } |> BoolOp
-        static member boolOp(op, values, ?loc) : Expression =
+        static member boolOp(op: BoolOperator, values, ?loc) : Expression = { Values = values; Operator = op; Loc=loc } |> BoolOp
+        static member boolOp(op: LogicalOperator, values, ?loc) : Expression =
             let op =
                 match op with
                 | LogicalAnd -> And

--- a/src/Fable.Transforms/Python/PythonPrinter.fs
+++ b/src/Fable.Transforms/Python/PythonPrinter.fs
@@ -359,7 +359,7 @@ module PrinterExtensions =
         member printer.Print(node: FormattedValue) = printer.Print("(FormattedValue)")
 
         member printer.Print(node: Call) =
-            printer.Print(node.Func)
+            printer.ComplexExpressionWithParens(node.Func)
             printer.Print("(")
             printer.PrintCommaSeparatedList(node.Args)
             if not node.Keywords.IsEmpty then
@@ -462,7 +462,7 @@ module PrinterExtensions =
         member printer.Print(node: IfExp) =
             printer.Print(node.Body)
             printer.Print(" if ")
-            printer.WithParens (node.Test)
+            printer.WithParens(node.Test)
             printer.Print(" else ")
             printer.WithParens(node.OrElse)
 

--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -1469,7 +1469,10 @@ let operators (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr o
     // KeyValuePair is already compiled as a tuple
     | ("KeyValuePattern"|"Identity"|"Box"|"Unbox"|"ToEnum"), [arg] -> TypeCast(arg, t) |> Some
     // Cast to unit to make sure nothing is returned when wrapped in a lambda, see #1360
-    | "Ignore", _ -> Operation(Unary(UnaryVoid, args.Head), t, r) |> Some // "void $0" |> emitJsExpr r t args |> Some
+    | "Ignore", _ ->
+        //Operation(Unary(UnaryVoid, args.Head), t, r) |> Some // "void $0" |> emitJsExpr r t args |> Some
+        Helper.LibCall(com, "util", "ignore", t, args, i.SignatureArgTypes, ?loc=r) |> Some
+
     // Number and String conversions
     | ("ToSByte"|"ToByte"|"ToInt8"|"ToUInt8"|"ToInt16"|"ToUInt16"|"ToInt"|"ToUInt"|"ToInt32"|"ToUInt32"), _ ->
         toInt com ctx r t args |> Some

--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -1575,7 +1575,7 @@ let operators (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr o
         match resolveArgTypes i.SignatureArgTypes i.GenericArgs with
         | Builtin (BclDecimal)::_  ->
             Helper.LibCall(com, "decimal", "truncate", t, args, i.SignatureArgTypes, ?thisArg=thisArg, ?loc=r) |> Some
-        | _ -> Helper.GlobalCall("Math", t, args, i.SignatureArgTypes, memb="trunc", ?loc=r) |> Some
+        | _ -> Helper.GlobalCall("math", t, args, i.SignatureArgTypes, memb="trunc", ?loc=r) |> Some
     | "Sign", _ ->
         let args = toFloat com ctx r t args |> List.singleton
         Helper.LibCall(com, "util", "sign", t, args, i.SignatureArgTypes, ?loc=r) |> Some
@@ -2369,7 +2369,7 @@ let intrinsicFunctions (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisAr
     // Type: PowDouble : float -> int -> float
     // Usage: PowDouble x n
     | "PowDouble", None, _ ->
-        Helper.GlobalCall("Math", t, args, i.SignatureArgTypes, memb="pow", ?loc=r) |> Some
+        Helper.GlobalCall("math", t, args, i.SignatureArgTypes, memb="pow", ?loc=r) |> Some
     | "PowDecimal", None, _ ->
         Helper.LibCall(com, "decimal", "pow", t, args, i.SignatureArgTypes, ?loc=r) |> Some
     // reference: https://msdn.microsoft.com/visualfsharpdocs/conceptual/operatorintrinsics.rangechar-function-%5bfsharp%5d
@@ -2767,7 +2767,7 @@ let random (com: ICompiler) (ctx: Context) r t (i: CallInfo) (_: Expr option) (a
             | _ -> failwith "Unexpected arg count for Random.Next"
         Helper.LibCall(com, "util", "randomNext", t, [min; max], [min.Type; max.Type], ?loc=r) |> Some
     | "NextDouble" ->
-        Helper.GlobalCall ("Math", t, [], [], memb="random") |> Some
+        Helper.GlobalCall ("math", t, [], [], memb="random") |> Some
     | "NextBytes" ->
         let byteArray =
             match args with

--- a/src/fable-library-py/fable_library/reg_exp.py
+++ b/src/fable-library-py/fable_library/reg_exp.py
@@ -3,3 +3,10 @@ import re
 
 def escape(string: str):
     return re.escape(string)
+
+
+def is_match(string: str, pattern: str) -> bool:
+    return re.match(pattern, string) is not None
+
+
+__all__ = ["escape", "is_match"]

--- a/src/fable-library-py/fable_library/time_span.py
+++ b/src/fable-library-py/fable_library/time_span.py
@@ -1,10 +1,21 @@
 from datetime import timedelta
+from typing import Optional
 
-def total_seconds(ts):
-    return ts / 1000
+def total_seconds(ts: timedelta) -> float:
+    return ts.total_seconds()
 
-def from_milliseconds(msecs):
+def from_milliseconds(msecs: int) -> timedelta:
     return timedelta(milliseconds=msecs)
 
-def to_milliseconds(td):
+
+def from_ticks(ticks: int) -> timedelta:
+    return timedelta(microseconds = ticks //10)
+
+def to_milliseconds(td: timedelta):
     return int(td.total_seconds() * 1000)
+
+def create(d: int = 0, h: Optional[int] = None, m: Optional[int] = None, s: Optional[int] = None, ms: Optional[int] = None) -> timedelta:
+    if h is None and m is None and s is None and ms is None:
+        return from_ticks(d)
+
+    return timedelta(days=d, hours=h or 0, minutes=m or 0, seconds=s or 0, milliseconds=ms or 0)

--- a/src/fable-library-py/fable_library/types.py
+++ b/src/fable-library-py/fable_library/types.py
@@ -174,7 +174,7 @@ def seq_to_string(self):
     return str + "]"
 
 
-def to_string(x, callStack=0):
+def to_string(x: Any, callStack: int=0) -> str:
     if x is not None:
         # if (typeof x.toString === "function") {
         #    return x.toString();
@@ -193,10 +193,10 @@ def to_string(x, callStack=0):
 
 
 class Exception(Exception):
-    def __init__(self, msg=None):
+    def __init__(self, msg: Optional[str]=None):
         self.msg = msg
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         if self is other:
             return True
 
@@ -219,7 +219,7 @@ class FSharpException(Exception, IComparable):
     def __repr__(self) -> str:
         return str(self)
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         if self is other:
             return True
 

--- a/src/fable-library-py/fable_library/uri.py
+++ b/src/fable-library-py/fable_library/uri.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from urllib.parse import urlparse
+from typing import Optional
 
 
 class UriKind(Enum):
@@ -9,8 +10,9 @@ class UriKind(Enum):
 
 
 class Uri:
-    def __init__(self, uri: str, uri_kind=None) -> None:
+    def __init__(self, uri: str, uri_kind: Optional[int] = None) -> None:
         self.res = urlparse(uri)
+        self.kind = UriKind(uri_kind) if uri_kind else UriKind.Absolute
 
     @property
     def is_absolute_uri(self) -> bool:
@@ -26,6 +28,9 @@ class Uri:
 
     @property
     def absolute_uri(self) -> str:
+        if self.kind == UriKind.Relative:
+            raise ValueError("This operation is not supported for a relative URI.")
+
         return self.res.geturl()
 
     @property
@@ -43,3 +48,6 @@ class Uri:
     @property
     def fragment(self) -> str:
         return f"#{self.res.fragment}"
+
+    def __str__(self) -> str:
+        return self.res.geturl()

--- a/src/fable-library-py/fable_library/util.py
+++ b/src/fable-library-py/fable_library/util.py
@@ -86,7 +86,7 @@ class IEquatable(ABC):
         return hash(self)
 
     @abstractmethod
-    def __eq__(self, other: Any):
+    def __eq__(self, other: Any) -> bool:
         return NotImplemented
 
     @abstractmethod
@@ -103,7 +103,7 @@ class IComparable(IEquatable):
         return 1
 
     @abstractmethod
-    def __lt__(self, other: Any):
+    def __lt__(self, other: Any) -> bool:
         raise NotImplementedError
 
 
@@ -185,7 +185,7 @@ def clamp(comparer: Callable[[T, T], int], value: T, min: T, max: T):
     return min if (comparer(value, min) < 0) else max if comparer(value, max) > 0 else value
 
 
-def assert_equal(actual, expected, msg=None) -> None:
+def assert_equal(actual, expected, msg: Optional[str]=None) -> None:
     if actual != expected:
         raise Exception(msg or f"Expected: ${expected} - Actual: ${actual}")
 
@@ -218,10 +218,10 @@ def lazy_from_value(v: T) -> Lazy[T]:
     return Lazy(lambda: v)
 
 
-def create_atom(value=None):
+def create_atom(value: Any=None):
     atom = value
 
-    def _(value=None, isSetter=None):
+    def _(value:Any=None, isSetter=None):
         nonlocal atom
 
         if not isSetter:
@@ -498,7 +498,7 @@ class ObjectRef:
     count = 0
 
     @staticmethod
-    def id(o: Any):
+    def id(o: Any) -> int:
         _id = id(o)
         if not _id in ObjectRef.id_map:
             count = ObjectRef.count + 1
@@ -507,11 +507,11 @@ class ObjectRef:
         return ObjectRef.id_map[_id]
 
 
-def safe_hash(x):
+def safe_hash(x: Any) -> int:
     return 0 if x is None else x.GetHashCode() if is_hashable(x) else number_hash(ObjectRef.id(x))
 
 
-def string_hash(s):
+def string_hash(s: str) -> int:
     h = 5381
     for c in s:
         h = (h * 33) ^ ord(c)
@@ -549,13 +549,13 @@ def structural_hash(x: Any) -> int:
 
 def array_hash(xs):
     hashes = []
-    for i, x in enumerate(xs):
+    for x in xs:
         hashes.append(structural_hash(x))
 
     return combine_hash_codes(hashes)
 
 
-def physical_hash(x):
+def physical_hash(x: Any) -> int:
     if hasattr(x, "__hash__") and callable(x.__hash__):
         return hash(x)
 

--- a/src/fable-library-py/fable_library/util.py
+++ b/src/fable-library-py/fable_library/util.py
@@ -40,7 +40,10 @@ class IDisposable:
         return self
 
     def __exit__(
-        self, exctype: Optional[Type[BaseException]], excinst: Optional[BaseException], exctb: Optional[TracebackType]
+        self,
+        exctype: Optional[Type[BaseException]],
+        excinst: Optional[BaseException],
+        exctb: Optional[TracebackType],
     ) -> bool:
         """Exit context management."""
 
@@ -182,10 +185,16 @@ def max(comparer, x, y):
 
 def clamp(comparer: Callable[[T, T], int], value: T, min: T, max: T):
     # return (comparer(value, min) < 0) ? min : (comparer(value, max) > 0) ? max : value;
-    return min if (comparer(value, min) < 0) else max if comparer(value, max) > 0 else value
+    return (
+        min
+        if (comparer(value, min) < 0)
+        else max
+        if comparer(value, max) > 0
+        else value
+    )
 
 
-def assert_equal(actual, expected, msg: Optional[str]=None) -> None:
+def assert_equal(actual, expected, msg: Optional[str] = None) -> None:
     if actual != expected:
         raise Exception(msg or f"Expected: ${expected} - Actual: ${actual}")
 
@@ -218,10 +227,10 @@ def lazy_from_value(v: T) -> Lazy[T]:
     return Lazy(lambda: v)
 
 
-def create_atom(value: Any=None):
+def create_atom(value: Any = None):
     atom = value
 
-    def _(value:Any=None, isSetter=None):
+    def _(value: Any = None, isSetter=None):
         nonlocal atom
 
         if not isSetter:
@@ -395,9 +404,13 @@ def curry(arity: int, fn: Callable) -> Callable:
     elif arity == 4:
         return lambda a1: lambda a2: lambda a3: lambda a4: fn(a1, a2, a3, a4)
     elif arity == 5:
-        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: fn(a1, a2, a3, a4, a5)
+        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: fn(
+            a1, a2, a3, a4, a5
+        )
     elif arity == 6:
-        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: fn(a1, a2, a3, a4, a5, a6)
+        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: fn(
+            a1, a2, a3, a4, a5, a6
+        )
     elif arity == 7:
         return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: fn(
             a1, a2, a3, a4, a5, a6, a7
@@ -434,9 +447,13 @@ def partial_apply(arity: int, fn: Callable, args: List) -> Any:
     if arity == 4:
         return lambda a1: lambda a2: lambda a3: lambda a4: fn(args + [a1, a2, a3, a4])
     if arity == 5:
-        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: fn(args + [a1, a2, a3, a4, a5])
+        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: fn(
+            args + [a1, a2, a3, a4, a5]
+        )
     if arity == 6:
-        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: fn(args + [a1, a2, a3, a4, a5, a6])
+        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: fn(
+            args + [a1, a2, a3, a4, a5, a6]
+        )
     if arity == 7:
         return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: fn(
             args + [a1, a2, a3, a4, a5, a6, a7]
@@ -445,7 +462,9 @@ def partial_apply(arity: int, fn: Callable, args: List) -> Any:
         return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: fn(
             args + [a1, a2, a3, a4, a5, a6, a7, a8]
         )
-    raise ValueError(f"Partially applying to more than 8-arity is not supported: {arity}")
+    raise ValueError(
+        f"Partially applying to more than 8-arity is not supported: {arity}"
+    )
 
 
 def is_array_like(x):
@@ -508,7 +527,13 @@ class ObjectRef:
 
 
 def safe_hash(x: Any) -> int:
-    return 0 if x is None else x.GetHashCode() if is_hashable(x) else number_hash(ObjectRef.id(x))
+    return (
+        0
+        if x is None
+        else x.GetHashCode()
+        if is_hashable(x)
+        else number_hash(ObjectRef.id(x))
+    )
 
 
 def string_hash(s: str) -> int:
@@ -568,7 +593,11 @@ def round(value, digits=0):
     i = math.floor(n)
     f = n - i
     e = 1e-8
-    r = (i if (i % 2 == 0) else i + 1) if (f > 0.5 - e and f < 0.5 + e) else builtins.round(n)
+    r = (
+        (i if (i % 2 == 0) else i + 1)
+        if (f > 0.5 - e and f < 0.5 + e)
+        else builtins.round(n)
+    )
     return r / m if digits else r
 
 
@@ -578,8 +607,12 @@ def unescape_data_string(s: str) -> str:
 
 
 def escape_data_string(s: str) -> str:
-    return quote(s)
+    return quote(s, safe="")
 
 
 def escape_uri_string(s: str) -> str:
-    return quote(s)
+    return quote(s, safe="&?:/!=")
+
+
+def ignore(a: Any = None):
+    return

--- a/tests/Python/Fable.Tests.fsproj
+++ b/tests/Python/Fable.Tests.fsproj
@@ -23,6 +23,7 @@
     <PackageReference Include="FSharp.UMX" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="../Main/Globs/*.fs" />
     <Compile Include="Util.fs" />
     <Compile Include="Misc/Util2.fs" />
     <Compile Include="Misc/Util3.fs" />

--- a/tests/Python/Fable.Tests.fsproj
+++ b/tests/Python/Fable.Tests.fsproj
@@ -36,6 +36,7 @@
     <Compile Include="TestSeqExpression.fs" />
     <Compile Include="TestList.fs" />
     <Compile Include="TestMath.fs" />
+    <Compile Include="MiscTestsHelper.fs" />
     <Compile Include="TestMisc.fs" />
     <Compile Include="TestFn.fs" />
     <Compile Include="TestEnum.fs" />

--- a/tests/Python/Fable.Tests.fsproj
+++ b/tests/Python/Fable.Tests.fsproj
@@ -17,9 +17,16 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../src/Fable.Core/Fable.Core.fsproj" />
+    <ProjectReference Include="../../tests_external/Fable.Tests.External.fsproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FSharp.UMX" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Util.fs" />
+    <Compile Include="Misc/Util2.fs" />
+    <Compile Include="Misc/Util3.fs" />
+    <Compile Include="../../tests_external/Util3.fs" />
     <Compile Include="TestTask.fs" />
     <Compile Include="TestComparison.fs" />
     <Compile Include="TestCustomOperators.fs" />
@@ -29,6 +36,7 @@
     <Compile Include="TestSeqExpression.fs" />
     <Compile Include="TestList.fs" />
     <Compile Include="TestMath.fs" />
+    <Compile Include="TestMisc.fs" />
     <Compile Include="TestFn.fs" />
     <Compile Include="TestEnum.fs" />
     <Compile Include="TestString.fs" />

--- a/tests/Python/Misc/Util2.fs
+++ b/tests/Python/Misc/Util2.fs
@@ -1,0 +1,19 @@
+namespace Fable.Tests.Util2
+
+open System
+
+// Check files with no root module compile properly
+type Helper =
+    static member Format(pattern: string, [<ParamArray>] args: obj[]) =
+        String.Format(pattern, args)
+
+type Helper3(i: int) =
+    member x.Value = string i
+
+type H = Helper3
+
+
+module Extensions =
+    type String with
+        member inline x.StartsWithIgnoreCase(value) =
+            x.StartsWith(value, StringComparison.OrdinalIgnoreCase)

--- a/tests/Python/Misc/Util3.fs
+++ b/tests/Python/Misc/Util3.fs
@@ -1,0 +1,20 @@
+// Test that a file with multiple namespaces works, see #1218
+
+// Different namespace together with namespaces
+// sharing a prefix doesn't work
+// namespace My.Namespace
+
+// Duplicating namespaces doesn't work
+// namespace Fable.Tests.A.C
+
+// Empty namespaces work
+namespace Fable.Tests.A.D
+
+// Multiple mamespaces sharing prefix work
+namespace Fable.Tests.A.B
+type Helper =
+    static member Add2(x) = x + 2
+
+namespace Fable.Tests.A.C
+type Helper =
+    static member Add5(x) = Fable.Tests.A.B.Helper.Add2(x + 3)

--- a/tests/Python/MiscTestsHelper.fs
+++ b/tests/Python/MiscTestsHelper.fs
@@ -1,0 +1,28 @@
+module Fable.Tests.MiscTestsHelper
+
+let counter =
+    let mutable i = 0
+    fun () ->
+        i <- i + 1
+        i
+
+type Type = {
+    a : int
+    b : int
+    c : int
+    d : int
+    e : int
+}
+  with
+    static member New(n) = {
+        a = n
+        b = n * 2
+        c = n * 3
+        d = n * 4
+        e = counter()  // <== should only be called twice
+      }
+
+    member        this.Method  (v:bool) = { this with a = this.a * if v then 2 else 3 }
+    member inline this.MethodI (v:bool) = { this with a = this.a * if v then 2 else 3 }
+    member        this.Method  ()       = { this with a = this.a * 10 }
+    member inline this.MethodI ()       = { this with a = this.a * 10 }

--- a/tests/Python/TestMisc.fs
+++ b/tests/Python/TestMisc.fs
@@ -1,0 +1,639 @@
+module Fable.Tests.Misc
+
+open System
+open System.Runtime.InteropServices
+open Fable.Core
+open Util.Testing
+
+let [<Literal>] LITERAL_JSON = """{
+    "widget": {
+        "debug": true,
+        "window": {
+            "title": "Sample Konfabulator Widget",
+            "name": "main_window",
+            "width": 500,
+            "height": 500
+        },
+        "image": {
+            "src": "Images/Sun.png",
+            "name": "sun1",
+            "hOffset": 250,
+            "vOffset": 250,
+            "alignment": "center"
+        },
+        "text": {
+            "data": "Click Here",
+            "size": [{ "width": 36, "height": 40 }],
+            "style": "bold",
+            "name": "text1",
+            "vOffset": 100,
+            "alignment": "center",
+            "onMouseUp": "sun1.opacity = (sun1.opacity / 100) * 90;"
+        }
+    }
+}"""
+
+let ANOTHER_JSON = """{
+    "widget": {
+        "debug": false,
+        "text": {
+            "data": "lots of",
+            "size": [{"width": 5}, { "height": 80 }],
+            "vOffset": 500
+        }
+    }
+}"""
+
+// We can have aliases with same name in same file #1662
+module One =
+    type Id = System.Guid
+
+module Two =
+    type Id = System.Guid
+
+type Base() =
+    let mutable x = 5
+    member this.Mutate i = x <- x + i
+    member __.Value = x
+
+type MyTest(i) as myself =
+    inherit Base()
+    let mutable y = 12
+    do myself.Mutate(i+2)
+    do myself.Mutate2(i)
+    member this.Mutate2 i = y <- y + i
+    member __.Value2 = y
+    member __.Foo() = myself.Value * 2
+
+let log2 (a: string) (b: string) = String.Format("a = {0}, b = {1}", a, b)
+let logItem1 = log2 "item1"
+let logItem2 = log2 "item2"
+
+type PartialFunctions() =
+    member __.logItem1 = log2 "item1"
+    member __.logItem2 = log2 "item2"
+
+type MaybeBuilder() =
+  member __.Bind(x,f) = Option.bind f x
+  member __.Return v = Some v
+  member __.ReturnFrom o = o
+let maybe = MaybeBuilder()
+
+let riskyOp x y =
+  if x + y < 100 then Some(x+y) else None
+
+let execMaybe a = maybe {
+  let! b = riskyOp a (a+1)
+  let! c = riskyOp b (b+1)
+  return c
+}
+
+[<Measure>] type km           // Define the measure units
+[<Measure>] type mi           // as simple types decorated
+[<Measure>] type h            // with Measure attribute
+
+[<Measure>] type Measure1
+[<Measure>] type Measure2 = Measure1
+
+type MeasureTest() =
+    member _.Method(x: float<Measure2>) = x
+
+// Can be used in a generic way
+type Vector3D<[<Measure>] 'u> =
+    { x: float<'u>; y: float<'u>; z: float<'u> }
+    static member (+) (v1: Vector3D<'u>, v2: Vector3D<'u>) =
+        { x = v1.x + v2.x; y = v1.y + v2.y; z = v1.z + v2.z }
+
+type PointWithCounter(a: int, b: int) =
+    // A variable i.
+    let mutable i = 0
+    // A let binding that uses a pattern.
+    let (x, y) = (a, b)
+    // A private function binding.
+    let privateFunction x y = x * x + 2*y
+    // A static let binding.
+    static let mutable count = 0
+    // A do binding.
+    do count <- count + 1
+    member this.Prop1 = x
+    member this.Prop2 = y
+    member this.CreatedCount = count
+    member this.FunctionValue = privateFunction x y
+
+
+let inline f x y = x + y
+
+let inline sum x = fun y -> x + y
+
+module FooModule =
+    let mutable genericValueBackend = 0
+    let inline genericValue<'T> = genericValueBackend <- genericValueBackend + 1; 5
+    let add x y = x + y
+
+    type FooInline() =
+        member __.Bar = "Bar"
+        member val Value = 0uy with get, set
+        member inline self.Foo = "Foo" + self.Bar
+        member inline self.Foofy(i) = String.replicate i self.Bar
+        member inline this.PropertyInline
+            with get() = this.Value
+            and set(v: uint8) = this.Value <- v
+
+type FooModule.FooInline with
+    member inline self.Bar2 = "Bar" + self.Bar
+    member inline self.FoofyPlus(i) = self.Foofy(i * 2)
+
+let counter =
+    let mutable i = 0
+    fun () ->
+        i <- i + 1
+        i
+
+type Type = {
+    a : int
+    b : int
+    c : int
+    d : int
+    e : int
+}
+  with
+    static member New(n) = {
+        a = n
+        b = n * 2
+        c = n * 3
+        d = n * 4
+        e = counter()  // <== should only be called twice
+      }
+
+    member        this.Method  (v:bool) = { this with a = this.a * if v then 2 else 3 }
+    member inline this.MethodI (v:bool) = { this with a = this.a * if v then 2 else 3 }
+    member        this.Method  ()       = { this with a = this.a * 10 }
+    member inline this.MethodI ()       = { this with a = this.a * 10 }
+
+let f1 x y z = x + y + z
+let f2 x = x + x
+
+let f3 () = 5
+
+type MyDelegate = Func<int>
+
+let mutable myMutableField = 0
+
+let f4 i = myMutableField <- i
+let f5 () = myMutableField <- 5
+let f6 i j = myMutableField <- i * j
+let f7 i () = myMutableField <- i * 3
+
+type DisposableFoo() =
+    member __.Foo() = 5
+    interface IDisposable with
+        member __.Dispose () = ()
+
+type DisposableBar(v: int ref) =
+    do v.Value <- 10
+    interface IDisposable with
+        member __.Dispose () = v.Value <- 20
+
+let createCellDiposable (cell: int ref) =
+  cell.Value <- 10
+  { new System.IDisposable with
+      member x.Dispose() = cell.Value <- 20 }
+
+let (|NonEmpty|_|) (s: string) =
+    match s.Trim() with "" -> None | s -> Some s
+
+type IFoo =
+   abstract Bar: s: string * [<ParamArray>] rest: obj[] -> string
+
+type IFoo2 =
+    abstract Value: int with get, set
+    abstract Test: int -> int
+    abstract MakeFoo: unit -> IFoo
+
+type Foo(i) =
+    let mutable j = 5
+    member x.Value = i + j
+    member x.MakeFoo2() = {
+        new IFoo2 with
+        member x2.Value
+            with get() = x.Value * 2
+            and set(i) = j <- j + i
+        member x2.Test(i) = x2.Value - i
+        member x2.MakeFoo() = {
+            new IFoo with
+            member x3.Bar(s: string, [<ParamArray>] rest: obj[]) =
+                sprintf "%s: %i %i %i" s x.Value x2.Value j
+        }
+    }
+
+type IRenderer =
+  abstract member doWork: unit -> string
+
+type MyComponent(name) as self =
+  let work i = sprintf "%s-%i" name i
+  let create2 () = { new IRenderer with member __.doWork () = work 2 }
+  let create3 = { new IRenderer with member __.doWork () = work 3 }
+  let create4 = { new IRenderer with member __.doWork () = self.Work 4 }
+  let create5() = { new IRenderer with member __.doWork () = self.Work 5 }
+  member __.Work i = work i
+  member __.works1 () = { new IRenderer with member __.doWork () = work 1 }
+  member __.works2 () = create2()
+  member __.works3 () = create3
+  member __.works4 () = create4
+  member __.works5 () = create5()
+
+type IFoo3 =
+   abstract Bar: int with get, set
+
+type SomeClass(name: string) =
+    member x.Name = name
+
+type AnotherClass(value: int) =
+    member x.Value = value
+
+module NestedModule =
+    type AnotherClass(value: int) =
+        member x.Value = value + 5
+
+type INum = abstract member Num: int
+let inline makeNum f = { new INum with member __.Num = f() }
+
+type MyTestClass(n) =
+    let addOne x = x + 4
+    let inner = makeNum (fun () -> addOne n)
+    member __.GetNum() = inner.Num
+
+type RecursiveType(subscribe) as self =
+    let foo = 3
+    let getNumber() = 3
+    do subscribe (getNumber >> self.Add2)
+    member __.Add2(i) = self.MultiplyFoo(i) + 2
+    member __.MultiplyFoo(i) = i * foo
+
+module Extensions =
+    type IDisposable with
+        static member Create(f) =
+            { new IDisposable with
+                member __.Dispose() = f() }
+
+    type SomeClass with
+        member x.FullName = sprintf "%s Smith" x.Name
+        member x.NameTimes (i: int, j: int) = String.replicate (i + j) x.Name
+
+    type AnotherClass with
+        member x.FullName = sprintf "%i" x.Value
+        member x.Overload(i: int) = i * 4
+        member x.Overload(s: string) = s + s
+        member x.Value2 = x.Value * 2
+
+    type NestedModule.AnotherClass with
+        member x.Value2 = x.Value * 4
+
+    [<AbstractClass>]
+    type ObjectExprBase (x: int ref) as this =
+        do x.Value <- this.dup x.contents
+        abstract member dup: int -> int
+
+open Extensions
+
+
+module StyleBuilderHelper =
+    type StyleBuilderHelper = { TopOffset : int; BottomOffset : int }
+    type DomBuilder = { ElementType : string; StyleBuilderHelper : StyleBuilderHelper }
+    let test() =
+        let helper = { TopOffset = 1; BottomOffset = 2 }
+        let builder1 = { ElementType = "test"; StyleBuilderHelper = helper }
+        let builder2 = { builder1 with StyleBuilderHelper =  { builder1.StyleBuilderHelper with BottomOffset = 3 } }
+        match builder1, builder2 with
+        | { StyleBuilderHelper = { BottomOffset = 2 } },
+          { StyleBuilderHelper = { TopOffset = 1; BottomOffset = 3 } } -> true
+        | _ -> false
+
+module Mutable =
+    let mutable prop = 10
+
+module Same =
+    let a = 5
+    module Same =
+        module Same =
+            let a = 10
+        let shouldEqual5 = a
+        let shouldEqual10 = Same.a
+
+        let private Same = 20
+        let shouldEqual20 = Same
+        let shouldEqual30 = let Same = 25 in Same + 5
+
+
+let f8 a b = a + b
+let mutable a = 10
+
+module B =
+  let c = a
+  a <- a + 5
+  let mutable a = 20
+  let d = f8 2 2
+  let f8 a b = a - b
+
+  module D =
+    let d = a
+    a <- a + 5
+    let e = f8 2 2
+
+module Internal =
+    let internal add x y = x + y
+
+    type internal MyType =
+        static member Subtract x y = x - y
+        static member Add(?x: int, ?y: int) =
+            let x = defaultArg x 20
+            let y = defaultArg y 50
+            x + y
+
+type MyEnum =
+    | One = 1
+    | Two = 2
+
+type MyTestRef = TestRef of bool ref
+
+let delay (f:unit -> unit) = f
+
+let mutable mutableValue = 0
+
+let rec recursive1 = delay (fun () -> recursive2())
+and recursive2 =
+    mutableValue <- 5
+    fun () -> mutableValue <- mutableValue * 2
+
+let empty<'a> = [Unchecked.defaultof<'a>]
+
+type IInterface =
+  abstract member Member : thing1:string -> thing2:string -> string
+
+type Taster =
+    abstract Starter: float
+    abstract Taste: quality: float * quantity: float -> int
+
+type Eater =
+    abstract Bite: unit -> int
+
+let taste (com: Taster) qlty qty =
+    com.Starter * qlty + qty |> int
+
+module private MyPrivateModule =
+    let private bar = "bar"
+    let publicFoo() = sprintf "foo %s" bar
+    type Concrete() =
+        interface IInterface with
+            member this.Member (thing1: string) (thing2: string) =
+                sprintf "%s %s" thing2 thing1
+
+module Trampoline =
+    type Result<'a, 'b> =
+        | Continue of 'a
+        | Break of 'b
+    let run func arg =
+        let mutable state = arg
+        let mutable result = None
+        while result.IsNone do
+            match func state with
+            | Continue r -> state <- r
+            | Break r -> result <- Some r
+        result.Value
+
+let setCellBuggy x: (int*int) option =
+    Option.map (fun (x, y) -> max (x - 1) 0, y) x
+
+let setCell x: (int*int) option =
+    let max = max
+    Option.map (fun (x, y) -> max (x - 1) 0, y) x
+
+type Shape =
+    | Circle of int
+    | Square of int
+    | Rectangle of int * int
+
+type StaticClass =
+    static member DefaultParam([<Optional; DefaultParameterValue(true)>] value: bool) = value
+
+    static member inline Add(x: int, ?y: int) =
+        x + (defaultArg y 2)
+
+type ValueType =
+  struct
+    val public X : int
+  end
+
+type MutableFoo =
+    { mutable x: int }
+
+let incByRef (a: int) (b: byref<int>) = b <- a + b
+let addInRef (a: int) (b: inref<int>) = a + b
+let setOutRef (a: int) (b: outref<int>) = b <- a
+
+let mutable mutX = 3
+
+open FSharp.UMX
+
+[<Measure>] type customerId
+[<Measure>] type orderId
+[<Measure>] type kg
+
+type Order =
+    {
+        id : string<orderId>
+        customer : string<customerId>
+        quantity : int<kg>
+    }
+
+let inline inlineLambdaWithAnonRecord callback =
+    fun () -> {| A = 1 |} |> callback
+
+let sideEffect() = ()
+
+#if FABLE_COMPILER
+
+[<Fact>]
+let ``test lambdas returning member expression accessing JS object work`` () = // #2311
+    let x = inlineLambdaWithAnonRecord (fun x -> x.A)
+    x() |> equal 1
+
+[<Fact>]
+let ``test can check compiler version with constant`` () =
+    let mutable x = 0
+    #if FABLE_COMPILER
+    x <- x + 1
+    #endif
+    #if FABLE_COMPILER_3
+    x <- x + 2
+    #endif
+    #if FABLE_COMPILER_4
+    x <- x + 3
+    #endif
+    #if FABLE_COMPILER_PY
+    x <- x + 4
+    #endif
+    #if FABLE_COMPILER_JS
+    x <- x + 5
+    #endif
+
+    equal 3 x // FIXME: Fix when FABLE_COMPILER_PY is added
+
+[<Fact>]
+let ``test Can check compiler version at runtime`` () =
+    Compiler.majorMinorVersion >=  3.0 |> equal true
+    Text.RegularExpressions.Regex.IsMatch(Compiler.version, @"^\d+\.\d+") |> equal true
+
+[<Fact>]
+let ``test Can access compiler options`` () =
+    let canAccessOpts =
+        match box Compiler.debugMode, box Compiler.typedArrays with
+        | :? bool, :? bool -> true
+        | _ -> false
+    equal true canAccessOpts
+
+[<Fact>]
+let ``test Can access extension for generated files`` () =
+    Compiler.extension.EndsWith(".py") |> equal true
+
+#endif
+
+[<Fact>]
+let ``test Values of autogenerated functions are not replaced by optimizations`` () = // See #1583
+    let model = Some (5, 5)
+    let model1 = setCellBuggy model
+    let model2 = setCell model
+    model1 = model2 |> equal true
+
+[<Fact>]
+let ``test Assignment block as expression is optimized`` () =
+    let foo x y = x - y
+    let mutable x = 15
+    let res = A.C.Helper.Add5(let mutable x = 2 in let mutable y = 3 in x + y)
+    let test () =
+        A.C.Helper.Add5(let mutable x = 4 in let mutable y = 3 in x + y)
+        |> equal 12
+    test()
+    equal 10 res
+    foo x 5 |> equal 10
+
+[<Fact>]
+let ``test Optimized assignment blocks inside try ... with work`` () =
+    let res =
+        try A.C.Helper.Add5(let mutable x = 2 in let mutable y = 3 in x + y)
+        with _ -> 1
+    equal 10 res
+
+[<Fact>]
+let ``test for .. downto works`` () = // See #411
+    let mutable x = ""
+    for i = 1 to 5 do
+        x <- x + (string i)
+    equal "12345" x
+    let mutable y = ""
+    for i = 5 downto 1 do
+        y <- y + (string i)
+    equal "54321" y
+
+[<Fact>]
+let ``test Self references in constructors work`` () = // See #124
+    let t = MyTest(5)
+    equal 12 t.Value
+    equal 17 t.Value2
+
+[<Fact>]
+let ``test Using self identifier from class definition in members works`` () = // See #124
+    let t = MyTest(5)
+    t.Foo() |> equal 24
+
+[<Fact>]
+let ``test Module members from partial functions work`` () = // See #115
+    logItem1 "item1" |> equal "a = item1, b = item1"
+
+[<Fact>]
+let ``test Class members from partial functions work`` () = // See #115
+    let x = PartialFunctions()
+    x.logItem1 "item1" |> equal "a = item1, b = item1"
+
+[<Fact>]
+let ``test Local values from partial functions work`` () = // See #115
+    let logItem1 = log2 "item1"
+    let logItem2 = log2 "item2"
+    logItem1 "item1" |> equal "a = item1, b = item1"
+
+[<Fact>]
+let ``test Custom computation expressions work`` () =
+    execMaybe 5 |> equal (Some 23)
+    execMaybe 99 |> equal None
+
+[<Fact>]
+let ``test Units of measure work`` () =
+    3<km/h> + 2<km/h> |> equal 5<km/h>
+
+    let v1 = { x = 4.3<mi>; y = 5.<mi>; z = 2.8<mi> }
+    let v2 = { x = 5.6<mi>; y = 3.8<mi>; z = 0.<mi> }
+    let v3 = v1 + v2
+    equal 8.8<mi> v3.y
+
+[<Fact>]
+let ``test Units of measure work with longs`` () =
+    3L<km/h> + 2L<km/h> |> equal 5L<km/h>
+
+[<Fact>]
+let ``test Units of measure work with decimals`` () =
+    3M<km/h> + 2M<km/h> |> equal 5M<km/h>
+
+[<Fact>]
+let ``test Abbreviated measures work`` () = // #2313
+    let x = 5.<Measure1>
+    let c = MeasureTest()
+    c.Method(5.<Measure2>) |> equal x
+
+[<Fact>]
+let ``test FSharp.UMX works`` () =
+    let lookupById (orders : Order list) (id : string<orderId>) =
+        orders |> List.tryFind (fun o -> o.id = id)
+
+    let order =
+        {
+            id = % "orderId"
+            customer = % "customerId"
+            quantity = % 42
+        }
+
+    // lookupById [] order.customer // compiler error
+    let orders = [{ order with quantity = %50 }]
+    lookupById orders order.id
+    |> Option.map (fun o -> UMX.untag o.quantity)
+    |> equal (Some 50)
+
+[<Fact>]
+let ``test FSharp.UMX: reflection info`` () =
+    let fields = Reflection.FSharpType.GetRecordFields typeof<Order>
+    fields.Length |> equal 3
+
+[<Fact>]
+let ``test Static constructors work`` () =
+    let point1 = PointWithCounter(10, 52)
+    sprintf "%d %d %d %d" (point1.Prop1) (point1.Prop2) (point1.CreatedCount) (point1.FunctionValue)
+    |> equal "10 52 1 204"
+    let point2 = PointWithCounter(20, 99)
+    sprintf "%d %d %d %d" (point2.Prop1) (point2.Prop2) (point2.CreatedCount) (point2.FunctionValue)
+    |> equal "20 99 2 598"
+
+[<Fact>]
+let ``test File with single type in namespace compiles`` () =
+    equal SingleTypeInNamespace.Hello "Hello"
+
+[<Fact>]
+let ``test Type abbreviation in namespace compiles`` () = // See #140
+    let h = Util2.H(5)
+    equal "5" h.Value
+
+[<Fact>]
+let ``test Multiple namespaces in same file work`` () = // See #1218
+    A.C.Helper.Add5(9) |> equal 14
+
+[<Fact>]
+let ``test Inline methods work`` () =
+    f 2 3 |> equal 5

--- a/tests/Python/TestMisc.fs
+++ b/tests/Python/TestMisc.fs
@@ -995,18 +995,18 @@ let ``test use calls Dispose at the end of the scope`` () =
     let cell = ref 0
     let res =
         use c = new DisposableBar(cell)
-        !cell
+        cell.Value
     res |> equal 10
-    !cell |> equal 20
+    cell.Value |> equal 20
 
 [<Fact>]
 let ``test use calls Dispose (of an object expression) at the end of the scope`` () =
     let cell = ref 0
     let res =
         use c = createCellDiposable cell
-        !cell
+        cell.Value
     res |> equal 10
-    !cell |> equal 20
+    cell.Value |> equal 20
 
 [<Fact>]
 let ``test Unchecked.defaultof works`` () =

--- a/tests/Python/TestOption.fs
+++ b/tests/Python/TestOption.fs
@@ -144,18 +144,18 @@ let ``test Option.fold works`` () =
     (5, None) ||> Option.fold (*) |> equal 5
     (5, Some 7) ||> Option.fold (*) |> equal 35
 
-// [<Fact>]
-// let ``test Option.foldBack works`` () =
-//     (None, 5) ||> Option.foldBack (*) |> equal 5
-//     (Some 7, 5) ||> Option.foldBack (*) |> equal 35
+[<Fact>]
+let ``test Option.foldBack works`` () =
+    (None, 5) ||> Option.foldBack (*) |> equal 5
+    (Some 7, 5) ||> Option.foldBack (*) |> equal 35
 
 [<Fact>]
 let ``test Option.fold works II`` () =
     folding1 (FoldA (Some (FoldB 1))) [] |> equal [1]
 
-// [<Fact>]
-// let ``test Option.foldBack works II`` ( )=
-//     folding2 (FoldA (Some (FoldB 1))) [] |> equal [1]
+[<Fact>]
+let ``test Option.foldBack works II`` ( )=
+    folding2 (FoldA (Some (FoldB 1))) [] |> equal [1]
 
 [<Fact>]
 let ``test Option.toArray works`` () =

--- a/tests/Python/TestSeq.fs
+++ b/tests/Python/TestSeq.fs
@@ -711,7 +711,7 @@ let ``test Seq.compareWith works`` () =
     Seq.compareWith (-) xs zs |> equal 1
 
 // FIXME:
-//[<Fact>]
+// [<Fact>]
 // let ``test Seq.countBy works`` () =
 //     let xs = [1; 2; 3; 4]
 //     let ys = xs |> Seq.countBy (fun x -> x % 2)

--- a/tests/Python/TestString.fs
+++ b/tests/Python/TestString.fs
@@ -796,24 +796,24 @@ let ``test System.Uri.UnescapeDataString works`` () =
     System.Uri.UnescapeDataString("http%3A%2F%2Fwww.google.nl%2Fsearch%3Fq%3DLocutus%26ie%3Dutf-8%26oe%3Dutf-8%26aq%3Dt%26rls%3Dcom.ubuntu%3Aen-US%3Aunofficial%26client%3Dfirefox-a")
     |> equal "http://www.google.nl/search?q=Locutus&ie=utf-8&oe=utf-8&aq=t&rls=com.ubuntu:en-US:unofficial&client=firefox-a"
 
-//[<Fact>]
-// let ``test System.Uri.EscapeDataString works`` () =
-//     System.Uri.EscapeDataString("Kevin van Zonneveld!") |> equal "Kevin%20van%20Zonneveld%21"
-//     System.Uri.EscapeDataString("http://kvz.io/") |> equal "http%3A%2F%2Fkvz.io%2F"
-//     System.Uri.EscapeDataString("http://www.google.nl/search?q=Locutus&ie=utf-8&oe=utf-8&aq=t&rls=com.ubuntu:en-US:unofficial&client=firefox-a")
-//     |> equal "http%3A%2F%2Fwww.google.nl%2Fsearch%3Fq%3DLocutus%26ie%3Dutf-8%26oe%3Dutf-8%26aq%3Dt%26rls%3Dcom.ubuntu%3Aen-US%3Aunofficial%26client%3Dfirefox-a"
+[<Fact>]
+ let ``test System.Uri.EscapeDataString works`` () =
+     System.Uri.EscapeDataString("Kevin van Zonneveld!") |> equal "Kevin%20van%20Zonneveld%21"
+     System.Uri.EscapeDataString("http://kvz.io/") |> equal "http%3A%2F%2Fkvz.io%2F"
+     System.Uri.EscapeDataString("http://www.google.nl/search?q=Locutus&ie=utf-8&oe=utf-8&aq=t&rls=com.ubuntu:en-US:unofficial&client=firefox-a")
+     |> equal "http%3A%2F%2Fwww.google.nl%2Fsearch%3Fq%3DLocutus%26ie%3Dutf-8%26oe%3Dutf-8%26aq%3Dt%26rls%3Dcom.ubuntu%3Aen-US%3Aunofficial%26client%3Dfirefox-a"
 
-// [<Fact>]
-// let ``test System.Uri.EscapeUriString works`` () =
-//     System.Uri.EscapeUriString("Kevin van Zonneveld!") |> equal "Kevin%20van%20Zonneveld!"
-//     System.Uri.EscapeUriString("http://kvz.io/") |> equal "http://kvz.io/"
-//     System.Uri.EscapeUriString("http://www.google.nl/search?q=Locutus&ie=utf-8&oe=utf-8&aq=t&rls=com.ubuntu:en-US:unofficial&client=firefox-a")
-//     |> equal "http://www.google.nl/search?q=Locutus&ie=utf-8&oe=utf-8&aq=t&rls=com.ubuntu:en-US:unofficial&client=firefox-a"
+ [<Fact>]
+ let ``test System.Uri.EscapeUriString works`` () =
+     System.Uri.EscapeUriString("Kevin van Zonneveld!") |> equal "Kevin%20van%20Zonneveld!"
+     System.Uri.EscapeUriString("http://kvz.io/") |> equal "http://kvz.io/"
+     System.Uri.EscapeUriString("http://www.google.nl/search?q=Locutus&ie=utf-8&oe=utf-8&aq=t&rls=com.ubuntu:en-US:unofficial&client=firefox-a")
+     |> equal "http://www.google.nl/search?q=Locutus&ie=utf-8&oe=utf-8&aq=t&rls=com.ubuntu:en-US:unofficial&client=firefox-a"
 
 // See #1628, though I'm not sure if the compiled tests are passing just the function reference without wrapping it
-// [<Fact>]
-// let ``test Passing Char.IsDigit as a function reference does not make String.filter hang`` () =
-//     "Hello! 123" |> String.filter System.Char.IsDigit |> equal "123"
+ [<Fact>]
+ let ``test Passing Char.IsDigit as a function reference does not make String.filter hang`` () =
+     "Hello! 123" |> String.filter System.Char.IsDigit |> equal "123"
 
 [<Fact>]
 let ``test sprintf with double percent should be unescaped`` () =

--- a/tests/Python/TestUri.fs
+++ b/tests/Python/TestUri.fs
@@ -26,3 +26,14 @@ let ``test Uri from absolute uri string with RelativeOrAbsolute works`` () =
     equal "?a=b" uri.Query
     equal "#c" uri.Fragment
     equal "http://www.test1.com/hello?a=b#c" uri.AbsoluteUri
+
+[<Fact>]
+let ``test Uri from relative uri string works`` () =
+    let uri = Uri("/hello.html", UriKind.Relative)
+    equal false uri.IsAbsoluteUri
+    equal "/hello.html" (uri.ToString())
+
+[<Fact>]
+let ``test AbsoluteUri from relative uri should throw`` () =
+    let uri = Uri("/hello.html", UriKind.Relative)
+    Util.throwsError "This operation is not supported for a relative URI." (fun () -> uri.AbsoluteUri)

--- a/tests/Python/Util.fs
+++ b/tests/Python/Util.fs
@@ -109,3 +109,37 @@ let throwsAnyError (f: unit -> 'a): unit =
 let doesntThrow (f: unit -> 'a): unit =
     run f
     |> RunResult.wasSuccess
+
+let Int32Array = [|1;2|]
+
+module Float64Array =
+    let Float64Array = [|3.;4.|]
+
+module Foo =
+    let update () = ()
+
+module Bar =
+    let rec nestedRecursive i = update (i+2)
+    and update i = i + 5
+
+let f2 a b = a + b
+
+// Assignment block as expression outside a function is NOT optimized
+f2(let mutable x = 5 in let mutable y = 6 in x + y) |> ignore
+
+let mutable a = 10
+
+module B =
+  let c = a
+  a <- a + 5
+  let mutable a = 20
+  let d = f2 2 2
+  let f2 a b = a - b
+
+  module D =
+    let d = a
+    a <- a + 5
+    let e = f2 2 2
+
+let rec nonNestedRecursive s = update s
+and update s = String.replicate 3 s


### PR DESCRIPTION
- Rewrite import handling to be more generic (less special cases)
- Add parenthesis around complex expressions in function call arguments
- Ignore should not return a value, so use a separate `ignore function`
- Uri fixes
- Misc tests