### PR TITLE
[Python] binding fixes

### DIFF
--- a/src/Fable.Transforms/Python/Python.fs
+++ b/src/Fable.Transforms/Python/Python.fs
@@ -102,12 +102,12 @@ type Statement =
     | Raise of Raise
     | Import of Import
     | Assign of Assign
-    | AnnAssign of AnnAssign
     | Return of Return
     | Global of Global
     | NonLocal of NonLocal
     | ClassDef of ClassDef
     | AsyncFor of AsyncFor
+    | AnnAssign of AnnAssign
     | ImportFrom of ImportFrom
     | FunctionDef of FunctionDef
     | AsyncFunctionDef of AsyncFunctionDef
@@ -224,7 +224,7 @@ type Assign =
 /// https://docs.python.org/3/library/ast.html#ast.AnnAssign
 type AnnAssign =
     { Target: Expression
-      Value: Expression
+      Value: Expression option
       Annotation: Expression
       Simple: bool }
 
@@ -796,13 +796,13 @@ module PythonExtensions =
               TypeComment = typeComment }
             |> Assign
 
-        static member assign(target, value, annotation, ?simple) : Statement =
+        static member assign(target, annotation, ?value, ?simple) : Statement =
             { Target = target
               Value = value
               Annotation = annotation
               Simple = defaultArg simple true }
             |> AnnAssign
-
+        
         static member return'(?value) : Statement = Return { Value = value }
 
         static member for'(target, iter, ?body, ?orelse, ?typeComment) : Statement =

--- a/src/Fable.Transforms/Python/PythonPrinter.fs
+++ b/src/Fable.Transforms/Python/PythonPrinter.fs
@@ -200,9 +200,11 @@ module PrinterExtensions =
             printer.Print(assign.Target)
             printer.Print(" : ")
             printer.Print(assign.Annotation)
-            printer.Print(" = ")
-
-            printer.Print(assign.Value)
+            match assign.Value with
+            | Some value ->
+                printer.Print(" = ")
+                printer.Print(value)
+            | _ -> ()
 
         member printer.Print(expr: Expr) = printer.Print(expr.Value)
 

--- a/src/fable-library-py/fable_library/async_.py
+++ b/src/fable-library-py/fable_library/async_.py
@@ -103,12 +103,12 @@ def await_task(task: Awaitable[_T]) -> Async[_T]:
 
 
 def start_with_continuations(
-    computation: Callable[[IAsyncContext[_T]], Async[_T]],
+    computation: Callable[[IAsyncContext[_T]], None],
     continuation: Optional[Callable[[Optional[_T]], None]] = None,
     exception_continuation: Optional[Callable[[Exception], None]] = None,
     cancellation_continuation: Optional[Callable[[OperationCanceledError], None]] = None,
     cancellation_token: Optional[CancellationToken] = None,
-) -> Callable[[IAsyncContext[_T]], None]:
+) -> None:
     trampoline = Trampoline()
 
     ctx = IAsyncContext.create(
@@ -123,12 +123,12 @@ def start_with_continuations(
 
 
 def start(
-    computation: Callable[[IAsyncContext[_T]], Async[_T]], cancellation_token: Optional[CancellationToken] = None
-) -> Async[_T]:
+    computation: Callable[[IAsyncContext[Any]], None], cancellation_token: Optional[CancellationToken] = None
+) -> None:
     return start_with_continuations(computation, cancellation_token=cancellation_token)
 
 
 def start_immediate(
-    computation: Callable[[IAsyncContext[_T]], Async[_T]], cancellation_token: Optional[CancellationToken] = None
-) -> Async[_T]:
+    computation: Callable[[IAsyncContext[Any]], None], cancellation_token: Optional[CancellationToken] = None
+) -> None:
     return start(computation, cancellation_token)


### PR DESCRIPTION
- Don't set default for bindings as statements (when typed)
- Value is optional for assignments with type annotations
- Fix typing issues with mailbox processor and async