### PR TITLE
Type.IsInstanceOfType works for types decorated with Global/Import

### DIFF
--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -132,6 +132,16 @@ module Reflection =
                 if not(Array.isEmpty generics) then
                     Expression.arrayExpression(generics)
             |]
+        let genericGlobalOrImportedEntity generics (ent: Fable.Entity) =
+            libReflectionCall com ctx None "class" [|
+                yield Expression.stringLiteral(ent.FullName)
+                match generics with
+                | [||] -> yield Util.undefined None
+                | generics -> yield Expression.arrayExpression(generics)
+                match tryJsConstructor com ctx ent with
+                | Some cons -> yield cons
+                | None -> ()
+            |]
         match t with
         | Fable.Any -> primitiveTypeInfo "obj"
         | Fable.GenericParam name ->
@@ -228,9 +238,10 @@ module Reflection =
                 let generics = generics |> List.map (transformTypeInfo com ctx r genMap) |> List.toArray
                 // Check if the entity is actually declared in JS code
                 // TODO: Interfaces should be declared when generating Typescript
-                if ent.IsInterface
+                if FSharp2Fable.Util.isGlobalOrImportedEntity ent then
+                    genericGlobalOrImportedEntity generics ent
+                elif ent.IsInterface
                     || FSharp2Fable.Util.isErasedOrStringEnumEntity ent
-                    || FSharp2Fable.Util.isGlobalOrImportedEntity ent
                     || FSharp2Fable.Util.isReplacementCandidate ent then
                     genericEntity ent.FullName generics
                 // TODO: Strictly measure types shouldn't appear in the runtime, but we support it for now

--- a/tests/Main/JsInteropTests.fs
+++ b/tests/Main/JsInteropTests.fs
@@ -315,6 +315,11 @@ let tests =
             ar.length |> equal 4
         | _ -> failwith "Not an array"
 
+    testCase "IsInstanceOfType works with interfaces decorated with Global" <| fun () ->
+        let ar = ResizeArray [| 1; 2; 3 |] |> box
+        typeof<JsArray>.IsInstanceOfType(ar) |> equal true
+        typeof<JsArray>.IsInstanceOfType("foo") |> equal false
+
     testCase "Decorators work" <| fun () ->
         myComplexAdder 3 4 |> equal 7
         myComplexAdder 6 7 |> equal 13


### PR DESCRIPTION
Same idea as #2631, but extends it to work with `Type.IsInstanceOfType` as well. As a side effect, `Activator.CreateInstance` should also work with imported/global types now, but I haven't tested that.