### PR TITLE
Disable uncurrying of functions passed as arguments to local lambdas

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 [Follow us on Twitter!](https://twitter.com/FableCompiler)
 
-Fable is an F# to JavaScript compiler powered by a [fork](/lib/fcs) of [FSharp Compiler Services](https://fsharp.github.io/fsharp-compiler-docs/fcs/), designed to make F# a first-class citizen of the JavaScript ecosystem. [Check the website](http://fable.io) for more information and if you find the project useful, don't forget to give us a star!
+Fable is an F# to JavaScript compiler powered [FSharp Compiler Services](https://fsharp.github.io/fsharp-compiler-docs/fcs/), designed to make F# a first-class citizen of the JavaScript ecosystem. [Check the website](http://fable.io) for more information and if you find the project useful, don't forget to give us a star!
+
+> Fable actually uses a fork of FCS with a few tweaks. Binaries are in `lib/fcs` folder. See [this PR](https://github.com/ncave/fsharp/pull/2) for more info.
 
 ## Getting started
 

--- a/src/Fable.AST/Fable.fs
+++ b/src/Fable.AST/Fable.fs
@@ -337,7 +337,10 @@ type Expr =
     | Test of Expr * TestKind * range: SourceLocation option
 
     // Operations
+
+    /// Call to a type/module member, function arguments will be uncurried
     | Call of callee: Expr * info: CallInfo * typ: Type * range: SourceLocation option
+    /// Application to local lambdas, function arguments will NOT be uncurried
     | CurriedApply of applied: Expr * args: Expr list * typ: Type * range: SourceLocation option
     | Curry of Expr * arity: int * Type * SourceLocation option
     | Operation of OperationKind * typ: Type * range: SourceLocation option

--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -1921,13 +1921,6 @@ module Util =
         ent.AllInterfaces |> Seq.exists (fun ifc -> ifc.Entity.FullName = interfaceFullname)
 
     let makeCallWithArgInfo com (ctx: Context) r typ (genArgs: Lazy<_>) callee (memb: FSharpMemberOrFunctionOrValue) (callInfo: Fable.CallInfo) =
-        let makeReturnType t =
-            match makeType (Map genArgs.Value) t with
-            // TODO: This is not ideal, but for proper currying when the call returns a lambda,
-            // let's use the type without filled generic args. See #2433.
-            | Fable.LambdaType _ -> makeType ctx.GenericArgs t
-            | t -> t
-
         match memb, memb.DeclaringEntity with
         | Emitted com r typ (Some callInfo) emitted, _ -> emitted
         | Imported com r typ (Some callInfo) imported -> imported
@@ -1981,11 +1974,11 @@ module Util =
             callAttachedMember com r typ callInfo entity memb
 
         | _, Some entity when isModuleValueForCalls entity memb ->
-            let typ = makeReturnType memb.FullType
+            let typ = makeType (Map genArgs.Value) memb.FullType
             memberRef com r typ memb
         | _ ->
             // If member looks like a value but behaves like a function (has generic args) the type from F# AST is wrong (#2045).
-            let typ = makeReturnType memb.ReturnParameter.Type
+            let typ = makeType (Map genArgs.Value) memb.ReturnParameter.Type
             let callExpr =
                 memberRef com r Fable.Any memb
                 |> makeCall r typ callInfo

--- a/src/Fable.Transforms/FSharp2Fable.fs
+++ b/src/Fable.Transforms/FSharp2Fable.fs
@@ -1263,10 +1263,6 @@ let private transformMemberFunctionOrValue (com: IFableCompiler) ctx (memb: FSha
         let typ = makeType Map.empty memb.FullType
         transformImport com None typ memb.IsMutable isPublic name fullDisplayName selector path
     | _ ->
-        let noArgs = memb.CurriedParameterGroups.Count = 0
-        if noArgs && memb.GenericParameters.Count = 0 then
-            transformMemberValue com ctx isPublic name fullDisplayName memb body
-        else
         if isModuleValueForDeclarations memb
         then transformMemberValue com ctx isPublic name fullDisplayName memb body
         else transformMemberFunction com ctx isPublic name fullDisplayName memb args body

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -3308,6 +3308,9 @@ let partialApplyAtRuntime com t arity (fn: Expr) (args: Expr list) =
     let args = NewArray(args, Any) |> makeValue None
     Helper.LibCall(com, "Util", "partialApply", t, [makeIntConst arity; fn; args])
 
+let checkArity com t arity expr =
+    Helper.LibCall(com, "Util", "checkArity", t, [makeIntConst arity; expr])
+
 let tryField com returnTyp ownerTyp fieldName =
     match ownerTyp, fieldName with
     | Builtin BclDecimal, _ ->

--- a/tests/Main/ApplicativeTests.fs
+++ b/tests/Main/ApplicativeTests.fs
@@ -710,6 +710,42 @@ let tests6 = [
 
         bind three (fun i -> three) "environment"
         |> equal 3
+
+    testCase "Piping to an alias of a function which returns a function works" <| fun () -> // See #2657
+        let f a b = sprintf $"{a} {b}"
+
+        let f_option = Some f
+        let defaultValue x = Option.defaultValue x
+
+        let functionA = f_option |> Option.defaultValue f
+        functionA "functionA" "works" |> equal "functionA works"
+
+        let functionB = defaultValue f f_option
+        functionB "functionB" "works" |> equal "functionB works"
+
+        let functionC = f_option |> defaultValue f
+        functionC "functionC" "works" |> equal "functionC works"
+
+        let functionC x = (f_option |> defaultValue f) x
+        functionC "functionC" "works" |> equal "functionC works"
+
+        let functionC x y = (f_option |> defaultValue f) x y
+        functionC "functionC" "works" |> equal "functionC works"
+
+    testCase "Piping to an alias of a function which returns a function works II" <| fun () -> // See #2657
+        let f a b = sprintf $"{a} {b}"
+
+        let getFunction x y = y
+        let getFunctionAlias = getFunction
+
+        let functionA = f |> getFunction 1
+        functionA "functionA" "works" |> equal "functionA works"
+
+        let functionB = getFunctionAlias 1 f
+        functionB "functionB" "works" |> equal "functionB works"
+
+        let functionC = f |> getFunctionAlias 2
+        functionC "functionC" "works?" |> equal "functionC works?"
 ]
 
 module CurriedApplicative =


### PR DESCRIPTION
Fix #2657

Issue #2657 has opened the pandora box. While investigating it, I realized the uncurrying system was faulty when passing functions as arguments to local lambdas so I've disabled it in this case. I believe it shouldn't have a big impact and should make the generated code more reliable. My only concern is whether this can break some bindings, but lambdas accepting/returning lambdas was already very flaky for interop (see [docs](https://fable.io/docs/communicate/fable-from-js.html#using-delegates-for-disambiguation)) so I hope it's ok. 