### PR TITLE
[Python] Fix typevar name

### DIFF
--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -4104,11 +4104,7 @@ module Compiler =
                 // TypeVars should be private and uppercase. For auto-generated (inferred) generics we use a double-undercore.
                 let name =
                     let name = name.ToUpperInvariant() |> Helpers.clean
-
-                    if name.EndsWith("_") then
-                        $"__{name.TrimEnd([| '_' |])}"
-                    else
-                        $"_{name}"
+                    $"_{name}"
 
                 // For object expressions we need to create a new type scope so we make an extra padding to ensure uniqueness
                 let name = name.PadRight(ctx.TypeParamsScope + name.Length, '_')

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -4109,8 +4109,9 @@ module Compiler =
                         $"__{name.TrimEnd([| '_' |])}"
                     else
                         $"_{name}"
+
                 // For object expressions we need to create a new type scope so we make an extra padding to ensure uniqueness
-                let name = name.PadLeft(ctx.TypeParamsScope + name.Length, '_')
+                let name = name.PadRight(ctx.TypeParamsScope + name.Length, '_')
                 typeVars.Add name |> ignore
 
                 ctx.UsedNames.DeclarationScopes.Add(name)


### PR DESCRIPTION
- Bugfix: Cannot start with more than 2 underscores. Prepend instead.