### PR TITLE
[Rust] fable-library-rust update

### DIFF
--- a/src/Fable.Transforms/Rust/Fable2Rust.fs
+++ b/src/Fable.Transforms/Rust/Fable2Rust.fs
@@ -161,7 +161,7 @@ module TypeInfo =
         mkGenericPathTy [name] None
 
     let getLibraryImportName (com: IRustCompiler) ctx moduleName typeName =
-        let selector = moduleName + "::" + typeName
+        let selector = moduleName + "_::" + typeName
         let libPath = getLibPath com moduleName
         com.GetImportName(ctx, selector, libPath, None)
 
@@ -1801,25 +1801,25 @@ module Util =
             // TODO: a more general way of doing this in Replacements
             let genArgs =
                 match info.Selector, typ with
-                | "Native::arrayEmpty", Fable.Array(genArg, _) ->
+                | "Native_::arrayEmpty", Fable.Array(genArg, _) ->
                     transformGenArgs com ctx [genArg]
-                | "Native::arrayWithCapacity", Fable.Array(genArg, _) ->
+                | "Native_::arrayWithCapacity", Fable.Array(genArg, _) ->
                     transformGenArgs com ctx [genArg]
-                | ("Native::defaultOf" | "Native::getZero"), genArg ->
+                | ("Native_::defaultOf" | "Native_::getZero"), genArg ->
                     transformGenArgs com ctx [genArg]
-                | "Set::empty", Replacements.Util.Builtin (Replacements.Util.FSharpSet(genArg)) ->
+                | "Set_::empty", Replacements.Util.Builtin (Replacements.Util.FSharpSet(genArg)) ->
                     transformGenArgs com ctx [genArg]
-                | "Map::empty", Replacements.Util.Builtin (Replacements.Util.FSharpMap(k, v)) ->
+                | "Map_::empty", Replacements.Util.Builtin (Replacements.Util.FSharpMap(k, v)) ->
                     transformGenArgs com ctx [k; v]
-                | "Seq::empty", IEnumerable genArg ->
+                | "Seq_::empty", IEnumerable genArg ->
                     transformGenArgs com ctx [genArg]
-                | "Native::hashSetEmpty", Replacements.Util.Builtin (Replacements.Util.BclHashSet(genArg)) ->
+                | "Native_::hashSetEmpty", Replacements.Util.Builtin (Replacements.Util.BclHashSet(genArg)) ->
                     transformGenArgs com ctx [genArg]
-                | "Native::hashSetWithCapacity", Replacements.Util.Builtin (Replacements.Util.BclHashSet(genArg)) ->
+                | "Native_::hashSetWithCapacity", Replacements.Util.Builtin (Replacements.Util.BclHashSet(genArg)) ->
                     transformGenArgs com ctx [genArg]
-                | "Native::hashMapEmpty", Replacements.Util.Builtin (Replacements.Util.BclDictionary(k, v)) ->
+                | "Native_::hashMapEmpty", Replacements.Util.Builtin (Replacements.Util.BclDictionary(k, v)) ->
                     transformGenArgs com ctx [k; v]
-                | "Native::hashMapWithCapacity", Replacements.Util.Builtin (Replacements.Util.BclDictionary(k, v)) ->
+                | "Native_::hashMapWithCapacity", Replacements.Util.Builtin (Replacements.Util.BclDictionary(k, v)) ->
                     transformGenArgs com ctx [k; v]
                 | _ -> None
             let callee = transformImport com ctx r t info genArgs

--- a/src/Fable.Transforms/Rust/Replacements.fs
+++ b/src/Fable.Transforms/Rust/Replacements.fs
@@ -1402,11 +1402,9 @@ let seqModule (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (thisArg
         Helper.LibCall(com, "Event", "createEvent", t, [addHandler; removeHandler], i.SignatureArgTypes, ?loc=r) |> Some
     | ("Distinct" | "DistinctBy" | "Except" | "GroupBy" | "CountBy" as meth), args ->
         let meth = Naming.lowerFirst meth
-        // let args = injectArg com ctx r "Seq2" meth i.GenericArgs args
-        Helper.LibCall(com, "Seq2", meth, t, args, i.SignatureArgTypes, ?loc=r) |> Some
+        Helper.LibCall(com, "Seq", meth, t, args, i.SignatureArgTypes, ?loc=r) |> Some
     | meth, _ ->
         let meth = Naming.lowerFirst meth
-        // let args = injectArg com ctx r "Seq" meth i.GenericArgs args
         Helper.LibCall(com, "Seq", meth, t, args, i.SignatureArgTypes, ?thisArg=thisArg, ?loc=r) |> Some
 
 let resizeArrays (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (thisArg: Expr option) (args: Expr list) =
@@ -1588,11 +1586,9 @@ let arrayModule (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (_: Ex
     //     Helper.InstanceCall(thisArg, meth, t, args, argTypes, ?loc=r) |> Some
     | ("Distinct" | "DistinctBy" | "Except" | "GroupBy" | "CountBy" as meth), args ->
         let meth = Naming.lowerFirst meth
-        // let args = injectArg com ctx r "Seq2" meth i.GenericArgs args
-        Helper.LibCall(com, "Seq2", "Array_" + meth, t, args, i.SignatureArgTypes, ?loc=r) |> Some
+        Helper.LibCall(com, "Array", meth, t, args, i.SignatureArgTypes, ?loc=r) |> Some
     | meth, _ ->
         let meth = Naming.lowerFirst meth
-        // let args = injectArg com ctx r "Array" meth i.GenericArgs args
         Helper.LibCall(com, "Array", meth, t, args, i.SignatureArgTypes, ?loc=r) |> Some
 
 let lists (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (thisArg: Expr option) (args: Expr list) =
@@ -1631,11 +1627,9 @@ let listModule (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (_: Exp
         Helper.LibCall(com, "List", Naming.lowerFirst meth, t, [toList com t arg], i.SignatureArgTypes, ?loc=r) |> Some
     | ("Distinct" | "DistinctBy" | "Except" | "GroupBy" | "CountBy" as meth), args ->
         let meth = Naming.lowerFirst meth
-        // let args = injectArg com ctx r "Seq2" meth i.GenericArgs args
-        Helper.LibCall(com, "Seq2", "List_" + meth, t, args, i.SignatureArgTypes, ?loc=r) |> Some
+        Helper.LibCall(com, "List", meth, t, args, i.SignatureArgTypes, ?loc=r) |> Some
     | meth, _ ->
         let meth = Naming.lowerFirst meth
-        // let args = injectArg com ctx r "List" meth i.GenericArgs args
         Helper.LibCall(com, "List", meth, t, args, i.SignatureArgTypes, ?loc=r) |> Some
 
 let discardUnitArgs args =

--- a/src/Fable.Transforms/Rust/Replacements.fs
+++ b/src/Fable.Transforms/Rust/Replacements.fs
@@ -286,7 +286,7 @@ let toList com t (expr: Expr) =
     | String ->
         let a = Helper.LibCall(com, "String", "toCharArray", t, [expr])
         Helper.LibCall(com, "List", "ofArray", t, [a])
-    | IEnumerable -> Helper.LibCall(com, "Seq", "toList", t, [expr])
+    | IEnumerable -> Helper.LibCall(com, "List", "ofSeq", t, [expr])
     | _ -> TypeCast(expr, t)
 
 let toSeq com t (expr: Expr) =
@@ -1398,6 +1398,10 @@ let formattableString (com: ICompiler) (_ctx: Context) r (t: Type) (i: CallInfo)
 let seqModule (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (thisArg: Expr option) (args: Expr list) =
     match i.CompiledName, args with
     | "Cast", [arg] -> Some arg // Erase
+    // | "ToArray", [arg] ->
+    //     Helper.LibCall(com, "Array", "ofSeq", t, args, i.SignatureArgTypes, ?loc=r) |> Some
+    | "ToList", [arg] ->
+        Helper.LibCall(com, "List", "ofSeq", t, args, i.SignatureArgTypes, ?loc=r) |> Some
     | "CreateEvent", [addHandler; removeHandler; createHandler] ->
         Helper.LibCall(com, "Event", "createEvent", t, [addHandler; removeHandler], i.SignatureArgTypes, ?loc=r) |> Some
     | ("Distinct" | "DistinctBy" | "Except" | "GroupBy" | "CountBy" as meth), args ->
@@ -1479,17 +1483,6 @@ let resizeArrays (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (this
     | "ToArray", Some ar, [] ->
         Helper.LibCall(com, "Native", "arrayCopy", t, [ar], ?loc=r) |> Some
     | _ -> None
-
-// let nativeArrayFunctions =
-//     dict [| "Exists", "some"
-//             "Filter", "filter"
-//             "Find", "find"
-//             "FindIndex", "findIndex"
-//             "ForAll", "every"
-//             "Iterate", "forEach"
-//             "Reduce", "reduce"
-//             "ReduceBack", "reduceRight"
-//             "SortInPlaceWith", "sort" |]
 
 let tuples (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (thisArg: Expr option) (args: Expr list) =
     let changeKind isStruct = function
@@ -1580,10 +1573,6 @@ let arrayModule (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (_: Ex
         copyToArray com r t i args
     | ("Concat" | "Transpose" as meth), [arg] ->
         Helper.LibCall(com, "Array", Naming.lowerFirst meth, t, [toArray com t arg], i.SignatureArgTypes, ?loc=r) |> Some
-    // | Patterns.DicContains nativeArrayFunctions meth, _ ->
-    //     let args, thisArg = List.splitLast args
-    //     let argTypes = List.take (List.length args) i.SignatureArgTypes
-    //     Helper.InstanceCall(thisArg, meth, t, args, argTypes, ?loc=r) |> Some
     | ("Distinct" | "DistinctBy" | "Except" | "GroupBy" | "CountBy" as meth), args ->
         let meth = Naming.lowerFirst meth
         Helper.LibCall(com, "Array", meth, t, args, i.SignatureArgTypes, ?loc=r) |> Some
@@ -1622,7 +1611,7 @@ let listModule (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (_: Exp
     | "ToSeq", [arg] ->
         Helper.LibCall(com, "Seq", "ofList", t, args, i.SignatureArgTypes, ?loc=r) |> Some
     | "OfSeq", [arg] ->
-        Helper.LibCall(com, "Seq", "toList", t, args, i.SignatureArgTypes, ?loc=r) |> Some
+        Helper.LibCall(com, "List", "ofSeq", t, args, i.SignatureArgTypes, ?loc=r) |> Some
     | ("Concat" | "Transpose" as meth), [arg] ->
         Helper.LibCall(com, "List", Naming.lowerFirst meth, t, [toList com t arg], i.SignatureArgTypes, ?loc=r) |> Some
     | ("Distinct" | "DistinctBy" | "Except" | "GroupBy" | "CountBy" as meth), args ->

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -605,7 +605,7 @@ module AST =
     let makeImportLib (com: Compiler) t memberName moduleName =
         let selector =
             match com.Options.Language with
-            | Rust -> moduleName + "::" + memberName //TODO: fix when imports change
+            | Rust -> moduleName + "_::" + memberName //TODO: fix when imports change
             | _ -> memberName
         Import({ Selector = selector
                  Path = getLibPath com moduleName

--- a/src/fable-library-rust/src/Array.fs
+++ b/src/fable-library-rust/src/Array.fs
@@ -1,4 +1,4 @@
-module Array
+module Array_
 
 // For optimization, functions may return ResizeArray instead of Array.
 // That's fine, because they both have the same representation in Rust.

--- a/src/fable-library-rust/src/Array.fs
+++ b/src/fable-library-rust/src/Array.fs
@@ -787,75 +787,77 @@ let groupBy<'T, 'Key when 'Key: equality> (projection: 'T -> 'Key) (xs: 'T[]): (
     |> asArray
     |> map (fun key -> key, dict.[key] |> asArray)
 
-// let insertAt (index: int) (y: 'T) (xs: 'T[]): 'T[] =
-//     let len = xs.Length
-//     if index < 0 || index > len then
-//         invalidArg "index" SR.indexOutOfBounds
-//     let target = zeroCreateFrom xs (len + 1)
-//     for i = 0 to (index - 1) do
-//         target.[i] <- xs.[i]
-//     target.[index] <- y
-//     for i = index to (len - 1) do
-//         target.[i + 1] <- xs.[i]
-//     target
+let insertAt (index: int) (y: 'T) (xs: 'T[]): 'T[] =
+    let len = xs.Length
+    if index < 0 || index > len then
+        invalidArg "index" SR.indexOutOfBounds
+    let res = ResizeArray<_>(len + 1)
+    for i = 0 to (index - 1) do
+        res.Add (xs.[i])
+    res.Add (y)
+    for i = index to (len - 1) do
+        res.Add (xs.[i])
+    res |> asArray
 
-// let insertManyAt (index: int) (ys: seq<'T>) (xs: 'T[]): 'T[] =
-//     let len = xs.Length
-//     if index < 0 || index > len then
-//         invalidArg "index" SR.indexOutOfBounds
-//     let ys = arrayFrom ys
-//     let len2 = ys.Length
-//     let target = zeroCreateFrom xs (len + len2)
-//     for i = 0 to (index - 1) do
-//         target.[i] <- xs.[i]
-//     for i = 0 to (len2 - 1) do
-//         target.[index + i] <- ys.[i]
-//     for i = index to (len - 1) do
-//         target.[i + len2] <- xs.[i]
-//     target
+let insertManyAt (index: int) (ys: seq<'T>) (xs: 'T[]): 'T[] =
+    let len = xs.Length
+    if index < 0 || index > len then
+        invalidArg "index" SR.indexOutOfBounds
+    let ys = Seq.toArray ys
+    let len2 = ys.Length
+    let res = ResizeArray<_>(len + len2)
+    for i = 0 to (index - 1) do
+        res.Add (xs.[i])
+    for i = 0 to (len2 - 1) do
+        res.Add (ys.[i])
+    for i = index to (len - 1) do
+        res.Add (xs.[i])
+    res |> asArray
 
-// let removeAt (index: int) (xs: 'T[]): 'T[] =
-//     if index < 0 || index >= xs.Length then
-//         invalidArg "index" SR.indexOutOfBounds
-//     let mutable i = -1
-//     xs |> filter (fun _ ->
-//         i <- i + 1
-//         i <> index)
+let removeAt (index: int) (xs: 'T[]): 'T[] =
+    if index < 0 || index >= xs.Length then
+        invalidArg "index" SR.indexOutOfBounds
+    let mutable i = -1
+    let res =
+        xs |> filter (fun _ ->
+            i <- i + 1
+            i <> index)
+    res
 
-// let removeManyAt (index: int) (count: int) (xs: 'T[]): 'T[] =
-//     let mutable i = -1
-//     // incomplete -1, in-progress 0, complete 1
-//     let mutable status = -1
-//     let ys =
-//         xs |> filter (fun _ ->
-//             i <- i + 1
-//             if i = index then
-//                 status <- 0
-//                 false
-//             elif i > index then
-//                 if i < index + count then
-//                     false
-//                 else
-//                     status <- 1
-//                     true
-//             else true)
-//     let status =
-//         if status = 0 && i + 1 = index + count then 1
-//         else status
-//     if status < 1 then
-//         // F# always says the wrong parameter is index but the problem may be count
-//         let arg = if status < 0 then "index" else "count"
-//         invalidArg arg SR.indexOutOfBounds
-//     ys
+let removeManyAt (index: int) (count: int) (xs: 'T[]): 'T[] =
+    let mutable i = -1
+    // incomplete -1, in-progress 0, complete 1
+    let mutable status = -1
+    let res =
+        xs |> filter (fun _ ->
+            i <- i + 1
+            if i = index then
+                status <- 0
+                false
+            elif i > index then
+                if i < index + count then
+                    false
+                else
+                    status <- 1
+                    true
+            else true)
+    let status =
+        if status = 0 && i + 1 = index + count then 1
+        else status
+    if status < 1 then
+        // F# always says the wrong parameter is index but the problem may be count
+        let arg = if status < 0 then "index" else "count"
+        invalidArg arg SR.indexOutOfBounds
+    res
 
-// let updateAt (index: int) (y: 'T) (xs: 'T[]): 'T[] =
-//     let len = xs.Length
-//     if index < 0 || index >= len then
-//         invalidArg "index" SR.indexOutOfBounds
-//     let target = zeroCreateFrom xs len
-//     for i = 0 to (len - 1) do
-//         target.[i] <- if i = index then y else xs.[i]
-//     target
+let updateAt (index: int) (y: 'T) (xs: 'T[]): 'T[] =
+    let len = xs.Length
+    if index < 0 || index >= len then
+        invalidArg "index" SR.indexOutOfBounds
+    let res = ResizeArray<_>(len)
+    for i = 0 to (len - 1) do
+        res.Add (if i = index then y else xs.[i])
+    res |> asArray
 
 // let init = initialize
 // let iter = iterate

--- a/src/fable-library-rust/src/Choice.fs
+++ b/src/fable-library-rust/src/Choice.fs
@@ -1,4 +1,4 @@
-module Choice
+module Choice_
 
 //[<CompiledName("FSharpChoice`2")>]
 type Choice<'T1,'T2> =

--- a/src/fable-library-rust/src/Func.rs
+++ b/src/fable-library-rust/src/Func.rs
@@ -1,6 +1,6 @@
 // [Y combinator](https://en.wikipedia.org/wiki/Fixed-point_combinator#Fixed-point_combinators_in_lambda_calculus)
 
-pub mod Func {
+pub mod Func_ {
 
     // fixed-point combinator for Fn(&T1) -> R
     trait Apply1<T1, R> {

--- a/src/fable-library-rust/src/Interfaces.fs
+++ b/src/fable-library-rust/src/Interfaces.fs
@@ -1,4 +1,4 @@
-module Interfaces
+module Interfaces_
 
 type IEnumerator<'T> =
     inherit System.IDisposable

--- a/src/fable-library-rust/src/Lazy.rs
+++ b/src/fable-library-rust/src/Lazy.rs
@@ -1,7 +1,7 @@
 /// Lazy values and one-time initialization.
 
 use core::fmt;
-use crate::Native::MutCell;
+use crate::Native_::MutCell;
 
 pub struct Lazy<T, F = fn() -> T> {
     cell: MutCell<Option<T>>,

--- a/src/fable-library-rust/src/List.fs
+++ b/src/fable-library-rust/src/List.fs
@@ -1,4 +1,4 @@
-module List
+module List_
 
 type Node<'T> = {
     head: 'T
@@ -28,9 +28,6 @@ let private setConsTail (t: 'T list) (xs: 'T list) =
     | Some node -> node.tail <- t
     | None -> ()
 
-let private emptyRoot (): 'T list =
-    Some { head = Unchecked.defaultof<_>; tail = None }
-
 let private appendConsNoTail (x: 'T) (xs: 'T list) =
     let t = consNoTail x
     setConsTail t xs
@@ -41,7 +38,6 @@ let private appendConsNoTail (x: 'T) (xs: 'T list) =
 
 let empty (): 'T list = //List.Empty
     None
-    // { head = Unchecked.defaultof<_>; tail = None }
 
 let cons (x: 'T) (xs: 'T list) = //List.Cons(x, xs)
     Some { head = x; tail = xs }

--- a/src/fable-library-rust/src/Map.fs
+++ b/src/fable-library-rust/src/Map.fs
@@ -2,7 +2,7 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.
 // See https://github.com/dotnet/fsharp/blob/main/License.txt
 
-module Map
+module Map_
 
 // A functional language implementation using binary trees
 

--- a/src/fable-library-rust/src/Native.rs
+++ b/src/fable-library-rust/src/Native.rs
@@ -4,10 +4,10 @@
 mod Mutable;
 mod Lazy;
 
-pub mod Native {
+pub mod Native_ {
 
     // re-export at module level
-    pub use crate::Choice::*;
+    pub use crate::Choice_::*;
     pub use std::collections::{HashMap, HashSet};
     pub use std::rc::Rc;
     pub use super::Mutable::*;
@@ -19,7 +19,7 @@ pub mod Native {
 
     // TODO: use these types in generated code
     pub type string = Rc<str>;
-    pub type seq<T> = Rc<dyn crate::Interfaces::IEnumerable_1<T>>;
+    pub type seq<T> = Rc<dyn crate::Interfaces_::IEnumerable_1<T>>;
     pub type RefCell<T> = Rc<MutCell<T>>;
     pub type Array<T> = Rc<MutCell<Vec<T>>>;
     pub type HashSet_1<T> = Rc<MutCell<HashSet<T>>>;
@@ -123,8 +123,8 @@ pub mod Native {
     {
         let iter = mkMut(iter);
         let f = mkRef(move || iter.get_mut().next());
-        let en = crate::Seq::Enumerable::fromFunction(f);
-        crate::Seq::mkSeq(mkRef(move || en.clone()))
+        let en = crate::Seq_::Enumerable::fromFunction(f);
+        crate::Seq_::mkSeq(mkRef(move || en.clone()))
     }
 
     // -----------------------------------------------------------

--- a/src/fable-library-rust/src/Option.fs
+++ b/src/fable-library-rust/src/Option.fs
@@ -1,4 +1,4 @@
-module Option
+module Option_
 
 let bind<'T, 'U> (binder: 'T -> 'U option) (opt: 'T option): 'U option =
     match opt with

--- a/src/fable-library-rust/src/Range.fs
+++ b/src/fable-library-rust/src/Range.fs
@@ -1,4 +1,4 @@
-module Range
+module Range_
 
 let inline rangeNumeric (start: 'T) (step: 'T) (stop: 'T) =
     let zero = LanguagePrimitives.GenericZero

--- a/src/fable-library-rust/src/Result.fs
+++ b/src/fable-library-rust/src/Result.fs
@@ -1,4 +1,4 @@
-module Result
+module Result_
 
 let map mapping result =
     match result with

--- a/src/fable-library-rust/src/Seq.fs
+++ b/src/fable-library-rust/src/Seq.fs
@@ -3,11 +3,11 @@
 // https://github.com/dotnet/fsharp/blob/main/src/fsharp/FSharp.Core/seq.fs
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
-module Seq
+module Seq_
 
 // open System.Collections.Generic
 
-open Interfaces
+open Interfaces_
 
 type 'T seq = IEnumerable<'T>
 

--- a/src/fable-library-rust/src/Seq.fs
+++ b/src/fable-library-rust/src/Seq.fs
@@ -12,6 +12,7 @@ open Interfaces_
 type 'T seq = IEnumerable<'T>
 
 module SR =
+    let indexOutOfBounds = "The index was outside the range of elements in the array."
     let enumerationAlreadyFinished = "Enumeration already finished."
     let enumerationNotStarted = "Enumeration has not started. Call MoveNext."
     let inputSequenceEmpty = "The input sequence was empty."
@@ -566,22 +567,20 @@ let fold (folder: 'State -> 'T -> 'State) (state: 'State) (xs: 'T seq) =
 let inline private asArray (a: ResizeArray<'T>): 'T[] =
     (a :> obj) :?> 'T[] // cast will go away, same representation in Rust
 
+// Redirected from Array.ofSeq (see Replacements)
 let toArray (xs: 'T seq): 'T[] =
     let res = ResizeArray<_>()
     for x in xs do
         res.Add(x)
     res |> asArray
 
-let toList (xs: 'T seq): 'T list =
-    // let mutable acc = []
-    // for x in xs do
-    //     acc <- x::acc
-    // List.rev acc // TODO: optimize to avoid reverse
-    use e = ofSeq xs
-    List.unfold (fun (e: IEnumerator<'T>) ->
-        if e.MoveNext()
-        then Some(e.Current, e)
-        else None) e
+// Redirected to List.ofSeq (see Replacements)
+// let toList (xs: 'T seq): 'T list =
+//     use e = ofSeq xs
+//     List.unfold (fun (e: IEnumerator<'T>) ->
+//         if e.MoveNext()
+//         then Some(e.Current, e)
+//         else None) e
 
 let foldBack folder (xs: 'T seq) state =
     Array.foldBack folder (toArray xs) state
@@ -1090,104 +1089,104 @@ let groupBy<'T, 'Key when 'Key: equality> (projection: 'T -> 'Key) (xs: 'T seq):
         |> ofArray
     )
 
-// let insertAt (index: int) (y: 'T) (xs: 'T seq): 'T seq =
-//     let mutable isDone = false
-//     if index < 0 then
-//         invalidArg "index" SR.indexOutOfBounds
-//     generateIndexed
-//         (fun () -> ofSeq xs)
-//         (fun i e ->
-//             if (isDone || i < index) && e.MoveNext()
-//             then Some e.Current
-//             elif i = index then
-//                 isDone <- true
-//                 Some y
-//             else
-//                 if not isDone then
-//                     invalidArg "index" SR.indexOutOfBounds
-//                 None)
-//         (fun e -> e.Dispose())
+let insertAt (index: int) (y: 'T) (xs: 'T seq): 'T seq =
+    let mutable isDone = false
+    if index < 0 then
+        invalidArg "index" SR.indexOutOfBounds
+    generateIndexed
+        (fun () -> ofSeq xs)
+        (fun i e ->
+            if (isDone || i < index) && e.MoveNext()
+            then Some e.Current
+            elif i = index then
+                isDone <- true
+                Some y
+            else
+                if not isDone then
+                    invalidArg "index" SR.indexOutOfBounds
+                None)
+        (fun e -> e.Dispose())
 
-// let insertManyAt (index: int) (ys: 'T seq) (xs: 'T seq): 'T seq =
-//     // incomplete -1, in-progress 0, complete 1
-//     let mutable status = -1
-//     if index < 0 then
-//         invalidArg "index" SR.indexOutOfBounds
-//     generateIndexed
-//         (fun () -> ofSeq xs, ofSeq ys)
-//         (fun i (e1, e2) ->
-//             if i = index then
-//                 status <- 0
-//             let inserted =
-//                 if status = 0 then
-//                     if e2.MoveNext() then Some e2.Current
-//                     else status <- 1; None
-//                 else None
-//             match inserted with
-//             | Some inserted -> Some inserted
-//             | None ->
-//                 if e1.MoveNext() then Some e1.Current
-//                 else
-//                     if status < 1 then
-//                         invalidArg "index" SR.indexOutOfBounds
-//                     None)
-//         (fun (e1, e2) ->
-//             e1.Dispose()
-//             e2.Dispose())
+let insertManyAt (index: int) (ys: 'T seq) (xs: 'T seq): 'T seq =
+    // incomplete -1, in-progress 0, complete 1
+    let mutable status = -1
+    if index < 0 then
+        invalidArg "index" SR.indexOutOfBounds
+    generateIndexed
+        (fun () -> ofSeq xs, ofSeq ys)
+        (fun i (e1, e2) ->
+            if i = index then
+                status <- 0
+            let inserted =
+                if status = 0 then
+                    if e2.MoveNext() then Some e2.Current
+                    else status <- 1; None
+                else None
+            match inserted with
+            | Some inserted -> Some inserted
+            | None ->
+                if e1.MoveNext() then Some e1.Current
+                else
+                    if status < 1 then
+                        invalidArg "index" SR.indexOutOfBounds
+                    None)
+        (fun (e1, e2) ->
+            e1.Dispose()
+            e2.Dispose())
 
-// let removeAt (index: int) (xs: 'T seq): 'T seq =
-//     let mutable isDone = false
-//     if index < 0 then
-//         invalidArg "index" SR.indexOutOfBounds
-//     generateIndexed
-//         (fun () -> ofSeq xs)
-//         (fun i e ->
-//             if (isDone || i < index) && e.MoveNext()
-//             then Some e.Current
-//             elif i = index && e.MoveNext() then
-//                 isDone <- true
-//                 if e.MoveNext() then Some e.Current else None
-//             else
-//                 if not isDone then
-//                     invalidArg "index" SR.indexOutOfBounds
-//                 None)
-//         (fun e -> e.Dispose())
+let removeAt (index: int) (xs: 'T seq): 'T seq =
+    let mutable isDone = false
+    if index < 0 then
+        invalidArg "index" SR.indexOutOfBounds
+    generateIndexed
+        (fun () -> ofSeq xs)
+        (fun i e ->
+            if (isDone || i < index) && e.MoveNext()
+            then Some e.Current
+            elif i = index && e.MoveNext() then
+                isDone <- true
+                if e.MoveNext() then Some e.Current else None
+            else
+                if not isDone then
+                    invalidArg "index" SR.indexOutOfBounds
+                None)
+        (fun e -> e.Dispose())
 
-// let removeManyAt (index: int) (count: int) (xs: 'T seq): 'T seq =
-//     if index < 0 then
-//         invalidArg "index" SR.indexOutOfBounds
-//     generateIndexed
-//         (fun () -> ofSeq xs)
-//         (fun i e ->
-//             if i < index then
-//                 if e.MoveNext() then Some e.Current
-//                 else invalidArg "index" SR.indexOutOfBounds
-//             else
-//                 if i = index then
-//                     for _ = 1 to count do
-//                         if not(e.MoveNext()) then
-//                             invalidArg "count" SR.indexOutOfBounds
-//                 if e.MoveNext() then Some e.Current
-//                 else None)
-//         (fun e -> e.Dispose())
+let removeManyAt (index: int) (count: int) (xs: 'T seq): 'T seq =
+    if index < 0 then
+        invalidArg "index" SR.indexOutOfBounds
+    generateIndexed
+        (fun () -> ofSeq xs)
+        (fun i e ->
+            if i < index then
+                if e.MoveNext() then Some e.Current
+                else invalidArg "index" SR.indexOutOfBounds
+            else
+                if i = index then
+                    for _i = 1 to count do
+                        if not(e.MoveNext()) then
+                            invalidArg "count" SR.indexOutOfBounds
+                if e.MoveNext() then Some e.Current
+                else None)
+        (fun e -> e.Dispose())
 
-// let updateAt (index: int) (y: 'T) (xs: 'T seq): 'T seq =
-//     let mutable isDone = false
-//     if index < 0 then
-//         invalidArg "index" SR.indexOutOfBounds
-//     generateIndexed
-//         (fun () -> ofSeq xs)
-//         (fun i e ->
-//             if (isDone || i < index) && e.MoveNext()
-//             then Some e.Current
-//             elif i = index && e.MoveNext() then
-//                 isDone <- true
-//                 Some y
-//             else
-//                 if not isDone then
-//                     invalidArg "index" SR.indexOutOfBounds
-//                 None)
-//         (fun e -> e.Dispose())
+let updateAt (index: int) (y: 'T) (xs: 'T seq): 'T seq =
+    let mutable isDone = false
+    if index < 0 then
+        invalidArg "index" SR.indexOutOfBounds
+    generateIndexed
+        (fun () -> ofSeq xs)
+        (fun i e ->
+            if (isDone || i < index) && e.MoveNext()
+            then Some e.Current
+            elif i = index && e.MoveNext() then
+                isDone <- true
+                Some y
+            else
+                if not isDone then
+                    invalidArg "index" SR.indexOutOfBounds
+                None)
+        (fun e -> e.Dispose())
 
 // // let init = initialize
 // // let initInfinite = initializeInfinite

--- a/src/fable-library-rust/src/Set.fs
+++ b/src/fable-library-rust/src/Set.fs
@@ -2,7 +2,7 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.
 // See https://github.com/dotnet/fsharp/blob/main/License.txt
 
-module Set
+module Set_
 
 // A functional language implementation of binary trees
 

--- a/src/fable-library-rust/src/String.rs
+++ b/src/fable-library-rust/src/String.rs
@@ -1,7 +1,7 @@
 #![allow(non_snake_case)]
 
 pub mod String_ {
-    use crate::Native::*;
+    use crate::Native_::*;
 
     // -----------------------------------------------------------
     // Strings

--- a/src/fable-library-rust/src/Util.fs
+++ b/src/fable-library-rust/src/Util.fs
@@ -1,4 +1,4 @@
-module Util
+module Util_
 
 let equals (x: 'T) (y: 'T): bool =
     x = y

--- a/tests/Rust/tests/src/ArrayTests.fs
+++ b/tests/Rust/tests/src/ArrayTests.fs
@@ -7,7 +7,7 @@ open Util.Testing
 
 // let add (xs: int[]) = ParamArrayTest.Add(xs)
 
-// type ExceptFoo = { Bar: string }
+type ExceptFoo = { Bar: string }
 
 // let f (x:obj) (y:obj) (z:obj) = (string x) + (string y) + (string z)
 
@@ -291,41 +291,41 @@ let ``Array.length works with non-numeric arrays`` () =
 //     Array.blit xs 3 ys 5 4
 //     ys.[5] + ys.[6] + ys.[7] + ys.[8] |> equal "defg"
 
-// [<Fact>]
-// let ``Array.distinct works`` () =
-//     let xs = [| 1; 1; 1; 2; 2; 3; 3 |]
-//     let ys = xs |> Array.distinct
-//     ys |> Array.length |> equal 3
-//     ys |> Array.sum |> equal 6
+[<Fact>]
+let ``Array.distinct works`` () =
+    let xs = [| 1; 1; 1; 2; 2; 3; 3 |]
+    let ys = xs |> Array.distinct
+    ys |> Array.length |> equal 3
+    ys |> Array.sum |> equal 6
 
-// [<Fact>]
-// let ``Array.distinct with tuples works`` () =
-//     let xs = [|(1, 2); (2, 3); (1, 2)|]
-//     let ys = xs |> Array.distinct
-//     ys |> Array.length |> equal 2
-//     ys |> Array.sumBy fst |> equal 3
+[<Fact>]
+let ``Array.distinct with tuples works`` () =
+    let xs = [|(1, 2); (2, 3); (1, 2)|]
+    let ys = xs |> Array.distinct
+    ys |> Array.length |> equal 2
+    ys |> Array.sumBy fst |> equal 3
 
-// [<Fact>]
-// let ``Array.distinctBy works`` () =
-//     let xs = [| 4; 4; 4; 6; 6; 5; 5 |]
-//     let ys = xs |> Array.distinctBy (fun x -> x % 2)
-//     ys |> Array.length |> equal 2
-//     ys |> Array.head >= 4 |> equal true
+[<Fact>]
+let ``Array.distinctBy works`` () =
+    let xs = [| 4; 4; 4; 6; 6; 5; 5 |]
+    let ys = xs |> Array.distinctBy (fun x -> x % 2)
+    ys |> Array.length |> equal 2
+    ys |> Array.head >= 4 |> equal true
 
-// [<Fact>]
-// let ``Array.distinctBy with tuples works`` () =
-//     let xs = [| 4,1; 4,2; 4,3; 6,4; 6,5; 5,6; 5,7 |]
-//     let ys = xs |> Array.distinctBy (fun (x,_) -> x % 2)
-//     ys |> Array.length |> equal 2
-//     ys |> Array.head |> fst >= 4 |> equal true
+[<Fact>]
+let ``Array.distinctBy with tuples works`` () =
+    let xs = [| 4,1; 4,2; 4,3; 6,4; 6,5; 5,6; 5,7 |]
+    let ys = xs |> Array.distinctBy (fun (x,_) -> x % 2)
+    ys |> Array.length |> equal 2
+    ys |> Array.head |> fst >= 4 |> equal true
 
-// [<Fact>]
-// let ``Array distinctBy works on large array`` () =
-//     let xs = [| 0 .. 50000 |]
-//     let ys =
-//         Array.append xs xs
-//         |> Array.distinctBy(fun x -> x.ToString())
-//     ys |> equal xs
+[<Fact>]
+let ``Array distinctBy works on large array`` () =
+    let xs = [| 0 .. 50000 |]
+    let ys =
+        Array.append xs xs
+        |> Array.distinctBy(fun x -> x.ToString())
+    ys |> equal xs
 
 [<Fact>]
 let ``Array.sub works`` () =
@@ -594,11 +594,11 @@ let ``Array.compareWith works`` () =
     Array.compareWith (-) xs ys |> equal -1
     Array.compareWith (-) xs zs |> equal 1
 
-// [<Fact>]
-// let ``Array.countBy works`` () =
-//     let xs = [|1; 2; 3; 4|]
-//     xs |> Array.countBy (fun x -> x % 2)
-//     |> Array.length |> equal 2
+[<Fact>]
+let ``Array.countBy works`` () =
+    let xs = [|1; 2; 3; 4|]
+    let ys = xs |> Array.countBy (fun x -> x % 2)
+    ys |> equal [|(1, 2); (0, 2)|]
 
 [<Fact>]
 let ``Array.map works`` () =
@@ -706,8 +706,6 @@ let ``Array.pairwise works`` () =
     let xs = [|1; 2; 3; 4|]
     let ys = xs |> Array.pairwise
     ys |> equal [|(1, 2); (2, 3); (3, 4)|]
-    // ys |> Array.map (fun (x, y) -> sprintf "%i%i" x y)
-    // |> String.concat "" |> equal "122334"
 
 [<Fact>]
 let ``Array.permute works`` () =
@@ -1043,36 +1041,37 @@ let ``Array.tail works`` () =
     let xs = [|1.; 2.; 3.; 4.|]
     Array.tail xs |> Array.length |> equal 3
 
-// [<Fact>]
-// let ``Array.groupBy returns valid array`` () =
-//     let xs = [|1; 2|]
-//     let actual = Array.groupBy (fun _ -> true) xs
-//     let actualKey, actualGroup = actual.[0]
-//     let worked = actualKey && actualGroup.[0] = 1 && actualGroup.[1] = 2
-//     worked |> equal true
+[<Fact>]
+let ``Array.groupBy returns valid array`` () =
+    let xs = [|1; 2|]
+    let actual = Array.groupBy (fun _ -> true) xs
+    let actualKey, actualGroup = actual.[0]
+    let worked = actualKey && actualGroup.[0] = 1 && actualGroup.[1] = 2
+    worked |> equal true
 
-// [<Fact>]
-// let ``Array.groupBy does not run into undefined exception`` () =
-//     let ys = [| 1;2;3 |] |> Array.groupBy (fun x -> x = 2)
-//     ys |> equal [| (false, [| 1;3 |]); (true, [| 2 |]) |]
+[<Fact>]
+let ``Array.groupBy does not run into undefined exception`` () =
+    let ys = [| 1;2;3 |] |> Array.groupBy (fun x -> x = 2)
+    ys |> equal [| (false, [| 1;3 |]); (true, [| 2 |]) |]
 
-// [<Fact>]
-// let ``Array.groupBy maintains order`` () =
-//     let xs = [| 0,5; 1,5; 2,5; 3,5; 0,6; 1,6; 2,6; 3,6 |]
-//     let mapped = xs |> Array.take 4 |> Array.map (fun (x,y) -> x, [|x,y; x,y+1|])
-//     let grouped = xs |> Array.groupBy fst
-//     grouped |> equal mapped
+[<Fact>]
+let ``Array.groupBy maintains order`` () =
+    let xs = [| 0,5; 1,5; 2,5; 3,5; 0,6; 1,6; 2,6; 3,6 |]
+    let mapped = xs |> Array.take 4 |> Array.map (fun (x,y) -> x, [|x,y; x,y+1|])
+    let grouped = xs |> Array.groupBy fst
+    grouped |> equal mapped
 
-// [<Fact>]
-// let ``Array.except works`` () =
-//     Array.except [|2|] [|1; 3; 2|] |> Array.last |> equal 3
-//     Array.except [|2|] [|2; 4; 6|] |> Array.head |> equal 4
-//     Array.except [|1|] [|1; 1; 1; 1|] |> Array.isEmpty |> equal true
-//     Array.except [|'t'; 'e'; 's'; 't'|] [|'t'; 'e'; 's'; 't'|] |> Array.isEmpty |> equal true
-//     Array.except [|'t'; 'e'; 's'; 't'|] [|'t'; 't'|] |> Array.isEmpty |> equal true
-//     Array.except [|(1, 2)|] [|(1, 2)|] |> Array.isEmpty |> equal true
-//     Array.except [|Map.empty |> (fun m -> m.Add(1, 2))|] [|Map.ofList [(1, 2)]|] |> Array.isEmpty |> equal true
-//     Array.except [|{ Bar= "test" }|] [|{ Bar = "test" }|] |> Array.isEmpty |> equal true
+[<Fact>]
+let ``Array.except works`` () =
+    Array.except [|2|] [|1; 3; 2|] |> Array.last |> equal 3
+    Array.except [|2|] [|2; 4; 6|] |> Array.head |> equal 4
+    Array.except [|1|] [|1; 1; 1; 1|] |> Array.isEmpty |> equal true
+    Array.except [|49|] [|7; 49|] |> Array.last |> equal 7
+    Array.except [|'t'; 'e'; 's'; 't'|] [|'t'; 'e'; 's'; 't'|] |> Array.isEmpty |> equal true
+    Array.except [|'t'; 'e'; 's'; 't'|] [|'t'; 't'|] |> Array.isEmpty |> equal true
+    Array.except [|(1, 2)|] [|(1, 2)|] |> Array.isEmpty |> equal true
+    Array.except [|{ Bar= "test" }|] [|{ Bar = "test" }|] |> Array.isEmpty |> equal true
+    // Array.except [|Map.empty |> (fun m -> m.Add(1, 2))|] [|Map.ofList [(1, 2)]|] |> Array.isEmpty |> equal true
 
 // [<Fact>]
 // let ``Array.[i] is undefined in Fable when i is out of range`` () =

--- a/tests/Rust/tests/src/ArrayTests.fs
+++ b/tests/Rust/tests/src/ArrayTests.fs
@@ -1249,92 +1249,92 @@ let ``Array.transpose works`` () =
     |> equal [| |]
     Array.transpose<int> [| [||]; [||] |]
     |> equal [| |]
+
     // jagged arrays throw on transpose
-    // TODO:
     // throwsAnyError (fun () -> Array.transpose [| [|1; 2|]; [|3|] |])
     // throwsAnyError (fun () -> Array.transpose [| [|1|]; [|2; 3|] |])
 
-// [<Fact>]
-// let ``Array.updateAt works`` () =
-//     // integer list
-//     equal [|0; 2; 3; 4; 5|] (Array.updateAt 0 0 [|1..5|])
-//     equal [|1; 2; 0; 4; 5|] (Array.updateAt 2 0 [|1..5|])
-//     equal [|1; 2; 3; 4; 0|] (Array.updateAt 4 0 [|1..5|])
+[<Fact>]
+let ``Array.updateAt works`` () =
+    // integer list
+    equal [|0; 2; 3; 4; 5|] (Array.updateAt 0 0 [|1..5|])
+    equal [|1; 2; 0; 4; 5|] (Array.updateAt 2 0 [|1..5|])
+    equal [|1; 2; 3; 4; 0|] (Array.updateAt 4 0 [|1..5|])
 
-//     //string list
-//     equal [|"0"; "2"; "3"; "4"; "5"|] (Array.updateAt 0 "0" [|"1"; "2"; "3"; "4"; "5"|])
-//     equal [|"1"; "2"; "0"; "4"; "5"|] (Array.updateAt 2 "0" [|"1"; "2"; "3"; "4"; "5"|])
-//     equal [|"1"; "2"; "3"; "4"; "0"|] (Array.updateAt 4 "0" [|"1"; "2"; "3"; "4"; "5"|])
+    //string list
+    equal [|"0"; "2"; "3"; "4"; "5"|] (Array.updateAt 0 "0" [|"1"; "2"; "3"; "4"; "5"|])
+    equal [|"1"; "2"; "0"; "4"; "5"|] (Array.updateAt 2 "0" [|"1"; "2"; "3"; "4"; "5"|])
+    equal [|"1"; "2"; "3"; "4"; "0"|] (Array.updateAt 4 "0" [|"1"; "2"; "3"; "4"; "5"|])
 
-//     // empty list & out of bounds
-//     throwsAnyError (fun () -> Array.updateAt 0 0 [||] |> ignore)
-//     throwsAnyError (fun () -> Array.updateAt -1 0 [|1|] |> ignore)
-//     throwsAnyError (fun () -> Array.updateAt 2 0 [|1|] |> ignore)
+    // empty list & out of bounds
+    // throwsAnyError (fun () -> Array.updateAt 0 0 [||] |> ignore)
+    // throwsAnyError (fun () -> Array.updateAt -1 0 [|1|] |> ignore)
+    // throwsAnyError (fun () -> Array.updateAt 2 0 [|1|] |> ignore)
 
-// [<Fact>]
-// let ``Array.insertAt works`` () =
-//     // integer list
-//     equal [|0; 1; 2; 3; 4; 5|] (Array.insertAt 0 0 [|1..5|])
-//     equal [|1; 2; 0; 3; 4; 5|] (Array.insertAt 2 0 [|1..5|])
-//     equal [|1; 2; 3; 4; 0; 5|] (Array.insertAt 4 0 [|1..5|])
+[<Fact>]
+let ``Array.insertAt works`` () =
+    // integer list
+    equal [|0; 1; 2; 3; 4; 5|] (Array.insertAt 0 0 [|1..5|])
+    equal [|1; 2; 0; 3; 4; 5|] (Array.insertAt 2 0 [|1..5|])
+    equal [|1; 2; 3; 4; 0; 5|] (Array.insertAt 4 0 [|1..5|])
 
-//     //string list
-//     equal [|"0"; "1"; "2"; "3"; "4"; "5"|] (Array.insertAt 0 "0" [|"1"; "2"; "3"; "4"; "5"|])
-//     equal [|"1"; "2"; "0"; "3"; "4"; "5"|] (Array.insertAt 2 "0" [|"1"; "2"; "3"; "4"; "5"|])
-//     equal [|"1"; "2"; "3"; "4"; "0"; "5"|] (Array.insertAt 4 "0" [|"1"; "2"; "3"; "4"; "5"|])
+    //string list
+    equal [|"0"; "1"; "2"; "3"; "4"; "5"|] (Array.insertAt 0 "0" [|"1"; "2"; "3"; "4"; "5"|])
+    equal [|"1"; "2"; "0"; "3"; "4"; "5"|] (Array.insertAt 2 "0" [|"1"; "2"; "3"; "4"; "5"|])
+    equal [|"1"; "2"; "3"; "4"; "0"; "5"|] (Array.insertAt 4 "0" [|"1"; "2"; "3"; "4"; "5"|])
 
-//     // empty list & out of bounds
-//     equal [|0|] (Array.insertAt 0 0 [||])
-//     throwsAnyError (fun () -> Array.insertAt -1 0 [|1|] |> ignore)
-//     throwsAnyError (fun () -> Array.insertAt 2 0 [|1|] |> ignore)
+    // empty list & out of bounds
+    equal [|0|] (Array.insertAt 0 0 [||])
+    // throwsAnyError (fun () -> Array.insertAt -1 0 [|1|] |> ignore)
+    // throwsAnyError (fun () -> Array.insertAt 2 0 [|1|] |> ignore)
 
-// [<Fact>]
-// let ``Array.insertManyAt works`` () =
-//     // integer list
-//     equal [|0; 0; 1; 2; 3; 4; 5|] (Array.insertManyAt 0 [0; 0] [|1..5|])
-//     equal [|1; 2; 0; 0; 3; 4; 5|] (Array.insertManyAt 2 [0; 0] [|1..5|])
-//     equal [|1; 2; 3; 4; 0; 0; 5|] (Array.insertManyAt 4 [0; 0] [|1..5|])
+[<Fact>]
+let ``Array.insertManyAt works`` () =
+    // integer list
+    equal [|0; 0; 1; 2; 3; 4; 5|] (Array.insertManyAt 0 [0; 0] [|1..5|])
+    equal [|1; 2; 0; 0; 3; 4; 5|] (Array.insertManyAt 2 [0; 0] [|1..5|])
+    equal [|1; 2; 3; 4; 0; 0; 5|] (Array.insertManyAt 4 [0; 0] [|1..5|])
 
-//     //string list
-//     equal [|"0"; "0"; "1"; "2"; "3"; "4"; "5"|] (Array.insertManyAt 0 ["0"; "0"] [|"1"; "2"; "3"; "4"; "5"|])
-//     equal [|"1"; "2"; "0"; "0"; "3"; "4"; "5"|] (Array.insertManyAt 2 ["0"; "0"] [|"1"; "2"; "3"; "4"; "5"|])
-//     equal [|"1"; "2"; "3"; "4"; "0"; "0"; "5"|] (Array.insertManyAt 4 ["0"; "0"] [|"1"; "2"; "3"; "4"; "5"|])
+    //string list
+    equal [|"0"; "0"; "1"; "2"; "3"; "4"; "5"|] (Array.insertManyAt 0 ["0"; "0"] [|"1"; "2"; "3"; "4"; "5"|])
+    equal [|"1"; "2"; "0"; "0"; "3"; "4"; "5"|] (Array.insertManyAt 2 ["0"; "0"] [|"1"; "2"; "3"; "4"; "5"|])
+    equal [|"1"; "2"; "3"; "4"; "0"; "0"; "5"|] (Array.insertManyAt 4 ["0"; "0"] [|"1"; "2"; "3"; "4"; "5"|])
 
-//     // empty list & out of bounds
-//     equal [|0; 0|] (Array.insertManyAt 0 [0; 0] [||])
-//     throwsAnyError (fun () -> Array.insertManyAt -1 [0; 0] [|1|] |> ignore)
-//     throwsAnyError (fun () -> Array.insertManyAt 2 [0; 0] [|1|] |> ignore)
+    // empty list & out of bounds
+    equal [|0; 0|] (Array.insertManyAt 0 [0; 0] [||])
+    // throwsAnyError (fun () -> Array.insertManyAt -1 [0; 0] [|1|] |> ignore)
+    // throwsAnyError (fun () -> Array.insertManyAt 2 [0; 0] [|1|] |> ignore)
 
-// [<Fact>]
-// let ``Array.removeAt works`` () =
-//     // integer list
-//     equal [|2; 3; 4; 5|] (Array.removeAt 0 [|1..5|])
-//     equal [|1; 2; 4; 5|] (Array.removeAt 2 [|1..5|])
-//     equal [|1; 2; 3; 4|] (Array.removeAt 4 [|1..5|])
+[<Fact>]
+let ``Array.removeAt works`` () =
+    // integer list
+    equal [|2; 3; 4; 5|] (Array.removeAt 0 [|1..5|])
+    equal [|1; 2; 4; 5|] (Array.removeAt 2 [|1..5|])
+    equal [|1; 2; 3; 4|] (Array.removeAt 4 [|1..5|])
 
-//     //string list
-//     equal [|"2"; "3"; "4"; "5"|] (Array.removeAt 0 [|"1"; "2"; "3"; "4"; "5"|])
-//     equal [|"1"; "2"; "4"; "5"|] (Array.removeAt 2 [|"1"; "2"; "3"; "4"; "5"|])
-//     equal [|"1"; "2"; "3"; "4"|] (Array.removeAt 4 [|"1"; "2"; "3"; "4"; "5"|])
+    //string list
+    equal [|"2"; "3"; "4"; "5"|] (Array.removeAt 0 [|"1"; "2"; "3"; "4"; "5"|])
+    equal [|"1"; "2"; "4"; "5"|] (Array.removeAt 2 [|"1"; "2"; "3"; "4"; "5"|])
+    equal [|"1"; "2"; "3"; "4"|] (Array.removeAt 4 [|"1"; "2"; "3"; "4"; "5"|])
 
-//     // empty list & out of bounds
-//     throwsAnyError (fun () -> Array.removeAt 0 [||] |> ignore)
-//     throwsAnyError (fun () -> Array.removeAt -1 [|1|] |> ignore)
-//     throwsAnyError (fun () -> Array.removeAt 2 [|1|] |> ignore)
+    // empty list & out of bounds
+    // throwsAnyError (fun () -> Array.removeAt 0 [||] |> ignore)
+    // throwsAnyError (fun () -> Array.removeAt -1 [|1|] |> ignore)
+    // throwsAnyError (fun () -> Array.removeAt 2 [|1|] |> ignore)
 
-// [<Fact>]
-// let ``Array.removeManyAt works`` () =
-//     // integer list
-//     equal [|3; 4; 5|] (Array.removeManyAt 0 2 [|1..5|])
-//     equal [|1; 2; 5|] (Array.removeManyAt 2 2 [|1..5|])
-//     equal [|1; 2; 3|] (Array.removeManyAt 3 2 [|1..5|])
+[<Fact>]
+let ``Array.removeManyAt works`` () =
+    // integer list
+    equal [|3; 4; 5|] (Array.removeManyAt 0 2 [|1..5|])
+    equal [|1; 2; 5|] (Array.removeManyAt 2 2 [|1..5|])
+    equal [|1; 2; 3|] (Array.removeManyAt 3 2 [|1..5|])
 
-//     //string list
-//     equal [|"3"; "4"; "5"|] (Array.removeManyAt 0 2 [|"1"; "2"; "3"; "4"; "5"|])
-//     equal [|"1"; "2"; "5"|] (Array.removeManyAt 2 2 [|"1"; "2"; "3"; "4"; "5"|])
-//     equal [|"1"; "2"; "3"|] (Array.removeManyAt 3 2 [|"1"; "2"; "3"; "4"; "5"|])
+    //string list
+    equal [|"3"; "4"; "5"|] (Array.removeManyAt 0 2 [|"1"; "2"; "3"; "4"; "5"|])
+    equal [|"1"; "2"; "5"|] (Array.removeManyAt 2 2 [|"1"; "2"; "3"; "4"; "5"|])
+    equal [|"1"; "2"; "3"|] (Array.removeManyAt 3 2 [|"1"; "2"; "3"; "4"; "5"|])
 
-//     // empty list & out of bounds
-//     throwsAnyError (fun () -> Array.removeManyAt 0 2 [||] |> ignore)
-//     throwsAnyError (fun () -> Array.removeManyAt -1 2 [|1|] |> ignore)
-//     throwsAnyError (fun () -> Array.removeManyAt 2 2 [|1|] |> ignore)
+    // empty list & out of bounds
+    // throwsAnyError (fun () -> Array.removeManyAt 0 2 [||] |> ignore)
+    // throwsAnyError (fun () -> Array.removeManyAt -1 2 [|1|] |> ignore)
+    // throwsAnyError (fun () -> Array.removeManyAt 2 2 [|1|] |> ignore)

--- a/tests/Rust/tests/src/ListTests.fs
+++ b/tests/Rust/tests/src/ListTests.fs
@@ -5,7 +5,7 @@ open Util.Testing
 // type List(x: int) =
 //     member val Value = x
 
-// type ExceptFoo = { Bar:string }
+type ExceptFoo = { Bar:string }
 
 // let testListChoose xss =
 //     let f xss = xss |> List.choose (function Some a -> Some a | _ -> None)
@@ -759,33 +759,33 @@ let ``List.averageBy works`` () =
 //     [{ MyNumber = MyNumber 5 }; { MyNumber = MyNumber 4 }; { MyNumber = MyNumber 3 }]
 //     |> List.averageBy (fun x -> x.MyNumber) |> equal (MyNumber 4)
 
-// [<Fact>]
-// let ``List.distinct works`` () =
-//     let xs = [1; 1; 1; 2; 2; 3; 3]
-//     let ys = xs |> List.distinct
-//     ys |> List.length |> equal 3
-//     ys |> List.sum |> equal 6
+[<Fact>]
+let ``List.distinct works`` () =
+    let xs = [1; 1; 1; 2; 2; 3; 3]
+    let ys = xs |> List.distinct
+    ys |> List.length |> equal 3
+    ys |> List.sum |> equal 6
 
-// [<Fact>]
-// let ``List.distinct with tuples works`` () =
-//     let xs = [(1, 2); (2, 3); (1, 2)]
-//     let ys = xs |> List.distinct
-//     ys |> List.length |> equal 2
-//     ys |> List.sumBy fst |> equal 3
+[<Fact>]
+let ``List.distinct with tuples works`` () =
+    let xs = [(1, 2); (2, 3); (1, 2)]
+    let ys = xs |> List.distinct
+    ys |> List.length |> equal 2
+    ys |> List.sumBy fst |> equal 3
 
-// [<Fact>]
-// let ``List.distinctBy works`` () =
-//     let xs = [4; 4; 4; 6; 6; 5; 5]
-//     let ys = xs |> List.distinctBy (fun x -> x % 2)
-//     ys |> List.length |> equal 2
-//     ys |> List.head >= 4 |> equal true
+[<Fact>]
+let ``List.distinctBy works`` () =
+    let xs = [4; 4; 4; 6; 6; 5; 5]
+    let ys = xs |> List.distinctBy (fun x -> x % 2)
+    ys |> List.length |> equal 2
+    ys |> List.head >= 4 |> equal true
 
-// [<Fact>]
-// let ``List.distinctBy with tuples works`` () =
-//     let xs = [4,1; 4,2; 4,3; 6,4; 6,5; 5,6; 5,7]
-//     let ys = xs |> List.distinctBy (fun (x,_) -> x % 2)
-//     ys |> List.length |> equal 2
-//     ys |> List.head |> fst >= 4 |> equal true
+[<Fact>]
+let ``List.distinctBy with tuples works`` () =
+    let xs = [4,1; 4,2; 4,3; 6,4; 6,5; 5,6; 5,7]
+    let ys = xs |> List.distinctBy (fun (x,_) -> x % 2)
+    ys |> List.length |> equal 2
+    ys |> List.head |> fst >= 4 |> equal true
 
 [<Fact>]
 let ``List.findBack works`` () =
@@ -871,14 +871,12 @@ let ``List.partition works`` () =
 
 [<Fact>]
 let ``List.pairwise works`` () =
-    List.pairwise<int> [] |> List.isEmpty |> equal true
-    List.pairwise [1] |> List.isEmpty |> equal true
+    ([]: int list) |> List.pairwise |> List.isEmpty |> equal true
+    [1] |> List.pairwise |> List.isEmpty |> equal true
+    [1; 2] |> Seq.pairwise |> Seq.head |> equal (1, 2)
     let xs = [1; 2; 3; 4]
     let ys = xs |> List.pairwise
-    ys |> List.head |> equal (1, 2)
-    // ys |> List.toArray |> equal [|(1, 2); (2, 3); (3, 4)|]
-    // ys |> List.map (fun (x, y) -> sprintf "%i%i" x y)
-    // |> String.concat "" |> equal "122334"
+    ys |> List.toArray |> equal [|(1, 2); (2, 3); (3, 4)|]
 
 [<Fact>]
 let ``List.permute works`` () =
@@ -933,27 +931,27 @@ let ``List.compareWith works`` () =
     List.compareWith (-) xs ys |> equal -1
     List.compareWith (-) xs zs |> equal 1
 
-// [<Fact>]
-// let ``List.countBy works`` () =
-//     let xs = [1; 2; 3; 4]
-//     xs |> List.countBy (fun x -> x % 2)
-//     |> List.length |> equal 2
+[<Fact>]
+let ``List.countBy works`` () =
+    let xs = [1; 2; 3; 4]
+    let ys = xs |> List.countBy (fun x -> x % 2)
+    ys |> List.toArray |> equal [|(1, 2); (0, 2)|]
 
-// [<Fact>]
-// let ``List.groupBy returns valid list`` () =
-//     let xs = [1; 2]
-//     let worked =
-//         match List.groupBy (fun _ -> true) xs with
-//         | [true, [1; 2]] -> true
-//         | _ -> false
-//     worked |> equal true
+[<Fact>]
+let ``List.groupBy returns valid list`` () =
+    let xs = [1; 2]
+    let worked =
+        match List.groupBy (fun _ -> true) xs with
+        | [true, [1; 2]] -> true
+        | _ -> false
+    worked |> equal true
 
-// [<Fact>]
-// let ``List.groupBy maintains order`` () =
-//     let xs = [ 0,5; 1,5; 2,5; 3,5; 0,6; 1,6; 2,6; 3,6 ]
-//     let mapped = xs |> List.take 4 |> List.map (fun (x,y) -> x, [x,y; x,y+1])
-//     let grouped = xs |> List.groupBy fst
-//     grouped |> equal mapped
+[<Fact>]
+let ``List.groupBy maintains order`` () =
+    let xs = [ 0,5; 1,5; 2,5; 3,5; 0,6; 1,6; 2,6; 3,6 ]
+    let mapped = xs |> List.take 4 |> List.map (fun (x,y) -> x, [x,y; x,y+1])
+    let grouped = xs |> List.groupBy fst
+    grouped |> equal mapped
 
 [<Fact>]
 let ``List.unfold works`` () =
@@ -981,47 +979,48 @@ let ``List.windowed works`` () = // See #1716
 
 // [<Fact>]
 // let ``Types with same name as imports work`` () =
-//         let li = [List 5]
-//         equal 5 li.Head.Value
+//     let li = [List 5]
+//     equal 5 li.Head.Value
 
 // [<Fact>]
 // let ``List.Item throws exception when index is out of range`` () =
 //     let xs = [0]
 //     (try (xs.Item 1) |> ignore; false with | _ -> true) |> equal true
 
-// [<Fact>]
-// let ``List.except works`` () =
-//     List.except [2] [1; 3; 2] |> List.last |> equal 3
-//     List.except [2] [2; 4; 6] |> List.head |> equal 4
-//     List.except [1] [1; 1; 1; 1] |> List.isEmpty |> equal true
-//     List.except ['t'; 'e'; 's'; 't'] ['t'; 'e'; 's'; 't'] |> List.isEmpty |> equal true
-//     List.except ['t'; 'e'; 's'; 't'] ['t'; 't'] |> List.isEmpty |> equal true
-//     List.except [(1, 2)] [(1, 2)] |> List.isEmpty |> equal true
-//     List.except [Map.empty |> (fun m -> m.Add(1, 2))] [Map.ofList [(1, 2)]] |> List.isEmpty |> equal true
-//     List.except [{ Bar= "test" }] [{ Bar = "test" }] |> List.isEmpty |> equal true
+[<Fact>]
+let ``List.except works`` () =
+    List.except [2] [1; 3; 2] |> List.last |> equal 3
+    List.except [2] [2; 4; 6] |> List.head |> equal 4
+    List.except [1] [1; 1; 1; 1] |> List.isEmpty |> equal true
+    List.except [49] [7; 49] |> List.last |> equal 7
+    List.except ['t'; 'e'; 's'; 't'] ['t'; 'e'; 's'; 't'] |> List.isEmpty |> equal true
+    List.except ['t'; 'e'; 's'; 't'] ['t'; 't'] |> List.isEmpty |> equal true
+    List.except [(1, 2)] [(1, 2)] |> List.isEmpty |> equal true
+    List.except [{ Bar= "test" }] [{ Bar = "test" }] |> List.isEmpty |> equal true
+    // List.except [Map.empty |> (fun m -> m.Add(1, 2))] [Map.ofList [(1, 2)]] |> List.isEmpty |> equal true
 
-// [<Fact>]
-// let ``List iterators from range do rewind`` () =
-//     let xs = [1..5] |> List.toSeq
-//     xs |> Seq.map string |> String.concat "," |> equal "1,2,3,4,5"
-//     xs |> Seq.map string |> String.concat "," |> equal "1,2,3,4,5"
+[<Fact>]
+let ``List iterators from range do rewind`` () =
+    let xs = [1..5] |> List.toSeq
+    xs |> Seq.map string |> String.concat "," |> equal "1,2,3,4,5"
+    xs |> Seq.map string |> String.concat "," |> equal "1,2,3,4,5"
 
 // [<Fact>]
 // let ``List comprehensions returning None work`` () =
 //     let spam : string option list = [for _ in 0..5 -> None]
 //     List.length spam |> equal 6
 
-// [<Fact>]
-// let ``Int list tail doesn't get wrapped with | 0`` () = // See #1447
-//     let revert xs =
-//         let rec rev acc (ls: int list) =
-//             match ls with
-//             | [] -> acc
-//             | h::t -> rev (h::acc) t
-//         rev [] xs
-//     let res = revert [2;3;4]
-//     equal 3 res.Length
-//     equal 4 res.Head
+[<Fact>]
+let ``Int list tail doesn't get wrapped with | 0`` () = // See #1447
+    let revert xs =
+        let rec rev acc (ls: int list) =
+            match ls with
+            | [] -> acc
+            | h::t -> rev (h::acc) t
+        rev [] xs
+    let res = revert [2;3;4]
+    equal 3 res.Length
+    equal 4 res.Head
 
 [<Fact>]
 let ``List.allPairs works`` () =
@@ -1034,20 +1033,17 @@ let ``List.allPairs works`` () =
             (3, 'c'); (3, 'd'); (3, 'e'); (3, 'f'); (4, 'a'); (4, 'b'); (4, 'c');
             (4, 'd'); (4, 'e'); (4, 'f')]
 
-// // TODO: Remove conditional compilation after upgrading to dotnet SDK with F# 4.7
-// // #if FABLE_COMPILER
-// [<Fact>]
-// let ``Implicit yields work`` () =
-//     let makeList condition =
-//         [
-//             1
-//             2
-//             if condition then
-//                 3
-//         ]
-//     makeList true |> List.sum |> equal 6
-//     makeList false |> List.sum |> equal 3
-// // #endif
+[<Fact>]
+let ``Implicit yields work`` () =
+    let makeList condition =
+        [
+            1
+            2
+            if condition then
+                3
+        ]
+    makeList true |> List.sum |> equal 6
+    makeList false |> List.sum |> equal 3
 
 [<Fact>]
 let ``List.splitInto works`` () =

--- a/tests/Rust/tests/src/ListTests.fs
+++ b/tests/Rust/tests/src/ListTests.fs
@@ -1075,87 +1075,87 @@ let ``List.transpose works`` () =
     // throwsAnyError (fun () -> List.transpose [[1; 2]; []; [3; 4]])
     // throwsAnyError (fun () -> List.transpose [[1; 2]; [3; 4]; []])
 
-// [<Fact>]
-// let ``List.updateAt works`` () =
-//     // integer list
-//     equal [0; 2; 3; 4; 5] (List.updateAt 0 0 [1..5])
-//     equal [1; 2; 0; 4; 5] (List.updateAt 2 0 [1..5])
-//     equal [1; 2; 3; 4; 0] (List.updateAt 4 0 [1..5])
+[<Fact>]
+let ``List.updateAt works`` () =
+    // integer list
+    equal [0; 2; 3; 4; 5] (List.updateAt 0 0 [1..5])
+    equal [1; 2; 0; 4; 5] (List.updateAt 2 0 [1..5])
+    equal [1; 2; 3; 4; 0] (List.updateAt 4 0 [1..5])
 
-//     //string list
-//     equal ["0"; "2"; "3"; "4"; "5"] (List.updateAt 0 "0" ["1"; "2"; "3"; "4"; "5"])
-//     equal ["1"; "2"; "0"; "4"; "5"] (List.updateAt 2 "0" ["1"; "2"; "3"; "4"; "5"])
-//     equal ["1"; "2"; "3"; "4"; "0"] (List.updateAt 4 "0" ["1"; "2"; "3"; "4"; "5"])
+    //string list
+    equal ["0"; "2"; "3"; "4"; "5"] (List.updateAt 0 "0" ["1"; "2"; "3"; "4"; "5"])
+    equal ["1"; "2"; "0"; "4"; "5"] (List.updateAt 2 "0" ["1"; "2"; "3"; "4"; "5"])
+    equal ["1"; "2"; "3"; "4"; "0"] (List.updateAt 4 "0" ["1"; "2"; "3"; "4"; "5"])
 
-//     // empty list & out of bounds
-//     throwsAnyError (fun () -> List.updateAt 0 0 [] |> ignore)
-//     throwsAnyError (fun () -> List.updateAt -1 0 [1] |> ignore)
-//     throwsAnyError (fun () -> List.updateAt 2 0 [1] |> ignore)
+    // empty list & out of bounds
+    // throwsAnyError (fun () -> List.updateAt 0 0 [] |> ignore)
+    // throwsAnyError (fun () -> List.updateAt -1 0 [1] |> ignore)
+    // throwsAnyError (fun () -> List.updateAt 2 0 [1] |> ignore)
 
-// [<Fact>]
-// let ``List.insertAt works`` () =
-//     // integer list
-//     equal [0; 1; 2; 3; 4; 5] (List.insertAt 0 0 [1..5])
-//     equal [1; 2; 0; 3; 4; 5] (List.insertAt 2 0 [1..5])
-//     equal [1; 2; 3; 4; 0; 5] (List.insertAt 4 0 [1..5])
+[<Fact>]
+let ``List.insertAt works`` () =
+    // integer list
+    equal [0; 1; 2; 3; 4; 5] (List.insertAt 0 0 [1..5])
+    equal [1; 2; 0; 3; 4; 5] (List.insertAt 2 0 [1..5])
+    equal [1; 2; 3; 4; 0; 5] (List.insertAt 4 0 [1..5])
 
-//     //string list
-//     equal ["0"; "1"; "2"; "3"; "4"; "5"] (List.insertAt 0 "0" ["1"; "2"; "3"; "4"; "5"])
-//     equal ["1"; "2"; "0"; "3"; "4"; "5"] (List.insertAt 2 "0" ["1"; "2"; "3"; "4"; "5"])
-//     equal ["1"; "2"; "3"; "4"; "0"; "5"] (List.insertAt 4 "0" ["1"; "2"; "3"; "4"; "5"])
+    //string list
+    equal ["0"; "1"; "2"; "3"; "4"; "5"] (List.insertAt 0 "0" ["1"; "2"; "3"; "4"; "5"])
+    equal ["1"; "2"; "0"; "3"; "4"; "5"] (List.insertAt 2 "0" ["1"; "2"; "3"; "4"; "5"])
+    equal ["1"; "2"; "3"; "4"; "0"; "5"] (List.insertAt 4 "0" ["1"; "2"; "3"; "4"; "5"])
 
-//     // empty list & out of bounds
-//     equal [0] (List.insertAt 0 0 [])
-//     throwsAnyError (fun () -> List.insertAt -1 0 [1] |> ignore)
-//     throwsAnyError (fun () -> List.insertAt 2 0 [1] |> ignore)
+    // empty list & out of bounds
+    equal [0] (List.insertAt 0 0 [])
+    // throwsAnyError (fun () -> List.insertAt -1 0 [1] |> ignore)
+    // throwsAnyError (fun () -> List.insertAt 2 0 [1] |> ignore)
 
-// [<Fact>]
-// let ``List.insertManyAt works`` () =
-//     // integer list
-//     equal [0; 0; 1; 2; 3; 4; 5] (List.insertManyAt 0 [0; 0] [1..5])
-//     equal [1; 2; 0; 0; 3; 4; 5] (List.insertManyAt 2 [0; 0] [1..5])
-//     equal [1; 2; 3; 4; 0; 0; 5] (List.insertManyAt 4 [0; 0] [1..5])
+[<Fact>]
+let ``List.insertManyAt works`` () =
+    // integer list
+    equal [0; 0; 1; 2; 3; 4; 5] (List.insertManyAt 0 [0; 0] [1..5])
+    equal [1; 2; 0; 0; 3; 4; 5] (List.insertManyAt 2 [0; 0] [1..5])
+    equal [1; 2; 3; 4; 0; 0; 5] (List.insertManyAt 4 [0; 0] [1..5])
 
-//     //string list
-//     equal ["0"; "0"; "1"; "2"; "3"; "4"; "5"] (List.insertManyAt 0 ["0"; "0"] ["1"; "2"; "3"; "4"; "5"])
-//     equal ["1"; "2"; "0"; "0"; "3"; "4"; "5"] (List.insertManyAt 2 ["0"; "0"] ["1"; "2"; "3"; "4"; "5"])
-//     equal ["1"; "2"; "3"; "4"; "0"; "0"; "5"] (List.insertManyAt 4 ["0"; "0"] ["1"; "2"; "3"; "4"; "5"])
+    //string list
+    equal ["0"; "0"; "1"; "2"; "3"; "4"; "5"] (List.insertManyAt 0 ["0"; "0"] ["1"; "2"; "3"; "4"; "5"])
+    equal ["1"; "2"; "0"; "0"; "3"; "4"; "5"] (List.insertManyAt 2 ["0"; "0"] ["1"; "2"; "3"; "4"; "5"])
+    equal ["1"; "2"; "3"; "4"; "0"; "0"; "5"] (List.insertManyAt 4 ["0"; "0"] ["1"; "2"; "3"; "4"; "5"])
 
-//     // empty list & out of bounds
-//     equal [0; 0] (List.insertManyAt 0 [0; 0] [])
-//     throwsAnyError (fun () -> List.insertManyAt -1 [0; 0] [1] |> ignore)
-//     throwsAnyError (fun () -> List.insertManyAt 2 [0; 0] [1] |> ignore)
+    // empty list & out of bounds
+    equal [0; 0] (List.insertManyAt 0 [0; 0] [])
+    // throwsAnyError (fun () -> List.insertManyAt -1 [0; 0] [1] |> ignore)
+    // throwsAnyError (fun () -> List.insertManyAt 2 [0; 0] [1] |> ignore)
 
-// [<Fact>]
-// let ``List.removeAt works`` () =
-//     // integer list
-//     equal [2; 3; 4; 5] (List.removeAt 0 [1..5])
-//     equal [1; 2; 4; 5] (List.removeAt 2 [1..5])
-//     equal [1; 2; 3; 4] (List.removeAt 4 [1..5])
+[<Fact>]
+let ``List.removeAt works`` () =
+    // integer list
+    equal [2; 3; 4; 5] (List.removeAt 0 [1..5])
+    equal [1; 2; 4; 5] (List.removeAt 2 [1..5])
+    equal [1; 2; 3; 4] (List.removeAt 4 [1..5])
 
-//     //string list
-//     equal ["2"; "3"; "4"; "5"] (List.removeAt 0 ["1"; "2"; "3"; "4"; "5"])
-//     equal ["1"; "2"; "4"; "5"] (List.removeAt 2 ["1"; "2"; "3"; "4"; "5"])
-//     equal ["1"; "2"; "3"; "4"] (List.removeAt 4 ["1"; "2"; "3"; "4"; "5"])
+    //string list
+    equal ["2"; "3"; "4"; "5"] (List.removeAt 0 ["1"; "2"; "3"; "4"; "5"])
+    equal ["1"; "2"; "4"; "5"] (List.removeAt 2 ["1"; "2"; "3"; "4"; "5"])
+    equal ["1"; "2"; "3"; "4"] (List.removeAt 4 ["1"; "2"; "3"; "4"; "5"])
 
-//     // empty list & out of bounds
-//     throwsAnyError (fun () -> List.removeAt 0 [] |> ignore)
-//     throwsAnyError (fun () -> List.removeAt -1 [1] |> ignore)
-//     throwsAnyError (fun () -> List.removeAt 2 [1] |> ignore)
+    // empty list & out of bounds
+    // throwsAnyError (fun () -> List.removeAt 0 [] |> ignore)
+    // throwsAnyError (fun () -> List.removeAt -1 [1] |> ignore)
+    // throwsAnyError (fun () -> List.removeAt 2 [1] |> ignore)
 
-// [<Fact>]
-// let ``List.removeManyAt works`` () =
-//     // integer list
-//     equal [3; 4; 5] (List.removeManyAt 0 2 [1..5])
-//     equal [1; 2; 5] (List.removeManyAt 2 2 [1..5])
-//     equal [1; 2; 3] (List.removeManyAt 3 2 [1..5])
+[<Fact>]
+let ``List.removeManyAt works`` () =
+    // integer list
+    equal [3; 4; 5] (List.removeManyAt 0 2 [1..5])
+    equal [1; 2; 5] (List.removeManyAt 2 2 [1..5])
+    equal [1; 2; 3] (List.removeManyAt 3 2 [1..5])
 
-//     //string list
-//     equal ["3"; "4"; "5"] (List.removeManyAt 0 2 ["1"; "2"; "3"; "4"; "5"])
-//     equal ["1"; "2"; "5"] (List.removeManyAt 2 2 ["1"; "2"; "3"; "4"; "5"])
-//     equal ["1"; "2"; "3"] (List.removeManyAt 3 2 ["1"; "2"; "3"; "4"; "5"])
+    //string list
+    equal ["3"; "4"; "5"] (List.removeManyAt 0 2 ["1"; "2"; "3"; "4"; "5"])
+    equal ["1"; "2"; "5"] (List.removeManyAt 2 2 ["1"; "2"; "3"; "4"; "5"])
+    equal ["1"; "2"; "3"] (List.removeManyAt 3 2 ["1"; "2"; "3"; "4"; "5"])
 
-//     // empty list & out of bounds
-//     throwsAnyError (fun () -> List.removeManyAt 0 2 [] |> ignore)
-//     throwsAnyError (fun () -> List.removeManyAt -1 2 [1] |> ignore)
-//     throwsAnyError (fun () -> List.removeManyAt 2 2 [1] |> ignore)
+    // empty list & out of bounds
+    // throwsAnyError (fun () -> List.removeManyAt 0 2 [] |> ignore)
+    // throwsAnyError (fun () -> List.removeManyAt -1 2 [1] |> ignore)
+    // throwsAnyError (fun () -> List.removeManyAt 2 2 [1] |> ignore)

--- a/tests/Rust/tests/src/SeqTests.fs
+++ b/tests/Rust/tests/src/SeqTests.fs
@@ -18,8 +18,8 @@ let sumFirstTwo (xs: seq<float>) =
 //     let f xss = xss |> List.choose (function Some a -> Some a | _ -> None)
 //     xss |> f |> List.collect (fun xs -> [ for s in xs do yield s ])
 
-// type DummyUnion = Number of int
-// type ExceptFoo = { Bar:string }
+type DummyUnion = Number of int
+type ExceptFoo = { Bar:string }
 
 type Point =
     { x: int; y: int }
@@ -884,73 +884,73 @@ let ``Seq.compareWith works`` () =
     Seq.compareWith (-) xs ys |> equal -1
     Seq.compareWith (-) xs zs |> equal 1
 
-// [<Fact>]
-// let ``Seq.countBy works`` () =
-//     let xs = [1; 2; 3; 4]
-//     let ys = xs |> Seq.countBy (fun x -> x % 2)
-//     ys |> Seq.length |> equal 2
+[<Fact>]
+let ``Seq.countBy works`` () =
+    let xs = [1; 2; 3; 4]
+    let ys = xs |> Seq.countBy (fun x -> x % 2)
+    ys |> Seq.toArray |> equal [|(1, 2); (0, 2)|]
 
-// [<Fact>]
-// let ``Seq.distinct works`` () =
-//     let xs = [1; 1; 1; 2; 2; 3; 3]
-//     let ys = xs |> Seq.distinct
-//     ys |> Seq.length |> equal 3
-//     ys |> Seq.sum |> equal 6
+[<Fact>]
+let ``Seq.distinct works`` () =
+    let xs = [1; 1; 1; 2; 2; 3; 3]
+    let ys = xs |> Seq.distinct
+    ys |> Seq.length |> equal 3
+    ys |> Seq.sum |> equal 6
 
-// [<Fact>]
-// let ``Seq.distinct with tuples works`` () =
-//     let xs = [(1, 2); (2, 3); (1, 2)]
-//     let ys = xs |> Seq.distinct
-//     ys |> Seq.length |> equal 2
-//     ys |> Seq.sumBy fst |> equal 3
+[<Fact>]
+let ``Seq.distinct with tuples works`` () =
+    let xs = [(1, 2); (2, 3); (1, 2)]
+    let ys = xs |> Seq.distinct
+    ys |> Seq.length |> equal 2
+    ys |> Seq.sumBy fst |> equal 3
 
-// [<Fact>]
-// let ``Seq.distinctBy works`` () =
-//     let xs = [4; 4; 4; 6; 6; 5; 5]
-//     let ys = xs |> Seq.distinctBy (fun x -> x % 2)
-//     ys |> Seq.length |> equal 2
-//     ys |> Seq.head >= 4 |> equal true
+[<Fact>]
+let ``Seq.distinctBy works`` () =
+    let xs = [4; 4; 4; 6; 6; 5; 5]
+    let ys = xs |> Seq.distinctBy (fun x -> x % 2)
+    ys |> Seq.length |> equal 2
+    ys |> Seq.head >= 4 |> equal true
 
-// [<Fact>]
-// let ``Seq.distinctBy with tuples works`` () =
-//     let xs = [4,1; 4,2; 4,3; 6,4; 6,5; 5,6; 5,7]
-//     let ys = xs |> Seq.distinctBy (fun (x,_) -> x % 2)
-//     ys |> Seq.length |> equal 2
-//     ys |> Seq.head |> fst >= 4 |> equal true
+[<Fact>]
+let ``Seq.distinctBy with tuples works`` () =
+    let xs = [4,1; 4,2; 4,3; 6,4; 6,5; 5,6; 5,7]
+    let ys = xs |> Seq.distinctBy (fun (x,_) -> x % 2)
+    ys |> Seq.length |> equal 2
+    ys |> Seq.head |> fst >= 4 |> equal true
 
-// [<Fact>]
-// let ``Seq.distinct works on infinite sequences`` () =
-//     let rec numbersFrom n =
-//         seq { yield n; yield n; yield! numbersFrom (n + 1) }
-//     let xs =
-//         numbersFrom 1
-//         |> Seq.distinct
-//         |> Seq.take 5
-//     xs |> Seq.toList |> equal [1; 2; 3; 4; 5]
+[<Fact>]
+let ``Seq.distinct works on infinite sequences`` () =
+    let rec numbersFrom n =
+        seq { yield n; yield n; yield! numbersFrom (n + 1) }
+    let xs =
+        numbersFrom 1
+        |> Seq.distinct
+        |> Seq.take 5
+    xs |> Seq.toList |> equal [1; 2; 3; 4; 5]
 
-// [<Fact>]
-// let ``Seq.distinctBy works on infinite sequences`` () =
-//     let rec numbersFrom n =
-//         seq { yield n; yield n; yield! numbersFrom (n + 1) }
-//     let xs =
-//         numbersFrom 1
-//         |> Seq.distinctBy (fun x -> x / 5)
-//         |> Seq.take 5
-//     xs |> Seq.toList |> equal [1; 5; 10; 15; 20]
+[<Fact>]
+let ``Seq.distinctBy works on infinite sequences`` () =
+    let rec numbersFrom n =
+        seq { yield n; yield n; yield! numbersFrom (n + 1) }
+    let xs =
+        numbersFrom 1
+        |> Seq.distinctBy (fun x -> x / 5)
+        |> Seq.take 5
+    xs |> Seq.toList |> equal [1; 5; 10; 15; 20]
 
-// [<Fact>]
-// let ``Seq.groupBy works`` () =
-//     let xs = [1; 2; 3; 4]
-//     let ys = xs |> Seq.groupBy (fun x -> x % 2)
-//     ys |> Seq.length |> equal 2
-//     ys |> Seq.iter (fun (k,v) ->
-//         v |> Seq.exists (fun x -> x % 2 <> k) |> equal false)
+[<Fact>]
+let ``Seq.groupBy works`` () =
+    let xs = [1; 2; 3; 4]
+    let ys = xs |> Seq.groupBy (fun x -> x % 2)
+    ys |> Seq.length |> equal 2
+    ys |> Seq.iter (fun (k,v) ->
+        v |> Seq.exists (fun x -> x % 2 <> k) |> equal false)
 
-// [<Fact>]
-// let ``Seq.groupBy with structural equality works`` () =
-//     let xs = [1; 2; 3; 4]
-//     let ys = xs |> Seq.groupBy (fun x -> Number (x % 2))
-//     ys |> Seq.length |> equal 2
+[<Fact>]
+let ``Seq.groupBy with structural equality works`` () =
+    let xs = [1; 2; 3; 4]
+    let ys = xs |> Seq.groupBy (fun x -> Number (x % 2))
+    ys |> Seq.length |> equal 2
 
 [<Fact>]
 let ``Seq.exactlyOne works`` () =
@@ -960,16 +960,16 @@ let ``Seq.exactlyOne works`` () =
 
 [<Fact>]
 let ``Seq.tryExactlyOne works`` () =
-        seq {1.} |> Seq.tryExactlyOne |> equal (Some 1.)
-        seq {1.; 2.} |> Seq.tryExactlyOne |> equal None
-        Seq.empty<float> |> Seq.tryExactlyOne |> equal None
+    seq {1.} |> Seq.tryExactlyOne |> equal (Some 1.)
+    seq {1.; 2.} |> Seq.tryExactlyOne |> equal None
+    Seq.empty<float> |> Seq.tryExactlyOne |> equal None
 
-// [<Fact>]
-// let ``Seq.initInfinite works`` () =
-//     Seq.initInfinite (fun i -> 2. * float i)
-//     |> Seq.take 10
-//     |> Seq.sum
-//     |> equal 90.
+[<Fact>]
+let ``Seq.initInfinite works`` () =
+    Seq.initInfinite (fun i -> 2. * float i)
+    |> Seq.take 10
+    |> Seq.sum
+    |> equal 90.
 
 [<Fact>]
 let ``Seq.last works`` () =
@@ -986,17 +986,12 @@ let ``Seq.tryLast works`` () =
 
 [<Fact>]
 let ``Seq.pairwise works`` () =
-    let xs = [1; 2; 3; 4]
+    Seq.pairwise<int> [] |> Seq.length |> equal 0
+    Seq.pairwise [1] |> Seq.length |> equal 0
+    Seq.pairwise [1; 2] |> Seq.head |> equal (1, 2)
+    let xs = seq {1; 2; 3; 4}
     let ys = xs |> Seq.pairwise
-    ys |> Seq.head |> equal (1, 2)
-    // ys |> Seq.map (fun (x, y) -> sprintf "%i%i" x y)
-    // |> String.concat "" |> equal "122334"
-
-[<Fact>]
-let ``Seq.pairwise works with empty input`` () = // See #1941
-    ([||] : int array) |> Seq.pairwise |> Seq.length |> equal 0
-    [1] |> Seq.pairwise |> Seq.length |> equal 0
-    [1; 2] |> Seq.pairwise |> Seq.head |> equal (1, 2)
+    ys |> Seq.toArray |> equal [|(1, 2); (2, 3); (3, 4)|]
 
 [<Fact>]
 let ``Seq.permute works`` () =
@@ -1078,36 +1073,36 @@ let ``Seq.where works`` () =
     |> Seq.length
     |> equal 3
 
-// [<Fact>]
-// let ``Seq.except works`` () =
-//     Seq.except [2] [1; 3; 2] |> Seq.last |> equal 3
-//     Seq.except [2] [2; 4; 6] |> Seq.head |> equal 4
-//     Seq.except [1] [1; 1; 1; 1] |> Seq.isEmpty |> equal true
-//     Seq.except ['t'; 'e'; 's'; 't'] ['t'; 'e'; 's'; 't'] |> Seq.isEmpty |> equal true
-//     Seq.except ['t'; 'e'; 's'; 't'] ['t'; 't'] |> Seq.isEmpty |> equal true
-//     Seq.except [(1, 2)] [(1, 2)] |> Seq.isEmpty |> equal true
-//     Seq.except [Map.empty |> (fun m -> m.Add(1, 2))] [Map.ofList [(1, 2)]] |> Seq.isEmpty |> equal true
-//     Seq.except [|49|] [|7; 49|] |> Seq.last|> equal 7
-//     Seq.except [{ Bar= "test" }] [{ Bar = "test" }] |> Seq.isEmpty |> equal true
+[<Fact>]
+let ``Seq.except works`` () =
+    Seq.except [2] [1; 3; 2] |> Seq.last |> equal 3
+    Seq.except [2] [2; 4; 6] |> Seq.head |> equal 4
+    Seq.except [1] [1; 1; 1; 1] |> Seq.isEmpty |> equal true
+    Seq.except [|49|] [|7; 49|] |> Seq.last |> equal 7
+    Seq.except ['t'; 'e'; 's'; 't'] ['t'; 'e'; 's'; 't'] |> Seq.isEmpty |> equal true
+    Seq.except ['t'; 'e'; 's'; 't'] ['t'; 't'] |> Seq.isEmpty |> equal true
+    Seq.except [(1, 2)] [(1, 2)] |> Seq.isEmpty |> equal true
+    Seq.except [{ Bar= "test" }] [{ Bar = "test" }] |> Seq.isEmpty |> equal true
+    // Seq.except [Map.empty |> (fun m -> m.Add(1, 2))] [Map.ofList [(1, 2)]] |> Seq.isEmpty |> equal true
 
 // [<Fact>]
 // let ``Seq.item throws exception when index is out of range`` () =
 //     let xs = [0]
 //     (try Seq.item 1 xs |> ignore; false with | _ -> true) |> equal true
 
-// [<Fact>]
-// let ``Seq iterators from range do rewind`` () =
-//     let xs = seq {for i=1 to 5 do i}
-//     xs |> Seq.map string |> String.concat "," |> equal "1,2,3,4,5"
-//     xs |> Seq.map string |> String.concat "," |> equal "1,2,3,4,5"
+[<Fact>]
+let ``Seq iterators from range do rewind`` () =
+    let xs = seq {for i=1 to 5 do i}
+    xs |> Seq.map string |> String.concat "," |> equal "1,2,3,4,5"
+    xs |> Seq.map string |> String.concat "," |> equal "1,2,3,4,5"
 
-//     let xs = seq {1..5}
-//     xs |> Seq.map string |> String.concat "," |> equal "1,2,3,4,5"
-//     xs |> Seq.map string |> String.concat "," |> equal "1,2,3,4,5"
+    let xs = seq {1..5}
+    xs |> Seq.map string |> String.concat "," |> equal "1,2,3,4,5"
+    xs |> Seq.map string |> String.concat "," |> equal "1,2,3,4,5"
 
-//     let xs = seq {'A'..'F'}
-//     xs |> Seq.map string |> String.concat "," |> equal "A,B,C,D,E,F"
-//     xs |> Seq.map string |> String.concat "," |> equal "A,B,C,D,E,F"
+    let xs = seq {'A'..'F'}
+    xs |> Seq.map string |> String.concat "," |> equal "A,B,C,D,E,F"
+    xs |> Seq.map string |> String.concat "," |> equal "A,B,C,D,E,F"
 
 [<Fact>]
 let ``Seq.filter doesn't blow the stack with long sequences`` () = // See #459

--- a/tests/Rust/tests/src/SeqTests.fs
+++ b/tests/Rust/tests/src/SeqTests.fs
@@ -1178,87 +1178,87 @@ let ``Seq.splitInto works`` () =
 //     Seq.transpose (seq { ["a";"b"]; ["c";"d"] })
 //     |> seqEqual [seq ["a";"c"]; seq ["b";"d"]]
 
-// [<Fact>]
-// let ``Seq.updateAt works`` () =
-//     // integer list
-//     equal [0; 2; 3; 4; 5] (Seq.updateAt 0 0 [1..5] |> Seq.toList)
-//     equal [1; 2; 0; 4; 5] (Seq.updateAt 2 0 [1..5] |> Seq.toList)
-//     equal [1; 2; 3; 4; 0] (Seq.updateAt 4 0 [1..5] |> Seq.toList)
+[<Fact>]
+let ``Seq.updateAt works`` () =
+    // integer list
+    equal [0; 2; 3; 4; 5] (Seq.updateAt 0 0 [1..5] |> Seq.toList)
+    equal [1; 2; 0; 4; 5] (Seq.updateAt 2 0 [1..5] |> Seq.toList)
+    equal [1; 2; 3; 4; 0] (Seq.updateAt 4 0 [1..5] |> Seq.toList)
 
-//     //string list
-//     equal ["0"; "2"; "3"; "4"; "5"] (Seq.updateAt 0 "0" ["1"; "2"; "3"; "4"; "5"] |> Seq.toList)
-//     equal ["1"; "2"; "0"; "4"; "5"] (Seq.updateAt 2 "0" ["1"; "2"; "3"; "4"; "5"] |> Seq.toList)
-//     equal ["1"; "2"; "3"; "4"; "0"] (Seq.updateAt 4 "0" ["1"; "2"; "3"; "4"; "5"] |> Seq.toList)
+    //string list
+    equal ["0"; "2"; "3"; "4"; "5"] (Seq.updateAt 0 "0" ["1"; "2"; "3"; "4"; "5"] |> Seq.toList)
+    equal ["1"; "2"; "0"; "4"; "5"] (Seq.updateAt 2 "0" ["1"; "2"; "3"; "4"; "5"] |> Seq.toList)
+    equal ["1"; "2"; "3"; "4"; "0"] (Seq.updateAt 4 "0" ["1"; "2"; "3"; "4"; "5"] |> Seq.toList)
 
-//     // empty list & out of bounds
-//     throwsAnyError (fun () -> Seq.updateAt 0 0 [] |> Seq.toList |> ignore)
-//     throwsAnyError (fun () -> Seq.updateAt -1 0 [1] |> Seq.toList |> ignore)
-//     throwsAnyError (fun () -> Seq.updateAt 2 0 [1] |> Seq.toList |> ignore)
+    // empty list & out of bounds
+    // throwsAnyError (fun () -> Seq.updateAt 0 0 [] |> Seq.toList |> ignore)
+    // throwsAnyError (fun () -> Seq.updateAt -1 0 [1] |> Seq.toList |> ignore)
+    // throwsAnyError (fun () -> Seq.updateAt 2 0 [1] |> Seq.toList |> ignore)
 
-// [<Fact>]
-// let ``Seq.insertAt works`` () =
-//     // integer list
-//     equal [0; 1; 2; 3; 4; 5] (Seq.insertAt 0 0 [1..5] |> Seq.toList)
-//     equal [1; 2; 0; 3; 4; 5] (Seq.insertAt 2 0 [1..5] |> Seq.toList)
-//     equal [1; 2; 3; 4; 0; 5] (Seq.insertAt 4 0 [1..5] |> Seq.toList)
+[<Fact>]
+let ``Seq.insertAt works`` () =
+    // integer list
+    equal [0; 1; 2; 3; 4; 5] (Seq.insertAt 0 0 [1..5] |> Seq.toList)
+    equal [1; 2; 0; 3; 4; 5] (Seq.insertAt 2 0 [1..5] |> Seq.toList)
+    equal [1; 2; 3; 4; 0; 5] (Seq.insertAt 4 0 [1..5] |> Seq.toList)
 
-//     //string list
-//     equal ["0"; "1"; "2"; "3"; "4"; "5"] (Seq.insertAt 0 "0" ["1"; "2"; "3"; "4"; "5"] |> Seq.toList)
-//     equal ["1"; "2"; "0"; "3"; "4"; "5"] (Seq.insertAt 2 "0" ["1"; "2"; "3"; "4"; "5"] |> Seq.toList)
-//     equal ["1"; "2"; "3"; "4"; "0"; "5"] (Seq.insertAt 4 "0" ["1"; "2"; "3"; "4"; "5"] |> Seq.toList)
+    //string list
+    equal ["0"; "1"; "2"; "3"; "4"; "5"] (Seq.insertAt 0 "0" ["1"; "2"; "3"; "4"; "5"] |> Seq.toList)
+    equal ["1"; "2"; "0"; "3"; "4"; "5"] (Seq.insertAt 2 "0" ["1"; "2"; "3"; "4"; "5"] |> Seq.toList)
+    equal ["1"; "2"; "3"; "4"; "0"; "5"] (Seq.insertAt 4 "0" ["1"; "2"; "3"; "4"; "5"] |> Seq.toList)
 
-//     // empty list & out of bounds
-//     equal [0] (Seq.insertAt 0 0 [] |> Seq.toList)
-//     throwsAnyError (fun () -> Seq.insertAt -1 0 [1] |> Seq.toList |> ignore)
-//     throwsAnyError (fun () -> Seq.insertAt 2 0 [1] |> Seq.toList |> ignore)
+    // empty list & out of bounds
+    equal [0] (Seq.insertAt 0 0 [] |> Seq.toList)
+    // throwsAnyError (fun () -> Seq.insertAt -1 0 [1] |> Seq.toList |> ignore)
+    // throwsAnyError (fun () -> Seq.insertAt 2 0 [1] |> Seq.toList |> ignore)
 
-// [<Fact>]
-// let ``Seq.insertManyAt works`` () =
-//     // integer list
-//     equal [0; 0; 1; 2; 3; 4; 5] (Seq.insertManyAt 0 [0; 0] [1..5] |> Seq.toList)
-//     equal [1; 2; 0; 0; 3; 4; 5] (Seq.insertManyAt 2 [0; 0] [1..5] |> Seq.toList)
-//     equal [1; 2; 3; 4; 0; 0; 5] (Seq.insertManyAt 4 [0; 0] [1..5] |> Seq.toList)
+[<Fact>]
+let ``Seq.insertManyAt works`` () =
+    // integer list
+    equal [0; 0; 1; 2; 3; 4; 5] (Seq.insertManyAt 0 [0; 0] [1..5] |> Seq.toList)
+    equal [1; 2; 0; 0; 3; 4; 5] (Seq.insertManyAt 2 [0; 0] [1..5] |> Seq.toList)
+    equal [1; 2; 3; 4; 0; 0; 5] (Seq.insertManyAt 4 [0; 0] [1..5] |> Seq.toList)
 
-//     //string list
-//     equal ["0"; "0"; "1"; "2"; "3"; "4"; "5"] (Seq.insertManyAt 0 ["0"; "0"] ["1"; "2"; "3"; "4"; "5"] |> Seq.toList)
-//     equal ["1"; "2"; "0"; "0"; "3"; "4"; "5"] (Seq.insertManyAt 2 ["0"; "0"] ["1"; "2"; "3"; "4"; "5"] |> Seq.toList)
-//     equal ["1"; "2"; "3"; "4"; "0"; "0"; "5"] (Seq.insertManyAt 4 ["0"; "0"] ["1"; "2"; "3"; "4"; "5"] |> Seq.toList)
+    //string list
+    equal ["0"; "0"; "1"; "2"; "3"; "4"; "5"] (Seq.insertManyAt 0 ["0"; "0"] ["1"; "2"; "3"; "4"; "5"] |> Seq.toList)
+    equal ["1"; "2"; "0"; "0"; "3"; "4"; "5"] (Seq.insertManyAt 2 ["0"; "0"] ["1"; "2"; "3"; "4"; "5"] |> Seq.toList)
+    equal ["1"; "2"; "3"; "4"; "0"; "0"; "5"] (Seq.insertManyAt 4 ["0"; "0"] ["1"; "2"; "3"; "4"; "5"] |> Seq.toList)
 
-//     // empty list & out of bounds
-//     equal [0; 0] (Seq.insertManyAt 0 [0; 0] [] |> Seq.toList)
-//     throwsAnyError (fun () -> Seq.insertManyAt -1 [0; 0] [1] |> Seq.toList |> ignore)
-//     throwsAnyError (fun () -> Seq.insertManyAt 2 [0; 0] [1] |> Seq.toList |> ignore)
+    // empty list & out of bounds
+    equal [0; 0] (Seq.insertManyAt 0 [0; 0] [] |> Seq.toList)
+    // throwsAnyError (fun () -> Seq.insertManyAt -1 [0; 0] [1] |> Seq.toList |> ignore)
+    // throwsAnyError (fun () -> Seq.insertManyAt 2 [0; 0] [1] |> Seq.toList |> ignore)
 
-// [<Fact>]
-// let ``Seq.removeAt works`` () =
-//     // integer list
-//     equal [2; 3; 4; 5] (Seq.removeAt 0 [1..5] |> Seq.toList)
-//     equal [1; 2; 4; 5] (Seq.removeAt 2 [1..5] |> Seq.toList)
-//     equal [1; 2; 3; 4] (Seq.removeAt 4 [1..5] |> Seq.toList)
+[<Fact>]
+let ``Seq.removeAt works`` () =
+    // integer list
+    equal [2; 3; 4; 5] (Seq.removeAt 0 [1..5] |> Seq.toList)
+    equal [1; 2; 4; 5] (Seq.removeAt 2 [1..5] |> Seq.toList)
+    equal [1; 2; 3; 4] (Seq.removeAt 4 [1..5] |> Seq.toList)
 
-//     //string list
-//     equal ["2"; "3"; "4"; "5"] (Seq.removeAt 0 ["1"; "2"; "3"; "4"; "5"] |> Seq.toList)
-//     equal ["1"; "2"; "4"; "5"] (Seq.removeAt 2 ["1"; "2"; "3"; "4"; "5"] |> Seq.toList)
-//     equal ["1"; "2"; "3"; "4"] (Seq.removeAt 4 ["1"; "2"; "3"; "4"; "5"] |> Seq.toList)
+    //string list
+    equal ["2"; "3"; "4"; "5"] (Seq.removeAt 0 ["1"; "2"; "3"; "4"; "5"] |> Seq.toList)
+    equal ["1"; "2"; "4"; "5"] (Seq.removeAt 2 ["1"; "2"; "3"; "4"; "5"] |> Seq.toList)
+    equal ["1"; "2"; "3"; "4"] (Seq.removeAt 4 ["1"; "2"; "3"; "4"; "5"] |> Seq.toList)
 
-//     // empty list & out of bounds
-//     throwsAnyError (fun () -> Seq.removeAt 0 [] |> Seq.toList |> ignore)
-//     throwsAnyError (fun () -> Seq.removeAt -1 [1] |> Seq.toList |> ignore)
-//     throwsAnyError (fun () -> Seq.removeAt 2 [1] |> Seq.toList |> ignore)
+    // empty list & out of bounds
+    // throwsAnyError (fun () -> Seq.removeAt 0 [] |> Seq.toList |> ignore)
+    // throwsAnyError (fun () -> Seq.removeAt -1 [1] |> Seq.toList |> ignore)
+    // throwsAnyError (fun () -> Seq.removeAt 2 [1] |> Seq.toList |> ignore)
 
-// [<Fact>]
-// let ``Seq.removeManyAt works`` () =
-//     // integer list
-//     equal [3; 4; 5] (Seq.removeManyAt 0 2 [1..5] |> Seq.toList)
-//     equal [1; 2; 5] (Seq.removeManyAt 2 2 [1..5] |> Seq.toList)
-//     equal [1; 2; 3] (Seq.removeManyAt 3 2 [1..5] |> Seq.toList)
+[<Fact>]
+let ``Seq.removeManyAt works`` () =
+    // integer list
+    equal [3; 4; 5] (Seq.removeManyAt 0 2 [1..5] |> Seq.toList)
+    equal [1; 2; 5] (Seq.removeManyAt 2 2 [1..5] |> Seq.toList)
+    equal [1; 2; 3] (Seq.removeManyAt 3 2 [1..5] |> Seq.toList)
 
-//     //string list
-//     equal ["3"; "4"; "5"] (Seq.removeManyAt 0 2 ["1"; "2"; "3"; "4"; "5"] |> Seq.toList)
-//     equal ["1"; "2"; "5"] (Seq.removeManyAt 2 2 ["1"; "2"; "3"; "4"; "5"] |> Seq.toList)
-//     equal ["1"; "2"; "3"] (Seq.removeManyAt 3 2 ["1"; "2"; "3"; "4"; "5"] |> Seq.toList)
+    //string list
+    equal ["3"; "4"; "5"] (Seq.removeManyAt 0 2 ["1"; "2"; "3"; "4"; "5"] |> Seq.toList)
+    equal ["1"; "2"; "5"] (Seq.removeManyAt 2 2 ["1"; "2"; "3"; "4"; "5"] |> Seq.toList)
+    equal ["1"; "2"; "3"] (Seq.removeManyAt 3 2 ["1"; "2"; "3"; "4"; "5"] |> Seq.toList)
 
-//     // empty list & out of bounds
-//     throwsAnyError (fun () -> Seq.removeManyAt 0 2 [] |> Seq.toList |> ignore)
-//     throwsAnyError (fun () -> Seq.removeManyAt -1 2 [1] |> Seq.toList |> ignore)
-//     throwsAnyError (fun () -> Seq.removeManyAt 2 2 [1] |> Seq.toList |> ignore)
+    // empty list & out of bounds
+    // throwsAnyError (fun () -> Seq.removeManyAt 0 2 [] |> Seq.toList |> ignore)
+    // throwsAnyError (fun () -> Seq.removeManyAt -1 2 [1] |> Seq.toList |> ignore)
+    // throwsAnyError (fun () -> Seq.removeManyAt 2 2 [1] |> Seq.toList |> ignore)


### PR DESCRIPTION
- Added the following functions for `Array`, `List` and `Seq` modules, as well as tests for them:
  - distinct
  - distinctBy
  - except
  - countBy
  - groupBy
  - insertAt
  - insertManyAt
  - removeAt
  - removeManyAt
  - updateAt
  
- Renamed `fable-library-rust` modules to remove dependencies so they can be compiled in any order.