### PR TITLE
Add StringTemplate to Fable AST

### DIFF
--- a/src/Fable.AST/Fable.fs
+++ b/src/Fable.AST/Fable.fs
@@ -259,6 +259,9 @@ type ValueKind =
     | BoolConstant of value: bool
     | CharConstant of value: char
     | StringConstant of value: string
+    /// String interpolation with support for JS tagged templates
+    /// String parts length should always be values.Length + 1
+    | StringTemplate of tag: Expr option * parts: string list * values: Expr list
     | NumberConstant of value: obj * kind: NumberKind * info: NumberInfo
     | RegexConstant of source: string * flags: RegexFlag list
     | NewOption of value: Expr option * typ: Type * isStruct: bool
@@ -278,7 +281,7 @@ type ValueKind =
         | UnitConstant -> Unit
         | BoolConstant _ -> Boolean
         | CharConstant _ -> Char
-        | StringConstant _ -> String
+        | StringConstant _ | StringTemplate _ -> String
         | NumberConstant (_, kind, info) -> Number(kind, info)
         | RegexConstant _ -> Regex
         | NewOption (_, t, isStruct) -> Option(t, isStruct)

--- a/src/Fable.Transforms/BabelPrinter.fs
+++ b/src/Fable.Transforms/BabelPrinter.fs
@@ -323,7 +323,19 @@ module PrinterExtensions =
             | Literal.StringLiteral(l) -> printer.Print(l)
             | BooleanLiteral(value, loc) -> printer.Print((if value then "true" else "false"), ?loc=loc)
             | NumericLiteral(value, loc) -> printer.PrintNumeric(value, loc)
-            | Literal.DirectiveLiteral(l) -> failwith "not implemented"
+            | Literal.DirectiveLiteral(l) -> failwith "Not implement: Directive literal"
+            | StringTemplate(tag, parts, values, loc) ->
+                let escape str = Regex.Replace(str, @"(?<!\\)\\", @"\\").Replace("`", @"\`")
+                printer.AddLocation(loc)
+                printer.PrintOptional(tag)
+                printer.Print("`")
+                for i = 0 to parts.Length - 2 do
+                    printer.Print(escape parts.[i])
+                    printer.Print("${")
+                    printer.Print(values.[i])
+                    printer.Print("}")
+                printer.Print(Array.last parts |> escape)
+                printer.Print("`")
 
         member printer.Print(stmt: Statement) =
             match stmt with

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -942,6 +942,10 @@ module Util =
         | Fable.BoolConstant x -> Expression.booleanLiteral(x, ?loc=r)
         | Fable.CharConstant x -> Expression.stringLiteral(string x, ?loc=r)
         | Fable.StringConstant x -> Expression.stringLiteral(x, ?loc=r)
+        | Fable.StringTemplate(tag, parts, values) ->
+            let tag = tag |> Option.map (fun e -> com.TransformAsExpr(ctx, e))
+            let values = values |> List.mapToArray (fun e -> com.TransformAsExpr(ctx, e))
+            StringTemplate(tag, List.toArray parts, values, r) |> Literal
         | Fable.NumberConstant (x, kind, _) ->
             match kind, x with
             | Decimal, (:? decimal as x) -> JS.Replacements.makeDecimal com r value.Type x |> transformAsExpr com ctx

--- a/src/Fable.Transforms/FableTransforms.fs
+++ b/src/Fable.Transforms/FableTransforms.fs
@@ -20,6 +20,7 @@ let getSubExpressions = function
         | TypeInfo _ | Null _ | UnitConstant
         | BoolConstant _ | CharConstant _ | StringConstant _
         | NumberConstant _ | RegexConstant _ -> []
+        | StringTemplate(_,_,exprs) -> exprs
         | NewOption(e, _, _) -> Option.toList e
         | NewTuple(exprs, _) -> exprs
         | NewArray(exprs, _) -> exprs
@@ -214,6 +215,7 @@ let noSideEffectBeforeIdent identName expr =
             | NewArrayFrom(e,_)
             | NewOption(Some e,_,_) -> findIdentOrSideEffect e
             | NewList(Some(h,t),_) -> findIdentOrSideEffect h || findIdentOrSideEffect t
+            | StringTemplate(_,_,exprs)
             | NewArray(exprs,_)
             | NewTuple(exprs,_)
             | NewUnion(exprs,_,_,_)

--- a/src/Fable.Transforms/Global/Babel.fs
+++ b/src/Fable.Transforms/Global/Babel.fs
@@ -109,6 +109,7 @@ type Pattern =
 
 type Literal =
     | StringLiteral of StringLiteral
+    | StringTemplate of tag: Expression option * parts: string array * values: Expression array * loc: SourceLocation option
     | DirectiveLiteral of DirectiveLiteral
     | NullLiteral of loc: SourceLocation option
     | BooleanLiteral of value: bool * loc: SourceLocation option

--- a/src/Fable.Transforms/Php/Fable2Php.fs
+++ b/src/Fable.Transforms/Php/Fable2Php.fs
@@ -985,6 +985,9 @@ and convertValue (com: IPhpCompiler)  (value: Fable.ValueKind) range =
         | _ ->
             addError com [] range $"Numeric literal is not supported: {x.GetType().FullName}"
             PhpConst(PhpConstNull)
+    | Fable.StringTemplate _ ->
+        addError com [] range $"String templates are not supported"
+        PhpConst(PhpConstNull)
     | Fable.StringConstant(s) ->
         PhpConst(PhpConstString s)
     | Fable.BoolConstant(b) ->

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -1019,25 +1019,6 @@ let getPrecompiledLibMangledName entityName memberName overloadSuffix isStatic =
         | _, false -> entityName, Naming.InstanceMemberPart(memberName, overloadSuffix)
     Naming.buildNameWithoutSanitation name memberPart |> Naming.checkJsKeywords
 
-let printJsTaggedTemplate (str: string) (holes: {| Index: int; Length: int |}[]) (printHoleContent: int -> string) =
-    // Escape ` quotations for JS. Note F# escapes for {, } and % are already replaced by the compiler
-    // TODO: Do we need to escape other sequences? See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates_and_escape_sequences
-    let escape (str: string) =
-        Regex.Replace(str, @"(?<!\\)\\", @"\\").Replace("`", @"\`") //.Replace("{{", "{").Replace("}}", "}").Replace("%%", "%")
-
-    let sb = System.Text.StringBuilder("`")
-    let mutable prevIndex = 0
-
-    for i = 0 to holes.Length - 1 do
-        let m = holes.[i]
-        let strPart = str.Substring(prevIndex, m.Index - prevIndex) |> escape
-        sb.Append(strPart + "${" + (printHoleContent i) + "}") |> ignore
-        prevIndex <- m.Index + m.Length
-
-    sb.Append(str.Substring(prevIndex) |> escape) |> ignore
-    sb.Append("`") |> ignore
-    sb.ToString()
-
 let fsFormat (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr option) (args: Expr list) =
     match i.CompiledName, thisArg, args with
     | "get_Value", Some callee, _ ->
@@ -1070,34 +1051,8 @@ let fsFormat (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr op
     |  "PrintFormatToStringBuilderThen"  // Printf.kbprintf
        ), _, _ -> fsharpModule com ctx r t i thisArg args
     | ".ctor", _, str::(Value(NewArray(templateArgs, _), _) as values)::_ ->
-        // Optimization: try to convert f# interpolated string to JS template
-        // for better performance
-        let template =
-            match str with
-            | StringConst str ->
-                // In the case of interpolated strings, the F# compiler doesn't resolve escaped %
-                // (though it does resolve double braces {{ }})
-                let str = str.Replace("%%" , "%")
-                (Some [], Regex.Matches(str, @"((?<!%)%(?:[0+\- ]*)(?:\d+)?(?:\.\d+)?\w)?%P\(\)") |> Seq.cast<Match>)
-                ||> Seq.fold (fun acc m ->
-                    match acc with
-                    | None -> None
-                    | Some acc ->
-                        let doesNotNeedFormat =
-                            not m.Groups.[1].Success
-                            || m.Groups.[1].Value = "%s"
-                            || m.Groups.[1].Value = "%i"
-                        if doesNotNeedFormat then
-                            {| Index = m.Index; Length = m.Length |}::acc |> Some
-                        else None)
-                |> Option.map (fun holes -> str, List.toArray holes |> Array.rev)
-            | _ -> None
-
-        match template with
-        | Some(str, holes) ->
-            printJsTaggedTemplate str holes (fun i -> $"${i}")
-            |> emitExpr r String templateArgs |> Some // Use String type so we can remove `toText` wrapper
-        // TODO: We could still use a JS template for formatting to increase performance?
+        match makeStringTemplateFrom [|"%s"; "%i"|] templateArgs str with
+        | Some v -> makeValue r v |> Some
         | None -> Helper.LibCall(com, "String", "interpolate", t, [str; values], i.SignatureArgTypes, ?loc=r) |> Some
     | ".ctor", _, arg::_ ->
         Helper.LibCall(com, "String", "printf", t, [arg], i.SignatureArgTypes, ?loc=r) |> Some
@@ -1474,22 +1429,20 @@ let formattableString (com: ICompiler) (_ctx: Context) r (t: Type) (i: CallInfo)
     | "Create", None, [StringConst str; Value(NewArray(args, _),_)] ->
         let matches = Regex.Matches(str, @"\{\d+(.*?)\}") |> Seq.cast<Match> |> Seq.toArray
         let hasFormat = matches |> Array.exists (fun m -> m.Groups.[1].Value.Length > 0)
-        let callMacro, args, offset =
+        let tag =
             if not hasFormat then
-                let fnArg = Helper.LibValue(com, "String", "fmt", t)
-                "$0", fnArg::args, 1
+                Helper.LibValue(com, "String", "fmt", Any) |> Some
             else
-                let fnArg = Helper.LibValue(com, "String", "fmtWith", t)
                 let fmtArg =
                     matches
                     |> Array.map (fun m -> makeStrConst m.Groups.[1].Value)
                     |> Array.toList
                     |> makeArray String
-                "$0($1)", fnArg::fmtArg::args, 2
-        let jsTaggedTemplate =
-            let holes = matches |> Array.map (fun m -> {| Index = m.Index; Length = m.Length |})
-            printJsTaggedTemplate str holes (fun i -> "$" + string(i + offset))
-        emitExpr r t args (callMacro + jsTaggedTemplate) |> Some
+                Helper.LibCall(com, "String", "fmtWith", Any, [fmtArg]) |> Some
+        let holes = matches |> Array.map (fun m -> {| Index = m.Index; Length = m.Length |})
+        let template = makeStringTemplate tag str holes args |> makeValue r
+        // Use a type cast to keep the FormattableString type
+        TypeCast(template, t) |> Some
     | "get_Format", Some x, _ -> Helper.LibCall(com, "String", "getFormat", t, [x], ?loc=r) |> Some
     | "get_ArgumentCount", Some x, _ -> getAttachedMemberWith r t (getAttachedMember x "args") "length" |> Some
     | "GetArgument", Some x, [idx] -> getExpr r t (getAttachedMember x "args") idx |> Some

--- a/src/Fable.Transforms/Rust/Fable2Rust.fs
+++ b/src/Fable.Transforms/Rust/Fable2Rust.fs
@@ -1500,6 +1500,7 @@ module Util =
         | Fable.BoolConstant b -> mkBoolLitExpr b //, ?loc=r)
         | Fable.CharConstant c -> mkCharLitExpr c //, ?loc=r)
         | Fable.StringConstant s -> mkStrLitExpr s |> makeString com ctx
+        | Fable.StringTemplate _ -> failwith "TODO: String templates are not supported"
         | Fable.NumberConstant (x, kind, _) -> makeNumber com ctx r value.Type kind x
         | Fable.RegexConstant (source, flags) ->
             // Expression.regExpLiteral(source, flags, ?loc=r)

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -371,8 +371,9 @@ module AST =
             | NewList(None,_) | NewOption(None,_,_) -> false
             | NewOption(Some e,_,_) -> canHaveSideEffects e
             | NewList(Some(h,t),_) -> canHaveSideEffects h || canHaveSideEffects t
+            | StringTemplate(_,_,exprs)
             | NewTuple(exprs,_)
-            | NewUnion(exprs,_,_,_) -> (false, exprs) ||> List.fold (fun result e -> result || canHaveSideEffects e)
+            | NewUnion(exprs,_,_,_) -> List.exists canHaveSideEffects exprs
             // Arrays can be mutable
             | NewArray _ | NewArrayFrom _ -> true
             | NewRecord _ | NewAnonymousRecord _ -> true
@@ -767,6 +768,7 @@ module AST =
             | TypeInfo _ | Null _ | UnitConstant
             | BoolConstant _ | CharConstant _ | StringConstant _
             | NumberConstant _ | RegexConstant _ -> e
+            | StringTemplate(tag, parts, exprs) -> StringTemplate(tag, parts, List.map f exprs) |> makeValue r
             | NewOption(e, t, isStruct) -> NewOption(Option.map f e, t, isStruct) |> makeValue r
             | NewTuple(exprs, isStruct) -> NewTuple(List.map f exprs, isStruct) |> makeValue r
             | NewArray(exprs, t) -> NewArray(List.map f exprs, t) |> makeValue r


### PR DESCRIPTION
This PR adds `StringTemplate` in the AST so we can have "formal" representation of string interpolation, as it's already present in most languages, instead of masking it with `Emit`. This is the last change I wanted to do in the AST for now so if we don't find anything else in the upcoming weeks we can start to consider it stable enough for a beta release and plugin updates. Some notes:

- The StringTemplate has an optional tag field to represent [JS tagged templates](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates) though this may not be needed in other languages.
- Likewise, I'm also using string templates to represent [F# formattable string](https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/interpolated-strings#interpolated-strings-and-formattablestring-formatting) in JS. This was mainly needed for Fable.Lit as lit caches the templates in a WeakMap which doesn't work with strings. But in other languages maybe you cannot use the interpolated string as FormattableString should give access to the argument array and the formatted template in runtime.
- For now, I'm just failing in other languages when trying to convert the StringTemplate. Please check out the code in this PR to see how it's done in JS Replacements for reference if you want to implement it in Rust/Python @ncave @dbrattli 