### PR TITLE
Fix Match.Groups

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -471,6 +471,8 @@ let testPython() =
     ]
 
     runInDir buildDir "pytest -x"
+    // Testing in Windows
+    // runInDir buildDir "python -m pytest -x"
 
 let testRust() =
     // buildLibraryRustIfNotExists()

--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -4007,11 +4007,6 @@ let regex com (ctx: Context) r t (i: CallInfo) (thisArg: Expr option) (args: Exp
     | "get_Success" ->
         makeEqOp r thisArg.Value (Value(Null thisArg.Value.Type, None)) BinaryUnequal
         |> Some
-    // Match
-    | "get_Groups" ->
-        //thisArg.Value |> Some
-        Helper.InstanceCall(thisArg.Value, "groups", t, [], i.SignatureArgTypes, ?loc = r)
-        |> Some
     // MatchCollection & GroupCollection
     | "get_Item" when i.DeclaringEntityFullName = "System.Text.RegularExpressions.GroupCollection" ->
         // can be group index or group name

--- a/src/fable-library-py/fable_library/reg_exp.py
+++ b/src/fable-library-py/fable_library/reg_exp.py
@@ -49,6 +49,11 @@ def is_match(reg: Union[Pattern[str], str], input: str, start_at: int = 0) -> bo
 
     return reg.search(input, pos=start_at) is not None
 
+def groups(m: Match) -> List[str]:
+    # .NET adds the whole capture as group 0
+    g = list(m.groups())
+    g.insert(0, m.string)
+    return g
 
 def options(reg: Pattern[str]) -> int:
     options = 256  # ECMAScript

--- a/tests/Python/TestRegex.fs
+++ b/tests/Python/TestRegex.fs
@@ -125,7 +125,7 @@ let ``test Regex instance Match and Matches with offset work`` () =
         (index + ms.Count) |> equal expected
     test 10 31
     test 40 -1
-    
+
 [<Fact>]
 let ``test Regex.IsMatch works`` () =
     let str = "For more information, see Chapter 3.4.5.1"
@@ -203,6 +203,34 @@ let ``test Regex.Replace with macros works`` () =
     let str = "Alfonso Garcia-Caro"
     Regex.Replace(str, "([A-Za-z]+) ([A-Za-z\-]+)", "$2 $1") |> equal "Garcia-Caro Alfonso"
     Regex.Replace(str, "(fon)(so)", "$2 $1") |> equal "Also fon Garcia-Caro"
+
+[<Fact>]
+let ``Match.Groups indexer getter works`` () =
+    let str = "For more information, see Chapter 3.4.5.1"
+    let m = Regex.Match(str, "Chapter \d+(\.\d)*")
+    let g = m.Groups.[1]
+    g.Value |> equal ".1"
+
+[<Fact>]
+let ``Match.Groups iteration works`` () =
+    let str = "For more information, see Chapter 3.4.5.1"
+    let m = Regex.Match(str, "Chapter \d+(\.\d)*")
+    let mutable count = 0
+    for g in m.Groups do count <- count + g.Value.Length
+    equal 17 count
+
+[<Fact>]
+let ``Match.Groups iteration works II`` () = // See #2167
+    let m = Regex.Match("foo bar baz", @"(\w+) \w+ (\w+)")
+    let li = [for g in m.Groups -> g.Value]
+    let x = li |> List.skip 1 |> List.reduce (+)
+    equal "foobaz" x
+
+[<Fact>]
+let ``Match.Groups.Count works`` () =
+    let str = "For more information, see Chapter 3.4.5.1"
+    let m = Regex.Match(str, "Chapter \d+(\.\d)*")
+    m.Groups.Count |> equal 2
 
 (* TODO
 [<Fact>]


### PR DESCRIPTION
@dbrattli Fix for `Match.Groups`, please note this PR targets your python-regexp branch.