### PR TITLE
Fixes

### DIFF
--- a/src/Fable.Cli/ProjectCracker.fs
+++ b/src/Fable.Cli/ProjectCracker.fs
@@ -518,10 +518,9 @@ let copyFableLibraryAndPackageSources (opts: CrackerOptions) (pkgs: FablePackage
     let fableModulesDir = opts.FableModulesDir
 
     let fableLibraryPath =
-        match opts.PrecompiledLib, opts.FableLib with
-        | Some _, _ -> "" // Fable Library path will be taken from the precompiled info
-        | None, Some path -> Path.normalizeFullPath path
-        | None, None ->
+        match opts.FableLib with
+        | Some path -> Path.normalizeFullPath path
+        | None ->
             let assemblyDir = AppContext.BaseDirectory
 
             let defaultFableLibraryPaths =

--- a/src/Fable.Core/Fable.Core.JS.fs
+++ b/src/Fable.Core/Fable.Core.JS.fs
@@ -232,6 +232,12 @@ module JS =
     and [<AllowNullLiteral>] WeakSetConstructor =
         [<Emit("new $0($1...)")>] abstract Create: ?iterable: seq<'T> -> WeakSet<'T>
 
+    and [<AllowNullLiteral>] AsyncIterable =
+        interface end
+
+    and [<AllowNullLiteral>] AsyncIterable<'T> =
+        inherit AsyncIterable
+
     and [<AllowNullLiteral>] Promise<'T> =
         abstract ``then``: ?onfulfilled: ('T->'TResult) * ?onrejected: (obj->'TResult) -> Promise<'TResult>
         abstract catch: ?onrejected: (obj->'T) -> Promise<'T>

--- a/src/Fable.Transforms/OverloadSuffix.fs
+++ b/src/Fable.Transforms/OverloadSuffix.fs
@@ -84,9 +84,11 @@ let private getGenericParamConstrainsHash genParams (p: FSharpGenericParameter) 
 let rec private getTypeFastFullName (genParams: IDictionary<_,_>) (t: FSharpType) =
     let t = nonAbbreviatedType t
     if t.IsGenericParameter then
-        match genParams.TryGetValue(t.GenericParameter.Name) with
-        | true, i -> i
-        | false, _ -> getGenericParamConstrainsHash genParams t.GenericParameter
+        if t.GenericParameter.IsMeasure then "measure"
+        else
+            match genParams.TryGetValue(t.GenericParameter.Name) with
+            | true, i -> i
+            | false, _ -> getGenericParamConstrainsHash genParams t.GenericParameter
     elif t.IsTupleType then
         let genArgs = t.GenericArguments |> Seq.map (getTypeFastFullName genParams) |> String.concat " * "
         if t.IsStructTupleType then "struct " + genArgs

--- a/src/fable-library/Types.ts
+++ b/src/fable-library/Types.ts
@@ -28,11 +28,11 @@ export function toString(x: any, callStack = 0): string {
     } else if (Symbol.iterator in x) {
       return seqToString(x);
     } else { // TODO: Date?
-      const cons = Object.getPrototypeOf(x).constructor;
+      const cons = Object.getPrototypeOf(x)?.constructor;
       return cons === Object && callStack < 10
         // Same format as recordToString
         ? "{ " + Object.entries(x).map(([k, v]) => k + " = " + toString(v, callStack + 1)).join("\n  ") + " }"
-        : cons.name;
+        : cons?.name ?? "";
     }
   }
   return String(x);

--- a/src/fable-library/Util.ts
+++ b/src/fable-library/Util.ts
@@ -82,7 +82,7 @@ export function disposeSafe(x: any) {
 }
 
 export function sameConstructor<T>(x: T, y: T) {
-  return Object.getPrototypeOf(x).constructor === Object.getPrototypeOf(y).constructor;
+  return Object.getPrototypeOf(x)?.constructor === Object.getPrototypeOf(y)?.constructor;
 }
 
 export interface IEnumerator<T> extends IDisposable {
@@ -334,7 +334,7 @@ export function structuralHash<T>(x: T): number {
         return arrayHash(x);
       } else if (x instanceof Date) {
         return dateHash(x);
-      } else if (Object.getPrototypeOf(x).constructor === Object) {
+      } else if (Object.getPrototypeOf(x)?.constructor === Object) {
         // TODO: check call-stack to prevent cyclic objects?
         const hashes = Object.values(x).map((v) => structuralHash(v));
         return combineHashCodes(hashes);
@@ -403,7 +403,7 @@ export function equals<T>(x: T, y: T): boolean {
   } else if (x instanceof Date) {
     return (y instanceof Date) && compareDates(x, y) === 0;
   } else {
-    return Object.getPrototypeOf(x).constructor === Object && equalObjects(x, y);
+    return Object.getPrototypeOf(x)?.constructor === Object && equalObjects(x, y);
   }
 }
 
@@ -480,7 +480,7 @@ export function compare<T>(x: T, y: T): number {
   } else if (x instanceof Date) {
     return y instanceof Date ? compareDates(x, y) : -1;
   } else {
-    return Object.getPrototypeOf(x).constructor === Object ? compareObjects(x, y) : -1;
+    return Object.getPrototypeOf(x)?.constructor === Object ? compareObjects(x, y) : -1;
   }
 }
 

--- a/tests/Main/JsInteropTests.fs
+++ b/tests/Main/JsInteropTests.fs
@@ -380,6 +380,13 @@ let tests =
         |> handleClass
         |> equal "Hello Narumi!!!!!!"
 
+    testCase "Can useq equals with Object.create(null)" <| fun () -> // See #2900
+        let o: obj = emitJsExpr () "Object.create(null)"
+        o = obj() |> equal false
+        o = null |> equal false
+        isNull o |> equal false
+        jsTypeof o |> equal "object"
+
     testCase "Dynamic application works" <| fun () ->
         let dynObj =
             createObj [

--- a/tests/Main/MiscTests.fs
+++ b/tests/Main/MiscTests.fs
@@ -107,6 +107,8 @@ type Vector3D<[<Measure>] 'u> =
     static member (+) (v1: Vector3D<'u>, v2: Vector3D<'u>) =
         { x = v1.x + v2.x; y = v1.y + v2.y; z = v1.z + v2.z }
 
+let lerp x (alpha: float<'u>) (delta: MiscTestsHelper.Vector2<'u>) = x + alpha * delta
+
 type PointWithCounter(a: int, b: int) =
     // A variable i.
     let mutable i = 0
@@ -590,6 +592,11 @@ let tests =
         let x = 5.<Measure1>
         let c = MeasureTest()
         c.Method(5.<Measure2>) |> equal x
+
+    testCase "Can resolve trait calls from another file with units of measure" <| fun () -> // See #2880
+        let expected = MiscTestsHelper.Vector2 (8.209999999999999<mi^2>, 7.72<mi^2>)
+        let x = MiscTestsHelper.Vector2(4.5<mi^2>, 4.5<mi^2>)
+        MiscTestsHelper.Vector2(5.3<mi>, 4.6<mi>) |> lerp x 0.7<mi> |> equal expected
 
     testCase "FSharp.UMX works" <| fun () ->
         let lookupById (orders : Order list) (id : string<orderId>) =

--- a/tests/Main/MiscTestsHelper.fs
+++ b/tests/Main/MiscTestsHelper.fs
@@ -27,3 +27,7 @@ type Type = {
     member        this.Method  ()       = { this with a = this.a * 10 }
     member inline this.MethodI ()       = { this with a = this.a * 10 }
 
+type Vector2<[<Measure>] 'u> = Vector2 of x: float<'u> * y: float<'u> with
+
+  static member inline ( + ) (Vector2(ax, ay), Vector2(bx, by)) = Vector2(ax + bx, ay + by)
+  static member inline ( * ) (scalar, Vector2(x, y)) = Vector2(scalar * x, scalar * y)


### PR DESCRIPTION
- Add AsyncIterable to Fable.Core.JS (see #2885). Implementation will be done in Fable.Promise
- Fix #2880: Trait call with unit of measure
- Fix #2895: FableLibDir in cached info is empty when using `--precompiledLib`
- Fix #2900: Equality with prototype-less JS objects







