### PR TITLE
Rust - Emit attribute support for string templates

### DIFF
--- a/src/Fable.Transforms/Rust/AST/Rust.AST.Helpers.fs
+++ b/src/Fable.Transforms/Rust/AST/Rust.AST.Helpers.fs
@@ -851,10 +851,17 @@ module Exprs =
         ExprKind.MacCall mac
         |> mkExpr
 
+    let mkExtMacroCallExpr emit args: Expr =
+        ExprKind.EmitExpression (emit, mkVec args)
+        |> mkExpr
+
     let mkMacroExpr (name: string) exprs: Expr =
         let tokens = exprs |> Seq.map mkExprToken
         mkParensCommaDelimitedMacCall name tokens
         |> mkMacCallExpr
+
+    let mkStringMacroExpr (macro: string) exprs: Expr =
+        mkExtMacroCallExpr macro exprs
 
     let mkMatchExpr expr (arms: Arm seq): Expr =
         ExprKind.Match(expr, mkVec arms)

--- a/src/Fable.Transforms/Rust/AST/Rust.AST.State.fs
+++ b/src/Fable.Transforms/Rust/AST/Rust.AST.State.fs
@@ -1427,6 +1427,76 @@ type State with
             m.span()
         )
 
+    member self.print_emit_expr(value, args: Vec<Types.Expr>) =
+        let args = args.ToArray()
+        // printer.AddLocation(loc)
+
+        let inline replace pattern (f: System.Text.RegularExpressions.Match -> string) input =
+            System.Text.RegularExpressions.Regex.Replace(input, pattern, f)
+
+        let printSegment (printer: Pretty.Printer) (value: string) segmentStart segmentEnd =
+            let segmentLength = segmentEnd - segmentStart
+            if segmentLength > 0 then
+                let segment = value.Substring(segmentStart, segmentLength)
+                self.s.word(segment)
+
+        // Macro transformations
+        // https://fable.io/docs/communicate/js-from-fable.html#Emit-when-F-is-not-enough
+        let value =
+            value
+            |> replace @"\$(\d+)\.\.\." (fun m ->
+                let rep = ResizeArray()
+                let i = int m.Groups.[1].Value
+                for j = i to args.Length - 1 do
+                    rep.Add("$" + string j)
+                String.concat ", " rep)
+
+            // |> replace @"\{\{\s*\$(\d+)\s*\?(.*?)\:(.*?)\}\}" (fun m ->
+            //     let i = int m.Groups.[1].Value
+            //     match args.[i] with
+            //     | Literal(BooleanLiteral(value=value)) when value -> m.Groups.[2].Value
+            //     | _ -> m.Groups.[3].Value)
+
+            |> replace @"\{\{([^\}]*\$(\d+).*?)\}\}" (fun m ->
+                let i = int m.Groups.[2].Value
+                match Array.tryItem i args with
+                | Some _ -> m.Groups.[1].Value
+                | None -> "")
+
+            // If placeholder is followed by !, emit string literals as JS: "let $0! = $1"
+            // |> replace @"\$(\d+)!" (fun m ->
+            //     let i = int m.Groups.[1].Value
+            //     match Array.tryItem i args with
+            //     | Some(Literal(Literal.StringLiteral(StringLiteral(value, _)))) -> value
+            //     | _ -> "")
+
+        let matches = System.Text.RegularExpressions.Regex.Matches(value, @"\$\d+")
+        if matches.Count > 0 then
+            for i = 0 to matches.Count - 1 do
+                let m = matches.[i]
+                let isSurroundedWithParens =
+                    m.Index > 0
+                    && m.Index + m.Length < value.Length
+                    && value.[m.Index - 1] = '('
+                    && value.[m.Index + m.Length] = ')'
+
+                let segmentStart =
+                    if i > 0 then matches.[i-1].Index + matches.[i-1].Length
+                    else 0
+
+                printSegment self.s value segmentStart m.Index
+
+                let argIndex = int m.Value.[1..]
+                match Array.tryItem argIndex args with
+                | Some e when isSurroundedWithParens -> self.print_expr(e)
+                | Some e -> self.print_expr(e)
+                | None -> self.s.word("undefined")
+
+            let lastMatch = matches.[matches.Count - 1]
+            printSegment self.s value (lastMatch.Index + lastMatch.Length) value.Length
+        else
+            printSegment self.s value 0 value.Length
+
     member self.print_call_post(args: Vec<P<ast.Expr>>) =
         self.s.popen()
         self.commasep_exprs(pp.Breaks.Inconsistent, args)
@@ -1947,6 +2017,8 @@ type State with
 
                 self.s.pclose()
             | ast.ExprKind.MacCall(m) -> self.print_mac(m)
+            | ast.ExprKind.EmitExpression(e, args) ->
+                self.print_emit_expr(e, args)
             | ast.ExprKind.Paren(e) ->
                 self.s.popen()
                 self.print_inner_attributes_inline(attrs)

--- a/src/Fable.Transforms/Rust/AST/Rust.AST.Types.fs
+++ b/src/Fable.Transforms/Rust/AST/Rust.AST.Types.fs
@@ -964,6 +964,9 @@ type ExprKind =
     /// Placeholder for an expression that wasn't syntactically well formed in some way.
     | Err
 
+    /// Escape hatch to allow adding custom macros - This is not in the core rust AST - Use with caution!!!
+    | EmitExpression of value: string * args: Vec<Expr>
+
 /// The explicit `Self` type in a "qualified path". The actual
 /// path, including the trait and the associated item, is stored
 /// separately. `position` represents the index of the associated

--- a/src/Fable.Transforms/Rust/Fable2Rust.fs
+++ b/src/Fable.Transforms/Rust/Fable2Rust.fs
@@ -1713,9 +1713,10 @@ module Util =
         let info = info.CallInfo
         let isNative = info.OptimizableInto |> Option.exists (fun s -> s.Contains("native"))
         let ctx = { ctx with Typegen = { ctx.Typegen with TakingOwnership = isNative } }
-        let args = transformCallArgs com ctx isNative info.HasSpread info.Args info.SignatureArgTypes
+
         if macro.EndsWith("!") then
             let macro = macro |> Fable.Naming.replaceSuffix "!" ""
+            let args = transformCallArgs com ctx isNative info.HasSpread info.Args info.SignatureArgTypes
             let args =
                 // for certain macros, use unwrapped format string as first argument
                 match macro, info.Args with
@@ -1727,9 +1728,12 @@ module Util =
             then expr |> makeString com ctx
             else expr
         else
-            // emit regular function call
-            let pathNames = splitFullName macro
-            makeCall pathNames None args
+            let ctx = { ctx with Typegen = { ctx.Typegen with TakingOwnership = true } }
+            let thisArg = info.ThisArg |> Option.map (fun e -> com.TransformAsExpr(ctx, e)) |> Option.toList
+            let args = transformCallArgs com ctx isNative info.HasSpread info.Args info.SignatureArgTypes
+            let args = args |> List.append thisArg
+            mkStringMacroExpr macro args
+
 
     let transformCallee (com: IRustCompiler) ctx calleeExpr =
         let ctx = { ctx with Typegen = { ctx.Typegen with TakingOwnership = false } }

--- a/src/fable-library-rust/src/Mutable.rs
+++ b/src/fable-library-rust/src/Mutable.rs
@@ -1,7 +1,7 @@
 use core::cell::UnsafeCell;
 use core::cmp::Ordering;
 use core::fmt;
-use core::ops::{Deref, Index};
+use core::ops::{Deref, DerefMut, Index};
 use core::hash::{Hash, Hasher};
 
 #[repr(transparent)]
@@ -129,6 +129,13 @@ impl<T> Deref for MutCell<T> {
 
     #[inline]
     fn deref(&self) -> &Self::Target {
+        self.get_mut()
+    }
+}
+
+impl<T> DerefMut for MutCell<T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
         self.get_mut()
     }
 }

--- a/tests/Rust/Fable.Tests.Rust.fsproj
+++ b/tests/Rust/Fable.Tests.Rust.fsproj
@@ -29,6 +29,7 @@
     <Compile Include="tests/src/EnumTests.fs" />
     <Compile Include="tests/src/HashSetTests.fs" />
     <Compile Include="tests/src/InterfaceTests.fs" />
+    <Compile Include="tests/src/InteropTests.fs" />
     <Compile Include="tests/src/ListTests.fs" />
     <Compile Include="tests/src/MapTests.fs" />
     <Compile Include="tests/src/MiscTests.fs" />

--- a/tests/Rust/tests/src/InteropTests.fs
+++ b/tests/Rust/tests/src/InteropTests.fs
@@ -1,0 +1,85 @@
+module Fable.Tests.InteropTests
+
+#if FABLE_COMPILER
+module Subs =
+    open Fable.Core
+    [<Emit("$0 + $1")>]
+    let add (a, b) = jsNative
+
+    [<Emit("$0 * $1")>]
+    let mul a b = jsNative
+
+    [<Emit("{ let mut v = std::vec::Vec::new(); v.append(&mut vec![$0,$1]); MutCell::from(v) }")>]
+    let fixedVec a b = jsNative
+
+    //doesn't currently work, but would be preferred
+    // [<Erase, Emit("std::vec::Vec::new()")>]
+    // type Vec() =
+    //     [<Emit("$0.push($1)")>]
+    //     member x.Push a = jsNative
+
+    module Vec =
+        [<Erase>]
+        type VecT =
+            [<Emit("$0.get_mut().push($1)")>]
+            abstract Push: 'a -> unit
+        [<Emit("MutCell::from(std::vec::Vec::new())")>]
+        let create (): VecT = jsNative
+        [<Emit("$1.get_mut().push($0)")>]
+        let push item (vec: VecT) = jsNative
+        [<Emit("{ $1.get_mut().append(&mut vec![$0]); $1 }")>]
+        let append item (vec: VecT): VecT = jsNative
+
+    module Float =
+        [<Emit("$0.sin()")>]
+        let sin (x: float): float = jsNative
+
+open Util.Testing
+
+[<Fact>]
+let ``simple add sub works`` () =
+    let res = Subs.add (2, 3)
+    res |> equal 5
+
+[<Fact>]
+let ``simple mul sub works`` () =
+    let res = Subs.mul 3 2
+    res |> equal 6
+
+[<Fact>]
+let ``simple float op sin works`` () =
+    let res = Subs.Float.sin (0.0)
+    res |> equal 0.0
+
+[<Fact>]
+let ``fixed vec should work`` () =
+    let a = Subs.fixedVec 3 4
+    let b = Subs.Vec.create()
+    b |> Subs.Vec.push 3
+    b |> Subs.Vec.push 4
+    a |> equal b
+
+
+[<Fact>]
+let ``vec mutable push should work`` () =
+    let a = Subs.Vec.create()
+    let b = Subs.Vec.create()
+    a |> Subs.Vec.push 1
+    b |> Subs.Vec.push 1
+    a |> equal b
+
+[<Fact>]
+let ``vec mutable append expressed as returnable should work`` () =
+    let a = Subs.Vec.create() |> Subs.Vec.append 1 |> Subs.Vec.append 2 |> Subs.Vec.append 3
+    let b = Subs.Vec.create() |> Subs.Vec.append 1 |> Subs.Vec.append 2 |> Subs.Vec.append 3
+    a |> equal b
+
+[<Fact>]
+let ``vec instance mutable push should work`` () =
+    let a = Subs.Vec.create()
+    let b = Subs.Vec.create()
+    a.Push 2
+    b.Push 2
+    a |> equal b
+
+#endif

--- a/tests/Rust/tests/src/main.fs
+++ b/tests/Rust/tests/src/main.fs
@@ -15,6 +15,7 @@ let tests: unit[] = [|
     importAll "EnumTests.rs"
     importAll "HashSetTests.rs"
     importAll "InterfaceTests.rs"
+    importAll "InteropTests.rs"
     importAll "ListTests.rs"
     importAll "MapTests.rs"
     importAll "MiscTests.rs"


### PR DESCRIPTION
### This adds support for full substitution syntax, allowing better bindings to be created to native Rust libs.

_I know we sort of agreed not to do this as it modifies the original Rust AST, which is a carbon copy of the real AST from the compiler (and thus runs the risk of diverging). That being said, It seems the only realistic alternative is to introduce a full Rust AST Parser, which seems like a massive undertaking and adds significant bloat to Fable._

At least this way we can move forward.

I have added a few basic tests to prove you can call into some std libs such as f64 and Vec by value or by reference, but there are still quite a few caveats to iron out. I have assumed everything entering a template is passed by value, as I think this is the most sensible default. If you want to pass by reference you can just prefix with & like normal Rust. This might need some refinement around function parameters, which will be implicitly by-ref, and need to be dereferenced with *.

Also added a MutDeref to MutCell. It occurred to me recently that Deref and MutDeref might well be a rather convenient escape hatch to deal with some of the complex unwrapping problems we have struggled with for classes etc down the road. One to revisit perhaps. These do need to be imported to work though, but it may clean up some dereferencing fluff.