### PR TITLE
[Rust] Uncurrying in function-type fields

### DIFF
--- a/src/Fable.Transforms/Dart/Fable2Dart.fs
+++ b/src/Fable.Transforms/Dart/Fable2Dart.fs
@@ -478,11 +478,6 @@ module Util =
 //    let getExceptionTypeIdent (com: IDartCompiler) ctx: Ident =
 //        transformIdentWith com ctx false Fable.MetaType "Exception"
 
-    let uncurryType (typ: Fable.Type) =
-        match FableTransforms.tryUncurryType typ with
-        | Some(_arity, uncurryType) -> uncurryType
-        | None -> typ
-
     /// Discards Measure generic arguments
     let transformGenArgs com ctx genArgs =
         genArgs |> List.choose (function
@@ -518,7 +513,7 @@ module Util =
             transformTupleType com ctx genArgs
         | Fable.AnonymousRecordType(_, genArgs) ->
             genArgs
-            |> List.map uncurryType
+            |> List.map FableTransforms.uncurryType
             |> transformTupleType com ctx
         | Fable.LambdaType(TransformType com ctx argType, TransformType com ctx returnType) ->
             Function([argType], returnType)
@@ -1905,7 +1900,7 @@ module Util =
             let kind =
                 if f.IsMutable then Var
                 else Final
-            let typ = uncurryType f.FieldType
+            let typ = FableTransforms.uncurryType f.FieldType
             let ident = sanitizeMember f.Name |> transformIdentWith com ctx f.IsMutable typ
             ident, InstanceVariable(ident, kind=kind))
         |> List.unzip
@@ -2100,7 +2095,7 @@ module Util =
                     let thisArgsSet = thisArgsDic |> Seq.map (fun kv -> kv.Value) |> HashSet
                     classEnt.FSharpFields |> List.map (fun f ->
                         let fieldName = sanitizeMember f.Name
-                        let t = uncurryType f.FieldType |> transformType com ctx
+                        let t = FableTransforms.uncurryType f.FieldType |> transformType com ctx
                         let ident = makeImmutableIdent t fieldName
                         let kind = if f.IsMutable then Var else Final
                         let isLate =

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -406,7 +406,7 @@ module Annotation =
         | Fable.Array(genArg, kind) -> makeArrayTypeAnnotation com ctx genArg kind
         | Fable.List genArg -> makeListTypeAnnotation com ctx genArg
         | Replacements.Util.Builtin kind -> makeBuiltinTypeAnnotation com ctx kind
-        | Fable.LambdaType _ -> Util.uncurryLambdaType typ ||> makeFunctionTypeAnnotation com ctx typ
+        | Fable.LambdaType _ -> FableTransforms.uncurryLambdaType typ ||> makeFunctionTypeAnnotation com ctx typ
         | Fable.DelegateType(argTypes, returnType) -> makeFunctionTypeAnnotation com ctx typ argTypes returnType
         | Fable.GenericParam(name=name) -> makeSimpleTypeAnnotation com ctx name
         | Fable.DeclaredType(ent, genArgs) ->
@@ -795,13 +795,6 @@ module Util =
         types
         |> List.collect getGenParams
         |> Set.ofList
-
-    let uncurryLambdaType t =
-        let rec uncurryLambdaArgs acc = function
-            | Fable.LambdaType(paramType, returnType) ->
-                uncurryLambdaArgs (paramType::acc) returnType
-            | t -> List.rev acc, t
-        uncurryLambdaArgs [] t
 
     type MemberKind =
         | ClassConstructor

--- a/src/Fable.Transforms/FableTransforms.fs
+++ b/src/Fable.Transforms/FableTransforms.fs
@@ -275,6 +275,18 @@ let tryUncurryType (typ: Type) =
     | arity, uncurriedType when arity > 1 -> Some(arity, uncurriedType)
     | _ -> None
 
+let uncurryType (typ: Type) =
+    match tryUncurryType typ with
+    | Some(_arity, uncurriedType) -> uncurriedType
+    | None -> typ
+
+let uncurryLambdaType (typ: Type) =
+    let rec uncurryLambdaArgs acc = function
+        | LambdaType(paramType, returnType) ->
+            uncurryLambdaArgs (paramType::acc) returnType
+        | t -> List.rev acc, t
+    uncurryLambdaArgs [] typ
+
 module private Transforms =
     let (|LambdaOrDelegate|_|) = function
         | Lambda(arg, body, info) -> Some([arg], body, info)

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -943,7 +943,7 @@ module Annotation =
             | Decimal, _ -> stdlibModuleTypeHint com ctx "decimal" "Decimal" []
             | _ -> numberInfo kind, []
         | Fable.LambdaType (argType, returnType) ->
-            let argTypes, returnType = Util.uncurryLambdaType t
+            let argTypes, returnType = FableTransforms.uncurryLambdaType t
             stdlibModuleTypeHint com ctx "typing" "Callable" (argTypes @ [ returnType ])
         | Fable.Option (genArg, _) -> stdlibModuleTypeHint com ctx "typing" "Optional" [ genArg ]
         | Fable.Tuple (genArgs, _) -> stdlibModuleTypeHint com ctx "typing" "Tuple" genArgs
@@ -1495,14 +1495,6 @@ module Util =
         |> List.countBy id
         |> List.choose (fun (param, count) -> if count > 1 then Some param else None)
         |> Set.ofList
-
-    let uncurryLambdaType t =
-        let rec uncurryLambdaArgs acc =
-            function
-            | Fable.LambdaType (paramType, returnType) -> uncurryLambdaArgs (paramType :: acc) returnType
-            | t -> List.rev acc, t
-
-        uncurryLambdaArgs [] t
 
     type MemberKind =
         | ClassConstructor

--- a/tests/Rust/tests/src/ArithmeticTests.fs
+++ b/tests/Rust/tests/src/ArithmeticTests.fs
@@ -10,17 +10,6 @@ let notALiteral = 5
 let checkTo3dp (expected: float) actual =
     floor (actual * 1000.) |> equal expected
 
-[<Measure>] type m
-[<Measure>] type s
-
-[<Fact>]
-let ``Units of measure work`` () =
-    let a = 4<m>
-    let b = 2<s>
-
-    let c = a / b
-    c |> equal (2<m/s>)
-
 [<Fact>]
 let ``Adding floats works`` () =
     3.141 + 2.85 |> equal 5.991

--- a/tests/Rust/tests/src/MiscTests.fs
+++ b/tests/Rust/tests/src/MiscTests.fs
@@ -2,17 +2,45 @@ module Fable.Tests.MiscTests
 
 open Util.Testing
 
-let inc1 (x: byref<int>) =
-    x <- x + 1
+[<Measure>] type km           // Define the measure units
+[<Measure>] type mi           // as simple types decorated
+[<Measure>] type h            // with Measure attribute
+[<Measure>] type m
+[<Measure>] type s
 
-let inc2 x =
-    x + 1
+[<Measure>] type Measure1
+[<Measure>] type Measure2 = Measure1
 
-let mx = 3
-let mutable my = 4
+type MeasureTest() =
+    member _.Method(x: float<Measure2>) = x
+
+// // Can be used in a generic way
+// type Vector3D<[<Measure>] 'u> =
+//     { x: float<'u>; y: float<'u>; z: float<'u> }
+//     static member (+) (v1: Vector3D<'u>, v2: Vector3D<'u>) =
+//         { x = v1.x + v2.x; y = v1.y + v2.y; z = v1.z + v2.z }
+
+type TestUnion =
+    | UncurryUnion of add: (int -> int -> int)
+
+let applyUncurryUnion x y = function
+    | UncurryUnion f -> f x y
+
+type TestClass(add: (int -> int -> int)) =
+    member _.Add(x, y) = add x y
+
+module ModuleBindings =
+    let inc1 (x: byref<int>) =
+        x <- x + 1
+    let inc2 x =
+        x + 1
+    let modx = 3
+    let mutable mody = 4
+
+open ModuleBindings
 
 [<Fact>]
-let ``byref works`` () =
+let ``Passing byref works`` () =
     let mutable x = 5
     inc1 &x
     let y = inc2 x
@@ -21,6 +49,46 @@ let ``byref works`` () =
 
 [<Fact>]
 let ``Module let bindings work`` () =
-    my <- my + 1
-    let z = mx + my
+    mody <- mody + 1
+    let z = modx + mody
     z |> equal 8
+
+[<Fact>]
+let ``Units of measure work`` () =
+    let a = 4<m>
+    let b = 2<s>
+    let c = a / b
+    c |> equal (2<m/s>)
+
+[<Fact>]
+let ``Units of measure work II`` () =
+    3<km/h> + 2<km/h> |> equal 5<km/h>
+    // let v1 = { x = 4.3<mi>; y = 5.<mi>; z = 2.8<mi> }
+    // let v2 = { x = 5.6<mi>; y = 3.8<mi>; z = 0.<mi> }
+    // let v3 = v1 + v2
+    // equal 8.8<mi> v3.y
+
+[<Fact>]
+let ``Units of measure work with longs`` () =
+    3L<km/h> + 2L<km/h> |> equal 5L<km/h>
+
+// [<Fact>]
+// let ``Units of measure work with decimals`` () =
+//     3M<km/h> + 2M<km/h> |> equal 5M<km/h>
+
+[<Fact>]
+let ``Abbreviated units of measure work`` () =
+    let x = 5.<Measure1>
+    let c = MeasureTest()
+    c.Method(5.<Measure2>) |> equal x
+
+[<Fact>]
+let ``Functions in union fields are uncurried`` () =
+    let res = UncurryUnion (-) |> applyUncurryUnion 5 2
+    res |> equal 3
+
+[<Fact>]
+let ``Functions in class fields are uncurried`` () =
+    let adder = TestClass((+))
+    let res = adder.Add(2, 3)
+    res |> equal 5


### PR DESCRIPTION
- Moved the `uncurryLambdaType` to `FableTransforms`.
- Fixed the call site for for function-type union and class fields.