### PR TITLE
Rust array updates

### DIFF
--- a/src/fable-library-rust/src/Array.fs
+++ b/src/fable-library-rust/src/Array.fs
@@ -208,13 +208,13 @@ let where predicate (source: 'T[]) =
     filter predicate source
 
 // let contains (value: 'T) (source: 'T[]) ([<Inject>] eq: IEqualityComparer<'T>) =
-//     let rec loop i =
+//     let rec inner_loop i =
 //         if i >= source.Length
 //         then false
 //         else
 //             if eq.Equals (value, source.[i]) then true
-//             else loop (i + 1)
-//     loop 0
+//             else inner_loop (i + 1)
+//     inner_loop 0
 
 let initialize count (initializer: int -> 'T) =
     if count < 0 then invalidArg "count" SR.inputMustBeNonNegative
@@ -383,11 +383,11 @@ let takeWhile (predicate: 'T -> bool) (source: 'T[]) =
 //     if count.IsSome && i >= start + count.Value then -1 else i
 
 let tryFind (predicate: 'T -> bool) (source: 'T[]): 'T option =
-    let rec loop i (predicate: 'T -> bool) (source: 'T[]) =
+    let rec inner_loop i (predicate: 'T -> bool) (source: 'T[]) =
         if i >= source.Length then None
         elif predicate source.[i] then Some source.[i]
-        else loop (i + 1) predicate source
-    loop 0 predicate source
+        else inner_loop (i + 1) predicate source
+    inner_loop 0 predicate source
 
 let find (predicate: 'T -> bool) (source: 'T[]): 'T =
     match tryFind predicate source with
@@ -395,11 +395,11 @@ let find (predicate: 'T -> bool) (source: 'T[]): 'T =
     | None -> indexNotFound()
 
 let tryFindIndex (predicate: 'T -> bool) (source: 'T[]): int option =
-    let rec loop i (predicate: 'T -> bool) (source: 'T[]) =
+    let rec inner_loop i (predicate: 'T -> bool) (source: 'T[]) =
         if i >= source.Length then None
         elif predicate source.[i] then Some i
-        else loop (i + 1) predicate source
-    loop 0 predicate source
+        else inner_loop (i + 1) predicate source
+    inner_loop 0 predicate source
 
 let findIndex (predicate: 'T -> bool) (source: 'T[]): int =
     match tryFindIndex predicate source with
@@ -407,11 +407,11 @@ let findIndex (predicate: 'T -> bool) (source: 'T[]): int =
     | None -> indexNotFound()
 
 let tryFindBack (predicate: 'T -> bool) (source: 'T[]): 'T option =
-    let rec loop i (predicate: 'T -> bool) (source: 'T[]) =
+    let rec inner_loop i (predicate: 'T -> bool) (source: 'T[]) =
         if i < 0 then None
         elif predicate source.[i] then Some source.[i]
-        else loop (i - 1) predicate source
-    loop (source.Length - 1) predicate source
+        else inner_loop (i - 1) predicate source
+    inner_loop (source.Length - 1) predicate source
 
 let findBack (predicate: 'T -> bool) (source: 'T[]): 'T =
     match tryFindBack predicate source with
@@ -419,11 +419,11 @@ let findBack (predicate: 'T -> bool) (source: 'T[]): 'T =
     | None -> indexNotFound()
 
 let tryFindIndexBack (predicate: 'T -> bool) (source: 'T[]): int option =
-    let rec loop i (predicate: 'T -> bool) (source: 'T[]) =
+    let rec inner_loop i (predicate: 'T -> bool) (source: 'T[]) =
         if i < 0 then None
         elif predicate source.[i] then Some i
-        else loop (i - 1) predicate source
-    loop (source.Length - 1) predicate source
+        else inner_loop (i - 1) predicate source
+    inner_loop (source.Length - 1) predicate source
 
 let findIndexBack (predicate: 'T -> bool) (source: 'T[]): int =
     match tryFindIndexBack predicate source with
@@ -436,14 +436,14 @@ let findLastIndex (predicate: 'T -> bool) (source: 'T[]): int =
     | None -> -1
 
 let tryPick (chooser: 'T -> 'U option) (source: 'T[]): 'U option =
-    let rec loop i (chooser: 'T -> 'U option) (source: 'T[]) =
+    let rec inner_loop i (chooser: 'T -> 'U option) (source: 'T[]) =
         if i >= source.Length then
             None
         else
             match chooser source.[i] with
-            | None -> loop (i + 1) chooser source
+            | None -> inner_loop (i + 1) chooser source
             | res -> res
-    loop 0 chooser source
+    inner_loop 0 chooser source
 
 let pick (chooser: 'T -> 'U option) (source: 'T[]): 'U =
     match tryPick chooser source with
@@ -582,14 +582,14 @@ let permute (indexMap: int -> int) (source: 'T[]) =
 //     res
 
 let unfold<'T, 'State> (generator: 'State -> ('T*'State) option) (state: 'State) =
-    let res = ResizeArray<'T>()
-    let rec loop state =
+    let rec inner_loop generator state (res: ResizeArray<'T>) =
         match generator state with
         | None -> ()
         | Some (x, s) ->
             res.Add (x)
-            loop s
-    loop state
+            inner_loop generator s res
+    let res = ResizeArray<'T>()
+    inner_loop generator state res
     res
 
 let unzip (source: ('T1 * 'T2)[]) =

--- a/src/fable-library-rust/src/List.fs
+++ b/src/fable-library-rust/src/List.fs
@@ -232,21 +232,14 @@ let ofArray (xs: 'T[]) =
 //     node |> setConsTailEmpty
 //     root |> tail
 
-// let scan (folder: 'State -> 'T -> 'State) (state: 'State) (xs: 'T list) =
-//     let root = (empty())
-//     let mutable node = root |> appendConsNoTail state
-//     let mutable acc = state
-//     let mutable xs = xs
-//     while not (isEmpty xs) do
-//         acc <- folder acc (head xs)
-//         node <- node |> appendConsNoTail acc
-//         xs <- (tail xs)
-//     node |> setConsTailEmpty
-//     root |> tail
+let scan (folder: 'State -> 'T -> 'State) (state: 'State) (xs: 'T list) =
+    toArray xs
+    |> Array.scan folder state
+    |> ofArray
 
-// let scanBack (folder: 'T -> 'State -> 'State) (xs: 'T list) (state: 'State) =
-//     Array.scanBack folder (toArray xs) state
-//     |> ofArray
+let scanBack (folder: 'T -> 'State -> 'State) (xs: 'T list) (state: 'State) =
+    Array.scanBack folder (toArray xs) state
+    |> ofArray
 
 let append (xs: 'T list) (ys: 'T list) =
     fold (fun acc x -> cons x acc) ys (reverse xs)
@@ -379,14 +372,13 @@ let findIndexBack (predicate: 'T -> bool) (xs: 'T list): int =
     | None -> indexNotFound()
 
 let tryItem index (xs: 'T list) =
-    let mutable xs = xs
-    let mutable i = 0
-    while i < index && not (isEmpty xs) do
-        i <- i + 1
-        xs <- tail xs
-    if i < index || index < 0
-    then None
-    else Some (head xs)
+    let rec loop i (xs: 'T list) =
+        if (isEmpty xs) then None
+        else
+            if i = 0 then Some (head xs)
+            elif i < 0 then None
+            else loop (i - 1) (tail xs)
+    loop index xs
 
 let item index (xs: 'T list) = // xs.Item(n)
     match tryItem index xs with

--- a/src/fable-library-rust/src/List.fs
+++ b/src/fable-library-rust/src/List.fs
@@ -68,22 +68,22 @@ let tail (xs: 'T list) = //xs.Tail
     | None -> invalidArg "list" SR.inputListWasEmpty
 
 let length (xs: 'T list) = //xs.Length
-    let rec loop i xs =
+    let rec inner_loop i xs =
         match xs with
         | None -> i
-        | Some node -> loop (i + 1) node.tail
-    loop 0 xs
+        | Some node -> inner_loop (i + 1) node.tail
+    inner_loop 0 xs
 
 // let compareWith (comparer: 'T -> 'T -> int) (xs: 'T list) (ys: 'T list): int =
-//     let rec loop (xs: 'T list) (ys: 'T list) =
+//     let rec inner_loop (xs: 'T list) (ys: 'T list) =
 //         match (isEmpty xs), (isEmpty ys) with
 //         | true, true -> 0
 //         | true, false -> -1
 //         | false, true -> 1
 //         | false, false ->
 //             let c = comparer (head xs) (head ys)
-//             if c = 0 then loop (tail xs) (tail ys) else c
-//     loop xs ys
+//             if c = 0 then inner_loop (tail xs) (tail ys) else c
+//     inner_loop xs ys
 
 let rec tryLast (xs: 'T list) =
     match xs with
@@ -106,11 +106,11 @@ let ofOption<'T> (opt: 'T option): 'T list =
 let toArray (xs: 'T list) =
     let len = length xs
     let res = Array.zeroCreate len
-    let rec loop (arr: 'T[]) i xs =
+    let rec inner_loop (arr: 'T[]) i xs =
         if not (isEmpty xs) then
             arr.[i] <- (head xs)
-            loop arr (i + 1) (tail xs)
-    loop res 0 xs
+            inner_loop arr (i + 1) (tail xs)
+    inner_loop res 0 xs
     res
 
 // let rec fold (folder: 'State -> 'T -> 'State) (state: 'State) (xs: 'T list) =
@@ -150,27 +150,15 @@ let foldBack2 (folder: 'T1 -> 'T2 -> 'State -> 'State) (xs: 'T1 list) (ys: 'T2 l
     fold2 (fun acc x y -> folder x y acc) state (reverse xs) (reverse ys)
     // Array.foldBack2 folder (toArray xs) (toArray ys) state
 
-// let foldIndexed (folder: int -> 'State -> 'T -> 'State) (state: 'State) (xs: 'T list) =
-//     // let rec loop i acc (xs: 'T list) =
-//     //     if (isEmpty xs) then acc
-//     //     else loop (i + 1) (folder i acc (head xs)) (tail xs)
-//     // loop 0 state xs
-//     let mutable acc = state
-//     let mutable xs = xs
-//     while not (isEmpty xs) do
-//         acc <- folder acc (head xs)
-//         xs <- (tail xs)
-//     acc
-
 let unfold (gen: 'State -> ('T * 'State) option) (state: 'State) =
-    let rec loop gen acc (root: 'T list) (xs: 'T list) =
+    let rec inner_loop gen acc (root: 'T list) (xs: 'T list) =
         match gen acc with
         | None -> root
         | Some (x, acc) ->
             let t = xs |> appendConsNoTail x
             let root = if isEmpty root then t else root
-            loop gen acc root t
-    loop gen state (empty()) (empty())
+            inner_loop gen acc root t
+    inner_loop gen state (empty()) (empty())
 
 let iterate action xs =
     fold (fun () x -> action x) () xs
@@ -187,16 +175,6 @@ let iterateIndexed2 action xs ys =
 // Redirected to Seq.ofList to avoid dependency (see Replacements)
 // let toSeq (xs: 'T list): 'T seq = Seq.ofList xs
 // //     xs :> System.Collections.Generic.IEnumerable<'T>
-
-// let toSeq (xs: 'T list): IEnumerator<'T> =
-//     let mutable curr = xs.root
-//     let next() =
-//         match curr with
-//         | Some node ->
-//             curr <- node.next
-//             Some (node.item)
-//         | None -> None
-//     Enumerable.fromFunction next
 
 let ofArrayWithTail (xs: 'T[]) (tail: 'T list) =
     let mutable res = tail
@@ -320,13 +298,13 @@ let map3 (mapping: 'T1 -> 'T2 -> 'T3 -> 'U) (xs: 'T1 list) (ys: 'T2 list) (zs: '
 //     mapFold (fun acc x -> mapping x acc) state (reverse xs)
 
 let tryPick (chooser: 'T -> 'U option) (xs: 'T list) =
-    let rec loop (xs: 'T list) =
+    let rec inner_loop (chooser: 'T -> 'U option) (xs: 'T list) =
         if (isEmpty xs) then None
         else
             match chooser (head xs) with
             | Some _  as res -> res
-            | None -> loop (tail xs)
-    loop xs
+            | None -> inner_loop chooser (tail xs)
+    inner_loop chooser xs
 
 let pick (chooser: 'T -> 'U option) (xs: 'T list) =
     match tryPick chooser xs with
@@ -350,13 +328,13 @@ let findBack (predicate: 'T -> bool) (xs: 'T list) =
     | None -> indexNotFound()
 
 let tryFindIndex (predicate: 'T -> bool) (xs: 'T list): int option =
-    let rec loop i (xs: 'T list) =
+    let rec inner_loop i (predicate: 'T -> bool) (xs: 'T list) =
         if (isEmpty xs) then None
         else
             if predicate (head xs)
             then Some i
-            else loop (i + 1) (tail xs)
-    loop 0 xs
+            else inner_loop (i + 1) predicate (tail xs)
+    inner_loop 0 predicate xs
 
 let findIndex (predicate: 'T -> bool) (xs: 'T list): int =
     match tryFindIndex predicate xs with
@@ -372,13 +350,13 @@ let findIndexBack (predicate: 'T -> bool) (xs: 'T list): int =
     | None -> indexNotFound()
 
 let tryItem index (xs: 'T list) =
-    let rec loop i (xs: 'T list) =
+    let rec inner_loop i (xs: 'T list) =
         if (isEmpty xs) then None
         else
             if i = 0 then Some (head xs)
             elif i < 0 then None
-            else loop (i - 1) (tail xs)
-    loop index xs
+            else inner_loop (i - 1) (tail xs)
+    inner_loop index xs
 
 let item index (xs: 'T list) = // xs.Item(n)
     match tryItem index xs with

--- a/src/fable-library-rust/src/Native.rs
+++ b/src/fable-library-rust/src/Native.rs
@@ -20,6 +20,14 @@ pub mod Native {
         Rc::from(s)
     }
 
+    pub fn arrayEmpty<T: Clone>() -> Rc<MutCell<Vec<T>>> {
+        Rc::from(MutCell::from(Vec::new()))
+    }
+
+    pub fn arrayWithCapacity<T: Clone>(capacity: &i32) -> Rc<MutCell<Vec<T>>> {
+        Rc::from(MutCell::from(Vec::with_capacity(*capacity as usize)))
+    }
+
     pub fn arrayFrom<T: Clone>(a: &[T]) -> Rc<MutCell<Vec<T>>> {
         Rc::from(MutCell::from(a.to_vec()))
     }

--- a/src/fable-library-rust/src/Seq.fs
+++ b/src/fable-library-rust/src/Seq.fs
@@ -830,20 +830,20 @@ let reverse (xs: seq<'T>) =
         |> ofArray
     )
 
-// let scan folder (state: 'State) (xs: seq<'T>) =
-//     delay (fun () ->
-//         let first = singleton state
-//         let mutable acc = state
-//         let rest = xs |> map (fun x -> acc <- folder acc x; acc)
-//         [| first; rest |] |> concat
-//     )
+let scan (folder: 'State -> 'T -> 'State) (state: 'State) (xs: seq<'T>) =
+    delay (fun () ->
+        let first = singleton state
+        let mutable acc = state
+        let rest = xs |> map (fun x -> acc <- folder acc x; acc)
+        append first rest
+    )
 
-// let scanBack folder (xs: seq<'T>) (state: 'State) =
-//     delay (fun () ->
-//         let arr = toArray xs
-//         Array.scanBack folder arr state
-//         |> ofArray
-//     )
+let scanBack (folder: 'T -> 'State -> 'State) (xs: seq<'T>) (state: 'State) =
+    delay (fun () ->
+        let arr = toArray xs
+        Array.scanBack folder arr state
+        |> ofArray
+    )
 
 let skip count (xs: seq<'T>) =
     mkSeq (fun () ->
@@ -901,20 +901,20 @@ let takeWhile predicate (xs: seq<'T>) =
             else None)
         (fun e -> e.Dispose())
 
-// let truncate count (xs: seq<'T>) =
-//     generateIndexed
-//         (fun () -> ofSeq xs)
-//         (fun i e ->
-//             if i < count && e.MoveNext()
-//             then Some (e.Current)
-//             else None)
-//         (fun e -> e.Dispose())
+let truncate count (xs: seq<'T>) =
+    generateIndexed
+        (fun () -> ofSeq xs)
+        (fun i e ->
+            if i < count && e.MoveNext()
+            then Some (e.Current)
+            else None)
+        (fun e -> e.Dispose())
 
-// let zip (xs: seq<'T1>) (ys: seq<'T2>) =
-//     map2 (fun x y -> (x, y)) xs ys
+let zip (xs: seq<'T1>) (ys: seq<'T2>) =
+    map2 (fun x y -> (x, y)) xs ys
 
-// let zip3 (xs: seq<'T1>) (ys: seq<'T2>) (zs: seq<'T3>) =
-//     map3 (fun x y z -> (x, y, z)) xs ys zs
+let zip3 (xs: seq<'T1>) (ys: seq<'T2>) (zs: seq<'T3>) =
+    map3 (fun x y z -> (x, y, z)) xs ys zs
 
 // let collect (mapping: 'T -> 'U seq) (xs: seq<'T>) =
 //     delay (fun () ->
@@ -926,13 +926,13 @@ let takeWhile predicate (xs: seq<'T>) =
 let where predicate (xs: seq<'T>) =
     filter predicate xs
 
-// let pairwise (xs: seq<'T>) =
-//     delay (fun () ->
-//         xs
-//         |> toArray
-//         |> Array.pairwise
-//         |> ofArray
-//     )
+let pairwise (xs: seq<'T>) =
+    delay (fun () ->
+        xs
+        |> toArray
+        |> Array.pairwise
+        |> ofArray
+    )
 
 // let splitInto (chunks: int) (xs: seq<'T>): 'T seq seq =
 //     delay (fun () ->
@@ -1015,13 +1015,13 @@ let where predicate (xs: seq<'T>) =
 //         invalidArg "xs" SR.inputSequenceEmpty
 //     else averager.DivideByInt(total, count)
 
-// let permute f (xs: seq<'T>) =
-//     delay (fun () ->
-//         xs
-//         |> toArray
-//         |> Array.permute f
-//         |> ofArray
-//     )
+let permute f (xs: seq<'T>) =
+    delay (fun () ->
+        xs
+        |> toArray
+        |> Array.permute f
+        |> ofArray
+    )
 
 // let chunkBySize (chunkSize: int) (xs: seq<'T>): seq<seq<'T>> =
 //     delay (fun () ->

--- a/src/fable-library-rust/src/Seq.fs
+++ b/src/fable-library-rust/src/Seq.fs
@@ -553,14 +553,14 @@ let find predicate (xs: seq<'T>) =
     | None -> indexNotFound()
 
 let tryFindIndex predicate (xs: seq<'T>) =
-    let rec loop i (e: Enumerable.IEnumerator<'T>) =
+    let rec inner_loop i predicate (e: Enumerable.IEnumerator<'T>) =
         if e.MoveNext() then
             if predicate e.Current then Some i
-            else loop (i + 1) e
+            else inner_loop (i + 1) predicate e
         else
             None
     use e = ofSeq xs
-    loop 0 e
+    inner_loop 0 predicate e
 
 let findIndex predicate (xs: seq<'T>) =
     match tryFindIndex predicate xs with

--- a/tests/Rust/tests/src/ArrayTests.fs
+++ b/tests/Rust/tests/src/ArrayTests.fs
@@ -305,10 +305,10 @@ let ``Array.length works with non-numeric arrays`` () =
 
 // [<Fact>]
 // let ``Array.distinctBy with tuples works`` () =
-//         let xs = [| 4,1; 4,2; 4,3; 6,4; 6,5; 5,6; 5,7 |]
-//         let ys = xs |> Array.distinctBy (fun (x,_) -> x % 2)
-//         ys |> Array.length |> equal 2
-//         ys |> Array.head |> fst >= 4 |> equal true
+//     let xs = [| 4,1; 4,2; 4,3; 6,4; 6,5; 5,6; 5,7 |]
+//     let ys = xs |> Array.distinctBy (fun (x,_) -> x % 2)
+//     ys |> Array.length |> equal 2
+//     ys |> Array.head |> fst >= 4 |> equal true
 
 // [<Fact>]
 // let ``Array distinctBy works on large array`` () =
@@ -336,11 +336,11 @@ let ``Array.append works`` () =
     let zs1 = Array.append [|5|] xs1
     zs1.[0] + zs1.[1] |> equal 6
 
-// [<Fact>]
-// let ``Array.append works II`` () =
-//     let xs2 = [|"a"; "b"; "c"|]
-//     let zs2 = Array.append [|"x";"y"|] xs2
-//     zs2.[1] + zs2.[3] |> equal "yb"
+[<Fact>]
+let ``Array.append works II`` () =
+    let xs2 = [|"a"; "b"; "c"|]
+    let zs2 = Array.append [|"x";"y"|] xs2
+    zs2.[1] + zs2.[3] |> equal "yb"
 
 // [<Fact>]
 // let ``Array.average works`` () =
@@ -677,6 +677,17 @@ let ``Array.partition works`` () =
     zs |> equal [| 1; 3; 5 |]
 
 [<Fact>]
+let ``Array.pairwise works`` () =
+    Array.pairwise<int> [||] |> equal [||]
+    Array.pairwise [|1|] |> equal [||]
+    Array.pairwise [|1; 2|] |> equal [|(1, 2)|]
+    let xs = [|1; 2; 3; 4|]
+    let ys = xs |> Array.pairwise
+    ys |> equal [|(1, 2); (2, 3); (3, 4)|]
+    // ys |> Array.map (fun (x, y) -> sprintf "%i%i" x y)
+    // |> String.concat "" |> equal "122334"
+
+[<Fact>]
 let ``Array.permute works`` () =
     let xs = [|1.; 2.; 3.; 4.; 5.; 6.|]
     let ys = xs |> Array.permute (fun i -> i + 1 - 2 * (i % 2))
@@ -749,19 +760,19 @@ let ``Array.rev works`` () =
     xs |> equal [|1;2;3|] // Make sure there is no side effects
     ys |> equal [|3;2;1|]
 
-// [<Fact>]
-// let ``Array.scan works`` () =
-//     let xs = [|1.; 2.; 3.; 4.|]
-//     let ys = xs |> Array.scan (+) 0.
-//     ys.[2] + ys.[3]
-//     |> equal 9.
+[<Fact>]
+let ``Array.scan works`` () =
+    let xs = [|1.; 2.; 3.; 4.|]
+    let ys = xs |> Array.scan (+) 0.
+    ys.[2] + ys.[3]
+    |> equal 9.
 
-// [<Fact>]
-// let ``Array.scanBack works`` () =
-//     let xs = [|1.; 2.; 3.; 4.|]
-//     let ys = Array.scanBack (-) xs 0.
-//     ys.[2] + ys.[3]
-//     |> equal 3.
+[<Fact>]
+let ``Array.scanBack works`` () =
+    let xs = [|1.; 2.; 3.; 4.|]
+    let ys = Array.scanBack (-) xs 0.
+    ys.[2] + ys.[3]
+    |> equal 3.
 
 // [<Fact>]
 // let ``Array.sort works`` () =
@@ -938,22 +949,22 @@ let ``Array.unzip3 works`` () =
     ys.[0] + zs.[0] + ks.[0]
     |> equal 6.
 
-// [<Fact>]
-// let ``Array.zip works`` () =
-//     let xs = [|1.; 2.; 3.|]
-//     let ys = [|1.; 2.; 3.|]
-//     let zs = Array.zip xs ys
-//     let x, y = zs.[0]
-//     x + y |> equal 2.
+[<Fact>]
+let ``Array.zip works`` () =
+    let xs = [|1.; 2.; 3.|]
+    let ys = [|1.; 2.; 3.|]
+    let zs = Array.zip xs ys
+    let x, y = zs.[0]
+    x + y |> equal 2.
 
-// [<Fact>]
-// let ``Array.zip3 works`` () =
-//     let xs = [|1.; 2.; 3.|]
-//     let ys = [|1.; 2.; 3.|]
-//     let zs = [|1.; 2.; 3.|]
-//     let ks = Array.zip3 xs ys zs
-//     let x, y, z = ks.[0]
-//     x + y + z |> equal 3.
+[<Fact>]
+let ``Array.zip3 works`` () =
+    let xs = [|1.; 2.; 3.|]
+    let ys = [|1.; 2.; 3.|]
+    let zs = [|1.; 2.; 3.|]
+    let ks = Array.zip3 xs ys zs
+    let x, y, z = ks.[0]
+    x + y + z |> equal 3.
 
 // [<Fact>]
 // let ``Array as IList indexer has same behaviour`` () =
@@ -1206,12 +1217,6 @@ let ``Array.takeWhile works`` () =
 //     [|1..5|] |> Array.splitInto 4 |> equal [| [|1..2|]; [|3|]; [|4|]; [|5|] |]
 //     [|1..4|] |> Array.splitInto 20 |> equal [| [|1|]; [|2|]; [|3|]; [|4|] |]
 
-// [<Fact>]
-// let ``Array.exactlyOne works`` () =
-//         [|1.|] |> Array.exactlyOne |> equal 1.
-//         (try Array.exactlyOne [|1.;2.|] |> ignore; false with | _ -> true) |> equal true
-//         (try Array.exactlyOne [||] |> ignore; false with | _ -> true) |> equal true
-
 [<Fact>]
 let ``Array.tryExactlyOne works`` () =
         [|1.|] |> Array.tryExactlyOne |> equal (Some 1.)
@@ -1219,15 +1224,10 @@ let ``Array.tryExactlyOne works`` () =
         [||] |> Array.tryExactlyOne<float> |> equal None
 
 // [<Fact>]
-// let ``Array.pairwise works`` () =
-//     Array.pairwise<int> [||] |> equal [||]
-//     Array.pairwise [|1|] |> equal [||]
-//     Array.pairwise [|1; 2|] |> equal [|(1, 2)|]
-//     let xs = [|1; 2; 3; 4|]
-//     let ys = xs |> Array.pairwise
-//     ys |> equal [|(1, 2); (2, 3); (3, 4)|]
-//     // ys |> Array.map (fun (x, y) -> sprintf "%i%i" x y)
-//     // |> String.concat "" |> equal "122334"
+// let ``Array.exactlyOne works II`` () =
+//     [|1.|] |> Array.exactlyOne |> equal 1.
+//     (try Array.exactlyOne [|1.;2.|] |> ignore; false with | _ -> true) |> equal true
+//     (try Array.exactlyOne [||] |> ignore; false with | _ -> true) |> equal true
 
 // [<Fact>]
 // let ``Array.transpose works`` () =

--- a/tests/Rust/tests/src/ListTests.fs
+++ b/tests/Rust/tests/src/ListTests.fs
@@ -433,19 +433,19 @@ let ``List.rev works`` () =
     ys.Head |> equal 3
     ys.Length |> equal 3
 
-// [<Fact>]
-// let ``List.scan works`` () =
-//     let xs = [1; 2; 3; 4]
-//     let ys = (0, xs) ||> List.scan (fun acc x -> acc - x)
-//     ys.[3] + ys.[4]
-//     |> equal -16
+[<Fact>]
+let ``List.scan works`` () =
+    let xs = [1; 2; 3; 4]
+    let ys = (0, xs) ||> List.scan (fun acc x -> acc - x)
+    ys.[3] + ys.[4]
+    |> equal -16
 
-// [<Fact>]
-// let ``List.scanBack works`` () =
-//     let xs = [1; 2; 3]
-//     let ys = List.scanBack (fun x acc -> acc - x) xs 0
-//     ys.Head + ys.Tail.Head
-//     |> equal -11
+[<Fact>]
+let ``List.scanBack works`` () =
+    let xs = [1; 2; 3]
+    let ys = List.scanBack (fun x acc -> acc - x) xs 0
+    ys.Head + ys.Tail.Head
+    |> equal -11
 
 // [<Fact>]
 // let ``List.sort works`` () =
@@ -877,15 +877,16 @@ let ``List.partition works`` () =
     ys |> List.toArray |> equal [| 2; 4 |]
     zs |> List.toArray |> equal [| 1; 3; 5 |]
 
-// [<Fact>]
-// let ``List.pairwise works`` () =
-//     List.pairwise<int> [] |> List.isEmpty |> equal true
-//     List.pairwise [1] |> List.isEmpty |> equal true
-//     let xs = [1; 2; 3; 4]
-//     let ys = xs |> List.pairwise
-//     ys |> List.toArray |> equal [|(1, 2); (2, 3); (3, 4)|]
-//     // ys |> List.map (fun (x, y) -> sprintf "%i%i" x y)
-//     // |> String.concat "" |> equal "122334"
+[<Fact>]
+let ``List.pairwise works`` () =
+    List.pairwise<int> [] |> List.isEmpty |> equal true
+    List.pairwise [1] |> List.isEmpty |> equal true
+    let xs = [1; 2; 3; 4]
+    let ys = xs |> List.pairwise
+    ys |> List.head |> equal (1, 2)
+    // ys |> List.toArray |> equal [|(1, 2); (2, 3); (3, 4)|]
+    // ys |> List.map (fun (x, y) -> sprintf "%i%i" x y)
+    // |> String.concat "" |> equal "122334"
 
 [<Fact>]
 let ``List.permute works`` () =
@@ -907,12 +908,12 @@ let ``List.permute works`` () =
 //     |> List.reduce (+)
 //     |> equal 20
 
-// [<Fact>]
-// let ``List.tryItem works`` () =
-//     let xs = [1.; 2.; 3.; 4.]
-//     List.tryItem 3 xs |> equal (Some 4.)
-//     List.tryItem 4 xs |> equal None
-//     List.tryItem -1 xs |> equal None
+[<Fact>]
+let ``List.tryItem works`` () =
+    let xs = [1.; 2.; 3.; 4.]
+    List.tryItem 3 xs |> equal (Some 4.)
+    List.tryItem 4 xs |> equal None
+    List.tryItem -1 xs |> equal None
 
 [<Fact>]
 let ``List.tryHead works`` () =

--- a/tests/Rust/tests/src/ResizeArrayTests.fs
+++ b/tests/Rust/tests/src/ResizeArrayTests.fs
@@ -3,14 +3,14 @@ module Fable.Tests.ResizeArrayTests
 open Util.Testing
 
 [<Fact>]
-let ``ResizeArray zero creation works`` () =
+let ``ResizeArray creation works`` () =
     let li = ResizeArray<float>()
     li.Count |> equal 0
 
-// [<Fact>]
-// let ``ResizeArray zero creation with size works`` () =
-//     let li = ResizeArray<string>(5)
-//      li.Count |> equal 0
+[<Fact>]
+let ``ResizeArray creation with capacity works`` () =
+    let li = ResizeArray<string>(5)
+    li.Count |> equal 0
 
 // [<Fact>]
 // let ``ResizeArray creation with seq works`` () =

--- a/tests/Rust/tests/src/SeqTests.fs
+++ b/tests/Rust/tests/src/SeqTests.fs
@@ -692,18 +692,18 @@ let ``Seq.reduceBack works`` () =
     xs |> Seq.reduceBack (+)
     |> equal 3.
 
-// [<Fact>]
-// let ``Seq.scan works`` () =
-//     let xs = [1.; 2.; 3.; 4.]
-//     let ys = xs |> Seq.scan (+) 0.
-//     sumFirstTwo ys |> equal 1.
+[<Fact>]
+let ``Seq.scan works`` () =
+    let xs = [1.; 2.; 3.; 4.]
+    let ys = xs |> Seq.scan (+) 0.
+    sumFirstTwo ys |> equal 1.
 
-// [<Fact>]
-// let ``Seq.scan works with empty input`` () =
-//     let xs = Seq.empty
-//     let ys = xs |> Seq.scan (+) 3
-//     Seq.head ys |> equal 3
-//     Seq.length ys |> equal 1
+[<Fact>]
+let ``Seq.scan works with empty input`` () =
+    let xs = Seq.empty<int>
+    let ys = xs |> Seq.scan (+) 3
+    Seq.head ys |> equal 3
+    Seq.length ys |> equal 1
 
 // [<Fact>]
 // let ``Seq.sort works`` () =
@@ -809,24 +809,24 @@ let ``Seq.tryPick works`` () =
     | None -> 0.
     |> equal 2.
 
-// [<Fact>]
-// let ``Seq.zip works`` () =
-//     let xs = [1.; 2.; 3.]
-//     let ys = [1.; 2.; 3.]
-//     let zs = Seq.zip xs ys
-//     let x, y = zs |> Seq.head
-//     x + y
-//     |> equal 2.
+[<Fact>]
+let ``Seq.zip works`` () =
+    let xs = [1.; 2.; 3.]
+    let ys = [1.; 2.; 3.]
+    let zs = Seq.zip xs ys
+    let x, y = zs |> Seq.head
+    x + y
+    |> equal 2.
 
-// [<Fact>]
-// let ``Seq.zip3 works`` () =
-//     let xs = [1.; 2.; 3.]
-//     let ys = [1.; 2.; 3.]
-//     let zs = [1.; 2.; 3.]
-//     let ks = Seq.zip3 xs ys zs
-//     let x, y, z = ks |> Seq.head
-//     x + y + z
-//     |> equal 3.
+[<Fact>]
+let ``Seq.zip3 works`` () =
+    let xs = [1.; 2.; 3.]
+    let ys = [1.; 2.; 3.]
+    let zs = [1.; 2.; 3.]
+    let ks = Seq.zip3 xs ys zs
+    let x, y, z = ks |> Seq.head
+    x + y + z
+    |> equal 3.
 
 // [<Fact>]
 // let ``Seq.cache works`` () =
@@ -956,19 +956,25 @@ let ``Seq.tryLast works`` () =
     xs |> Seq.tryLast |> equal (Some 4.)
     empty |> Seq.tryLast |> equal None
 
-// [<Fact>]
-// let ``Seq.pairwise works`` () =
-//     let xs = [1; 2; 3; 4]
-//     xs |> Seq.pairwise
-//     |> Seq.map (fun (x, y) -> sprintf "%i%i" x y)
-//     |> String.concat ""
-//     |> equal "122334"
+[<Fact>]
+let ``Seq.pairwise works`` () =
+    let xs = [1; 2; 3; 4]
+    let ys = xs |> Seq.pairwise
+    ys |> Seq.head |> equal (1, 2)
+    // ys |> Seq.map (fun (x, y) -> sprintf "%i%i" x y)
+    // |> String.concat "" |> equal "122334"
 
-// [<Fact>]
-// let ``Seq.pairwise works with empty input`` () = // See #1941
-//     ([||] : int array) |> Seq.pairwise |> Seq.toArray |> equal [||]
-//     [1] |> Seq.pairwise |> Seq.toList |> equal []
-//     [1; 2] |> Seq.pairwise |> Seq.toList |> equal [(1, 2)]
+[<Fact>]
+let ``Seq.pairwise works with empty input`` () = // See #1941
+    ([||] : int array) |> Seq.pairwise |> Seq.length |> equal 0
+    [1] |> Seq.pairwise |> Seq.length |> equal 0
+    [1; 2] |> Seq.pairwise |> Seq.head |> equal (1, 2)
+
+[<Fact>]
+let ``Seq.permute works`` () =
+    let xs = [1; 2; 3; 4; 5; 6]
+    let ys = xs |> Seq.permute (fun i -> i + 1 - 2 * (i % 2))
+    ys |> Seq.toArray |> equal [| 2; 1; 4; 3; 6; 5 |]
 
 [<Fact>]
 let ``Seq.readonly works`` () =


### PR DESCRIPTION
- Rust array updates
- Added more tests

@alexswan10k Array pre-allocation now works for all element types, including reference types.
Using the same representation for Array and ResizeArray was the only option to pre-allocate ref type arrays.