### PR TITLE
[Beyond] Building standalone in beyond

### DIFF
--- a/src/fable-standalone/src/Worker/Worker.fsproj
+++ b/src/fable-standalone/src/Worker/Worker.fsproj
@@ -11,7 +11,7 @@
     <Content Include="util.js" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Fable.Core" Version="3.1.6" />
-    <PackageReference Include="Thoth.Json" Version="4.0.0" />
+    <PackageReference Include="Fable.Core.Experimental" Version="4.0.0-alpha-030" />
+    <PackageReference Include="Thoth.Json" Version="7.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I was looking at what it would take to compile the Fable compiler to Python by looking at fable-compiler-js and Fable.Standalone. In order to have `dotnet fsi build.fsx standalone` work I had to make these fixes to handle the removal of `ITypeResolver` and also have a 4.0.0 version of Fable.Core with e.g `nativeOnly` defined. So this means that the worker cannot be part of the current CI. What is the btw role of the worker? I guess I just need to build `dotnet fsi build.fsx compiler-js` instead and look at making e.g `fable-compiler-py`?