### PR TITLE
Add NoReflectionAttribute

### DIFF
--- a/src/Fable.Core/Fable.Core.Types.fs
+++ b/src/Fable.Core/Fable.Core.Types.fs
@@ -30,6 +30,9 @@ type EraseAttribute() =
     inherit Attribute()
     new (caseRules: CaseRules) = EraseAttribute()
 
+type NoReflectionAttribute() =
+    inherit Attribute()
+
 /// Used for "tagged" union types, which is commonly used in TypeScript.
 type TypeScriptTaggedUnionAttribute(tagName: string, caseRules: CaseRules) =
     inherit Attribute()

--- a/src/Fable.Core/Fable.Core.Types.fs
+++ b/src/Fable.Core/Fable.Core.Types.fs
@@ -30,6 +30,10 @@ type EraseAttribute() =
     inherit Attribute()
     new (caseRules: CaseRules) = EraseAttribute()
 
+/// Used on unions or records to disable emitting code required to support reflection.
+/// Reflection of unions or records that reference a type with this attribute may cause runtime errors.
+/// Unions also reuse the same base class instead of having a specialized class for each.
+[<AttributeUsage(AttributeTargets.Class)>]
 type NoReflectionAttribute() =
     inherit Attribute()
 

--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -1528,6 +1528,9 @@ module Util =
             | Atts.erase | Atts.stringEnum | Atts.tsTaggedUnion -> true
             | _ -> false)
 
+    let isNoReflectionEntity (ent: Fable.Entity) =
+        ent.Attributes |> Seq.exists (fun att -> att.Entity.FullName = Atts.noReflection)
+
     let isGlobalOrImportedEntity (ent: Fable.Entity) =
         ent.Attributes |> Seq.exists (fun att ->
             match att.Entity.FullName with

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -29,6 +29,7 @@ module Atts =
     let [<Literal>] paramObject = "Fable.Core.ParamObjectAttribute"// typeof<Fable.Core.ParamObjectAttribute>.FullName
     let [<Literal>] decorator = "Fable.Core.JS.DecoratorAttribute" // typeof<Fable.Core.JS.DecoratorAttribute>.FullName
     let [<Literal>] reflectedDecorator = "Fable.Core.JS.ReflectedDecoratorAttribute" // typeof<Fable.Core.JS.ReflectedDecoratorAttribute>.FullName
+    let [<Literal>] noReflection = "Fable.Core.NoReflectionAttribute"
 
 [<RequireQualifiedAccess>]
 module Types =

--- a/src/fable-library/Types.ts
+++ b/src/fable-library/Types.ts
@@ -54,6 +54,49 @@ export function unionToString(name: string, fields: any[]) {
   }
 }
 
+export class CommonUnion implements IEquatable<CommonUnion>, IComparable<CommonUnion> {
+  public tag!: number;
+  public fields!: any[];
+
+  public toJSON() {
+    return this.fields.length === 0 ? String(this.tag) : [String(this.tag)].concat(this.fields);
+  }
+
+  public toString() {
+    return unionToString(String(this.tag), this.fields);
+  }
+
+  public GetHashCode() {
+    const hashes = this.fields.map((x: any) => structuralHash(x));
+    hashes.splice(0, 0, numberHash(this.tag));
+    return combineHashCodes(hashes);
+  }
+
+  public Equals(other: CommonUnion) {
+    if (this === other) {
+      return true;
+    } else if (!sameConstructor(this, other)) {
+      return false;
+    } else if (this.tag === other.tag) {
+      return equalArrays(this.fields, other.fields);
+    } else {
+      return false;
+    }
+  }
+
+  public CompareTo(other: CommonUnion) {
+    if (this === other) {
+      return 0;
+    } else if (!sameConstructor(this, other)) {
+      return -1;
+    } else if (this.tag === other.tag) {
+      return compareArrays(this.fields, other.fields);
+    } else {
+      return this.tag < other.tag ? -1 : 1;
+    }
+  }
+}
+
 export abstract class Union implements IEquatable<Union>, IComparable<Union> {
   public tag!: number;
   public fields!: any[];


### PR DESCRIPTION
Implements https://github.com/fable-compiler/Fable/pull/2710#issuecomment-1107456133.

Given

```fsharp
[<Fable.Core.NoReflectionAttribute>]
type U =
    | A
    | B of int

type R = {
    W: U
}
```

I get

```js
export class U extends Union {
    constructor(tag, ...fields) {
        super();
        this.tag = (tag | 0);
        this.fields = fields;
    }
    //cases() {
    //    return ["A", "B"];
    //}
}

//export function U$reflection() {
//    return union_type("QuickTest.U", [], U, () => [[], [["Item", int32_type]]]);
//}

export class R extends Record {
    constructor(W) {
        super();
        this.W = W;
    }
}

export function R$reflection() {
    //return record_type("QuickTest.R", [], R, () => [["W", U$reflection()]]);
    return record_type("QuickTest.R", [], R, () => [["W", null]]);
}
```

with comments denoting changes with the attribute. There's also a warning `warning FABLE: QuickTest.U is annotated with NoReflectionAttribute, but is being used in types which support reflection. This may lead to runtime errors.` because `R` uses `U`, but does not itself have the attribute.

@alfonsogarciacaro, if you think this is a good addition, I can add tests and try to figure out https://github.com/fable-compiler/Fable/pull/2710#issuecomment-1107456736.

One thing that worries me is that `Union.name()` refers to the case names, and it's used both in `toString` and `toJSON`. ~~Perhaps `NoReflection` could also imply that default stringification/serialization is for all intents and purposes not supported?~~ For these cases we could have a different base union class in TS that would just use the tag instead of case name. No specialized classes for unions with no reflection would then be needed to be emitted at all.