### PR TITLE
[Dart] Imports

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -505,7 +505,7 @@ let testRust() =
     copyFile (projectDir </> "Cargo.toml") buildDir
     runInDir buildDir "cargo test"
 
-let testDart() =
+let testDart(isWatch) =
     let projectDir = "tests/Dart"
     let runDir = "tests/Dart/run"
 
@@ -513,6 +513,8 @@ let testDart() =
         "--exclude Fable.Core"
         "--lang Dart"
         "--noCache"
+        if isWatch then
+            "--watch"
     ]
     runInDir runDir "dart test main.dart"
 
@@ -671,7 +673,8 @@ match BUILD_ARGS_LOWER with
 | "test-integration"::_ -> testIntegration()
 | "test-py"::_ -> testPython()
 | "test-rust"::_ -> testRust()
-| "test-dart"::_ -> testDart()
+| "test-dart"::_ -> testDart(false)
+| "watch-test-dart"::_ -> testDart(true)
 | "quicktest"::_ ->
     buildLibraryIfNotExists()
     run "dotnet watch --project src/Fable.Cli run -- watch --cwd ../quicktest --exclude Fable.Core --noCache --runScript"

--- a/src/Fable.Cli/Util.fs
+++ b/src/Fable.Cli/Util.fs
@@ -143,15 +143,25 @@ module Log =
 module File =
     open System.IO
 
-    let changeFsExtension isInFableHiddenDir filePath fileExt =
+    let defaultFileExt usesOutDir (language: Fable.Language) =
         let fileExt =
-            // Prevent conflicts in package sources as they may include
-            // native files with same name as the F# .fs file
-            if fileExt <> Fable.CompilerOptionsHelper.DefaultExtension
-                && isInFableHiddenDir then
-                    Fable.CompilerOptionsHelper.DefaultExtension
+            match language with
+            | Fable.TypeScript -> ".ts"
+            | Fable.Python -> ".py"
+            | Fable.Php -> ".php"
+            | Fable.Dart -> ".dart"
+            | Fable.Rust -> ".rs"
+            | Fable.JavaScript -> ".js"
+        if usesOutDir then fileExt else ".fs" + fileExt
+
+    // Some Fable JS packages have native files with same name as the F# file
+    // so we need to use the default extension .fs.js to prevent conflicts.
+    // We should avoid this practice for other languages (Rust, Python...).
+    let changeExtensionButUseDefaultExtensionInFableModules lang isInFableModules filePath fileExt =
+        let fileExt =
+            if isInFableModules then defaultFileExt false lang
             else fileExt
-        Fable.Path.replaceExtension fileExt filePath
+        Fable.Path.ChangeExtension(filePath, fileExt)
 
     let relPathToCurDir (path: string) =
         Path.GetRelativePath(Directory.GetCurrentDirectory(), path)

--- a/src/Fable.Transforms/Dart/Dart.fs
+++ b/src/Fable.Transforms/Dart/Dart.fs
@@ -8,6 +8,10 @@ type Type =
     | Boolean
     | String
 
+    | Object
+    | Dynamic
+    | Void
+
     | Generic of name: string
     | TypeReference of ref: Expression
 
@@ -20,11 +24,15 @@ type Literal =
     | DoubleLiteral of value: double
     | BooleanLiteral of value: bool
     | StringLiteral of value: string
+    | NullLiteral
 
 and Expression =
     | Literal of Literal
+    // Dart AST includes simple and prefixed identifiers: https://pub.dev/documentation/analyzer/latest/dart_ast_ast/Identifier-class.html
     | IdentExpression of Ident
-    | BinaryExpression of operator: BinaryOperator * left: Expression * right: Expression
+    | PropertyAccess of Expression * string
+    | InvocationExpression of Expression * genArgs: Type list * args: Expression list
+    | BinaryExpression of operator: BinaryOperator * left: Expression * right: Expression * isInt: bool
     | AnonymousFunction of args: Ident list * body: Choice<Statement list, Expression> * genericParams: string list //* returnType: Type
     | Assignment of target: Expression * value: Expression
 

--- a/src/Fable.Transforms/Global/Compiler.fs
+++ b/src/Fable.Transforms/Global/Compiler.fs
@@ -4,7 +4,6 @@ module Literals =
     let [<Literal>] VERSION = "4.0.0"
 
 type CompilerOptionsHelper =
-    static member DefaultExtension = ".fs.js"
     static member Make(?language,
                        ?typedArrays,
                        ?define,
@@ -18,10 +17,10 @@ type CompilerOptionsHelper =
             CompilerOptions.Define = defaultArg define []
             DebugMode = defaultArg debugMode true
             Language = defaultArg language JavaScript
+            FileExtension = defaultArg fileExtension ".fs.js"
             TypedArrays = defaultArg typedArrays true
             OptimizeFSharpAst = defaultArg optimizeFSharpAst false
             Verbosity = defaultArg verbosity Verbosity.Normal
-            FileExtension = defaultArg fileExtension CompilerOptionsHelper.DefaultExtension
             ClampByteArrays = defaultArg clampByteArrays false
             NoReflection = defaultArg noReflection false
             TriggeredByDependency = false
@@ -128,7 +127,7 @@ module CompilerExt =
                 member _.LogWarning(msg, r) = com.AddLog(msg, Severity.Warning, ?range=r, fileName=com.CurrentFile)
                 member _.LogError(msg, r) = com.AddLog(msg, Severity.Error, ?range=r, fileName=com.CurrentFile)
                 member _.GetOutputPath() =
-                    let file = Path.replaceExtension com.Options.FileExtension com.CurrentFile
+                    let file = Path.ChangeExtension(com.CurrentFile, com.Options.FileExtension)
                     match com.OutputDir with
                     | None -> file
                     | Some outDir ->

--- a/src/Fable.Transforms/Global/Prelude.fs
+++ b/src/Fable.Transforms/Global/Prelude.fs
@@ -545,11 +545,6 @@ module Path =
     let normalizePathAndEnsureFsExtension (path: string) =
         normalizePath path |> ensureFsExtension
 
-    let replaceExtension (newExt: string) (path: string) =
-        let i = path.LastIndexOf(".")
-        if i > 0 then path.Substring(0, i) + newExt
-        else path + newExt
-
     /// Checks if path starts with "./", ".\" or ".."
     let isRelativePath (path: string) =
         let len = path.Length

--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -1062,14 +1062,7 @@ let fableCoreLib (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Exp
         | Value (StringConstant path, r) when path.EndsWith(".fs") ->
             // In imports *.ts extensions have to be converted to *.py extensions instead
             let fileExt = com.Options.FileExtension
-
-            let fileExt =
-                if fileExt.EndsWith(".ts") then
-                    Path.replaceExtension ".py" fileExt
-                else
-                    fileExt
-
-            Value(StringConstant(Path.replaceExtension fileExt path), r)
+            Value(StringConstant(Path.ChangeExtension(path, fileExt)), r)
         | path -> path
 
     match i.DeclaringEntityFullName, i.CompiledName with

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -842,8 +842,8 @@ let fableCoreLib (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Exp
         | Value(StringConstant path, r) when path.EndsWith(".fs") ->
             // In imports *.ts extensions have to be converted to *.js extensions instead
             let fileExt = com.Options.FileExtension
-            let fileExt = if fileExt.EndsWith(".ts") then Path.replaceExtension ".js" fileExt else fileExt
-            Value(StringConstant(Path.replaceExtension fileExt path), r)
+            let fileExt = if fileExt.EndsWith(".ts") then Path.ChangeExtension(".js", fileExt) else fileExt
+            Value(StringConstant(Path.ChangeExtension(path, fileExt)), r)
         | path -> path
 
     match i.DeclaringEntityFullName, i.CompiledName with

--- a/src/Fable.Transforms/Rust/Replacements.fs
+++ b/src/Fable.Transforms/Rust/Replacements.fs
@@ -837,8 +837,8 @@ let fableCoreLib (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Exp
         | Value(StringConstant path, r) when path.EndsWith(".fs") ->
             // In imports *.ts extensions have to be converted to *.js extensions instead
             let fileExt = com.Options.FileExtension
-            let fileExt = if fileExt.EndsWith(".ts") then Path.replaceExtension ".js" fileExt else fileExt
-            Value(StringConstant(Path.replaceExtension fileExt path), r)
+            let fileExt = if fileExt.EndsWith(".ts") then Path.ChangeExtension(".js", fileExt) else fileExt
+            Value(StringConstant(Path.ChangeExtension(path, fileExt)), r)
         | path -> path
 
     match i.DeclaringEntityFullName, i.CompiledName with

--- a/tests/Dart/.gitignore
+++ b/tests/Dart/.gitignore
@@ -1,1 +1,1 @@
-*Tests.dart
+*.fs.dart

--- a/tests/Dart/ArithmeticTests.fs
+++ b/tests/Dart/ArithmeticTests.fs
@@ -1,3 +1,38 @@
 module Fable.Tests.Dart.Arithmetic
 
-let addPlus2 x y = x + y + 2
+open Util
+
+let tests () =
+    testCase "Infix add can be generated" <| fun () ->
+        4 + 2 |> equal 6
+
+    // testCase "Int32 literal addition is optimized" <| fun () ->
+    //     aLiteral + 7 |> equal 12
+    //     notALiteral + 7 |> equal 12
+
+    // testCase "Unary negation with negative literal values works" <| fun () ->
+    //     -literalNegativeValue |> equal 345
+
+    // testCase "Unary negation with integer MinValue works" <| fun () ->
+    //     -(-128y) |> equal System.SByte.MinValue
+    //     -(-32768s) |> equal System.Int16.MinValue
+    //     -(-2147483648) |> equal System.Int32.MinValue
+    //     -(-9223372036854775808L) |> equal System.Int64.MinValue
+
+    testCase "Infix subtract can be generated" <| fun () ->
+        4 - 2 |> equal 2
+
+    testCase "Infix multiply can be generated" <| fun () ->
+        4 * 2 |> equal 8
+
+    // testCase "Infix divide can be generated" <| fun () ->
+    //     4 / 2 |> equal 2
+
+    // testCase "Integer division doesn't produce floats" <| fun () ->
+    //     5. / 2. |> equal 2.5
+    //     5 / 2 |> equal 2
+    //     5 / 3 |> equal 1
+    //     // float 5 / 2. |> equal 2.5 // TODO: Number conversion
+
+    testCase "Infix modulo can be generated" <| fun () ->
+        4 % 3 |> equal 1

--- a/tests/Dart/Fable.Tests.Dart.fsproj
+++ b/tests/Dart/Fable.Tests.Dart.fsproj
@@ -2,10 +2,11 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
-  <!-- <ItemGroup>
-    <ProjectReference Include="../../src/Fable.Core/Fable.Core.fsproj" />
-  </ItemGroup> -->
   <ItemGroup>
+    <ProjectReference Include="../../src/Fable.Core/Fable.Core.fsproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Tests.Util.fs" />
     <Compile Include="ArithmeticTests.fs" />
   </ItemGroup>
 </Project>

--- a/tests/Dart/Tests.Util.fs
+++ b/tests/Dart/Tests.Util.fs
@@ -1,0 +1,15 @@
+module Fable.Tests.Dart.Util
+
+open Fable.Core
+
+type Assertion<'T> =
+    interface end
+
+[<ImportAll("package:test/test.dart")>]
+type Test =
+    static member test(msg: string, f: unit -> unit): unit = nativeOnly
+    static member expect(actual: 'T, assertion: Assertion<'T>): unit = nativeOnly
+    static member equals(value: 'T): Assertion<'T> = nativeOnly
+
+let testCase msg f = Test.test(msg, f)
+let equal expected actual = Test.expect(actual, Test.equals(expected))

--- a/tests/Dart/run/main.dart
+++ b/tests/Dart/run/main.dart
@@ -1,9 +1,5 @@
-import 'package:test/test.dart';
-import '../ArithmeticTests.dart' as Arithmetic;
+import '../ArithmeticTests.fs.dart' as Arithmetic;
 
 void main() {
-  test('+ operator works', () {
-    var actual = Arithmetic.addPlus2(3,4);
-    expect(actual, equals(9));
-  });
+  Arithmetic.tests();
 }


### PR DESCRIPTION
First support for imports in Dart and add a few more binary expression tests.

@dbrattli @ncave In this PR I'm also trying to unify the code to decide the extension of the generated files based on the language. I realized we had two methods to change extensions, the `ChangeExtension` polyfill and `replaceExtension` with slightly different behavior so I've removed the latter for simplicity. I've also made more explicit (`changeExtensionButUseDefaultExtensionInFableModules`) a mild hack I added when transitioning to Fable 3: files compiled within `fable_modules` would always use `.fs.js` extension, because in some packages they can conflict with native .js files. I've restricted the hack now to JS as we should avoid this practice in other languages and always use different names for the files regardless of the extension.