### PR TITLE
Fix failing test (again)

### DIFF
--- a/tests/Main/AsyncTests.fs
+++ b/tests/Main/AsyncTests.fs
@@ -263,8 +263,8 @@ let tests =
             let! result = Async.Sequential works
             let ``then`` = DateTimeOffset.Now
             let d = ``then`` - now
-            if d.TotalSeconds < 1. then
-                failwithf "expected sequential operations to take longer than 1 second, but took %.3f" d.TotalSeconds
+            if d.TotalSeconds < 0.999 then
+                failwithf "expected sequential operations to take 1 second or more, but took %.3f" d.TotalSeconds
             result |> equal [| 1 .. 5 |]
             result |> Seq.sum |> equal _aggregate
         }


### PR DESCRIPTION
The async test `All.Async.Async.Sequential works` is still [failing](https://github.com/fable-compiler/Fable/runs/4552424291?check_suite_focus=true) intermittently. A better error message reveals that it sometimes do take shorter than 1 second to execute:

`System.Exception: expected sequential operations to take longer than 1 second, but took 0.999``

Thus reducing the check to be less than 0.999 seconds should be OK here.