### PR TITLE
[Python] Fix accessing DU tags

### DIFF
--- a/src/fable-library-py/fable_library/types.py
+++ b/src/fable-library-py/fable_library/types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import array
-from abc import abstractmethod, abstractstaticmethod
+from abc import abstractmethod
 from typing import Any, Callable, Generic, Iterable, List, Optional, TypeVar
 from typing import Union as Union_
 from typing import cast

--- a/src/fable-library-py/fable_library/types.py
+++ b/src/fable-library-py/fable_library/types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import array
-from abc import abstractstaticmethod
+from abc import abstractmethod, abstractstaticmethod
 from typing import Any, Callable, Generic, Iterable, List, Optional, TypeVar
 from typing import Union as Union_
 from typing import cast
@@ -42,13 +42,14 @@ class Union(IComparable):
         self.tag: int
         self.fields: List[Any] = []
 
-    @abstractstaticmethod
+    @staticmethod
+    @abstractmethod
     def cases() -> List[str]:
         ...
 
     @property
     def name(self) -> str:
-        return Union.cases()[self.tag]
+        return self.cases()[self.tag]
 
     def __str__(self) -> str:
         if not len(self.fields):
@@ -203,7 +204,7 @@ class FSharpException(Exception, IComparable):
         self.Data0: Any = None
 
     def __str__(self) -> str:
-        return record_to_string(self)
+        return record_to_string(self)  # type: ignore
 
     def __repr__(self) -> str:
         return str(self)

--- a/tests/Python/TestMisc.fs
+++ b/tests/Python/TestMisc.fs
@@ -454,6 +454,8 @@ let inline inlineLambdaWithAnonRecord callback =
 
 let sideEffect() = ()
 
+type Union_TestUnionTag = Union_TestUnionTag of int
+
 #if FABLE_COMPILER
 
 [<Fact>]
@@ -1282,3 +1284,7 @@ let ``test incr and decr works`` () =
 
     f value |> equal 43
     g value |> equal 42
+
+[<Fact>]
+let ``test Accessing union tags `` () =
+    sprintf "%A" (Union_TestUnionTag 1) |> equal "Union_TestUnionTag 1"


### PR DESCRIPTION
fix fable-compiler/Fable.Python#41


The way to define abstract static methods comes from [docs.python.org/3/library/abc](https://docs.python.org/3/library/abc.html):

```python
@staticmethod
@abstractmethod
def cases():
      ...
```
