### PR TITLE
Add --noParallel option

### DIFF
--- a/src/Fable.Cli/Entry.fs
+++ b/src/Fable.Cli/Entry.fs
@@ -77,6 +77,7 @@ let knownCliArgs() = [
   // Hidden args
   ["--precompiledLib"], []
   ["--noReflection"], []
+  ["--noParallel"], []
   ["--typescript"], []
   ["--trimRootModule"], []
   ["--fableLib"], []
@@ -252,6 +253,8 @@ type Runner =
           SourceMapsRoot = args.Value "--sourceMapsRoot"
           NoRestore = args.FlagEnabled "--noRestore"
           NoCache = args.FlagEnabled "--noCache"
+          // TODO: If we select optimize we cannot have F#/Fable parallelization
+          NoParallel = args.FlagEnabled "--noParallel"
           Exclude = args.Value "--exclude"
           Replace =
             args.Values "--replace"

--- a/src/Fable.Cli/Fable.Cli.fsproj
+++ b/src/Fable.Cli/Fable.Cli.fsproj
@@ -5,9 +5,9 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <Version>3.7.0</Version>
-    <PackageVersion>3.7.0-beta-012</PackageVersion>
-    <PackageReleaseNotes>* Disable uncurrying functions passed as arguments to local lambdas
-* Fix typeof(obj).IsInstanceOfType @chkn</PackageReleaseNotes>
+    <PackageVersion>3.7.0-beta-014</PackageVersion>
+    <PackageReleaseNotes>* Add --noParallel option to disable F#/Fable parallel compilation
+* Watch .proj files</PackageReleaseNotes>
     <!-- Allow users with newer dotnet SDK to run Fable, see #1910 -->
     <RollForward>Major</RollForward>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -241,7 +241,7 @@ open FileWatcher
 open FileWatcherUtil
 
 type FsWatcher(delayMs: int) =
-    let globFilters = [ "*.fs"; "*.fsi"; "*.fsx"; "*.fsproj"; "*.proj" ]
+    let globFilters = [ "*.fs"; "*.fsi"; "*.fsx"; "*.fsproj" ]
     let createWatcher () =
         let usePolling =
             // This is the same variable used by dotnet watch
@@ -284,8 +284,7 @@ type FsWatcher(delayMs: int) =
         observable
         |> Observable.choose (fun fullPath ->
             let fullPath = Path.normalizePath fullPath
-            // HACK: .proj files are ignored by the ProjectCracker but users expect Fable to react when changing them
-            if filePaths.Contains(fullPath) || fullPath.EndsWith(".proj")
+            if filePaths.Contains(fullPath)
             then Some fullPath
             else None)
         |> Observable.throttle delayMs
@@ -691,7 +690,7 @@ let private compilationCycle (state: State) (changes: ISet<string>) = async {
 
         | Some(projCracked, fableCompiler) ->
             // For performance reasons, don't crack .fsx scripts for every change
-            let fsprojChanged = changes |> Seq.exists (fun c -> c.EndsWith(".fsproj") || c.EndsWith(".proj"))
+            let fsprojChanged = changes |> Seq.exists (fun c -> c.EndsWith(".fsproj"))
 
             if fsprojChanged then
                 let oldProjCracked = projCracked

--- a/src/Fable.Cli/RELEASE_NOTES.md
+++ b/src/Fable.Cli/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+### 3.7.0-beta-014
+
+* Add --noParallel option to disable F#/Fable parallel compilation
+* Watch .proj files
+
 ### 3.7.0-beta-012
 
 * Disable uncurrying functions passed as arguments to local lambdas

--- a/src/Fable.Cli/RELEASE_NOTES.md
+++ b/src/Fable.Cli/RELEASE_NOTES.md
@@ -1,7 +1,6 @@
 ### 3.7.0-beta-014
 
 * Add --noParallel option to disable F#/Fable parallel compilation
-* Watch .proj files
 
 ### 3.7.0-beta-012
 

--- a/src/Fable.Cli/Util.fs
+++ b/src/Fable.Cli/Util.fs
@@ -24,6 +24,7 @@ type CliArgs =
       Configuration: string
       NoRestore: bool
       NoCache: bool
+      NoParallel: bool
       SourceMaps: bool
       SourceMapsRoot: string option
       Exclude: string option
@@ -143,7 +144,8 @@ module File =
     open System.IO
 
     let relPathToCurDir (path: string) =
-        Path.GetRelativePath(Directory.GetCurrentDirectory(), path)
+        if String.IsNullOrEmpty(path) then ""
+        else Path.GetRelativePath(Directory.GetCurrentDirectory(), path)
 
     let existsAndIsNewerThanSource (sourcePath: string) (targetPath: string) =
         try

--- a/src/Fable.Transforms/Global/Compiler.fs
+++ b/src/Fable.Transforms/Global/Compiler.fs
@@ -1,7 +1,7 @@
 namespace Fable
 
 module Literals =
-    let [<Literal>] VERSION = "3.7.0-beta-012"
+    let [<Literal>] VERSION = "3.7.0-beta-014"
 
 type CompilerOptionsHelper =
     static member DefaultExtension = ".fs.js"

--- a/src/Fable.Transforms/State.fs
+++ b/src/Fable.Transforms/State.fs
@@ -145,6 +145,14 @@ type Project(projFile: string,
             Map.add key file this.ImplementationFiles
         Project(this.ProjectFile, implFiles, this.Assemblies, this.PrecompiledInfo)
 
+    member this.Update(files: FSharpImplementationFileContents list) =
+        let implFiles =
+            (this.ImplementationFiles, files) ||> List.fold (fun implFiles file ->
+                let key = Path.normalizePathAndEnsureFsExtension file.FileName
+                let file = ImplFile.From(file)
+                Map.add key file implFiles)
+        Project(this.ProjectFile, implFiles, this.Assemblies, this.PrecompiledInfo)
+
     member _.TryGetInlineExpr(com: Compiler, memberUniqueName: string) =
         inlineExprsDic.TryValue(memberUniqueName)
         |> Option.map (fun e -> e.Calculate(com))

--- a/tests/Compiler/Util/Compiler.fs
+++ b/tests/Compiler/Util/Compiler.fs
@@ -49,6 +49,7 @@ module Compiler =
           SourceMapsRoot = None
           NoRestore = false
           NoCache = false
+          NoParallel = false
           Exclude = Some "Fable.Core"
           Replace = Map.empty
           RunProcess = None


### PR DESCRIPTION
In some big projects watch compilations can take more than 10 seconds. Because now there's more gap between each file compilation, Webpack triggers multiple times which can be annoying. This PR adds the `--noParallel` to have a "classic" compilation where FCS ends type checking all files before Fable kicks in. Note the name is a bit misleading because Fable compilation itself still keeps running in parallel, but I couldn't come up with something better.

~~There's also a fix to "watch" .proj files, as some projects use them. Though it's not ideal because .proj files are not included in the project references returned by the cracker so they remain invisible to Fable.~~