### PR TITLE
[Dart] Use wrapping options

### DIFF
--- a/src/Fable.AST/Fable.fs
+++ b/src/Fable.AST/Fable.fs
@@ -281,6 +281,7 @@ type ValueKind =
     // BaseValue can appear both in constructor and instance members (where they're associated to this arg)
     | ThisValue of typ: Type
     | BaseValue of boundIdent: Ident option * typ: Type
+    | DefaultValue of value: Expr * typ: Type
     | TypeInfo of typ: Type * details: TypeInfoDetails
     | Null of typ: Type
     | UnitConstant
@@ -302,7 +303,8 @@ type ValueKind =
     member this.Type =
         match this with
         | ThisValue t
-        | BaseValue(_,t) -> t
+        | BaseValue(_,t)
+        | DefaultValue(_, t) -> t
         | TypeInfo _ -> MetaType
         | Null t -> t
         | UnitConstant -> Unit
@@ -322,7 +324,8 @@ type ValueKind =
 type ParamInfo =
     { Name: string option
       Type: Type
-      IsNamed: bool }
+      IsNamed: bool
+      IsOptional: bool }
 
 type CallMemberInfo =
     { CurriedParameterGroups: ParamInfo list list
@@ -439,6 +442,7 @@ type GetKind =
     | UnionTag
     | ListHead
     | ListTail
+    // TODO: Add isForced flag to distinguish between value accessed in pattern matching or not
     | OptionValue
 
 type SetKind =

--- a/src/Fable.Core/Fable.Core.Dart.fs
+++ b/src/Fable.Core/Fable.Core.Dart.fs
@@ -5,6 +5,17 @@ open System
 type IsConstAttribute() =
     inherit Attribute()
 
+type DartNullable<'T>() =
+    new (value: 'T) = DartNullable()
+    member _.HasValue: bool = nativeOnly
+    member _.Value: 'T = nativeOnly
+
+module DartNullable =
+    let toOption (x: DartNullable<'T>): 'T option = nativeOnly
+    let ofOption (x: 'T option): DartNullable<'T> = nativeOnly
+    let toNullable (x: DartNullable<'T>): Nullable<'T> = nativeOnly
+    let ofNullable (x: 'T Nullable): DartNullable<'T> = nativeOnly
+
 [<Global>]
 type Future<'T> =
     interface end
@@ -15,3 +26,23 @@ type Stream<'T> =
 
 [<Global>]
 let print(item: obj): unit = nativeOnly
+
+/// Destructure a tuple of arguments and apply them to literal code as with EmitAttribute.
+/// E.g. `emitExpr (arg1, arg2) "$0 + $1"` becomes `arg1 + arg2`
+let emitExpr<'T> (args: obj) (code: string): 'T = nativeOnly
+
+/// Same as emitExpr but intended for code that must appear in statement position
+/// (so it can contain `return`, `break`, loops, etc)
+/// E.g. `emitStatement aValue "while($0 < 5) { doSomething() }"`
+let emitStatement<'T> (args: obj) (code: string): 'T = nativeOnly
+
+/// Works like `ImportAttribute` (same semantics as Dart imports).
+/// You can use "*" selector.
+let import<'T> (selector: string) (path: string):'T = nativeOnly
+
+/// Must be immediately assigned to a value in a let binding.
+/// Imports a member from the external module with same name as value in binding.
+let importMember<'T> (path: string):'T = nativeOnly
+
+/// Imports a whole external module.
+let importAll<'T> (path: string):'T = nativeOnly

--- a/src/Fable.Core/Fable.Core.JsInterop.fs
+++ b/src/Fable.Core/Fable.Core.JsInterop.fs
@@ -39,7 +39,7 @@ let emitJsExpr<'T> (args: obj) (jsCode: string): 'T = nativeOnly
 
 /// Same as emitJsExpr but intended for JS code that must appear in a statement position
 /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements
-/// E.g. `emitJsExpr aValue "while($0 < 5) doSomething()"`
+/// E.g. `emitJsStatement aValue "while($0 < 5) doSomething()"`
 let emitJsStatement<'T> (args: obj) (jsCode: string): 'T = nativeOnly
 
 /// Create a literal JS object from a collection of key-value tuples.

--- a/src/Fable.Transforms/Dart/Dart.fs
+++ b/src/Fable.Transforms/Dart/Dart.fs
@@ -45,6 +45,12 @@ type Type =
     | TypeReference of Ident * generics: Type list * info: TypeInfo
     | Function of argTypes: Type list * returnType: Type
 
+    member this.Generics =
+        match this with
+        | TypeReference(_, gen, _) -> gen
+        | Function(gen1, gen2) -> gen1 @ [gen2]
+        | _ -> []
+
     static member reference(ident, ?generics, ?isRecord, ?isUnion) =
         let info: TypeInfo = { IsRecord = defaultArg isRecord false; IsUnion = defaultArg isUnion false }
         TypeReference(ident, defaultArg generics [], info)

--- a/src/Fable.Transforms/Dart/DartPrinter.fs
+++ b/src/Fable.Transforms/Dart/DartPrinter.fs
@@ -858,15 +858,15 @@ module PrinterExtensions =
                     // Nullable types and unions usually need to be typed explicitly
                     // Print type also if ident and expression types are different?
                     // (this usually happens when removing unnecessary casts)
-                    match kind, ident.Type with
-                    | Var, _ -> true
-                    | _, Nullable _ -> true
-                    | _, TypeReference(_, _, info) -> info.IsUnion
+                    match ident.Type with
+                    | Nullable _ -> true
+                    | TypeReference(_, _, info) -> info.IsUnion
                     | _ -> false
 
                 match kind with
                 | Const -> printer.Print("const ")
                 | Final -> printer.Print("final ")
+                | Var when not printType -> printer.Print("var ")
                 | Var -> ()
 
                 if printType then

--- a/src/Fable.Transforms/Dart/Fable2Dart.fs
+++ b/src/Fable.Transforms/Dart/Fable2Dart.fs
@@ -160,9 +160,6 @@ module Util =
         let tup = List.length genArgs |> getTupleTypeIdent com ctx
         Type.reference(tup, transformGenArgs com ctx genArgs)
 
-    let transformNestedOptionType com ctx nestedOptGen =
-        Type.reference(getNestedOptionTypeIdent com ctx, [transformType com ctx nestedOptGen |> Nullable]) |> Nullable
-
     let transformDeclaredTypeIgnoreMeasure ignoreMeasure (com: IDartCompiler) ctx (entRef: Fable.EntityRef) genArgs =
         match entRef.FullName with
         | "System.Enum" -> Integer |> Some
@@ -474,9 +471,6 @@ module Util =
     let getUnitTypeIdent (com: IDartCompiler) ctx =
         libValue com ctx Fable.MetaType "Types" "Unit"
 
-    let getNestedOptionTypeIdent (com: IDartCompiler) ctx =
-        libValue com ctx Fable.MetaType "Types" "Some"
-
     let getUnitValueIdent (com: IDartCompiler) ctx =
         let t = Type.reference(getUnitTypeIdent com ctx)
         { libValue com ctx Fable.Any "Types" "unit" with Type = t }
@@ -508,7 +502,8 @@ module Util =
         | Fable.Option(genArg, _isStruct) ->
             match genArg with
             | Fable.Any -> Dynamic
-            | Fable.Option(nestedOptGen, _) -> transformNestedOptionType com ctx nestedOptGen
+            // For now we "unnest" options when compiling
+            | Fable.Option _ -> transformType com ctx genArg
             // Allow `unit option` as this is used by "empty" active patterns
             | Fable.Unit -> Nullable(Type.reference(getUnitTypeIdent com ctx))
             | TransformType com ctx genArg -> Nullable genArg
@@ -628,30 +623,30 @@ module Util =
             |> resolveExpr returnStrategy
 
         | Fable.NewOption(expr, typ, isStruct) ->
-            match expr, typ with
+            match expr with
             // Allow `unit option` as this is used by "empty" active patterns
-            | Some(Fable.Value(Fable.UnitConstant, _)), _ ->
+            | Some(Fable.Value(Fable.UnitConstant, _)) ->
                 getUnitValueIdent com ctx
                 |> IdentExpression
                 |> resolveExpr returnStrategy
 
-            // | Some expr, (Fable.GenericParam _) ->
-            //     // $"NewOption with generic expression" |> addWarning com [] r
-            //     transformExprAndResolve com ctx returnStrategy expr (fun expr ->
-            //         let typ = Fable.Option(typ, isStruct)
-            //         libCall com ctx typ "Types" "some" [expr])
-
-            | Some expr, (Fable.Option(nestedOptGen, _)) ->
+            // If we don't know the type of the expr add a runtime check to make sure
+            // we're not passing null to Some (nested options are not supported atm)
+            | Some(ExprType(Fable.GenericParam _) as expr) ->
                 transformExprAndResolve com ctx returnStrategy expr (fun expr ->
-                    let cons = getNestedOptionTypeIdent com ctx
-                    let typ = transformNestedOptionType com ctx nestedOptGen
-                    Expression.invocationExpression(cons.Expr, [expr], typ)
-                )
+                    let typ = Fable.Option(typ, isStruct)
+                    libCall com ctx typ "Types" "some" [expr])
 
-            | Some expr, _ ->
+            | Some(Fable.Value(Fable.NewOption(None, _, _), _)) ->
+                "Nested options are not supported" |> addError com [] r
+                transformType com ctx typ
+                |> Expression.nullLiteral
+                |> resolveExpr returnStrategy
+
+            | Some expr ->
                 transform com ctx returnStrategy expr
 
-            | None, typ ->
+            | None ->
                 transformType com ctx typ
                 |> Expression.nullLiteral
                 |> resolveExpr returnStrategy
@@ -1022,25 +1017,10 @@ module Util =
                     Expression.propertyAccess(expr, $"item%i{index + 1}", t))
 
         | Fable.OptionValue ->
-            // Dart can detect if a value has already been null-checked for variables declared in current function scope
-            let isDeclaredInScope =
-                match fableExpr with
-                | Fable.IdentExpr i -> ctx.VarsDeclaredInScope.Contains(i.Name)
-                | _ -> false
-
             match fableExpr with
-//            | ExprType(Fable.Option(Fable.GenericParam _, _)) ->
-//                transformExprAndResolve com ctx returnStrategy fableExpr (fun expr ->
-//                    libCall com ctx t "Types" "value" [expr])
-
-            | ExprType(Fable.Option((Fable.Option _ as nestedOption), _)) ->
-                transformExprAndResolve com ctx returnStrategy fableExpr (fun expr ->
-                    let expr = if isDeclaredInScope then expr else NotNullAssert expr
-                    let nestedOption = transformNestedOptionType com ctx nestedOption
-                    Expression.propertyAccess(expr, "value", nestedOption))
-
-            | fableExpr when isDeclaredInScope -> transform com ctx returnStrategy fableExpr
-            | fableExpr -> transformExprAndResolve com ctx returnStrategy fableExpr NotNullAssert
+            // Dart can detect if a value has already been null-checked for variables declared in current function scope
+            | Fable.IdentExpr i when ctx.VarsDeclaredInScope.Contains(i.Name) -> transform com ctx returnStrategy fableExpr
+            | _ -> transformExprAndResolve com ctx returnStrategy fableExpr NotNullAssert
 
         | Fable.UnionTag ->
             transformExprAndResolve com ctx returnStrategy fableExpr getUnionExprTag
@@ -1757,10 +1737,6 @@ module Util =
                     transformDeclaredType com ctx ifc.Entity ifc.GenericArgs |> Some)
             |> Seq.toList
 
-        if Option.isSome implementsEnumerable && classEnt.IsFSharpUnion then
-            $"Unions cannot implement IEnumerable: {classEnt.FullName}"
-            |> addError com [] None
-
         let info = {|
             implementsEnumerable = implementsEnumerable
             implementsStructuralEquatable = implementsStructuralEquatable
@@ -2185,7 +2161,7 @@ module Util =
             decl.Members |> List.collect (transformDeclaration com ctx)
 
         | Fable.ActionDeclaration d ->
-            "Standalone actions are not supported in Dart, please use an initialize function"
+            "Standalone actions are not supported in Dart, please use a function"
             |> addError com [] d.Body.Range
             []
 

--- a/src/Fable.Transforms/FSharp2Fable.fs
+++ b/src/Fable.Transforms/FSharp2Fable.fs
@@ -580,7 +580,8 @@ let private transformExpr (com: IFableCompiler) (ctx: Context) fsExpr =
                 return makeValueFrom com ctx r var
 
     | FSharpExprPatterns.DefaultValue (FableType com ctx typ) ->
-        return Replacements.Api.defaultof com ctx typ
+        let value = Replacements.Api.defaultof com ctx typ
+        return Fable.DefaultValue(value, typ) |> makeValue (makeRangeFrom fsExpr)
 
     | FSharpExprPatterns.Let((var, value), body) ->
         match value with
@@ -1715,6 +1716,7 @@ let resolveInlineExpr (com: IFableCompiler) ctx info expr =
         | Fable.StringConstant _
         | Fable.NumberConstant _
         | Fable.RegexConstant _ -> e
+        | Fable.DefaultValue(e, t) -> Fable.DefaultValue(resolveInlineExpr com ctx info e, t) |> makeValue r
         | Fable.StringTemplate(tag, parts, exprs) -> Fable.StringTemplate(tag, parts, List.map (resolveInlineExpr com ctx info) exprs) |> makeValue r
         | Fable.NewOption(e, t, isStruct) -> Fable.NewOption(Option.map (resolveInlineExpr com ctx info) e, resolveInlineType ctx t, isStruct) |> makeValue r
         | Fable.NewTuple(exprs, isStruct) -> Fable.NewTuple(List.map (resolveInlineExpr com ctx info) exprs, isStruct) |> makeValue r

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -927,6 +927,7 @@ module Util =
 
     let transformValue (com: IBabelCompiler) (ctx: Context) r value: Expression =
         match value with
+        | Fable.DefaultValue(value,_) -> com.TransformAsExpr(ctx, value)
         | Fable.BaseValue(None,_) -> Super(None)
         | Fable.BaseValue(Some boundIdent,_) -> identAsExpr boundIdent
         | Fable.ThisValue _ -> Expression.thisExpression()

--- a/src/Fable.Transforms/FableTransforms.fs
+++ b/src/Fable.Transforms/FableTransforms.fs
@@ -20,6 +20,7 @@ let getSubExpressions = function
         | TypeInfo _ | Null _ | UnitConstant
         | BoolConstant _ | CharConstant _ | StringConstant _
         | NumberConstant _ | RegexConstant _ -> []
+        | DefaultValue(e,_) -> [e]
         | StringTemplate(_,_,exprs) -> exprs
         | NewOption(e, _, _) -> Option.toList e
         | NewTuple(exprs, _) -> exprs
@@ -212,8 +213,8 @@ let noSideEffectBeforeIdent identName expr =
         | Value(value,_) ->
             match value with
             | ThisValue _ | BaseValue _
-            | TypeInfo _ | Null _ | UnitConstant | NumberConstant _ | BoolConstant _
-            | CharConstant _ | StringConstant _ | RegexConstant _  -> false
+            | DefaultValue _| TypeInfo _ | Null _ | UnitConstant | NumberConstant _
+            | BoolConstant _ | CharConstant _ | StringConstant _ | RegexConstant _  -> false
             | NewList(None,_) | NewOption(None,_,_) -> false
             | NewOption(Some e,_,_) -> findIdentOrSideEffect e
             | NewList(Some(h,t),_) -> findIdentOrSideEffect h || findIdentOrSideEffect t
@@ -246,7 +247,7 @@ let noSideEffectBeforeIdent identName expr =
 
     findIdentOrSideEffect expr && not sideEffect
 
-let canInlineArg com identName value body =
+let canInlineArg _com identName value body =
     (canHaveSideEffects value |> not && countReferences 1 identName body <= 1)
      || (noSideEffectBeforeIdent identName body
          && isIdentCaptured identName body |> not

--- a/src/Fable.Transforms/Php/Fable2Php.fs
+++ b/src/Fable.Transforms/Php/Fable2Php.fs
@@ -1035,7 +1035,8 @@ and convertValue (com: IPhpCompiler)  (value: Fable.ValueKind) range =
         PhpVar("this", None)
     | Fable.TypeInfo _ ->
         failwith "Not implemented"
-
+    | Fable.DefaultValue(value, _) ->
+        convertExpr com value
 
 and canBeCompiledAsSwitch evalExpr tree =
     match tree with

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -1702,6 +1702,7 @@ module Util =
 
     let transformValue (com: IPythonCompiler) (ctx: Context) r value : Expression * Statement list =
         match value with
+        | Fable.DefaultValue(value,_) -> com.TransformAsExpr(ctx, value)
         | Fable.BaseValue (None, _) -> Expression.identifier "super()", []
         | Fable.BaseValue (Some boundIdent, _) -> identAsExpr com ctx boundIdent, []
         | Fable.ThisValue _ -> Expression.identifier "self", []

--- a/src/Fable.Transforms/Replacements.Util.fs
+++ b/src/Fable.Transforms/Replacements.Util.fs
@@ -440,7 +440,7 @@ let tryFindInScope (ctx: Context) identName =
 
 let (|MaybeInScope|) (ctx: Context) e =
     match e with
-    | MaybeCasted(IdentExpr ident) ->
+    | MaybeCasted(IdentExpr ident) when not ident.IsMutable ->
         match tryFindInScope ctx ident.Name with
         | Some e -> e
         | None -> e

--- a/src/Fable.Transforms/Rust/Fable2Rust.fs
+++ b/src/Fable.Transforms/Rust/Fable2Rust.fs
@@ -1497,6 +1497,8 @@ module Util =
             |> addWarning com [] None
             TODO_EXPR $"%A{value}"
         match value with
+        | Fable.DefaultValue(value,_) ->
+            com.TransformAsExpr(ctx, value)
         | Fable.BaseValue (None, _) ->
             // Super(None)
             unimplemented ()

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -477,6 +477,9 @@ module AST =
     let makeEqOp range left right op =
         Operation(Binary(op, left, right), Boolean, range)
 
+    let makeNullTyped t =
+        Value(Null t, None)
+
     let makeNull () =
         Value(Null Any, None)
 

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -385,7 +385,7 @@ module AST =
         | _ -> None
 
     let (|NullConst|_|) = function
-        | MaybeCasted(Value(Null _, _)) -> Some()
+        | MaybeCasted(Value((Null _|DefaultValue(Value(Null _,_),_)), _)) -> Some()
         | _ -> None
 
     // TODO: Improve this, see https://github.com/fable-compiler/Fable/issues/1659#issuecomment-445071965
@@ -401,8 +401,8 @@ module AST =
         | Value(value,_) ->
             match value with
             | ThisValue _ | BaseValue _ -> true
-            | TypeInfo _ | Null _ | UnitConstant | NumberConstant _ | BoolConstant _
-            | CharConstant _ | StringConstant _ | RegexConstant _  -> false
+            | DefaultValue _ | TypeInfo _ | Null _ | UnitConstant | NumberConstant _
+            | BoolConstant _ | CharConstant _ | StringConstant _ | RegexConstant _  -> false
             | NewList(None,_) | NewOption(None,_,_) -> false
             | NewOption(Some e,_,_) -> canHaveSideEffects e
             | NewList(Some(h,t),_) -> canHaveSideEffects h || canHaveSideEffects t
@@ -828,6 +828,7 @@ module AST =
             | TypeInfo _ | Null _ | UnitConstant
             | BoolConstant _ | CharConstant _ | StringConstant _
             | NumberConstant _ | RegexConstant _ -> e
+            | DefaultValue(value, t) -> DefaultValue(f value, t) |> makeValue r
             | StringTemplate(tag, parts, exprs) -> StringTemplate(tag, parts, List.map f exprs) |> makeValue r
             | NewOption(e, t, isStruct) -> NewOption(Option.map f e, t, isStruct) |> makeValue r
             | NewTuple(exprs, isStruct) -> NewTuple(List.map f exprs, isStruct) |> makeValue r

--- a/src/fable-library-dart/Array.fs
+++ b/src/fable-library-dart/Array.fs
@@ -4,6 +4,7 @@ module ArrayModule
 #nowarn "1204"
 #nowarn "1182"
 
+open System.Runtime.InteropServices
 open System.Collections.Generic
 open Fable.Core
 
@@ -39,10 +40,10 @@ type Native =
     static member fillRange (xs: 'T[]) (start: int) (end_: int) (fill: 'T): unit = jsNative
 
     [<Emit("$0.sublist($1...)")>]
-    static member sublist (xs: 'T[], start: int, ?end_: int): 'T[] = jsNative
+    static member sublist (xs: 'T[], start: int, [<Optional>] end_: int): 'T[] = jsNative
 
     [<Emit("List.copyRange($0...)")>]
-    static member copyRange (target: 'T[], at: int, source: 'T[], start: int, ?end_: int): unit = jsNative
+    static member copyRange (target: 'T[], at: int, source: 'T[], start: int, [<Optional>] end_: int): unit = jsNative
 
     [<Emit("$0.toList(growable: false)")>]
     static member toList (xs: 'T seq): 'T[] = nativeOnly
@@ -78,22 +79,22 @@ type Native =
     static member removeWhere (xs: 'T[]) (predicate: 'T->bool): unit = nativeOnly
 
     [<Emit("$0.sort($1...)")>]
-    static member sort (xs: 'T[], ?compare: 'T->'T->int): unit = nativeOnly
+    static member sort (xs: 'T[], [<Optional>] compare: 'T->'T->int): unit = nativeOnly
 
     [<Emit("$0.contains($1)")>]
     static member contains (xs: 'T[]) (value: obj): bool = nativeOnly
 
     [<Emit("$0.indexOf($1...)")>]
-    static member indexOf (xs: 'T[], item: 'T, ?start: int): int = jsNative
+    static member indexOf (xs: 'T[], item: 'T, [<Optional>] start: int): int = jsNative
 
     [<Emit("$0.indexWhere($1...)")>]
-    static member indexWhere (xs: 'T[], predicate: 'T->bool, ?start: int): int = jsNative
+    static member indexWhere (xs: 'T[], predicate: 'T->bool, [<Optional>] start: int): int = jsNative
 
     [<Emit("$0.lastIndexOf($1...)")>]
-    static member lastIndexOf (xs: 'T[], item: 'T, ?start: int): 'T[] = jsNative
+    static member lastIndexOf (xs: 'T[], item: 'T, [<Optional>] start: int): 'T[] = jsNative
 
     [<Emit("$0.lastIndexWhere($1...)")>]
-    static member lastIndexWhere (xs: 'T[], predicate: 'T->bool, ?start: int): 'T[] = jsNative
+    static member lastIndexWhere (xs: 'T[], predicate: 'T->bool, [<Optional>] start: int): 'T[] = jsNative
 
     // Dart's native function includes a named argument `orElse` for an alternative predicate
     [<Emit("$0.firstWhere($1...)")>]

--- a/src/fable-library-dart/Date.dart
+++ b/src/fable-library-dart/Date.dart
@@ -17,7 +17,7 @@ class DateTimeKind {
 DateTime minValue() => DateTime.utc(-271821, 04, 20);
 DateTime maxValue() => DateTime.utc(275760, 09, 13);
 
-final _epochMicrosecondsOffset = 62135596800000000;
+const _epochMicrosecondsOffset = 62135596800000000;
 
 int unixEpochMicrosecondsToTicks(int ms) {
   return (ms + _epochMicrosecondsOffset) * 10;

--- a/src/fable-library-dart/Option.fs
+++ b/src/fable-library-dart/Option.fs
@@ -1,9 +1,19 @@
 ﻿module OptionModule
 
+let defaultValue (def: 'T) (opt: 'T option): 'T =
+    match opt with
+    | None -> def
+    | Some opt -> opt
+
 let defaultWith (fn: unit -> 'T) (opt: 'T option): 'T =
     match opt with
     | None -> fn()
     | Some opt -> opt
+
+let orElse (def: 'T option) (opt: 'T option): 'T option =
+    match opt with
+    | None -> def
+    | Some opt -> Some opt
 
 let orElseWith (fn: unit -> 'T option) (opt: 'T option): 'T option =
     match opt with

--- a/src/fable-library-dart/Option.fs
+++ b/src/fable-library-dart/Option.fs
@@ -1,5 +1,7 @@
 ﻿module OptionModule
 
+open System
+
 let defaultValue (def: 'T) (opt: 'T option): 'T =
     match opt with
     | None -> def
@@ -70,6 +72,11 @@ let filter (fn: 'T -> bool) (opt: 'T option): 'T option =
     | None -> None
     | Some opt -> if fn opt then Some opt else None
 
+let flatten<'T> (opt: 'T option option): 'T option =
+    match opt with
+    | Some x -> x
+    | None -> None
+
 let map (fn: 'T -> 'U) (opt: 'T option): 'U option =
     match opt with
     | None -> None
@@ -89,3 +96,11 @@ let bind (fn: 'T -> 'U option) (opt: 'T option): 'U option =
     match opt with
     | None -> None
     | Some opt -> fn opt
+
+let ofNullable (x: Nullable<'T>): 'T option =
+    if x.HasValue then Some(x.Value) else None
+
+let toNullable (opt: 'T option): Nullable<'T> =
+    match opt with
+    | Some x -> Nullable x
+    | None -> Nullable()

--- a/src/fable-library-dart/Types.dart
+++ b/src/fable-library-dart/Types.dart
@@ -3,12 +3,6 @@
 import 'dart:collection';
 import 'Util.dart' as util;
 
-class Unit {
-  const Unit._();
-}
-
-const unit = Unit._();
-
 T value<T>(Some<T>? option) => option!.value;
 
 Some<T>? toOption<T>(T? value) => value != null ? Some(value) : null;

--- a/src/fable-library-dart/Types.dart
+++ b/src/fable-library-dart/Types.dart
@@ -9,28 +9,12 @@ class Unit {
 
 const unit = Unit._();
 
-class Some<T> implements Comparable<Some<T>> {
-  T value;
-  Some(this.value);
-
-  // Don't add "Some" for consistency with erased options
-  @override
-  String toString() => '$value';
-
-  @override
-  bool operator ==(Object other) =>
-      other is Some<T> &&
-      other.runtimeType == runtimeType &&
-      util.equalsDynamic(other.value, value);
-
-  @override
-  int get hashCode => value.hashCode;
-
-  @override
-  int compareTo(Some<T> other) => util.compareDynamic(other.value, value);
+T? some<T>(T value) {
+  if (value == null) {
+    throw Exception("Nested options are not supported");
+  }
+  return value;
 }
-
-T value<T>(T? option) => option is Some<T> ? option.value : option!;
 
 Map<K,V> mapFromTuples<K,V>(Iterable<Tuple2<K,V>> tuples) {
   return Map.fromEntries(tuples.map((tuple) => MapEntry(tuple.item1, tuple.item2)));

--- a/src/fable-library-dart/Types.dart
+++ b/src/fable-library-dart/Types.dart
@@ -11,6 +11,9 @@ const unit = Unit._();
 
 T value<T>(Some<T>? option) => option!.value;
 
+Some<T>? toOption<T>(T? value) => value != null ? Some(value) : null;
+T? ofOption<T>(Some<T>? value) => value?.value;
+
 class Some<T> implements Comparable<Some<T>> {
   final T value;
   const Some(this.value);

--- a/src/fable-library-dart/Types.dart
+++ b/src/fable-library-dart/Types.dart
@@ -9,11 +9,26 @@ class Unit {
 
 const unit = Unit._();
 
-T? some<T>(T value) {
-  if (value == null) {
-    throw Exception("Nested options are not supported");
-  }
-  return value;
+T value<T>(Some<T>? option) => option!.value;
+
+class Some<T> implements Comparable<Some<T>> {
+  final T value;
+  const Some(this.value);
+
+  @override
+  String toString() => 'Some($value)';
+
+  @override
+  bool operator ==(Object other) =>
+      other is Some<T> &&
+      other.runtimeType == runtimeType &&
+      util.equalsDynamic(other.value, value);
+
+  @override
+  int get hashCode => value.hashCode;
+
+  @override
+  int compareTo(Some<T> other) => util.compareDynamic(other.value, value);
 }
 
 Map<K,V> mapFromTuples<K,V>(Iterable<Tuple2<K,V>> tuples) {

--- a/src/fable-library-dart/Util.dart
+++ b/src/fable-library-dart/Util.dart
@@ -1,5 +1,9 @@
 // ignore_for_file: file_names
 
+void ignore([dynamic _]) {}
+
+T value<T>(T? value) => value!;
+
 // From https://stackoverflow.com/a/37449594
 int combineHashCodes(Iterable<int> hashes) =>
     hashes.isEmpty ? 0 : hashes.reduce((h1, h2) => ((h1 << 5) + h1) ^ h2);

--- a/src/fable-library-dart/pubspec.lock
+++ b/src/fable-library-dart/pubspec.lock
@@ -16,4 +16,4 @@ packages:
     source: hosted
     version: "1.0.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.17.0 <3.0.0"

--- a/src/fable-library-dart/pubspec.yaml
+++ b/src/fable-library-dart/pubspec.yaml
@@ -3,7 +3,7 @@ description: Core library for Fable F#/Dart applications
 version: 1.0.0
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dev_dependencies:
   flutter_lints: ^1.0.0

--- a/tests/Dart/pubspec.lock
+++ b/tests/Dart/pubspec.lock
@@ -366,4 +366,4 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.17.0 <3.0.0"

--- a/tests/Dart/pubspec.yaml
+++ b/tests/Dart/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 # homepage: https://www.example.com
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 # dependencies:
 #   path: ^1.8.0

--- a/tests/Dart/src/ComparisonTests.fs
+++ b/tests/Dart/src/ComparisonTests.fs
@@ -452,7 +452,8 @@ let tests() =
     testCase "GetHashCode with options works" <| fun () ->
         ((Some 1).GetHashCode(), (Some 1).GetHashCode()) ||> equal
         ((Some 2).GetHashCode(), (Some 1).GetHashCode()) ||> notEqual
-        ((Some None).GetHashCode(), (Some 1).GetHashCode()) ||> notEqual
+        // TODO: Nested options
+        // ((Some None).GetHashCode(), (Some 1).GetHashCode()) ||> notEqual
 
     testCase "GetHashCode with unions works" <| fun () ->
         ((UTest.A 1).GetHashCode(), (UTest.A 1).GetHashCode()) ||> equal
@@ -503,7 +504,8 @@ let tests() =
     testCase "hash with options works" <| fun () ->
         (hash (Some 1), hash (Some 1)) ||> equal
         (hash (Some 2), hash (Some 1)) ||> notEqual
-        (hash (Some None), hash (Some 1)) ||> notEqual
+        // TODO: Nested options
+        // (hash (Some None), hash (Some 1)) ||> notEqual
 
     testCase "hash with unions works" <| fun () ->
         (hash (UTest.A 1), hash (UTest.A 1)) ||> equal

--- a/tests/Dart/src/EnumTests.fs
+++ b/tests/Dart/src/EnumTests.fs
@@ -161,20 +161,22 @@ let tests() =
         enum 4 |> equal Fruits.Coconut
 
     testCase "Pattern matching can be nested within a switch statement" <| fun () -> // See #483
+        let test fruit veggie =
+            match fruit with
+            | Fruits.Apple ->
+                match veggie with
+                | Tomato kind -> kind.Replace("to","")
+                | _ -> "foo"
+            | Fruits.Banana
+            | Fruits.Coconut ->
+                match veggie with
+                | Lettuce kind -> kind
+                | _ -> "bar"
+            | _ -> "invalid choice"
+            |> equal "kuma"
         let fruit = Fruits.Apple
         let veggie = Tomato("kumato")
-        match fruit with
-        | Fruits.Apple ->
-            match veggie with
-            | Tomato kind -> kind.Replace("to","")
-            | _ -> "foo"
-        | Fruits.Banana
-        | Fruits.Coconut ->
-            match veggie with
-            | Lettuce kind -> kind
-            | _ -> "bar"
-        | _ -> "invalid choice"
-        |> equal "kuma"
+        test fruit veggie
 
     testCase "Non-scoped (in JS) variables with same name can be used" <| fun () -> // See #700
         equal 10 myRootValue

--- a/tests/Dart/src/OptionTests.fs
+++ b/tests/Dart/src/OptionTests.fs
@@ -1,5 +1,6 @@
 ﻿module Fable.Tests.Dart.Option
 
+open System
 open Util
 
 type Tree =
@@ -28,7 +29,7 @@ let rec folding2 test acc =
 
 type OptTest = OptTest of int option
 
-let makeSome (x: 'a): 'a option =
+let inline makeSome (x: 'a): 'a option =
     Some x
 
 let tests() =
@@ -177,65 +178,63 @@ let tests() =
             | None -> 0.
         test(Some 4.) |> equal 7.
 
-    // TODO
-//    testCase "Mixing refs and options works" <| fun () -> // See #238
-//        let res = ref 0
-//        let setter, getter =
-//            let slot = ref None
-//            (fun f -> slot.Value <- Some f),
-//            // TODO!!! If we change this to `slot.Value.Value` it fails
-//            (fun v -> slot.Value.Value v)
-//        setter (fun i -> res := i + 2)
-//        getter 5
-//        equal 7 !res
+    testCase "Mixing refs and options works" <| fun () -> // See #238
+        let res = ref 0
+        let setter, getter =
+            let slot = ref None
+            (fun f -> slot.Value <- Some f),
+            (fun v -> slot.Value.Value v)
+        setter (fun i -> res.Value <- i + 2)
+        getter 5
+        equal 7 res.Value
 
-    // TODO: What to do when unit is used as a generic arg
-//    testCase "Option.map ignore generates Some ()" <| fun () -> // See #1923
-//        let mySome = Some ()
-//        let myOtherSome = mySome |> Option.map (ignore)
-//        equal mySome myOtherSome
+    // TODO: Check functions with arity 0 or arity 1 receiving unit
+    // testCase "Option.map ignore generates Some ()" <| fun () -> // See #1923
+    //    let mySome = Some ()
+    //    let myOtherSome = mySome |> Option.map (ignore)
+    //    equal mySome myOtherSome
 
     testCase "Generic options work" <| fun () ->
-//        let x1 = makeSome ()
-//        let x2 = makeSome None
-//        let x3 = makeSome null |> makeSome
+        let x1 = makeSome ()
+        let x2 = makeSome None
+        let x3 = makeSome null |> makeSome
         let x4 = makeSome 5
-//        Option.isSome x1 |> equal true
-//        Option.isNone x1 |> equal false
-//        x1.IsSome |> equal true
-//        x1.IsNone |> equal false
-//        match x1 with Some _ -> true | None -> false
-//        |> equal true
-//        Option.isSome x2 |> equal true
-//        Option.isNone x2 |> equal false
-//        x2.IsSome |> equal true
-//        x2.IsNone |> equal false
-//        match x2 with
-//        | Some(Some _) -> 0
-//        | Some(None) -> 1
-//        | None -> 2
-//        |> equal 1
-//        Option.isSome x3 |> equal true
-//        Option.isNone x3 |> equal false
-//        x3.IsSome |> equal true
-//        x3.IsNone |> equal false
-//        match x3 with
-//        | None -> 0
-//        | Some(None) -> 1
-//        | Some(Some _) -> 2
-//        |> equal 2
+        Option.isSome x1 |> equal true
+        Option.isNone x1 |> equal false
+        x1.IsSome |> equal true
+        x1.IsNone |> equal false
+        match x1 with Some _ -> true | None -> false
+        |> equal true
+        Option.isSome x2 |> equal true
+        Option.isNone x2 |> equal false
+        x2.IsSome |> equal true
+        x2.IsNone |> equal false
+        match x2 with
+        | Some(Some _) -> 0
+        | Some(None) -> 1
+        | None -> 2
+        |> equal 1
+        Option.isSome x3 |> equal true
+        Option.isNone x3 |> equal false
+        x3.IsSome |> equal true
+        x3.IsNone |> equal false
+        match x3 with
+        | None -> 0
+        | Some(None) -> 1
+        | Some(Some _) -> 2
+        |> equal 2
         match x4 with Some i -> i = 5 | None -> false
         |> equal true
         x4.Value = 5 |> equal true
         Option.get x4 = 5 |> equal true
 
-//    testCase "Option.flatten works" <| fun () ->
-//        let o1: int option option = Some (Some 1)
-//        let o2: int option option = Some None
-//        let o3: int option option = None
-//        Option.flatten o1 |> equal (Some 1)
-//        Option.flatten o2 |> equal None
-//        Option.flatten o3 |> equal None
+    testCase "Option.flatten works" <| fun () ->
+       let o1: int option option = Some (Some 1)
+       let o2: int option option = Some None
+       let o3: int option option = None
+       Option.flatten o1 |> equal (Some 1)
+       Option.flatten o2 |> equal None
+       Option.flatten o3 |> equal None
 
 //    testCase "Option.toObj works" <| fun () ->
 //        let o1: string option = Some "foo"
@@ -288,16 +287,17 @@ let tests() =
         let x3: int option option = Some(None)
         test x1 x2 x3
 
-//    testCase "Some (box null) |> Option.isSome evals to true" <| fun () -> // See #1948
-//        Some (box null) |> Option.isSome |> equal true
-//        Some (null) |> Option.isSome |> equal true
+    testCase "Some (box null) |> Option.isSome evals to true" <| fun () -> // See #1948
+       Some (box null) |> Option.isSome |> equal true
+       Some (null) |> Option.isSome |> equal true
 
-//    testCase "Nullable works" <| fun () ->
-//        let x = Nullable 5
-//        x.HasValue |> equal true
-//        x.Value |> equal 5
-//
-//        let y: Nullable<int> = Nullable()
-//        y.HasValue |> equal false
-//        let errorThrown = try y.Value |> ignore; false with _ -> true
-//        equal true errorThrown
+    testCase "Nullable works" <| fun () ->
+       let x = Nullable 5
+       x.HasValue |> equal true
+       x.Value |> equal 5
+
+       let mutable z = 0
+       let y: Nullable<int> = Nullable()
+       y.HasValue |> equal false
+       let errorThrown = try z <- y.Value; false with _ -> true
+       equal true errorThrown

--- a/tests/Dart/src/OptionTests.fs
+++ b/tests/Dart/src/OptionTests.fs
@@ -250,7 +250,7 @@ let tests() =
 //        Option.ofObj o2 |> equal None
 
     testCase "Nested options work" <| fun () ->
-        let test x1 x3 =
+        let test x1 x2 =
             Option.isSome x1 |> equal true
             Option.isNone x1 |> equal false
             x1.IsSome |> equal true
@@ -261,34 +261,33 @@ let tests() =
             | Some(None) -> 2
             | None -> 3
             |> equal 0
-            // Option.isSome x2 |> equal true
-            // Option.isNone x2 |> equal false
-            // x2.IsSome |> equal true
-            // x2.IsNone |> equal false
-            // match x2 with
-            // | Some(None) -> 0
-            // | Some(Some _) -> 1
-            // | None -> 2
-            // |> equal 1
-            Option.isSome x3 |> equal true
-            Option.isNone x3 |> equal false
-            x3.IsSome |> equal true
-            x3.IsNone |> equal false
-            match x3 with
-            | None -> 0
+            Option.isSome x2 |> equal true
+            Option.isNone x2 |> equal false
+            x2.IsSome |> equal true
+            x2.IsNone |> equal false
+            match x2 with
+            | Some(None) -> 0
             | Some(Some _) -> 1
-            | Some(None) -> 2
-            |> equal 2
+            | None -> 2
+            |> equal 1
+            // Option.isSome x3 |> equal true
+            // Option.isNone x3 |> equal false
+            // x3.IsSome |> equal true
+            // x3.IsNone |> equal false
+            // match x3 with
+            // | None -> 0
+            // | Some(Some _) -> 1
+            // | Some(None) -> 2
+            // |> equal 2
 
-            // FIXME: Passing nested options to Option module functions
-            // x1 |> Option.map (Option.map ((+) 3)) |> equal (Some(Some 8))
+            x1 |> Option.map (Option.map ((+) 3)) |> equal (Some(Some 8))
             // x3 |> Option.map (Option.map ((+) 3)) |> equal None
 
         let x1 = Some(Some 5)
-        // FIXME: Nested unit options
-        // let x2 = Some(Some ())
-        let x3: int option option = Some(None)
-        test x1 x3
+        let x2 = Some(Some ())
+        // TODO: Nested options like Some None
+        // let x3: int option option = Some(None)
+        test x1 x2
 
 //    testCase "Some (box null) |> Option.isSome evals to true" <| fun () -> // See #1948
 //        Some (box null) |> Option.isSome |> equal true

--- a/tests/Dart/src/OptionTests.fs
+++ b/tests/Dart/src/OptionTests.fs
@@ -250,7 +250,7 @@ let tests() =
 //        Option.ofObj o2 |> equal None
 
     testCase "Nested options work" <| fun () ->
-        let test x1 x2 =
+        let test x1 x2 x3 =
             Option.isSome x1 |> equal true
             Option.isNone x1 |> equal false
             x1.IsSome |> equal true
@@ -270,24 +270,23 @@ let tests() =
             | Some(Some _) -> 1
             | None -> 2
             |> equal 1
-            // Option.isSome x3 |> equal true
-            // Option.isNone x3 |> equal false
-            // x3.IsSome |> equal true
-            // x3.IsNone |> equal false
-            // match x3 with
-            // | None -> 0
-            // | Some(Some _) -> 1
-            // | Some(None) -> 2
-            // |> equal 2
+            Option.isSome x3 |> equal true
+            Option.isNone x3 |> equal false
+            x3.IsSome |> equal true
+            x3.IsNone |> equal false
+            match x3 with
+            | None -> 0
+            | Some(Some _) -> 1
+            | Some(None) -> 2
+            |> equal 2
 
             x1 |> Option.map (Option.map ((+) 3)) |> equal (Some(Some 8))
-            // x3 |> Option.map (Option.map ((+) 3)) |> equal None
+            x3 |> Option.map (Option.map ((+) 3)) |> equal (Some None)
 
         let x1 = Some(Some 5)
         let x2 = Some(Some ())
-        // TODO: Nested options like Some None
-        // let x3: int option option = Some(None)
-        test x1 x2
+        let x3: int option option = Some(None)
+        test x1 x2 x3
 
 //    testCase "Some (box null) |> Option.isSome evals to true" <| fun () -> // See #1948
 //        Some (box null) |> Option.isSome |> equal true


### PR DESCRIPTION
I'm not happy with PR #2917. The wrapping `Some` class doesn't add much value, it's only useful in the rare case where nested options are declared explicitly, but not in the most common case when nested options occur because of a combination of generic helpers (e.g. when using `List.choose` with a list of options). `Some<T>?` was also not compatible with generic functions dealing with options/nullables. So I've removed the class.

For now, I'm just "unnesting" the options and throwing an error when non-supported patterns are used (like `Some None`). I've also opened #2919 to discuss the representation of options in Dart.