### PR TITLE
[Rust] Value options

### DIFF
--- a/src/fable-library-rust/src/Option.fs
+++ b/src/fable-library-rust/src/Option.fs
@@ -40,7 +40,7 @@ let filter<'T> (predicate: 'T -> bool) (opt: 'T option): 'T option =
     | Some x -> if predicate x then opt else None
     | None -> None
 
-let flatten<'T> (opt: Option<'T option>): 'T option =
+let flatten<'T> (opt: 'T option option): 'T option =
     match opt with
     | Some x -> x
     | None -> None


### PR DESCRIPTION
- All options are now value options by default, resulting in substantial decrease in allocations.
- Anecdotal performance is comparable to (or a bit faster than) running on the latest highly optimized .NET 6.0 runtime (faster by about 20% in some samples compiled to Rust).