### PR TITLE
File lock

### DIFF
--- a/src/Fable.Cli/Entry.fs
+++ b/src/Fable.Cli/Entry.fs
@@ -268,10 +268,15 @@ type Runner =
             |> Some
         else None
 
-    return!
+    let startCompilation() =
         State.Create(cliArgs, ?watchDelay=watchDelay)
         |> startCompilation
         |> Async.RunSynchronously
+
+    return!
+        match outDir with
+        | None -> startCompilation()
+        | Some outDir -> File.withLock outDir startCompilation
 }
 
 let clean (args: CliArgs) rootDir =


### PR DESCRIPTION
Fable precompilation is causing issues when two processes try to trigger precompilation of a common library at the same time. This tries to avoid that.