### PR TITLE
[Python] Fix delimiter issue

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -677,7 +677,7 @@ match BUILD_ARGS_LOWER with
     run "dotnet watch --project src/Fable.Cli run -- watch --cwd ../quicktest --exclude Fable.Core --noCache --runScript"
 | "quicktest-py"::_ ->
     buildPyLibraryIfNotExists()
-    run "dotnet watch --project src/Fable.Cli run -- watch --lang Python --delimiter #fsharp --cwd ../quicktest-py --noCache"
+    run "dotnet watch --project src/Fable.Cli run -- watch --lang Python --delimiter # fsharp --cwd ../quicktest-py --noCache"
 | "quicktest-dart"::_ ->
     run "dotnet watch --project src/Fable.Cli run -- watch --lang dart --cwd ../quicktest --exclude Fable.Core --noCache"
 | "run"::_ ->


### PR DESCRIPTION
There is an issue if you have the black formatter installed (you should) that it will automatically rewrite `#fsharp` to `# fsharp` since the style guide [PEP 8 states about comments](https://www.python.org/dev/peps/pep-0008/#inline-comments): "They should start with a # and a single space.". So black will rewrite the delimiter, and then you suddenly have a double set of delimiters in the file, both `#fsharp` and `# fsharp`, and then black will again rewrite `#fsharp` ...

PS: It looks a bit scary to have a space ` ` in the build command, but using quotes or `\ ` did not work so I suppose it's the correct way!?