### PR TITLE
Make tests/Compiler depend on Fable.Cli

### DIFF
--- a/src/Fable.Cli/Entry.fs
+++ b/src/Fable.Cli/Entry.fs
@@ -54,6 +54,7 @@ let knownCliArgs() = [
   ["-c"; "--configuration"], ["The configuration to use when parsing .fsproj with MSBuild,"
                               "default is 'Debug' in watch mode, or 'Release' otherwise"]
   ["--verbose"],         ["Print more info during compilation"]
+  ["--silent"],          ["Don't print any log during compilation"]
   ["--typedArrays"],     ["Compile numeric arrays as JS typed arrays (default true)"]
   ["--watch"],           ["Alias of watch command"]
   ["--watchDelay"],      ["Delay in ms before recompiling after a file changes (default 200)"]
@@ -280,6 +281,7 @@ type Runner =
         match outDir, precompile, watch with
         | Some outDir, true, false -> File.withLock outDir startCompilation
         | _ -> startCompilation()
+        |> Result.mapEither ignore fst
 }
 
 let clean (args: CliArgs) rootDir =
@@ -364,10 +366,10 @@ let main argv =
             match commands with
             | ["--version"] -> ()
             | _ ->
-                Log.always("Fable: F# to JS compiler " + Literals.VERSION)
-                Log.always("Thanks to the contributor! @" + Contributors.getRandom() + "\n")
                 if args.FlagEnabled "--verbose" then
                     Log.makeVerbose()
+                Log.always("Fable: F# to JS compiler " + Literals.VERSION)
+                Log.always("Thanks to the contributor! @" + Contributors.getRandom() + "\n")
 
         match commands with
         | ["--help"] -> return printHelp()

--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -580,7 +580,8 @@ type State =
       PendingFiles: string[]
       DeduplicateDic: ConcurrentDictionary<string, string>
       Watcher: Watcher option
-      SilentCompilation: bool }
+      SilentCompilation: bool
+      RecompileAllFiles: bool }
 
     member this.TriggeredByDependency(path: string, changes: ISet<string>) =
         match Map.tryFind path this.WatchDependencies with
@@ -605,14 +606,15 @@ type State =
                     |> addTargetDir)
         }
 
-    static member Create(cliArgs, ?watchDelay) =
+    static member Create(cliArgs, ?watchDelay, ?recompileAllFiles) =
         { CliArgs = cliArgs
           ProjectCrackedAndFableCompiler = None
           WatchDependencies = Map.empty
           Watcher = watchDelay |> Option.map Watcher.Create
           DeduplicateDic = ConcurrentDictionary()
           PendingFiles = [||]
-          SilentCompilation = false }
+          SilentCompilation = false
+          RecompileAllFiles = defaultArg recompileAllFiles false }
 
 let private getFilesToCompile (state: State) (changes: ISet<string>) (oldFiles: IDictionary<string, File> option) (projCracked: ProjectCracked) =
     let pendingFiles = set state.PendingFiles
@@ -685,6 +687,9 @@ let private compilationCycle (state: State) (changes: ISet<string>) = async {
                 let newProjCracked, filesToCompile = getFilesToCompile state changes (Some oldFiles) newProjCracked
                 newProjCracked, fableCompiler, filesToCompile
             else
+                let changes =
+                    if state.RecompileAllFiles then HashSet projCracked.SourceFilePaths :> ISet<_>
+                    else changes
                 let projCracked, filesToCompile = getFilesToCompile state changes None projCracked
                 projCracked, Some fableCompiler, filesToCompile
 
@@ -698,7 +703,7 @@ let private compilationCycle (state: State) (changes: ISet<string>) = async {
         && projCracked.CanReuseCompiledFiles
         && areCompiledFilesUpToDate state filesToCompile then
             Log.always "Skipped compilation because all generated files are up-to-date!"
-            return state, 0
+            return state, [||], 0
     else
         // Optimization for watch mode, if files haven't changed run the process as with --runFast
         let state, cliArgs =
@@ -762,6 +767,7 @@ let private compilationCycle (state: State) (changes: ISet<string>) = async {
         errorLogs |> Array.iter (formatLog cliArgs.RootDir >> Log.error)
         let hasError = Array.isEmpty errorLogs |> not
 
+        // Generate assembly and serialize info if precompile is selected
         let! exitCode = async {
             match hasError, cliArgs.Precompile with
             | false, true ->
@@ -809,6 +815,7 @@ let private compilationCycle (state: State) (changes: ISet<string>) = async {
             | _ -> return 0
         }
 
+        // Run process
         let exitCode, state =
             match cliArgs.RunProcess with
             // Only run process if there are no errors
@@ -847,7 +854,7 @@ let private compilationCycle (state: State) (changes: ISet<string>) = async {
                                 errorLogs |> Array.choose (fun l -> l.FileName) |> Array.distinct
                             else state.PendingFiles }
 
-        return state, exitCode
+        return state, logs, exitCode
 }
 
 type FileWatcherMsg =
@@ -863,7 +870,7 @@ let startCompilation state = async {
 
     // Initialize changes with an empty set
     let changes = HashSet() :> ISet<_>
-    let! _state, exitCode =
+    let! _state, logs, exitCode =
         match state.Watcher with
         | None -> compilationCycle state changes
         | Some watcher ->
@@ -877,7 +884,7 @@ let startCompilation state = async {
                             | Some w when w.StartedAt < timestamp ->
                                 // TODO: Get all messages until QueueLength is 0 before starting the compilation cycle?
                                 Log.verbose(lazy $"""Changes:{Log.newLine}    {changes |> String.concat $"{Log.newLine}    "}""")
-                                let! state, _exitCode = compilationCycle state changes
+                                let! state, _logs, _exitCode = compilationCycle state changes
                                 Log.always "Watching..."
                                 return! loop state
                             | _ -> return! loop state
@@ -893,10 +900,10 @@ let startCompilation state = async {
             Async.FromContinuations(fun (_onSuccess, onError, _onCancel) -> agent.Error.Add(onError))
 
     match exitCode with
-    | 0 -> return Ok()
-    | _ -> return Error "Compilation failed"
+    | 0 -> return Ok(state, logs)
+    | _ -> return Error("Compilation failed", logs)
 
   with
-    | FableError e -> return Error e
+    | FableError e -> return Error(e, [||])
     | exn -> return raise exn
 }

--- a/src/Fable.Transforms/Global/Prelude.fs
+++ b/src/Fable.Transforms/Global/Prelude.fs
@@ -110,6 +110,16 @@ module List =
         | Some i -> List.splitAt i xs
         | None -> xs, []
 
+[<RequireQualifiedAccess>]
+module Result =
+    let mapEither mapOk mapError = function
+        | Ok x -> mapOk x |> Ok
+        | Error e -> mapError e |> Error
+
+    let extract extractOk extractError = function
+        | Ok x -> extractOk x
+        | Error e -> extractError e
+
 module Patterns =
     let (|Try|_|) (f: 'a -> 'b option) a = f a
 

--- a/tests/Compiler/AnonRecordInInterfaceTests.fs
+++ b/tests/Compiler/AnonRecordInInterfaceTests.fs
@@ -122,16 +122,16 @@ let settings: Compiler.Settings =
           yield "Fable.Core.JsInterop"
         ]
   }
-let compile = Compiler.Cached.compile settings
+let compile source = Compiler.Cached.compile settings source
 let private testCase msg test = testCase msg (test >> ignore)
 
 module Error =
 
-  let missingField = "FABLE: Object doesn't contain field"
-  let unexpectedType = "FABLE: Expected type"
-  let unexpectedTypeMulti = "FABLE: Expected any type of"
-  let unexpectedIndexerType = "FABLE: Expected type"
-  let unexpectedIndexerTypeMulti = "FABLE: Expected any type of"
+  let missingField = "Object doesn't contain field"
+  let unexpectedType = "Expected type"
+  let unexpectedTypeMulti = "Expected any type of"
+  let unexpectedIndexerType = "Expected type"
+  let unexpectedIndexerTypeMulti = "Expected any type of"
 
   type private Rx = System.Text.RegularExpressions.Regex
   /// Note: names cannot contain `'` (or `"`)
@@ -149,21 +149,21 @@ module Error =
       let interfaceName = interfaceName |> orNameRegex
       let fieldName = fieldName |> orNameRegex
       let expectedType = expectedType |> orNameRegex
-      $"FABLE: Object doesn't contain field '{fieldName}' of type '{expectedType}' required by interface '{interfaceName}'"
+      $"Object doesn't contain field '{fieldName}' of type '{expectedType}' required by interface '{interfaceName}'"
       |> Rx
     static member UnexpectedType (?interfaceName: string, ?fieldName: string, ?expectedType: string, ?actualType: string) =
       let interfaceName = interfaceName |> orNameRegex
       let fieldName = fieldName |> orNameRegex
       let expectedType = expectedType |> orNameRegex
       let actualType = actualType |> orNameRegex
-      $"FABLE: Expected type '{expectedType}' for field '{fieldName}' in interface '{interfaceName}', but is '{actualType}'"
+      $"Expected type '{expectedType}' for field '{fieldName}' in interface '{interfaceName}', but is '{actualType}'"
       |> Rx
     static member UnexpectedTypeMulti (?interfaceName: string, ?fieldName: string, ?expectedTypes: string list, ?actualType: string) =
       let interfaceName = interfaceName |> orNameRegex
       let fieldName = fieldName |> orNameRegex
       let expectedTypes = expectedTypes |> orNamesRegex
       let actualType = actualType |> orNameRegex
-      $"FABLE: Expected any type of {expectedTypes} for field '{fieldName}' in interface '{interfaceName}', but is '{actualType}'"
+      $"Expected any type of {expectedTypes} for field '{fieldName}' in interface '{interfaceName}', but is '{actualType}'"
       |> Rx
     static member UnexpectedIndexerType (?interfaceName: string, ?indexerName: string, ?fieldName: string, ?expectedType: string, ?actualType: string) =
       let interfaceName = interfaceName |> orNameRegex
@@ -171,7 +171,7 @@ module Error =
       let fieldName = fieldName |> orNameRegex
       let expectedType = expectedType |> orNameRegex
       let actualType = actualType |> orNameRegex
-      $"FABLE: Expected type '{expectedType}' for field '{fieldName}' because of Indexer '{indexerName}' in interface '{interfaceName}', but is '{actualType}'"
+      $"Expected type '{expectedType}' for field '{fieldName}' because of Indexer '{indexerName}' in interface '{interfaceName}', but is '{actualType}'"
       |> Rx
     static member UnexpectedIndexerTypeMulti (?interfaceName: string, ?indexerName: string, ?fieldName: string, ?expectedTypes: string list, ?actualType: string) =
       let interfaceName = interfaceName |> orNameRegex
@@ -179,7 +179,7 @@ module Error =
       let fieldName = fieldName |> orNameRegex
       let expectedTypes = expectedTypes |> orNamesRegex
       let actualType = actualType |> orNameRegex
-      $"FABLE: Expected any type of {expectedTypes} for field '{fieldName}' because of Indexer '{indexerName}' in interface '{interfaceName}', but is '{actualType}'"
+      $"Expected any type of {expectedTypes} for field '{fieldName}' because of Indexer '{indexerName}' in interface '{interfaceName}', but is '{actualType}'"
       |> Rx
 
 module private Ty =

--- a/tests/Compiler/Compiler.fsproj
+++ b/tests/Compiler/Compiler.fsproj
@@ -10,13 +10,19 @@
     <PackageReference Include="Expecto" Version="9.0.4" />
   </ItemGroup>
   <ItemGroup>
+    <!-- <ProjectReference Include="../../src/Fable.Core/Fable.Core.fsproj" /> -->
+    <ProjectReference Include="..\..\src\Fable.AST\Fable.AST.fsproj" />
+    <ProjectReference Include="..\..\src\Fable.Transforms\Fable.Transforms.fsproj" />
     <ProjectReference Include="..\..\src\Fable.Cli\Fable.Cli.fsproj" />
-    <ProjectReference Include="../../src/Fable.Core/Fable.Core.fsproj" />
-    <ProjectReference Include="..\..\src\fable-standalone\src\Fable.Standalone.fsproj" />
+    <Reference Include="../../lib/fcs/FSharp.Compiler.Service.dll" />
+    <Reference Include="../../lib/fcs/FSharp.Core.dll" />
   </ItemGroup>
   <ItemGroup>
+    <!-- <Compile Include="..\..\src\fable-standalone\src\Interfaces.fs"/>
+    <Compile Include="..\..\src\fable-standalone\src\Lexer.fs"/>
+    <Compile Include="..\..\src\fable-standalone\src\Main.fs"/>
+    <Compile Include="..\..\src\fable-standalone\test\bench\Platform.fs" /> -->
     <Compile Include="../Main/Util/Util.Testing.fs" />
-    <Compile Include="..\..\src\fable-standalone\test\bench\Platform.fs" />
     <Compile Include="Util/Compiler.fs" />
     <Compile Include="CompilerMessagesTests.fs" />
     <Compile Include="AnonRecordInInterfaceTests.fs" />

--- a/tests/Compiler/CompilerMessagesTests.fs
+++ b/tests/Compiler/CompilerMessagesTests.fs
@@ -5,7 +5,7 @@ open Util.Testing
 open Fable.Tests.Compiler.Util
 open Fable.Tests.Compiler.Util.Compiler
 
-let private compile = Compiler.Cached.compile Compiler.Settings.standard
+let private compile source = Compiler.Cached.compile Compiler.Settings.standard source
 
 let tests =
   testList "Compiler Messages" [

--- a/tests/Compiler/TestProject/.gitignore
+++ b/tests/Compiler/TestProject/.gitignore
@@ -1,0 +1,1 @@
+Program.fs

--- a/tests/Compiler/TestProject/TestProject.fsproj
+++ b/tests/Compiler/TestProject/TestProject.fsproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Fable.Core\Fable.Core.fsproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
As discussed in https://github.com/fable-compiler/Fable/pull/2712#issuecomment-1009550587 this makes tests/Compiler depend on Fable.Cli so it doesn't need to build Fable.Standalone (which includes a tweaked FCS).