### PR TITLE
Enable more F# features when targeting Dart

### DIFF
--- a/src/Fable.AST/Fable.fs
+++ b/src/Fable.AST/Fable.fs
@@ -59,6 +59,7 @@ type Constraint =
 
 type GenericParam =
     { Name: string
+      IsMeasure: bool
       Constraints: Constraint list }
 
 type Parameter =
@@ -139,7 +140,7 @@ type Type =
     | List of genericArg: Type
     | LambdaType of argType: Type * returnType: Type
     | DelegateType of argTypes: Type list * returnType: Type
-    | GenericParam of name: string * constraints: Constraint list
+    | GenericParam of name: string * isMeasure: bool * constraints: Constraint list
     | DeclaredType of ref: EntityRef * genericArgs: Type list
     | AnonymousRecordType of fieldNames: string [] * genericArgs: Type list
 

--- a/src/Fable.Transforms/Dart/Replacements.fs
+++ b/src/Fable.Transforms/Dart/Replacements.fs
@@ -2741,7 +2741,7 @@ let types (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr optio
         match thisArg with
         | Some(Value(TypeInfo(exprType, _), exprRange) as thisArg) ->
             match exprType with
-            | GenericParam(name,_) -> genericTypeInfoError name |> addError com ctx.InlinePath exprRange
+            | GenericParam(name=name) -> genericTypeInfoError name |> addError com ctx.InlinePath exprRange
             | _ -> ()
             match i.CompiledName with
             | "GetInterface" ->
@@ -2757,7 +2757,7 @@ let types (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr optio
                         let ifcName = splitFullName ifc.Entity.FullName |> snd
                         if ifcName.Equals(name, comp) then
                             let genArgs = ifc.GenericArgs |> List.map (function
-                                | GenericParam(name,_) as gen -> Map.tryFind name genMap |> Option.defaultValue gen
+                                | GenericParam(name=name) as gen -> Map.tryFind name genMap |> Option.defaultValue gen
                                 | gen -> gen)
                             Some(ifc.Entity, genArgs)
                         else None)

--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -107,6 +107,7 @@ type FsGenParam =
 
     static member Create(gen: FSharpGenericParameter): Fable.GenericParam =
         { Name = TypeHelpers.genParamName gen
+          IsMeasure = gen.IsMeasure
           Constraints = FsGenParam.Constraints gen }
 
 type FsParam =
@@ -911,7 +912,7 @@ module TypeHelpers =
         match Map.tryFind name ctxTypeArgs with
         | None ->
             let constraints = FsGenParam.Constraints genParam |> Seq.toList
-            Fable.GenericParam(name, constraints)
+            Fable.GenericParam(name, genParam.IsMeasure, constraints)
         | Some typ -> typ
 
     // TODO: We need to filter the measure generic arguments
@@ -1773,8 +1774,8 @@ module Util =
         isReplacementCandidatePrivate isFromDllRef (FsEnt.FullName ent)
 
     let getEntityType (ent: Fable.Entity): Fable.Type =
-        let genArgs = ent.GenericParameters |> List.map (fun x ->
-            Fable.Type.GenericParam(x.Name, Seq.toList x.Constraints))
+        let genArgs = ent.GenericParameters |> List.map (fun g ->
+            Fable.Type.GenericParam(g.Name, g.IsMeasure, Seq.toList g.Constraints))
         Fable.Type.DeclaredType(ent.Ref, genArgs)
 
     /// We can add a suffix to the entity name for special methods, like reflection declaration

--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -1046,7 +1046,7 @@ module TypeHelpers =
             | Types.type_ -> Fable.MetaType
             | Types.valueOption -> Fable.Option(makeTypeGenArgs ctxTypeArgs genArgs |> List.head, true)
             | Types.option -> Fable.Option(makeTypeGenArgs ctxTypeArgs genArgs |> List.head, false)
-            | Types.resizeArray -> Fable.Array(makeTypeGenArgs ctxTypeArgs genArgs |> List.head, Fable.ResizeArray) 
+            | Types.resizeArray -> Fable.Array(makeTypeGenArgs ctxTypeArgs genArgs |> List.head, Fable.ResizeArray)
             | Types.list -> makeTypeGenArgs ctxTypeArgs genArgs |> List.head |> Fable.List
             | DicContains numberTypes kind -> Fable.Number(kind, Fable.NumberInfo.Empty)
             | DicContains numbersWithMeasure kind ->
@@ -1126,7 +1126,7 @@ module TypeHelpers =
     let tryGetXmlDoc = function
         | FSharpXmlDoc.FromXmlText(xmlDoc) -> xmlDoc.GetXmlText() |> Some
         | _ -> None
-    
+
     let tryGetInterfaceTypeFromMethod (meth: FSharpMemberOrFunctionOrValue) =
         if meth.ImplementedAbstractSignatures.Count > 0
         then nonAbbreviatedType meth.ImplementedAbstractSignatures[0].DeclaringType |> Some
@@ -1561,7 +1561,7 @@ module Util =
             | Some params_ when List.sameLength args params_ ->
                 params_ |> List.map Some |> List.zip args
             | _ -> args |> List.map (fun a -> a, None)
-        
+
         let ctx, thisArg, args =
             match args with
             | firstArg::restArgs when firstArg.IsMemberThisValue ->
@@ -1917,7 +1917,7 @@ module Util =
             let callInfo =
                 if callInfo.GenericArgs.Length < entityGenParamsCount then callInfo
                 else { callInfo with GenericArgs = List.skip entityGenParamsCount callInfo.GenericArgs }
-            getAttachedMember callee name |> makeCall r typ callInfo
+            getField callee name |> makeCall r typ callInfo
 
     let failReplace (com: IFableCompiler) ctx r (info: Fable.ReplaceCallInfo) =
         let msg =

--- a/src/Fable.Transforms/FSharp2Fable.fs
+++ b/src/Fable.Transforms/FSharp2Fable.fs
@@ -107,7 +107,7 @@ let private transformTraitCall com (ctx: Context) r typ (sourceTypes: Fable.Type
 
     let rec matchGenericType (genArgs: Map<string, Fable.Type>) (signatureType: Fable.Type, concreteType: Fable.Type) =
         match signatureType with
-        | Fable.GenericParam(name,_) when not(genArgs.ContainsKey(name)) -> Map.add name concreteType genArgs
+        | Fable.GenericParam(name=name) when not(genArgs.ContainsKey(name)) -> Map.add name concreteType genArgs
         | signatureType ->
             let signatureTypeGenerics = signatureType.Generics
             if List.isEmpty signatureTypeGenerics then
@@ -140,7 +140,7 @@ let private transformTraitCall com (ctx: Context) r typ (sourceTypes: Fable.Type
                 let name = genParamName p
                 match Map.tryFind name genArgsMap with
                 | Some t -> t
-                | None -> Fable.GenericParam(name, p.Constraints |> Seq.chooseToList FsGenParam.Constraint))
+                | None -> Fable.GenericParam(name, p.IsMeasure, p.Constraints |> Seq.chooseToList FsGenParam.Constraint))
 
             makeCallFrom com ctx r typ (entGenArgs @ genArgs) thisArg args memb)
 
@@ -1548,7 +1548,7 @@ let getRootModule (declarations: FSharpImplementationFileDeclaration list) =
     getRootModuleInner None declarations
 
 let resolveInlineType (ctx: Context) = function
-    | Fable.GenericParam(name,_) as v ->
+    | Fable.GenericParam(name=name) as v ->
         match Map.tryFind name ctx.GenericArgs with
         | Some v -> v
         | None -> v

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -142,7 +142,7 @@ module Reflection =
         match t with
         | Fable.Measure _
         | Fable.Any -> primitiveTypeInfo "obj"
-        | Fable.GenericParam(name,_) ->
+        | Fable.GenericParam(name=name) ->
             match genMap with
             | None -> [| Expression.stringLiteral(name) |] |> libReflectionCall com ctx None "generic"
             | Some genMap ->
@@ -408,7 +408,7 @@ module Annotation =
         | Replacements.Util.Builtin kind -> makeBuiltinTypeAnnotation com ctx kind
         | Fable.LambdaType _ -> Util.uncurryLambdaType typ ||> makeFunctionTypeAnnotation com ctx typ
         | Fable.DelegateType(argTypes, returnType) -> makeFunctionTypeAnnotation com ctx typ argTypes returnType
-        | Fable.GenericParam(name,_) -> makeSimpleTypeAnnotation com ctx name
+        | Fable.GenericParam(name=name) -> makeSimpleTypeAnnotation com ctx name
         | Fable.DeclaredType(ent, genArgs) ->
             makeEntityTypeAnnotation com ctx ent genArgs
         | Fable.AnonymousRecordType(fieldNames, genArgs) ->
@@ -792,7 +792,7 @@ module Util =
 
     let getGenericTypeParams (types: Fable.Type list) =
         let rec getGenParams = function
-            | Fable.GenericParam(name,_) -> [name]
+            | Fable.GenericParam(name=name) -> [name]
             | t -> t.Generics |> List.collect getGenParams
         types
         |> List.collect getGenParams

--- a/src/Fable.Transforms/OverloadSuffix.fs
+++ b/src/Fable.Transforms/OverloadSuffix.fs
@@ -43,7 +43,7 @@ let private getConstraintHash genParams = function
 let rec private getTypeFastFullName (genParams: IDictionary<_,_>) (t: Fable.Type) =
     match t with
     | Fable.Measure fullname -> fullname
-    | Fable.GenericParam(name, constraints) ->
+    | Fable.GenericParam(name, _, constraints) ->
         match genParams.TryGetValue(name) with
         | true, i -> i
         | false, _ -> constraints |> List.map (getConstraintHash genParams) |> String.concat ","

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -229,7 +229,7 @@ module Reflection =
         match t with
         | Fable.Measure _
         | Fable.Any -> primitiveTypeInfo "obj", []
-        | Fable.GenericParam (name, _) ->
+        | Fable.GenericParam (name=name) ->
             match Map.tryFind name genMap with
             | Some t -> t, []
             | None ->
@@ -892,7 +892,7 @@ module Annotation =
         match t with
         | Fable.Measure _
         | Fable.Any -> stdlibModuleTypeHint com ctx "typing" "Any" []
-        | Fable.GenericParam (name, _) ->
+        | Fable.GenericParam (name=name) ->
             match repeatedGenerics with
             | Some names when names.Contains name ->
                 com.GetImportExpr(ctx, "typing", "TypeVar")
@@ -1477,7 +1477,7 @@ module Util =
     let getGenericTypeParams (types: Fable.Type list) =
         let rec getGenParams =
             function
-            | Fable.GenericParam (name, _) -> [ name ]
+            | Fable.GenericParam (name=name) -> [ name ]
             | t -> t.Generics |> List.collect getGenParams
 
         types |> List.collect getGenParams |> Set.ofList
@@ -1486,7 +1486,7 @@ module Util =
     let getRepeatedGenericTypeParams ctx (types: Fable.Type list) =
         let rec getGenParams =
             function
-            | Fable.GenericParam (name, _) -> [ name ]
+            | Fable.GenericParam (name=name) -> [ name ]
             | t -> t.Generics |> List.collect getGenParams
 
         types
@@ -2353,7 +2353,7 @@ module Util =
             let subscript =
                 match fableExpr.Type with
                 | Fable.AnonymousRecordType _ -> true
-                | Fable.GenericParam (_, [ Fable.Constraint.HasMember (_, false) ]) -> true
+                | Fable.GenericParam (_, _, [ Fable.Constraint.HasMember (_, false) ]) -> true
                 | _ -> false
             // printfn "Fable.FieldGet: %A" (fieldName, fableExpr.Type)
             get com ctx range expr fieldName subscript, stmts

--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -3742,7 +3742,7 @@ let types (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr optio
         match thisArg with
         | Some (Value (TypeInfo(exprType, _), exprRange) as thisArg) ->
             match exprType with
-            | GenericParam (name, _) ->
+            | GenericParam (name=name) ->
                 genericTypeInfoError name
                 |> addError com ctx.InlinePath exprRange
             | _ -> ()
@@ -3774,7 +3774,7 @@ let types (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr optio
                             let genArgs =
                                 ifc.GenericArgs
                                 |> List.map (function
-                                    | GenericParam (name, _) as gen -> Map.tryFind name genMap |> Option.defaultValue gen
+                                    | GenericParam (name=name) as gen -> Map.tryFind name genMap |> Option.defaultValue gen
                                     | gen -> gen)
 
                             Some(ifc.Entity, genArgs)

--- a/src/Fable.Transforms/Replacements.Api.fs
+++ b/src/Fable.Transforms/Replacements.Api.fs
@@ -81,34 +81,40 @@ let getReference (com: ICompiler) r typ var =
     match com.Options.Language with
     | Python -> PY.Replacements.getReference r typ var
     | Rust -> Rust.Replacements.getReference r typ var
+    | Dart -> Dart.Replacements.getReference r typ var
     | _ -> JS.Replacements.getReference r typ var
 
 let setReference (com: ICompiler) r expr value =
     match com.Options.Language with
     | Python -> PY.Replacements.setReference r expr value
     | Rust -> Rust.Replacements.setReference r expr value
+    | Dart -> Dart.Replacements.setReference r expr value
     | _ -> JS.Replacements.setReference r expr value
 
 let newReference (com: ICompiler) r typ value =
     match com.Options.Language with
     | Python -> PY.Replacements.newReference com r typ value
     | Rust -> Rust.Replacements.newReference com r typ value
+    | Dart -> Dart.Replacements.newReference com r typ value
     | _ -> JS.Replacements.newReference com r typ value
 
 let makeRefFromMutableFunc (com: ICompiler) ctx r t (value: Expr) =
     match com.Options.Language with
     | Python -> PY.Replacements.makeRefFromMutableFunc com ctx r t value
     | Rust -> Rust.Replacements.makeRefFromMutableFunc com ctx r t value
+    | Dart -> Dart.Replacements.makeRefFromMutableFunc com ctx r t value
     | _ -> JS.Replacements.makeRefFromMutableFunc com ctx r t value
 
 let makeRefFromMutableValue (com: ICompiler) ctx r t (value: Expr) =
     match com.Options.Language with
     | Python -> PY.Replacements.makeRefFromMutableValue com ctx r t value
     | Rust -> Rust.Replacements.makeRefFromMutableValue com ctx r t value
+    | Dart -> Dart.Replacements.makeRefFromMutableValue com ctx r t value
     | _ -> JS.Replacements.makeRefFromMutableValue com ctx r t value
 
 let makeRefFromMutableField (com: ICompiler) ctx r t (value: Expr) =
     match com.Options.Language with
     | Python -> PY.Replacements.makeRefFromMutableField com ctx r t value
     | Rust -> Rust.Replacements.makeRefFromMutableField com ctx r t value
+    | Dart -> Dart.Replacements.makeRefFromMutableField com ctx r t value
     | _ -> JS.Replacements.makeRefFromMutableField com ctx r t value

--- a/src/Fable.Transforms/Replacements.Util.fs
+++ b/src/Fable.Transforms/Replacements.Util.fs
@@ -245,7 +245,7 @@ let getTypeNameFromFullName (fullname: string) =
 
 let rec getTypeName com (ctx: Context) r t =
     match t with
-    | GenericParam(name,_) ->
+    | GenericParam(name=name) ->
         genericTypeInfoError name
         |> addError com ctx.InlinePath r
         name

--- a/src/Fable.Transforms/Replacements.Util.fs
+++ b/src/Fable.Transforms/Replacements.Util.fs
@@ -20,7 +20,7 @@ type Helper =
 
     static member InstanceCall(callee: Expr, memb: string, returnType: Type, args: Expr list,
                                ?argTypes: Type list, ?genArgs, ?loc: SourceLocation) =
-        let callee = getAttachedMember callee memb
+        let callee = getField callee memb
         let info = CallInfo.Make(args=args, ?sigArgTypes=argTypes, ?genArgs=genArgs)
         Call(callee, info, returnType, loc)
 
@@ -34,7 +34,7 @@ type Helper =
 
     static member LibCall(com, coreModule: string, coreMember: string, returnType: Type, args: Expr list,
                            ?argTypes: Type list, ?genArgs, ?thisArg: Expr, ?hasSpread: bool, ?isConstructor: bool, ?loc: SourceLocation) =
-                
+
         let callee = makeImportLib com Any coreMember coreModule
         let info = CallInfo.Make(?thisArg=thisArg, args=args, ?sigArgTypes=argTypes, ?genArgs=genArgs)
         Call(callee, { info with HasSpread = defaultArg hasSpread false
@@ -51,13 +51,13 @@ type Helper =
                              ?memb: string, ?isConstructor: bool, ?loc: SourceLocation) =
         let callee =
             match memb with
-            | Some memb -> getAttachedMember (makeIdentExpr ident) memb
+            | Some memb -> getField (makeIdentExpr ident) memb
             | None -> makeIdentExpr ident
         let info = CallInfo.Make(args=args, ?sigArgTypes=argTypes, ?genArgs=genArgs)
         Call(callee, { info with IsConstructor = defaultArg isConstructor false }, returnType, loc)
 
     static member GlobalIdent(ident: string, memb: string, typ: Type, ?loc: SourceLocation) =
-        getAttachedMemberWith loc typ (makeIdentExpr ident) memb
+        getFieldWith loc typ (makeIdentExpr ident) memb
 
 let makeUniqueIdent ctx t name =
     FSharp2Fable.Helpers.getIdentUniqueName ctx name

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -2750,7 +2750,7 @@ let types (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr optio
         match thisArg with
         | Some(Value(TypeInfo(exprType, _), exprRange) as thisArg) ->
             match exprType with
-            | GenericParam(name,_) -> genericTypeInfoError name |> addError com ctx.InlinePath exprRange
+            | GenericParam(name=name) -> genericTypeInfoError name |> addError com ctx.InlinePath exprRange
             | _ -> ()
             match i.CompiledName with
             | "GetInterface" ->
@@ -2766,7 +2766,7 @@ let types (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr optio
                         let ifcName = splitFullName ifc.Entity.FullName |> snd
                         if ifcName.Equals(name, comp) then
                             let genArgs = ifc.GenericArgs |> List.map (function
-                                | GenericParam(name,_) as gen -> Map.tryFind name genMap |> Option.defaultValue gen
+                                | GenericParam(name=name) as gen -> Map.tryFind name genMap |> Option.defaultValue gen
                                 | gen -> gen)
                             Some(ifc.Entity, genArgs)
                         else None)

--- a/src/Fable.Transforms/Rust/Replacements.fs
+++ b/src/Fable.Transforms/Rust/Replacements.fs
@@ -2669,7 +2669,7 @@ let types (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr optio
         match thisArg with
         | Some(Value(TypeInfo(exprType, _), exprRange) as thisArg) ->
             match exprType with
-            | GenericParam(name,_) -> genericTypeInfoError name |> addError com ctx.InlinePath exprRange
+            | GenericParam(name=name) -> genericTypeInfoError name |> addError com ctx.InlinePath exprRange
             | _ -> ()
             match i.CompiledName with
             | "GetInterface" ->
@@ -2685,7 +2685,7 @@ let types (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr optio
                         let ifcName = splitFullName ifc.Entity.FullName |> snd
                         if ifcName.Equals(name, comp) then
                             let genArgs = ifc.GenericArgs |> List.map (function
-                                | GenericParam(name,_) as gen -> Map.tryFind name genMap |> Option.defaultValue gen
+                                | GenericParam(name=name) as gen -> Map.tryFind name genMap |> Option.defaultValue gen
                                 | gen -> gen)
                             Some(ifc.Entity, genArgs)
                         else None)

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -699,7 +699,7 @@ module AST =
         | DeclaredType(ent1, gen1), DeclaredType(ent2, gen2) ->
             ent1 = ent2 && listEquals (typeEquals strict) gen1 gen2
         | GenericParam _, _ | _, GenericParam _ when not strict -> true
-        | GenericParam(name1,_), GenericParam(name2,_) -> name1 = name2
+        | GenericParam(name=name1), GenericParam(name=name2) -> name1 = name2
         // Field names must be already sorted
         | AnonymousRecordType(fields1, gen1), AnonymousRecordType(fields2, gen2) ->
             fields1.Length = fields2.Length
@@ -746,7 +746,7 @@ module AST =
         match t with
         | Measure fullname -> fullname
         | AnonymousRecordType _ -> ""
-        | GenericParam(name,_) -> "'" + name
+        | GenericParam(name=name) -> "'" + name
         | Regex    -> Types.regex
         | MetaType -> Types.type_
         | Unit    -> Types.unit

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -626,14 +626,17 @@ module AST =
     let setExpr r left memb (value: Expr) =
         Set(left, ExprSet memb, value.Type, value, r)
 
-    let getImmutableAttachedMemberWith r t callee membName =
+    let getImmutableFieldWith r t callee membName =
         Get(callee, FieldInfo.Create(membName), t, r)
 
-    let getAttachedMemberWith r t callee membName =
+    let getFieldWith r t callee membName =
         Get(callee, FieldInfo.Create(membName, maybeCalculated=true), t, r)
 
-    let getAttachedMember (e: Expr) membName =
-        getAttachedMemberWith e.Range Any e membName
+    let getField (e: Expr) membName =
+        getFieldWith e.Range Any e membName
+
+    let setField r callee membName (value: Expr) =
+        Set(callee, FieldSet membName, value.Type, value, r)
 
     let getNumberKindName kind =
         match kind with

--- a/src/fable-library-dart/Date.dart
+++ b/src/fable-library-dart/Date.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: file_names, constant_identifier_names
 import 'dart:math' as math;
 import 'TimeSpan.dart' as timespan;
+import 'Types.dart' as types;
 import 'Util.dart' as util;
 
 // We define Unspecified for .NET compatibility but it's not used in Dart DateTime
@@ -124,6 +125,15 @@ DateTime parse(String input) {
   }
   // .NET always parses as local, even if input is UTC
   return parsedDate.isUtc ? parsedDate.toLocal() : parsedDate;
+}
+
+bool tryParse(String input, types.FSharpRef<DateTime> defaultValue) {
+  try {
+    defaultValue.contents = parse(input);
+    return true;
+  } catch (_) {
+    return false;
+  }
 }
 
 DateTime create(int year, int month, int day,

--- a/src/fable-library-dart/Types.dart
+++ b/src/fable-library-dart/Types.dart
@@ -48,6 +48,15 @@ void addKeyValue<K,V>(Map<K,V> map, K key, V value) {
   map[key] = value;
 }
 
+bool tryGetValue<K, V>(Map<K,V> map, K key, FSharpRef<V> defaultValue) {
+  if (map.containsKey(key)) {
+    defaultValue.contents = map[key]!;
+    return true;
+  } else {
+    return false;
+  }
+}
+
 bool removeKey<K,V>(Map<K,V> map, K key) {
   if (map.containsKey(key)) {
     map.remove(key);
@@ -212,6 +221,20 @@ abstract class Union {
 // }
 
 abstract class Record {}
+
+class FSharpRef<T> {
+  final T Function() _getter;
+  final Function(T) _setter;
+
+  T get contents => _getter();
+  set contents(T value) => _setter(value);
+
+  FSharpRef(this._getter, this._setter);
+
+  static FSharpRef<T> ofValue<T>(T value) {
+    return FSharpRef(() => value, (T newValue) { value = newValue; });
+  }
+}
 
 class Tuple1<T1> implements Comparable<Tuple1<T1>> {
   final T1 item1;

--- a/tests/Dart/main.dart
+++ b/tests/Dart/main.dart
@@ -9,6 +9,7 @@ import './src/EnumerableTests.fs.dart' as enumerable;
 import './src/HashSetTests.fs.dart' as hash_set;
 import './src/ListTests.fs.dart' as list;
 import './src/MapTests.fs.dart' as map;
+import './src/MiscTests.fs.dart' as misc;
 import './src/OptionTests.fs.dart' as option;
 import './src/RecordTests.fs.dart' as record;
 import './src/RegexTests.fs.dart' as regex;
@@ -36,6 +37,7 @@ void main() {
   hash_set.tests();
   list.tests();
   map.tests();
+  misc.tests();
   option.tests();
   record.tests();
   regex.tests();

--- a/tests/Dart/src/ComparisonTests.fs
+++ b/tests/Dart/src/ComparisonTests.fs
@@ -412,17 +412,17 @@ let tests() =
         | _ -> () // ignore
         equal true disposed
 
-    testCase "isNull with primitives works" <| fun () ->
-        isNull null |> equal true
-        isNull "" |> equal false
-        isNull "0" |> equal false
-        isNull "hello" |> equal false
+    // testCase "isNull with primitives works" <| fun () ->
+    //     isNull null |> equal true
+    //     isNull "" |> equal false
+    //     isNull "0" |> equal false
+    //     isNull "hello" |> equal false
 
-    testCase "isNull with objects works" <| fun () ->
-        let s1: String = null
-        isNull s1 |> equal true
-        let s2: String = "hello"
-        isNull s2 |> equal false
+    // testCase "isNull with objects works" <| fun () ->
+    //     let s1: String = null
+    //     isNull s1 |> equal true
+    //     let s2: String = "hello"
+    //     isNull s2 |> equal false
 
     testCase "Classes must use identity hashing by default" <| fun () -> // See #2291
         let x = MyClass(5)

--- a/tests/Dart/src/DateTimeTests.fs
+++ b/tests/Dart/src/DateTimeTests.fs
@@ -225,20 +225,19 @@ let tests() =
        let d = DateTime.Parse("1:5:34 PM", CultureInfo.InvariantCulture)
        d.Hour + d.Minute + d.Second |> equal 52
 
-    // TODO: refs
-//    testCase "DateTime.TryParse works" <| fun () ->
-//        let f (d: string) =
-//            match DateTime.TryParse(d, CultureInfo.InvariantCulture, DateTimeStyles.None) with
-//            | true, _ -> true
-//            | false, _ -> false
-//        f "foo" |> equal false
-//        f "9/10/2014 1:50:34 PM" |> equal true
-//        f "1:50:34" |> equal true
-//
-//    testCase "Parsing doesn't succeed for invalid dates" <| fun () ->
-//        let invalidAmericanDate = "13/1/2020"
-//        let r, _date = DateTime.TryParse(invalidAmericanDate, CultureInfo.InvariantCulture, DateTimeStyles.None)
-//        r |> equal false
+    testCase "DateTime.TryParse works" <| fun () ->
+        let f (d: string) =
+            match DateTime.TryParse(d, CultureInfo.InvariantCulture, DateTimeStyles.None) with
+            | true, _ -> true
+            | false, _ -> false
+        f "foo" |> equal false
+        f "9/10/2014 1:50:34 PM" |> equal true
+        f "1:50:34" |> equal true
+
+    testCase "Parsing doesn't succeed for invalid dates" <| fun () ->
+        let invalidAmericanDate = "13/1/2020"
+        let r, _date = DateTime.TryParse(invalidAmericanDate, CultureInfo.InvariantCulture, DateTimeStyles.None)
+        r |> equal false
 
     testCase "DateTime.Today works" <| fun () ->
        let d = DateTime.Today

--- a/tests/Dart/src/DictionaryTests.fs
+++ b/tests/Dart/src/DictionaryTests.fs
@@ -96,22 +96,21 @@ let tests() =
         dic.["B"].ToString()
         |> equal "2"
 
-    // TODO: refs
-//    testCase "Dictionary.TryGetValue works" <| fun () ->
-//        let dic1 = dict ["A", 1]
-//        let dic2 = dict ["B", "2"]
-//        let success1, val1 = dic1.TryGetValue("A")
-//        let success2, val2 = dic1.TryGetValue("B")
-//        let success3, val3 = dic2.TryGetValue("B")
-//        let success4, val4 = dic2.TryGetValue("C")
-//        equal success1 true
-//        equal success2 false
-//        equal success3 true
-//        equal success4 false
-//        equal val1 1
-//        equal val2 0
-//        equal val3 "2"
-//        equal val4 null
+    testCase "Dictionary.TryGetValue works" <| fun () ->
+        let dic1 = dict ["A", 1]
+        let dic2 = dict ["B", "2"]
+        let success1, val1 = dic1.TryGetValue("A")
+        let success2, val2 = dic1.TryGetValue("B")
+        let success3, val3 = dic2.TryGetValue("B")
+        let success4, val4 = dic2.TryGetValue("C")
+        equal success1 true
+        equal success2 false
+        equal success3 true
+        equal success4 false
+        equal val1 1
+        equal val2 0
+        equal val3 "2"
+        equal val4 null
 
     testCase "Dictionary.Keys works" <| fun () ->
         let dic = Dictionary<_,_>()

--- a/tests/Dart/src/Fable.Tests.Dart.fsproj
+++ b/tests/Dart/src/Fable.Tests.Dart.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="HashSetTests.fs" />
     <Compile Include="ListTests.fs" />
     <Compile Include="MapTests.fs" />
+    <Compile Include="MiscTests.fs" />
     <Compile Include="OptionTests.fs" />
     <Compile Include="RecordTests.fs" />
     <Compile Include="RegexTests.fs" />

--- a/tests/Dart/src/MiscTests.fs
+++ b/tests/Dart/src/MiscTests.fs
@@ -6,8 +6,44 @@ open Util
 let increase (x: int ref) =
     x.Value <- x.Value + 1
 
+[<Measure>] type km           // Define the measure units
+[<Measure>] type mi           // as simple types decorated
+[<Measure>] type h            // with Measure attribute
+
+[<Measure>] type Measure1
+[<Measure>] type Measure2 = Measure1
+
+type MeasureTest() =
+    member _.Method(x: float<Measure2>) = x
+
+// Can be used in a generic way
+type Vector3D<[<Measure>] 'u> =
+    { x: float<'u>; y: float<'u>; z: float<'u> }
+    static member (+) (v1: Vector3D<'u>, v2: Vector3D<'u>) =
+        { x = v1.x + v2.x; y = v1.y + v2.y; z = v1.z + v2.z }
+
 let tests() =
     testCase "ref works" <| fun () ->
         let x = ref 5
         increase x
         x.Value |> equal 6
+
+    testCase "Units of measure work" <| fun () ->
+        3<km/h> + 2<km/h> |> equal 5<km/h>
+
+        let v1 = { x = 4.3<mi>; y = 5.<mi>; z = 2.8<mi> }
+        let v2 = { x = 5.6<mi>; y = 3.8<mi>; z = 0.<mi> }
+        let v3 = v1 + v2
+        equal 8.8<mi> v3.y
+
+    testCase "Units of measure work with longs" <| fun () ->
+        3L<km/h> + 2L<km/h> |> equal 5L<km/h>
+
+    // TODO: decimals
+    // testCase "Units of measure work with decimals" <| fun () ->
+    //     3M<km/h> + 2M<km/h> |> equal 5M<km/h>
+
+    testCase "Abbreviated measures work" <| fun () -> // #2313
+        let x = 5.<Measure1>
+        let c = MeasureTest()
+        c.Method(5.<Measure2>) |> equal x

--- a/tests/Dart/src/MiscTests.fs
+++ b/tests/Dart/src/MiscTests.fs
@@ -1,0 +1,13 @@
+module Fable.Tests.Dart.Misc
+
+open System
+open Util
+
+let increase (x: int ref) =
+    x.Value <- x.Value + 1
+
+let tests() =
+    testCase "ref works" <| fun () ->
+        let x = ref 5
+        increase x
+        x.Value |> equal 6


### PR DESCRIPTION
This PR:
1. Enables `ref` support for Dart
2. Fixes measure types by deleting them from type annotations in Dart
3. Uncurries classes and (anonymous) records' fields

@dbrattli @ncave I think point 3. will also bite you. During the uncurry transformation, it's assumed that record/union/class function fields are uncurried. But unfortunately we cannot uncurry them in FableTransforms because `FSharpFields` belong to the entities which are out of the AST, so in the case of Dart I have to uncurry the types in the Fable2Dart step. It's probable you need to do it for Rust and Python too so please take the changes in this file as reference: https://github.com/fable-compiler/Fable/pull/2886/commits/3bd6eeac5d00eea29473344e5296a6269edb265b#diff-e865800cded862e6a7b41e472ddd8812d0af3f1d3341da2d7f1b29a6c4c3d2ea

> Note: If you happen to have type annotations for union fields in your language (in Dart atm I'm just using a dynamic array) you will have to uncurry them too.