### PR TITLE
[Python] Ignore base call for DecoratorAttribute

### DIFF
--- a/src/Fable.Core/Fable.Core.PY.fs
+++ b/src/Fable.Core/Fable.Core.PY.fs
@@ -5,7 +5,8 @@ namespace Fable.Core
 open System
 
 module PY =
-    type [<AllowNullLiteral>] Function =
+    [<Import("typing", "Callable")>]
+    type [<AllowNullLiteral>] Callable =
         [<Emit "$0.__name__)">] abstract name: string
         [<Emit "$0$1...">] abstract Invoke: [<ParamArray>] args: obj[] -> obj
         [<Emit "$0">] abstract Instance: obj
@@ -13,16 +14,16 @@ module PY =
     [<AbstractClass>]
     type DecoratorAttribute() =
         inherit Attribute()
-        abstract Decorate: fn: Function -> Function
+        abstract Decorate: fn: Callable -> Callable
 
     [<AbstractClass>]
     type ReflectedDecoratorAttribute() =
         inherit Attribute()
-        abstract Decorate: fn: Function * info: Reflection.MethodInfo -> Function
+        abstract Decorate: fn: Callable * info: Reflection.MethodInfo -> Callable
 
-    // Hack because currently Fable doesn't keep information about spread for anonymous function
+    // Hack because currently Fable doesn't keep information about spread for anonymous functions
     [<Emit("lambda *args: $0(args)")>]
-    let argsFunc (fn: obj[] -> obj): Function = nativeOnly
+    let argsFunc (fn: obj[] -> obj): Callable = nativeOnly
 
     type [<AllowNullLiteral>] ArrayConstructor =
         [<Emit "$0([None]*$1...)">]

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -1833,9 +1833,15 @@ module Util =
             Some(baseExpr, (expr, keywords, stmts @ stmts'))
         | Some (Fable.ObjectExpr ([], Fable.Unit, None)), _ ->
             let range = baseCall |> Option.bind (fun x -> x.Range)
-            let name = baseType |> Option.map (fun t -> t.Entity.FullName) |> Option.defaultValue "unknown type"
+
+            let name =
+                baseType
+                |> Option.map (fun t -> t.Entity.FullName)
+                |> Option.defaultValue "unknown type"
+
             sprintf "Ignoring base call for %s" name
             |> addWarning com [] range
+
             None
         | Some (Fable.Value _), Some baseType ->
             // let baseEnt = com.GetEntity(baseType.Entity)

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -1831,6 +1831,12 @@ module Util =
             let expr, keywords, stmts' = transformCallArgs com ctx None (CallInfo info)
 
             Some(baseExpr, (expr, keywords, stmts @ stmts'))
+        | Some (Fable.ObjectExpr ([], Fable.Unit, None)), _ ->
+            let range = baseCall |> Option.bind (fun x -> x.Range)
+            let name = baseType |> Option.map (fun t -> t.Entity.FullName) |> Option.defaultValue "unknown type"
+            sprintf "Ignoring base call for %s" name
+            |> addWarning com [] range
+            None
         | Some (Fable.Value _), Some baseType ->
             // let baseEnt = com.GetEntity(baseType.Entity)
             // let entityName = FSharp2Fable.Helpers.getEntityDeclarationName com baseType.Entity

--- a/src/fable-library-py/fable_library/int32.py
+++ b/src/fable-library-py/fable_library/int32.py
@@ -16,7 +16,9 @@ def get_range(unsigned: bool, bitsize: int) -> Tuple[int, int]:
 AllowHexSpecifier = 0x00000200
 
 
-def parse(string: str, style, unsigned, bitsize, radix: int = 10) -> int:
+def parse(
+    string: str, style: int, unsigned: bool, bitsize: int, radix: int = 10
+) -> int:
     # const res = isValid(str, style, radix);
     if style & AllowHexSpecifier or string.startswith("0x"):
         radix = 16
@@ -53,13 +55,13 @@ def try_parse(
         return False
 
 
-def op_unary_negation_int8(x):
+def op_unary_negation_int8(x: int) -> int:
     return x if x == -128 else -x
 
 
-def op_unary_negation_int16(x):
+def op_unary_negation_int16(x: int) -> int:
     return x if x == -32768 else -x
 
 
-def op_unary_negation_int32(x):
+def op_unary_negation_int32(x: int) -> int:
     return x if x == -2147483648 else -x

--- a/src/fable-library-py/fable_library/time_span.py
+++ b/src/fable-library-py/fable_library/time_span.py
@@ -31,3 +31,12 @@ def create(
     return timedelta(
         days=d, hours=h or 0, minutes=m or 0, seconds=s or 0, milliseconds=ms or 0
     )
+
+
+__all__ = [
+    "create",
+    "to_milliseconds",
+    "from_ticks",
+    "from_milliseconds",
+    "total_seconds",
+]

--- a/src/fable-library-py/requirements.txt
+++ b/src/fable-library-py/requirements.txt
@@ -1,4 +1,2 @@
-expression
 pytest
-pytest-cov
-pytest-asyncio
+pytest-xdist


### PR DESCRIPTION
- Ignore base call for now to not error the compile (related to type annotations?)
- Rename Function to Callable (TODO: why does import not work here?)