### PR TITLE
[Python] inlining incorrectly postpones variable mutations

### DIFF
--- a/tests/Python/TestMisc.fs
+++ b/tests/Python/TestMisc.fs
@@ -1229,7 +1229,7 @@ let ``test Assigning to unit works`` () =
     value |> equal 4
 
 
-type Test(l: int, r: int) =
+type TestInliningMutation(l: int, r: int) =
     let mutable left = 0
 
     let call() =
@@ -1242,5 +1242,5 @@ type Test(l: int, r: int) =
 
 [<Fact>]
 let ``test Mutating variables is not postponed`` =
-    Test(1, 2).Run() |> equal 3
-    Test(15, 25).Run() |> equal 40
+    TestInliningMutation(1, 2).Run() |> equal 3
+    TestInliningMutation(15, 25).Run() |> equal 40

--- a/tests/Python/TestMisc.fs
+++ b/tests/Python/TestMisc.fs
@@ -1228,7 +1228,6 @@ let ``test Assigning to unit works`` () =
     doit 2 (fun x -> value <- value + x)
     value |> equal 4
 
-
 type TestInliningMutation(l: int, r: int) =
     let mutable left = 0
 
@@ -1240,7 +1239,30 @@ type TestInliningMutation(l: int, r: int) =
         let right = call()
         left + right
 
+let ``inlineData PR #2683`` =  [3, 2, 5; 5, 10, 15; 10, 20, 30]
+
 [<Fact>]
-let ``test Mutating variables is not postponed`` =
-    TestInliningMutation(1, 2).Run() |> equal 3
-    TestInliningMutation(15, 25).Run() |> equal 40
+let ``test Mutating variables is not postponed (functions) `` () =
+    let runCase (l: int) (r: int) (expect: int) =
+        let mutable left = 0
+        let call() =
+            left <- l
+            r
+
+        let run() =
+            let right = call()
+            left + right
+
+        run() |> equal expect
+
+    for (l, r, ``l + r``) in ``inlineData PR #2683`` do
+        runCase l r ``l + r``
+
+[<Fact>]
+let ``test Mutating variables is not postponed (classes) `` () =
+    let runCase (l: int) (r: int) (expect: int) =
+        TestInliningMutation(l, r).Run() |> equal expect
+        TestInliningMutation(l, r).Run() |> equal expect
+
+    for (l, r, ``l + r``) in ``inlineData PR #2683`` do
+        runCase l r ``l + r``

--- a/tests/Python/TestMisc.fs
+++ b/tests/Python/TestMisc.fs
@@ -1227,3 +1227,20 @@ let ``test Assigning to unit works`` () =
 
     doit 2 (fun x -> value <- value + x)
     value |> equal 4
+
+
+type Test(l: int, r: int) =
+    let mutable left = 0
+
+    let call() =
+        left <- l
+        r
+
+    member __.Run() =
+        let right = call()
+        left + right
+
+[<Fact>]
+let ``test Mutating variables is not postponed`` =
+    Test(1, 2).Run() |> equal 3
+    Test(15, 25).Run() |> equal 40


### PR DESCRIPTION
So far there is a bug described at fable-compiler/Fable.Python#32
This seems not resolved, and I add a dedicated test case to the `beyond` branch.
Thanks to @dbrattli for the instructions.