### PR TITLE
Use a local link for FCS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [Follow us on Twitter!](https://twitter.com/FableCompiler)
 
-Fable is an F# to JavaScript compiler powered by [FSharp Compiler Services](https://fsharp.github.io/fsharp-compiler-docs/fcs/), designed to make F# a first-class citizen of the JavaScript ecosystem. [Check the website](http://fable.io) for more information and if you find the project useful, don't forget to give us a star!
+Fable is an F# to JavaScript compiler powered by a [fork](/lib/fcs) of [FSharp Compiler Services](https://fsharp.github.io/fsharp-compiler-docs/fcs/), designed to make F# a first-class citizen of the JavaScript ecosystem. [Check the website](http://fable.io) for more information and if you find the project useful, don't forget to give us a star!
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [Follow us on Twitter!](https://twitter.com/FableCompiler)
 
-Fable is an F# to JavaScript compiler powered by [FSharp Compiler Services](https://fsharp.github.io/FSharp.Compiler.Service/), designed to make F# a first-class citizen of the JavaScript ecosystem. [Check the website](http://fable.io) for more information and if you find the project useful, don't forget to give us a star!
+Fable is an F# to JavaScript compiler powered by [FSharp Compiler Services](/lib/fcs), designed to make F# a first-class citizen of the JavaScript ecosystem. [Check the website](http://fable.io) for more information and if you find the project useful, don't forget to give us a star!
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [Follow us on Twitter!](https://twitter.com/FableCompiler)
 
-Fable is an F# to JavaScript compiler powered by [FSharp Compiler Services](/lib/fcs), designed to make F# a first-class citizen of the JavaScript ecosystem. [Check the website](http://fable.io) for more information and if you find the project useful, don't forget to give us a star!
+Fable is an F# to JavaScript compiler powered by [FSharp Compiler Services](https://fsharp.github.io/fsharp-compiler-docs/fcs/), designed to make F# a first-class citizen of the JavaScript ecosystem. [Check the website](http://fable.io) for more information and if you find the project useful, don't forget to give us a star!
 
 ## Getting started
 


### PR DESCRIPTION
On the main branch, the readme has a broken link to [FSharp Compiler Services](https://fsharp.github.io/FSharp.Compiler.Service/). I found https://github.com/dotnet/fsharp and https://github.com/fable-compiler/Fable/tree/main/lib/fcs. Since we're using the later anyway and it has its own readme then why not link there?