### PR TITLE
Rust - Tasks, task builder, really basic thread pool

### DIFF
--- a/src/Fable.Transforms/Rust/Fable2Rust.fs
+++ b/src/Fable.Transforms/Rust/Fable2Rust.fs
@@ -516,6 +516,9 @@ module TypeInfo =
     let transformTaskType com ctx genArg: Rust.Ty =
         transformImportType com ctx [genArg] "Task" "Task`1"
 
+    let transformTaskBuilderType com ctx: Rust.Ty =
+        transformImportType com ctx [] "TaskBuilder" "TaskBuilder"
+
     let transformTupleType com ctx genArgs: Rust.Ty =
         genArgs
         |> List.map (transformType com ctx)
@@ -751,6 +754,8 @@ module TypeInfo =
             | Replacements.Util.IsEntity (Types.icollectionGeneric) (entRef, [t]) -> transformArrayType com ctx (inferIfAny t)
             | Replacements.Util.IsEntity (Types.fsharpAsyncGeneric) (_, [t]) -> transformAsyncType com ctx t
             | Replacements.Util.IsEntity (Types.taskGeneric) (_, [t]) -> transformTaskType com ctx t
+            | Replacements.Util.IsEntity (Types.taskBuilder) (_, []) -> transformTaskBuilderType com ctx
+            | Replacements.Util.IsEntity (Types.taskBuilderModule) (_, []) -> transformTaskBuilderType com ctx
             | Replacements.Util.IsEnumerator (entRef, genArgs) ->
                 // get IEnumerator interface from enumerator object
                 match tryFindInterface com Types.ienumeratorGeneric entRef with
@@ -1842,7 +1847,11 @@ module Util =
                 | Fable.Import(info, t, r) ->
                     match info.Selector with
                     | "AsyncBuilder_::delay"
-                    | "AsyncBuilder_::bind" -> true
+                    | "AsyncBuilder_::bind"
+                    | "Task_::bind"
+                    | "Task_::delay"
+                    | "TaskBuilder_::bind"
+                    | "TaskBuilder_::delay" -> true
                     | _ -> false
                 | _ -> false
             { ctx with IsCallingFunction = true

--- a/src/Fable.Transforms/Rust/Replacements.fs
+++ b/src/Fable.Transforms/Rust/Replacements.fs
@@ -2577,6 +2577,10 @@ let taskBuilder (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr
     match thisArg, i.CompiledName, args with
     // | _, "Run", _ -> Helper.LibCall(com, "Task", "run", t, args, ?loc=r) |> Some
     // | _, "Singleton", _ -> makeImportLib com t "singleton" "TaskBuilder" |> Some
+    | None, ".ctor", _ ->
+        makeImportLib com t "new" "TaskBuilder" |> Some
+    | Some x, "Run", _ ->
+        Helper.InstanceCall(x, "run", t, args, i.SignatureArgTypes, ?loc=r) |> Some
     | Some x, meth, _ -> Helper.InstanceCall(x, meth, t, args, i.SignatureArgTypes, ?loc=r) |> Some
     | None, meth, _ -> Helper.LibCall(com, "TaskBuilder", Naming.lowerFirst meth, t, args, i.SignatureArgTypes, ?loc=r) |> Some
 
@@ -2595,7 +2599,7 @@ let taskBuilderHP (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Ex
 
 let taskBuilderM (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr option) (args: Expr list) =
     match thisArg, i.CompiledName, args with
-    | _, "task", _ -> Helper.LibCall(com, "Task", "new", t, [], ?loc=r) |> Some
+    | _, "task", _ -> Helper.LibCall(com, "TaskBuilder", "new", t, [], ?loc=r) |> Some
     | Some x, meth, _ -> Helper.InstanceCall(x, meth, t, args, i.SignatureArgTypes, ?loc=r) |> Some
     | None, meth, _ -> Helper.LibCall(com, "TaskBuilder", Naming.lowerFirst meth, t, args, i.SignatureArgTypes, ?loc=r) |> Some
 

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -101,6 +101,7 @@ module Types =
     let [<Literal>] fsharpSet = "Microsoft.FSharp.Collections.FSharpSet`1"
     let [<Literal>] fsharpAsyncGeneric = "Microsoft.FSharp.Control.FSharpAsync`1"
     let [<Literal>] taskBuilder = "Microsoft.FSharp.Control.TaskBuilder"
+    let [<Literal>] taskBuilderModule = "Microsoft.FSharp.Control.TaskBuilderModule"
     let [<Literal>] task = "System.Threading.Tasks.Task"
     let [<Literal>] taskGeneric = "System.Threading.Tasks.Task`1"
     let [<Literal>] cancellationToken = "System.Threading.CancellationToken"

--- a/src/fable-library-rust/Cargo.toml
+++ b/src/fable-library-rust/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-futures = "0.3.21"
+futures = { version = "0.3.21", features = ["executor", "thread-pool" ] }

--- a/tests/Rust/tests/src/AsyncTests.fs
+++ b/tests/Rust/tests/src/AsyncTests.fs
@@ -32,14 +32,14 @@ let shouldCorrectlyScopeArcRecord () =
     let t = Async.StartAsTask comp
     t.Result |> equal 5
 
-// open System.Threading.Tasks
-// [<Fact>]
-// let shouldExecutedTask () =
-//     let a = Task.FromResult 1
-//     let b = Task.FromResult 2
-//     let comp = task {
-//         let! a = a
-//         let! b = b
-//         return a + b
-//     }
-//     comp.Result |> equal 3
+open System.Threading.Tasks
+[<Fact>]
+let shouldExecuteTask () =
+    let a = Task.FromResult 1
+    let b = Task.FromResult 2
+    let comp = task {
+        let! a = a
+        let! b = b
+        return a + b
+    }
+    comp.Result |> equal 3


### PR DESCRIPTION
Some progress on tasks

* Builder now supports basic ops (bind and return)
* Tasks implement future (although they block at the moment, so this needs another pass)
* Tasks are executed on the thread pool