### PR TITLE
Fix #2598: Disabled tests in beyond

### DIFF
--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -1800,9 +1800,9 @@ module Util =
                 if indexedProp then memb.CompiledName, false, false
                 else getMemberDisplayName memb, isGetter, isSetter
         if isGetter then
-            // let membType = memb.ReturnParameter.Type |> makeType Map.empty
+            let t = memb.ReturnParameter.Type |> makeType Map.empty
             // Set the field as mutable to prevent beta reduction
-            Fable.Get(callee, Fable.FieldGet(name, true), typ, r)
+            Fable.Get(callee, Fable.FieldGet(name, true), t, r)
         elif isSetter then
             let membType = memb.CurriedParameterGroups.[0].[0].Type |> makeType Map.empty
             let arg = callInfo.Args |> List.tryHead |> Option.defaultWith makeNull

--- a/tests/Js/Main/ApplicativeTests.fs
+++ b/tests/Js/Main/ApplicativeTests.fs
@@ -1366,17 +1366,17 @@ let tests7 = [
             | _ -> -1
         equal 7 x
 
-    // // See https://github.com/fable-compiler/Fable/issues/2436#issuecomment-919165092
-    // testCase "Functions passed to an object expression are uncurried" <| fun () ->
-    //     let mutable d = 0
-    //     let getAdder x =
-    //         d <- d + 1
-    //         fun y z -> x + y + z
-    //     let _ = getAdder 4
-    //     let f = getAdder 4
-    //     let adder = { new IAdder with member _.Add = f }
-    //     d |> equal 2
-    //     adder.Add 3 4 |> equal 11
+    // See https://github.com/fable-compiler/Fable/issues/2436#issuecomment-919165092
+    testCase "Functions passed to an object expression are uncurried" <| fun () ->
+        let mutable d = 0
+        let getAdder x =
+            d <- d + 1
+            fun y z -> x + y + z
+        let _ = getAdder 4
+        let f = getAdder 4
+        let adder = { new IAdder with member _.Add = f }
+        d |> equal 2
+        adder.Add 3 4 |> equal 11
 
     testCase "Iterating list of functions #2047" <| fun _ ->
         let mutable s = "X"

--- a/tests/Js/Main/ImportTests.fs
+++ b/tests/Js/Main/ImportTests.fs
@@ -167,9 +167,9 @@ let tests =
         let x = Fable.Tests.DllRef.Lib2.Bar(2, "ho")
         x.generator() |> equal "hoho"
 
-    // testCase "Files in outDir don't conflict" <| fun () -> // See #2259
-    //     Fable.Tests.DllRef.Lib2.value |> equal 10
-    //     Fable.Tests.DllRef2.Lib2.value |> equal 20
+    testCase "Files in outDir don't conflict" <| fun () -> // See #2259
+        Fable.Tests.DllRef.Lib2.value |> equal 10
+        Fable.Tests.DllRef2.Lib2.value |> equal 20
 
     testCase "Referencing a Fable project through a dll works" <| fun () ->
         Fable.Tests.DllRef.Util.add2 5 |> equal 7


### PR DESCRIPTION
Fix #2598

The test about conflicting conflicting files in outDir seems to be working now, not sure why it failed at some point 🤷 