### PR TITLE
Dart fixes

### DIFF
--- a/src/Fable.Cli/Entry.fs
+++ b/src/Fable.Cli/Entry.fs
@@ -387,6 +387,8 @@ let main argv =
 
         let! args = parseCliArgs args
         let language = argLanguage args
+        Compiler.SetLanguageUnsafe language
+
         let rootDir =
             match args.Value "--cwd" with
             | Some rootDir -> File.getExactFullPath rootDir

--- a/src/Fable.Transforms/Dart/Replacements.fs
+++ b/src/Fable.Transforms/Dart/Replacements.fs
@@ -643,6 +643,9 @@ let tryReplacedEntityRef (com: Compiler) entFullName =
             | -1 -> entFullName
             | i -> entFullName[0..i-1]
         makeImportLib com MetaType entFullName "Types" |> Some
+// Don't use `Exception` for now because it doesn't catch all errors in Dart
+// See Fable2Dart.transformDeclaredType
+
 //    | Types.matchFail
 //    | Types.systemException
 //    | Types.timeoutException
@@ -650,8 +653,8 @@ let tryReplacedEntityRef (com: Compiler) entFullName =
 //    | "System.InvalidOperationException"
 //    | "System.Collections.Generic.KeyNotFoundException"
 //    | Types.exception_
-     | Naming.EndsWith "Exception" _
-        -> makeIdentExpr "Exception" |> Some
+//     | Naming.EndsWith "Exception" _
+//        -> makeIdentExpr "Exception" |> Some
     | "System.Lazy`1" -> makeImportLib com MetaType "Lazy" "FSharp.Core" |> Some
     | _ -> None
 

--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -911,7 +911,13 @@ module TypeHelpers =
 
     let genParamName (genParam: FSharpGenericParameter) =
         // Sometimes the names of user-declared and compiler-generated clash, see #1900 and https://github.com/dotnet/fsharp/issues/13062
-        if genParam.IsCompilerGenerated then genParam.Name.Replace("?", "$") + "$" else genParam.Name
+        let name = if genParam.IsCompilerGenerated then "$" + genParam.Name.Replace("?", "$") else genParam.Name
+        match Compiler.Language with
+        // In Dart we cannot have the same generic name as a variable or argument, so we add $ to reduce the probabilities of conflict
+        // Other solutions would be to add generic names to the name deduplication context or enforce Dart case conventions:
+        // Pascal case for types and camel case for variables
+        | Dart -> "$" + name
+        | _ -> name
 
     let resolveGenParam ctxTypeArgs (genParam: FSharpGenericParameter) =
         let name = genParamName genParam

--- a/src/Fable.Transforms/FSharp2Fable.fs
+++ b/src/Fable.Transforms/FSharp2Fable.fs
@@ -1559,7 +1559,7 @@ let resolveFieldType (ctx: Context) (entityType: FSharpType) (fieldType: FSharpT
         match tryDefinition entityType with
         | Some(def, _) when def.GenericParameters.Count = entityType.GenericArguments.Count->
             Seq.zip def.GenericParameters entityType.GenericArguments
-            |> Seq.map (fun (p, a) -> p.Name, makeType Map.empty a)
+            |> Seq.map (fun (p, a) -> genParamName p, makeType Map.empty a)
             |> Map
         | _ -> Map.empty
     let fieldType = makeType entityGenArgs fieldType

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -1068,7 +1068,7 @@ module Util =
             Option.isSome baseCall || members |> List.exists (fun m ->
                 // Optimization: Object literals with getters and setters are very slow in V8
                 // so use a class expression instead. See https://github.com/fable-compiler/Fable/pull/2165#issuecomment-695835444
-                m.Info.IsSetter || (m.Info.IsGetter && canHaveSideEffects com m.Body))
+                m.Info.IsSetter || (m.Info.IsGetter && canHaveSideEffects m.Body))
 
         let makeMethod kind prop computed hasSpread args body =
             let args, body, returnType, typeParamDecl =
@@ -1502,7 +1502,7 @@ module Util =
             let bindings, replacements =
                 (([], Map.empty), identsAndValues)
                 ||> List.fold (fun (bindings, replacements) (ident, expr) ->
-                    if canHaveSideEffects com expr then
+                    if canHaveSideEffects expr then
                         (ident, expr)::bindings, replacements
                     else
                         bindings, Map.add ident.Name expr replacements)

--- a/src/Fable.Transforms/FableTransforms.fs
+++ b/src/Fable.Transforms/FableTransforms.fs
@@ -247,7 +247,7 @@ let noSideEffectBeforeIdent identName expr =
     findIdentOrSideEffect expr && not sideEffect
 
 let canInlineArg com identName value body =
-    (canHaveSideEffects com value |> not && countReferences 1 identName body <= 1)
+    (canHaveSideEffects value |> not && countReferences 1 identName body <= 1)
      || (noSideEffectBeforeIdent identName body
          && isIdentCaptured identName body |> not
          // Make sure is at least referenced once so the expression is not erased

--- a/src/Fable.Transforms/Global/Compiler.fs
+++ b/src/Fable.Transforms/Global/Compiler.fs
@@ -102,9 +102,14 @@ module CompilerExt =
         with _ -> false
 
     let private coreAssemblyNames = set Metadata.coreAssemblies
+    let mutable private _lang = JavaScript
 
     type Compiler with
         static member CoreAssemblyNames = coreAssemblyNames
+
+        static member Language = _lang
+        /// Use this only once at the start of the program
+        static member SetLanguageUnsafe lang = _lang <- lang
 
         member com.GetEntity(entityRef: Fable.EntityRef) =
             match com.TryGetEntity(entityRef) with

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -2575,7 +2575,7 @@ module Util =
             let bindings, replacements =
                 (([], Map.empty), identsAndValues)
                 ||> List.fold (fun (bindings, replacements) (ident, expr) ->
-                    if canHaveSideEffects com expr then
+                    if canHaveSideEffects expr then
                         (ident, expr) :: bindings, replacements
                     else
                         bindings, Map.add ident.Name expr replacements)

--- a/src/Fable.Transforms/Rust/Fable2Rust.fs
+++ b/src/Fable.Transforms/Rust/Fable2Rust.fs
@@ -2391,7 +2391,7 @@ module Util =
             let bindings, replacements =
                 (([], Map.empty), identsAndValues)
                 ||> List.fold (fun (bindings, replacements) (ident, expr) ->
-                    if canHaveSideEffects com expr then
+                    if canHaveSideEffects expr then
                         (ident, expr)::bindings, replacements
                     else
                         bindings, Map.add ident.Name expr replacements)

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -385,28 +385,28 @@ module AST =
         | _ -> None
 
     // TODO: Improve this, see https://github.com/fable-compiler/Fable/issues/1659#issuecomment-445071965
-    let rec canHaveSideEffects (com: Compiler) = function
+    let rec canHaveSideEffects = function
         | Import _ -> false
         | Lambda _ | Delegate _ -> false
         | TypeCast(e,_) ->
-            match com.Options.Language with
+            match Compiler.Language with
             | Dart -> true
-            | _ -> canHaveSideEffects com e
+            | _ -> canHaveSideEffects e
         | Value(value,_) ->
             match value with
             | ThisValue _ | BaseValue _ -> true
             | TypeInfo _ | Null _ | UnitConstant | NumberConstant _ | BoolConstant _
             | CharConstant _ | StringConstant _ | RegexConstant _  -> false
             | NewList(None,_) | NewOption(None,_,_) -> false
-            | NewOption(Some e,_,_) -> canHaveSideEffects com e
-            | NewList(Some(h,t),_) -> canHaveSideEffects com h || canHaveSideEffects com t
+            | NewOption(Some e,_,_) -> canHaveSideEffects e
+            | NewList(Some(h,t),_) -> canHaveSideEffects h || canHaveSideEffects t
             | StringTemplate(_,_,exprs)
             | NewTuple(exprs,_)
-            | NewUnion(exprs,_,_,_) -> List.exists (canHaveSideEffects com) exprs
+            | NewUnion(exprs,_,_,_) -> List.exists canHaveSideEffects exprs
             | NewArray(newKind, _, kind) ->
                 match kind, newKind with
-                | ImmutableArray, ArrayFrom expr -> canHaveSideEffects com expr
-                | ImmutableArray, ArrayValues exprs -> List.exists (canHaveSideEffects com) exprs
+                | ImmutableArray, ArrayFrom expr -> canHaveSideEffects expr
+                | ImmutableArray, ArrayValues exprs -> List.exists canHaveSideEffects exprs
                 | _, ArrayAlloc _
                 | _, ArrayValues [] -> false
                 | _ -> true
@@ -415,15 +415,15 @@ module AST =
         | Get(e,kind,_,_) ->
             match kind with
             | OptionValue ->
-                match com.Options.Language with
-                | Dart -> canHaveSideEffects com e
+                match Compiler.Language with
+                | Dart -> canHaveSideEffects e
                 // Other languages include a runtime check for options
                 | _ -> true
             | ListHead | ListTail | TupleIndex _
-            | UnionTag | UnionField _ -> canHaveSideEffects com e
+            | UnionTag | UnionField _ -> canHaveSideEffects e
             | FieldGet info ->
                 if info.CanHaveSideEffects then true
-                else canHaveSideEffects com e
+                else canHaveSideEffects e
             | ExprGet _ -> true
         | _ -> true
 

--- a/tests/Dart/src/ComparisonTests.fs
+++ b/tests/Dart/src/ComparisonTests.fs
@@ -50,6 +50,9 @@ type UTest2 =
 [<ReferenceEquality>]
 type RTest2 = { a2: int; b2: int }
 
+// Records/unions containing functions don't implement IComparable
+type RTest3 = { a2: int; b2: int -> int }
+
 type Test(i: int) =
     member x.Value = i
     override x.GetHashCode() = i


### PR DESCRIPTION
- Prevent conflict between generic and variable names
- Don't implement Record/Union comparison if it's not comparable (e.g. it contains function fields)
- Use `dynamic` as a catch-all type for all errors for now

@ncave @dbrattli In this PR I've also added a static property `Compiler.Language` so you can also use a language switch in contexts where the Compiler object is not available.