### PR TITLE
Fix off-by-one for array allocation in Array.windowed

### DIFF
--- a/src/fable-library/Array.fs
+++ b/src/fable-library/Array.fs
@@ -791,7 +791,7 @@ let averageBy (projection: 'T -> 'T2) (array: 'T[]) ([<Inject>] averager: IGener
 let windowed (windowSize: int) (source: 'T[]): 'T[][] =
     if windowSize <= 0 then
         failwith "windowSize must be positive"
-    let res = FSharp.Core.Operators.max 0 (source.Length - windowSize) |> allocateArray
+    let res = FSharp.Core.Operators.max 0 (source.Length - windowSize + 1) |> allocateArray
     for i = windowSize to source.Length do
         res.[i - windowSize] <- source.[i-windowSize..i-1]
     res

--- a/tests/Python/TestArray.fs
+++ b/tests/Python/TestArray.fs
@@ -953,3 +953,11 @@ let ``test Array.groupBy returns valid array`` () =
     let worked = actualKey && actualGroup.[0] = 1 && actualGroup.[1] = 2
     worked |> equal true
 *)
+
+[<Fact>]
+let ``Array.windowed works`` () = // See #1716
+    let nums = [| 1.0; 1.5; 2.0; 1.5; 1.0; 1.5 |]
+    Array.windowed 3 nums |> equal [|[|1.0; 1.5; 2.0|]; [|1.5; 2.0; 1.5|]; [|2.0; 1.5; 1.0|]; [|1.5; 1.0; 1.5|]|]
+    Array.windowed 5 nums |> equal [|[| 1.0; 1.5; 2.0; 1.5; 1.0 |]; [| 1.5; 2.0; 1.5; 1.0; 1.5 |]|]
+    Array.windowed 6 nums |> equal [|[| 1.0; 1.5; 2.0; 1.5; 1.0; 1.5 |]|]
+    Array.windowed 7 nums |> Array.isEmpty |> equal true


### PR DESCRIPTION
The array allocated in `Array.windowed` is not large enough for the generated windows (off-by-one). @alfonsogarciacaro This should probably be back-ported to main, but JavaScript is immune to the error so not critical.

Fixes #2815