### PR TITLE
[Python] avoid `dict[_, _]` to support py38

### DIFF
--- a/src/fable-library-py/fable_library/util.py
+++ b/src/fable-library-py/fable_library/util.py
@@ -163,7 +163,7 @@ def is_comparable(x: Any) -> bool:
     return hasattr(x, "CompareTo") and callable(x.CompareTo)
 
 
-def compare_dicts(x: Dict[str, Any], y: dict[str, Any]) -> int:
+def compare_dicts(x: Dict[str, Any], y: Dict[str, Any]) -> int:
     """Compare Python dicts with string keys.
 
     Python cannot do this natively.


### PR DESCRIPTION
This is just a tiny fix, but this issue suggests that it could be better for us to set up a test that specifies python versions.
