### PR TITLE
Updated fable-standalone

### DIFF
--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -147,8 +147,9 @@ module private Util =
                 changeExtension file fileExt
 
     let compileFile (com: CompilerImpl) (cliArgs: CliArgs) pathResolver isSilent = async {
+        let fileName = (com :> Compiler).CurrentFile
         try
-            let outPath = getOutPath cliArgs pathResolver com.CurrentFile
+            let outPath = getOutPath cliArgs pathResolver fileName
 
             // ensure directory exists
             let dir = IO.Path.GetDirectoryName outPath
@@ -156,13 +157,13 @@ module private Util =
 
             do! Pipeline.compileFile com cliArgs pathResolver isSilent outPath
 
-            return Ok {| File = com.CurrentFile
+            return Ok {| File = fileName
                          OutPath = outPath
                          Logs = com.Logs
                          InlineExprs = Array.empty<string * InlineExpr>
                          WatchDependencies = com.WatchDependencies |}
         with e ->
-            return Error {| File = com.CurrentFile
+            return Error {| File = fileName
                             Exception = e |}
     }
 

--- a/src/Fable.Transforms/BabelPrinter.fs
+++ b/src/Fable.Transforms/BabelPrinter.fs
@@ -614,7 +614,7 @@ module PrinterExtensions =
 
         member printer.PrintRegExp(pattern, flags, loc) =
             printer.Print("/", ?loc=loc)
-            // Note we cannot use EscapeStringLiteral literal because it will corrupt the regex pattern
+            // Note we cannot use Naming.escapeString because it will corrupt the regex pattern
             printer.Print(Regex.Replace(pattern, @"(?<!\\)\/", @"\/").Replace("\r", @"\r").Replace("\n", @"\n"))
             printer.Print("/")
             printer.Print(flags)
@@ -622,7 +622,7 @@ module PrinterExtensions =
         member printer.Print(node: StringLiteral) =
             let (StringLiteral(value, loc)) = node
             printer.Print("\"", ?loc=loc)
-            printer.Print(printer.EscapeStringLiteral(value))
+            printer.Print(Naming.escapeString (fun _ -> false) value)
             printer.Print("\"")
 
         member printer.PrintNumeric(value, loc) =

--- a/src/Fable.Transforms/Dart/Dart.fs
+++ b/src/Fable.Transforms/Dart/Dart.fs
@@ -364,5 +364,3 @@ type Import =
 type File =
     { Imports: Import list
       Declarations: Declaration list }
-    member this.IsEmpty =
-        List.isEmpty this.Declarations

--- a/src/Fable.Transforms/Dart/DartPrinter.fs
+++ b/src/Fable.Transforms/Dart/DartPrinter.fs
@@ -92,7 +92,7 @@ module PrinterExtensions =
                         rep.Add("$" + string j)
                     String.concat ", " rep)
 
-                |> replace @"\{\{\s*\$(\d+)\s*\?(.*?)\:(.*?)\}\}" (fun m ->
+                |> replace @"\{\{\s*\$(\d+)\s*\?(.*?):(.*?)\}\}" (fun m ->
                     let i = int m.Groups[1].Value
                     match args[i] with
                     | Literal(BooleanLiteral(value=value)) when value -> m.Groups[2].Value
@@ -337,8 +337,10 @@ module PrinterExtensions =
                     printer.PrintExprList("[", values, "]")
             | BooleanLiteral v -> printer.Print(if v then "true" else "false")
             | StringLiteral value ->
+                let escape str =
+                    (Naming.escapeString (fun _ -> false) str).Replace(@"$", @"\$")
                 printer.Print("'")
-                printer.Print(printer.EscapeStringLiteral(value))
+                printer.Print(escape value)
                 printer.Print("'")
             | IntegerLiteral value ->
                 printer.Print(value.ToString())

--- a/src/Fable.Transforms/Dart/DartPrinter.fs
+++ b/src/Fable.Transforms/Dart/DartPrinter.fs
@@ -884,6 +884,9 @@ module PrinterExtensions =
 
 open PrinterExtensions
 
+let isEmpty (file: File): bool =
+    List.isEmpty file.Declarations
+
 let run (writer: Writer) (file: File): Async<unit> =
     let printDeclWithExtraLine extraLine (printer: Printer) (decl: Declaration) =
         match decl with

--- a/src/Fable.Transforms/Global/Prelude.fs
+++ b/src/Fable.Transforms/Global/Prelude.fs
@@ -157,7 +157,7 @@ module Patterns =
 
     let (|SetContains|_|) set item =
         if Set.contains item set then Some SetContains else None
-    
+
     let (|ListLast|_|) (xs: 'a list) =
         if List.isEmpty xs then None
         else
@@ -603,6 +603,13 @@ module Path =
         let i = normPath.LastIndexOf("/")
         if i < 0 then "", normPath
         else normPath.Substring(0, i), normPath.Substring(i + 1)
+
+    let IsPathRooted (path: string): bool =
+#if FABLE_COMPILER
+        path.StartsWith("/") || path.StartsWith("\\") || path.IndexOf(":") = 1
+#else
+        IO.Path.IsPathRooted(path)
+#endif
 
     let GetFullPath (path: string): string =
 #if FABLE_COMPILER

--- a/src/Fable.Transforms/Php/Fable2Php.fs
+++ b/src/Fable.Transforms/Php/Fable2Php.fs
@@ -1,6 +1,5 @@
 ﻿module Fable.Transforms.Fable2Php
 
-open System.IO
 open Fable
 open Fable.AST
 open Fable.AST.Php
@@ -1585,30 +1584,32 @@ type PhpCompiler(com: Fable.Compiler) =
         member this.FindLableLevel(label) =
             List.findIndex(function Some v when v = label -> true | _ -> false) breakable
 
+module Compiler =
 
-let transformFile com (file: Fable.File) =
-    let phpComp = PhpCompiler(com) :> IPhpCompiler
-    phpComp.ClearRequire(__SOURCE_DIRECTORY__ + @"/src/")
+    let transformFile com (file: Fable.File) =
+        let phpComp = PhpCompiler(com) :> IPhpCompiler
+        phpComp.ClearRequire(__SOURCE_DIRECTORY__ + @"/src/")
 
-    let rootModule = com.GetRootModule(phpComp.CurrentFile) |> nsreplacement
-    phpComp.SetPhpNamespace(rootModule)
-    let decls =
-        [
-            for i,decl in List.indexed file.Declarations do
-                let decls =
-                    try
-                        convertDecl phpComp decl
-                    with
-                    |    ex ->
-                        eprintfn "Error while transpiling decl %d: %O" i ex
-                        reraise()
-                for d in decls  do
-                    i,d
-        ]
+        let rootModule = com.GetRootModule(phpComp.CurrentFile) |> nsreplacement
+        phpComp.SetPhpNamespace(rootModule)
+        let decls =
+            [
+                for i,decl in List.indexed file.Declarations do
+                    let decls =
+                        try
+                            convertDecl phpComp decl
+                        with
+                        |    ex ->
+                            eprintfn "Error while transpiling decl %d: %O" i ex
+                            reraise()
+                    for d in decls  do
+                        i,d
+            ]
 
-
-    { Filename = phpComp.CurrentFile + ".php"
-      Namespace = Some phpComp.PhpNamespace
-      Require = phpComp.Require
-      Uses = phpComp.NsUse
-      Decls = decls }
+        {
+            Filename = phpComp.CurrentFile + ".php"
+            Namespace = Some phpComp.PhpNamespace
+            Require = phpComp.Require
+            Uses = phpComp.NsUse
+            Decls = decls
+        }

--- a/src/Fable.Transforms/Php/Php.fs
+++ b/src/Fable.Transforms/Php/Php.fs
@@ -1,6 +1,5 @@
 namespace rec Fable.AST.Php
 
-
 type PhpConst =
     | PhpConstNumber of float
     | PhpConstString of string
@@ -13,7 +12,7 @@ type PhpArrayIndex =
     | PhpArrayString of string
 
 type PhpField =
-    { Name: string 
+    { Name: string
       Type: string }
 
 type Capture =
@@ -25,7 +24,7 @@ type Prop =
     | StrField of string
 
 type PhpIdentity =
-    { Namespace: string option 
+    { Namespace: string option
       Class: string option
       Name: string
     }
@@ -51,7 +50,7 @@ and PhpExpr =
     | PhpAnonymousFunc of args: string list * uses: Capture list * body: PhpStatement list
     | PhpMacro of macro: string * args: PhpExpr list
     | PhpParent
-   
+
 and PhpStatement =
     | PhpReturn of PhpExpr
     | PhpExpr of PhpExpr
@@ -60,7 +59,7 @@ and PhpStatement =
     | PhpAssign of target:PhpExpr * value:PhpExpr
     | PhpIf of guard: PhpExpr * thenCase: PhpStatement list * elseCase: PhpStatement list
     | PhpThrow of PhpExpr
-    | PhpTryCatch of body: PhpStatement list * catch: (string * PhpStatement list) option * finallizer: PhpStatement list 
+    | PhpTryCatch of body: PhpStatement list * catch: (string * PhpStatement list) option * finallizer: PhpStatement list
     | PhpWhileLoop of guard: PhpExpr * body: PhpStatement list
     | PhpFor of ident: string * start: PhpExpr * limit: PhpExpr * isUp: bool * body: PhpStatement list
     | PhpDo of PhpExpr
@@ -75,7 +74,7 @@ and PhpTypeRef =
     | InType of PhpType
     | ArrayRef of PhpTypeRef
 
-and PhpFun = 
+and PhpFun =
     { Name: string
       Args: string list
       Matchings: PhpStatement list
@@ -83,7 +82,7 @@ and PhpFun =
       Static: bool
     }
 and PhpConstructor =
-    { Args: string list 
+    { Args: string list
       Body: PhpStatement list
     }
 
@@ -113,5 +112,3 @@ type PhpFile =
       Require: (string option * string) list
       Uses: PhpType list
       Decls: (int * PhpDecl) list }
-
-

--- a/src/Fable.Transforms/Printer.fs
+++ b/src/Fable.Transforms/Printer.fs
@@ -11,7 +11,6 @@ type SourceMapping =
 type Writer =
     inherit IDisposable
     abstract AddSourceMapping: SourceMapping -> unit
-    abstract EscapeStringLiteral: string -> string
     abstract MakeImportPath: string -> string
     abstract Write: string -> Async<unit>
     abstract AddLog: msg:string * severity: Fable.Severity * ?range: SourceLocation -> unit
@@ -24,7 +23,6 @@ type Printer =
     abstract Print: string * ?loc: SourceLocation -> unit
     abstract PrintNewLine: unit -> unit
     abstract AddLocation: SourceLocation option -> unit
-    abstract EscapeStringLiteral: string -> string
     abstract MakeImportPath: string -> string
     abstract AddLog: msg:string * severity: Fable.Severity * ?range: SourceLocation -> unit
 
@@ -86,9 +84,6 @@ type PrinterImpl(writer: Writer, ?indent: string) =
 
                 builder.Append(str) |> ignore
                 column <- column + str.Length
-
-        member _.EscapeStringLiteral(str) =
-            writer.EscapeStringLiteral(str)
 
         member _.MakeImportPath(path) =
             writer.MakeImportPath(path)

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -546,7 +546,7 @@ module Helpers =
             | ""
             | "." -> fileDir
             | _ ->
-                IO.Path.GetFullPath(Path.Combine(Path.GetDirectoryName(com.CurrentFile), fileDir))
+                Path.GetFullPath(Path.Combine(Path.GetDirectoryName(com.CurrentFile), fileDir))
                 |> Path.normalizePath
 
         let outDir = com.OutputDir |> Option.defaultValue projDir
@@ -590,7 +590,7 @@ module Helpers =
                 // Avoid going out of fable_modules and back down again, i.e ../fable_modules/fable_library
                 if Naming.isInFableModules com.CurrentFile then
                     Path.getCommonBaseDir [ com.CurrentFile
-                                            IO.Path.GetFullPath(Path.Combine(Path.GetDirectoryName(com.CurrentFile), com.LibraryDir)) ]
+                                            Path.GetFullPath(Path.Combine(Path.GetDirectoryName(com.CurrentFile), com.LibraryDir)) ]
                 else
                     Path.getCommonBaseDir [ com.CurrentFile
                                             com.ProjectFile ]
@@ -644,10 +644,12 @@ module Helpers =
 
             if normalizedPath.Length > 1 then
                 notInProjectDir
+#if !FABLE_COMPILER
                 // import exists in file dir
                 && IO.Directory.Exists(Path.Combine(fileDir, normalizedPath))
                 // import exists in project dir
                 && (not (IO.Directory.Exists(Path.Combine(projDir, normalizedPath))))
+#endif
             else
                 notInProjectDir
 

--- a/src/Fable.Transforms/Python/PythonPrinter.fs
+++ b/src/Fable.Transforms/Python/PythonPrinter.fs
@@ -756,6 +756,9 @@ let printLine (printer: Printer) (line: string) =
     printer.Print(line)
     printer.PrintNewLine()
 
+let isEmpty (program: Module): bool =
+    false //TODO: determine if printer will not print anything
+
 let run writer (program: Module) : Async<unit> =
     async {
         use printerImpl = new PrinterImpl(writer)

--- a/src/Fable.Transforms/Python/PythonPrinter.fs
+++ b/src/Fable.Transforms/Python/PythonPrinter.fs
@@ -347,7 +347,7 @@ module PrinterExtensions =
 
                     String.concat ", " rep)
 
-                |> replace @"\{\{\s*\$(\d+)\s*\?(.*?)\:(.*?)\}\}" (fun m ->
+                |> replace @"\{\{\s*\$(\d+)\s*\?(.*?):(.*?)\}\}" (fun m ->
                     let i = int m.Groups.[1].Value
 
                     match node.Args.[i] with
@@ -550,8 +550,10 @@ module PrinterExtensions =
                 match value with
                 | :? string as value ->
                     printer.Print("\"")
-                    printer.Print(printer.EscapeStringLiteral(value))
+                    printer.Print(Naming.escapeString (fun _ -> false) value)
                     printer.Print("\"")
+                | :? bool as value ->
+                    printer.Print(if value then "True" else "False")
                 | _ -> printer.Print(string value)
 
             | IfExp ex -> printer.Print(ex)

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -262,8 +262,8 @@ let toLong com (ctx: Context) r (unsigned: bool) targetType (args: Expr list): E
         | BigInt -> Helper.LibCall(com, "BigInt", castBigIntMethod targetType, targetType, args)
         | Int64 | UInt64 -> Helper.LibCall(com, "Long", "fromValue", targetType, args @ [makeBoolConst unsigned])
         | Int8 | Int16 | Int32 | UInt8 | UInt16 | UInt32 as kind -> fromInteger kind args.Head
+        | NativeInt | UNativeInt
         | Float32 | Float64 -> Helper.LibCall(com, "Long", "fromNumber", targetType, args @ [makeBoolConst unsigned])
-        | NativeInt | UNativeInt -> FableError "Converting (u)nativeint to long is not supported" |> raise
     | _ ->
         addWarning com ctx.InlinePath r "Cannot make conversion because source type is unknown"
         TypeCast(args.Head, targetType)
@@ -1079,6 +1079,8 @@ let operators (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr o
         toInt com ctx r t args |> Some
     | "ToInt64", _ -> toLong com ctx r false t args |> Some
     | "ToUInt64", _ -> toLong com ctx r true t args |> Some
+    | "ToIntPtr", _ -> toLong com ctx r false t args |> Some
+    | "ToUIntPtr", _ -> toLong com ctx r true t args |> Some
     | ("ToSingle"|"ToDouble"), _ -> toFloat com ctx r t args |> Some
     | "ToDecimal", _ -> toDecimal com ctx r t args |> Some
     | "ToChar", _ -> toChar args.Head |> Some

--- a/src/Fable.Transforms/Rust/AST/Rust.AST.Adapters.fs
+++ b/src/Fable.Transforms/Rust/AST/Rust.AST.Adapters.fs
@@ -153,14 +153,14 @@ type System.String with
         let res = self.Replace("\\", @"\\").Replace("\'", @"\'").Replace("\"", @"\""")
         let res = res.Replace("\t", @"\t").Replace("\r", @"\r").Replace("\n", @"\n")
         let res = System.Text.RegularExpressions.Regex.Replace(res, @"[\x00-\x1F]",
-                    fun c -> System.String.Format(@"\u{{{0:x4}}}", int c.Value.[0]))
+            fun c -> System.String.Format(@"\u{0}{1:x4}{2}", "{", int c.Value.[0], "}"))
         res
     member self.escape_default() =
         // escapes \\, \', \", \t, \r, \n, [^\x20-\x7F]
         let res = self.Replace("\\", @"\\").Replace("\'", @"\'").Replace("\"", @"\""")
         let res = res.Replace("\t", @"\t").Replace("\r", @"\r").Replace("\n", @"\n")
         let res = System.Text.RegularExpressions.Regex.Replace(res, @"[^\x20-\x7F]",
-                    fun c -> System.String.Format(@"\u{{{0:x4}}}", int c.Value.[0]))
+            fun c -> System.String.Format(@"\u{0}{1:x4}{2}", "{", int c.Value.[0], "}"))
         res
 
 type System.Text.StringBuilder with

--- a/src/Fable.Transforms/Rust/AST/Rust.AST.Helpers.fs
+++ b/src/Fable.Transforms/Rust/AST/Rust.AST.Helpers.fs
@@ -234,6 +234,11 @@ module Literals =
           kind = LitKind.Int(value, LitIntType.Unsuffixed)
           span = DUMMY_SP }
 
+    let mkIsizeLit (value: uint64): Lit =
+        { token = mkIntTokenLit (string value) (Some "isize")
+          kind = LitKind.Int(value, LitIntType.Signed(IntTy.Isize))
+          span = DUMMY_SP }
+
     let mkInt8Lit (value: uint64): Lit =
         { token = mkIntTokenLit (string value) (Some "i8")
           kind = LitKind.Int(value, LitIntType.Signed(IntTy.I8))
@@ -252,6 +257,11 @@ module Literals =
     let mkInt64Lit (value: uint64): Lit =
         { token = mkIntTokenLit (string value) (Some "i64")
           kind = LitKind.Int(value, LitIntType.Signed(IntTy.I64))
+          span = DUMMY_SP }
+
+    let mkUsizeLit (value: uint64): Lit =
+        { token = mkIntTokenLit (string value) (Some "usize")
+          kind = LitKind.Int(value, LitIntType.Unsigned(UintTy.Usize))
           span = DUMMY_SP }
 
     let mkUInt8Lit (value: uint64): Lit =
@@ -605,6 +615,11 @@ module Exprs =
         |> mkIntLit
         |> mkLitExpr
 
+    let mkIsizeLitExpr value: Expr =
+        value
+        |> mkIsizeLit
+        |> mkLitExpr
+
     let mkInt8LitExpr value: Expr =
         value
         |> mkInt8Lit
@@ -623,6 +638,11 @@ module Exprs =
     let mkInt64LitExpr value: Expr =
         value
         |> mkInt64Lit
+        |> mkLitExpr
+
+    let mkUsizeLitExpr value: Expr =
+        value
+        |> mkUsizeLit
         |> mkLitExpr
 
     let mkUInt8LitExpr value: Expr =

--- a/src/Fable.Transforms/Rust/AST/Rust.AST.State.fs
+++ b/src/Fable.Transforms/Rust/AST/Rust.AST.State.fs
@@ -260,7 +260,7 @@ let print_emit_expr self value (args: Vec<_>, printArgs) =
                 rep.Add("$" + string j)
             String.concat ", " rep)
 
-        // |> replace @"\{\{\s*\$(\d+)\s*\?(.*?)\:(.*?)\}\}" (fun m ->
+        // |> replace @"\{\{\s*\$(\d+)\s*\?(.*?):(.*?)\}\}" (fun m ->
         //     let i = int m.Groups.[1].Value
         //     match args.[i] with
         //     | Literal(BooleanLiteral(value=value)) when value -> m.Groups.[2].Value

--- a/src/Fable.Transforms/Rust/Fable2Rust.fs
+++ b/src/Fable.Transforms/Rust/Fable2Rust.fs
@@ -1381,6 +1381,9 @@ module Util =
         | Float64, (:? float as x) when System.Double.IsNegativeInfinity(x) ->
             mkGenericPathExpr ["f64";"NEG_INFINITY"] None
 
+        | NativeInt, (:? nativeint as x) ->
+            let expr = mkIsizeLitExpr (abs x |> uint64)
+            if x < 0n then expr |> mkNegExpr else expr
         | Int8, (:? int8 as x) ->
             let expr = mkInt8LitExpr (abs x |> uint64)
             if x < 0y then expr |> mkNegExpr else expr
@@ -1393,6 +1396,8 @@ module Util =
         | Int64, (:? int64 as x) ->
             let expr = mkInt64LitExpr (abs x |> uint64)
             if x < 0 then expr |> mkNegExpr else expr
+        | UNativeInt, (:? unativeint as x) ->
+            mkUsizeLitExpr (x |> uint64)
         | UInt8, (:? uint8 as x) ->
             mkUInt8LitExpr (x |> uint64)
         | UInt16, (:? uint16 as x) ->

--- a/src/Fable.Transforms/Rust/Replacements.fs
+++ b/src/Fable.Transforms/Rust/Replacements.fs
@@ -229,10 +229,7 @@ let toLong com (ctx: Context) r (unsigned: bool) targetType (args: Expr list): E
             let n = Helper.LibCall(com, "Decimal", "toNumber", Number(Float64, NumberInfo.Empty), args)
             Helper.LibCall(com, "Long", "fromNumber", targetType, [n; makeBoolConst unsigned])
         | BigInt -> Helper.LibCall(com, "BigInt", castBigIntMethod targetType, targetType, args)
-        | Int64 | UInt64 -> TypeCast(args.Head, targetType)
-        | Int8 | Int16 | Int32 | UInt8 | UInt16 | UInt32 as kind -> TypeCast(args.Head, targetType)
-        | Float32 | Float64 -> TypeCast(args.Head, targetType)
-        | NativeInt | UNativeInt -> FableError "Converting (u)nativeint to long is not supported" |> raise
+        | _ -> TypeCast(args.Head, targetType)
     | _ ->
         addWarning com ctx.InlinePath r "Cannot make conversion because source type is unknown"
         TypeCast(args.Head, targetType)
@@ -933,6 +930,8 @@ let operators (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr o
         toInt com ctx r t args |> Some
     | "ToInt64", _ -> toLong com ctx r false t args |> Some
     | "ToUInt64", _ -> toLong com ctx r true t args |> Some
+    | "ToIntPtr", _ -> toLong com ctx r false t args |> Some
+    | "ToUIntPtr", _ -> toLong com ctx r true t args |> Some
     | ("ToSingle"|"ToDouble"), _ -> toFloat com ctx r t args |> Some
     | "ToDecimal", _ -> toDecimal com ctx r t args |> Some
     | "ToChar", _ -> toChar com args.Head |> Some

--- a/src/Fable.Transforms/Rust/RustPrinter.fs
+++ b/src/Fable.Transforms/Rust/RustPrinter.fs
@@ -4,6 +4,9 @@ module Rust = Fable.Transforms.Rust.AST.Types
 open Fable.Transforms.Rust.AST.State
 open Fable.Transforms.Printer
 
+let isEmpty (crate: Rust.Crate): bool =
+    false //TODO: determine if printer will not print anything
+
 let run (writer: Writer) (crate: Rust.Crate): Async<unit> =
     async {
         let sm: SourceMap = SourceMap()

--- a/src/Fable.Transforms/State.fs
+++ b/src/Fable.Transforms/State.fs
@@ -197,8 +197,6 @@ type CompilerImpl(currentFile, project: Project, options, fableLibraryDir: strin
         | Some "Winexe" -> OutputType.Winexe
         | _ -> OutputType.Library
 
-    member _.Options = options
-    member _.CurrentFile = currentFile
     member _.Logs = logs.ToArray()
     member _.WatchDependencies =
         match watchDependencies with Some w -> Array.ofSeq w | None -> [||]

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -566,23 +566,7 @@ module AST =
         | Boolean, (:? bool as x) -> BoolConstant x |> makeValue r
         | String, (:? string as x) -> StringConstant x |> makeValue r
         | Char, (:? char as x) -> CharConstant x |> makeValue r
-        // Integer types
-        | Number(Int8, info), (:? int8 as x) -> NumberConstant(x, Int8, info) |> makeValue r
-        | Number(UInt8, info), (:? uint8 as x) -> NumberConstant(x, UInt8, info) |> makeValue r
-        | Number(Int16, info), (:? int16 as x) -> NumberConstant(x, Int16, info) |> makeValue r
-        | Number(UInt16, info), (:? uint16 as x) -> NumberConstant(x, UInt16, info) |> makeValue r
-        | Number(Int32, info), (:? int32 as x) -> NumberConstant(x, Int32, info) |> makeValue r
-        | Number(UInt32, info), (:? uint32 as x) -> NumberConstant(x, UInt32, info) |> makeValue r
-        | Number(Int64, info), (:? int64 as x) -> NumberConstant(x, Int64, info) |> makeValue r
-        | Number(UInt64, info), (:? uint64 as x) -> NumberConstant(x, UInt64, info) |> makeValue r
-        // Float types
-        | Number(Float32, info), (:? float32 as x) -> NumberConstant(x, Float32, info) |> makeValue r
-        | Number(Float64, info), (:? float as x) -> NumberConstant(x, Float64, info) |> makeValue r
-        | Number(Decimal, info), (:? decimal as x) -> NumberConstant(x, Decimal, info) |> makeValue r
-        // Pointer types
-        | Number(NativeInt, info), (:? nativeint as x) -> NumberConstant(x, Int64, info) |> makeValue r
-        | Number(UNativeInt, info), (:? unativeint as x) -> NumberConstant(x, UInt64, info) |> makeValue r
-        // Unit
+        | Number(kind, info), x -> NumberConstant(x, kind, info) |> makeValue r
         | Unit, _ -> UnitConstant |> makeValue r
         // Arrays with small data type (ushort, byte) are represented
         // in F# AST as BasicPatterns.Const

--- a/src/fable-compiler-js/src/Platform.fs
+++ b/src/fable-compiler-js/src/Platform.fs
@@ -62,7 +62,6 @@ let measureTime (f: 'a -> 'b) x =
     let elapsed = JS.proc.hrtime(startTime)
     res, int64 (elapsed.[0] * 1e3 + elapsed.[1] / 1e6)
 
-let escapeJsString (str: string) = JS.util.escapeJsStringLiteral(str)
 let ensureDirExists (dir: string) = JS.util.ensureDirExists(dir)
 let serializeToJson (data: obj) = JS.util.serializeToJson(data)
 let copyFolder (from: string) (dest: string) = JS.util.copyFolder(from, dest)

--- a/src/fable-compiler-js/src/app.fs
+++ b/src/fable-compiler-js/src/app.fs
@@ -87,7 +87,6 @@ type SourceWriter(sourcePath, targetPath, projDir, options: CmdLineOptions, file
     let mapGenerator = lazy (SourceMapSharp.SourceMapGenerator())
     interface Fable.Standalone.IWriter with
         member _.Write(str) = async { return sb.Append(str) |> ignore }
-        member _.EscapeStringLiteral(str) = escapeJsString(str)
         member _.MakeImportPath(path) =
             let path = Imports.getImportPath dedupTargetDir sourcePath targetPath projDir options.outDir path
             if path.EndsWith(".fs") then Path.ChangeExtension(path, fileExt) else path
@@ -263,7 +262,7 @@ let run opts projectFileName outDir =
             // TODO: This only works if the project is an .fsx file
             let outDir = Option.defaultValue "." outDir
             let scriptFile = Path.Combine(outDir, Path.GetFileNameWithoutExtension(projectFileName) + ".js")
-            let runArgs = opts.[i+1..] |> String.concat " "
+            let runArgs = opts[i+1..] |> String.concat " "
             sprintf "node %s %s" scriptFile runArgs)
     let options = {
         outDir = opts |> argValue ["--outDir"; "-o"] |> Option.orElse outDir

--- a/src/fable-compiler-js/src/util.js
+++ b/src/fable-compiler-js/src/util.js
@@ -1,12 +1,6 @@
 import * as fs from "fs";
 import * as Path from "path";
 
-// JSON.stringify doesn't escape line/paragraph separators, which are not valid in JS.
-// https://github.com/expressjs/express/issues/1132
-export function escapeJsStringLiteral(str) {
-  return JSON.stringify(str).slice(1, -1).replace(/\u2028/g, '\\u2028').replace(/\u2029/g, '\\u2029');
-}
-
 export function getVersion() {
   return require("../package.json").version;
 }

--- a/src/fable-standalone/src/Fable.Standalone.fsproj
+++ b/src/fable-standalone/src/Fable.Standalone.fsproj
@@ -11,10 +11,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Fable.Transforms -->
+    <!-- Fable.AST -->
     <Compile Include="../../Fable.AST/Common.fs" />
     <Compile Include="../../Fable.AST/Fable.fs" />
     <Compile Include="../../Fable.AST/Plugins.fs" />
+
+    <!-- Fable.Transforms -->
     <Compile Include="../../Fable.Transforms/Global/Babel.fs" />
     <Compile Include="../../Fable.Transforms/Global/Fable.Core.fs" />
     <Compile Include="../../Fable.Transforms/Global/Metadata.fs" />
@@ -37,10 +39,20 @@
     <Compile Include="../../Fable.Transforms/Fable2Babel.fs" />
     <Compile Include="../../Fable.Transforms/Printer.fs" />
     <Compile Include="../../Fable.Transforms/BabelPrinter.fs" />
+    <Compile Include="../../Fable.Transforms/Python/Python.fs" />
+    <Compile Include="../../Fable.Transforms/Python/Fable2Python.fs" />
+    <Compile Include="../../Fable.Transforms/Python/PythonPrinter.fs" />
+    <Compile Include="../../Fable.Transforms/Php/Php.fs" />
+    <Compile Include="../../Fable.Transforms/Php/Fable2Php.fs" />
+    <Compile Include="../../Fable.Transforms/Php/PhpPrinter.fs" />
+    <Compile Include="../../Fable.Transforms/Dart/Dart.fs" />
+    <Compile Include="../../Fable.Transforms/Dart/Fable2Dart.fs" />
+    <Compile Include="../../Fable.Transforms/Dart/DartPrinter.fs" />
     <Compile Include="../../Fable.Transforms/Rust/RustPrinter.fs" />
     <Compile Include="../../Fable.Transforms/Rust/Fable2Rust.fs" />
     <Compile Include="../../Fable.Transforms/State.fs" />
 
+    <!-- Fable.Standalone -->
     <Compile Include="Interfaces.fs"/>
     <Compile Include="Lexer.fs"/>
     <Compile Include="Main.fs"/>

--- a/src/fable-standalone/src/Interfaces.fs
+++ b/src/fable-standalone/src/Interfaces.fs
@@ -52,7 +52,6 @@ type IFableResult =
 type IWriter =
     inherit System.IDisposable
     abstract AddSourceMapping: SourceMapping -> unit
-    abstract EscapeStringLiteral: string -> string
     abstract MakeImportPath: string -> string
     abstract Write: string -> Async<unit>
 

--- a/src/fable-standalone/src/Main.fs
+++ b/src/fable-standalone/src/Main.fs
@@ -318,7 +318,6 @@ let compileToTargetAst (results: IParseAndCheckResults) fileName fableLibrary ty
 let makeWriter (writer: IWriter) =
     { new Printer.Writer with
         member _.Dispose() = writer.Dispose()
-        member _.EscapeStringLiteral(str) = writer.EscapeStringLiteral(str)
         member _.MakeImportPath(path) = writer.MakeImportPath(path)
         member _.AddLog(msg, severity, ?range) = ()
         member _.AddSourceMapping(mapping) = writer.AddSourceMapping(mapping)

--- a/src/fable-standalone/src/Worker/Worker.fs
+++ b/src/fable-standalone/src/Worker/Worker.fs
@@ -48,7 +48,6 @@ type SourceWriter(sourceMaps: bool) =
     let sb = System.Text.StringBuilder()
     interface Fable.Standalone.IWriter with
         member _.Write(str) = async { return sb.Append(str) |> ignore }
-        member _.EscapeStringLiteral(str) = escapeJsStringLiteral(str)
         member _.MakeImportPath(path) = path
         member _.AddSourceMapping(mapping) = ()
         member _.Dispose() = ()

--- a/src/fable-standalone/test/bench-compiler/Platform.fs
+++ b/src/fable-standalone/test/bench-compiler/Platform.fs
@@ -26,9 +26,6 @@ let measureTime (f: 'a -> 'b) x =
     sw.Stop()
     res, sw.ElapsedMilliseconds
 
-let escapeJsString (str: string) =
-    System.Web.HttpUtility.JavaScriptStringEncode(str)
-
 let ensureDirExists (path: string): unit =
     Directory.CreateDirectory(path) |> ignore
 
@@ -126,7 +123,6 @@ let measureTime (f: 'a -> 'b) x =
     let elapsed = JS.proc.hrtime(startTime)
     res, int64 (elapsed.[0] * 1e3 + elapsed.[1] / 1e6)
 
-let escapeJsString (str: string) = JS.util.escapeJsStringLiteral(str)
 let ensureDirExists (dir: string) = JS.util.ensureDirExists(dir)
 let serializeToJson (data: obj) = JS.util.serializeToJson(data)
 

--- a/src/fable-standalone/test/bench-compiler/app.fs
+++ b/src/fable-standalone/test/bench-compiler/app.fs
@@ -71,7 +71,6 @@ type SourceWriter(sourcePath, targetPath, projDir, options: CmdLineOptions, file
     let mapGenerator = lazy (SourceMapSharp.SourceMapGenerator())
     interface Fable.Standalone.IWriter with
         member _.Write(str) = async { return sb.Append(str) |> ignore }
-        member _.EscapeStringLiteral(str) = escapeJsString(str)
         member _.MakeImportPath(path) =
             let path = Imports.getImportPath dedupTargetDir sourcePath targetPath projDir options.outDir path
             if path.EndsWith(".fs") then Path.ChangeExtension(path, fileExt) else path

--- a/src/fable-standalone/test/bench-compiler/package.json
+++ b/src/fable-standalone/test/bench-compiler/package.json
@@ -4,8 +4,12 @@
   "scripts": {
     "clean": "git clean -fdX",
 
-    "build-rust": "dotnet run -c Release -- ../../../../tests/Rust/Fable.Tests.Rust.fsproj --outDir out-tests-rust --fableLib out-lib --lang Rust",
-    "trace-rust": "dotnet trace collect --duration 00:00:01:00 --format speedscope -- dotnet bin/Release/net5.0/bench-compiler.dll ../../../../tests/Rust/Fable.Tests.Rust.fsproj --outDir out-tests-rust --fableLib out-lib --lang Rust",
+    "build-tests-rust": "dotnet run -c Release -- ../../../../tests/Rust/Fable.Tests.Rust.fsproj --outDir out-tests-rust --fableLib out-lib --lang Rust",
+    "build-tests-dart": "dotnet run -c Release -- ../../../../tests/Dart/src/Fable.Tests.Dart.fsproj --outDir out-tests-dart --fableLib out-lib --lang Dart",
+    "build-tests-python": "dotnet run -c Release -- ../../../../tests/Python/Fable.Tests.Python.fsproj --outDir out-tests-python --fableLib out-lib --lang Python",
+    "build-tests-rust-node": "node --stack_size=1200 out-node/app.js ../../../../tests/Rust/Fable.Tests.Rust.fsproj --outDir out-tests-rust --fableLib out-lib --lang Rust",
+    "build-tests-dart-node": "node --stack_size=1200 out-node/app.js ../../../../tests/Dart/src/Fable.Tests.Dart.fsproj --outDir out-tests-dart --fableLib out-lib --lang Dart",
+    "build-tests-python-node": "node --stack_size=1200 out-node/app.js ../../../../tests/Python/Fable.Tests.Python.fsproj --outDir out-tests-python --fableLib out-lib --lang Python",
 
     "prebuild-cli": "npm run clean && npm run prebuild-lib && npm run build-lib-cli",
     "build-cli": "dotnet run -c Release -p ../../../Fable.Cli -- bench-compiler.fsproj --outDir out-node --fableLib out-lib",
@@ -26,7 +30,7 @@
     "native": "cd . && \"bin/Release/net5.0/win-x64/native/bench-compiler\"",
     "build-native": "npm run native bench-compiler.fsproj out-node",
     "build-test-native": "npm run native ../../../../../fable-test/fable-test.fsproj out-test",
-    "build-tests-native": "npm run native ../../../../tests/Main/Fable.Tests.fsproj out-tests",
+    "build-tests-native": "npm run native ../../../../tests/Js/Main/Fable.Tests.fsproj out-tests",
 
     "rollup-bundle": "npm run rollup -- out-node/app.js -o dist/bundle.js --format esm",
     "terser-bundle": "npm run terser -- dist/bundle.js -o dist/bundle.min.js --mangle --compress",
@@ -49,10 +53,10 @@
 
     "prebuild-tests": "npm run clean && npm run build-lib",
     "prebuild-tests-ts": "npm run clean && npm run build-lib-ts",
-    "build-tests": "dotnet run -c Release ../../../../tests/Main/Fable.Tests.fsproj out-tests --fableLib out-lib --sourceMaps",
+    "build-tests": "dotnet run -c Release ../../../../tests/Js/Main/Fable.Tests.fsproj out-tests --fableLib out-lib --sourceMaps",
     "build-tests-ts": "npm run build-tests -- --fableLib out-lib-ts --typescript",
     "build-tests-opt": "npm run build-tests -- --optimize",
-    "build-tests-node": "node out-node/app.js ../../../../tests/Main/Fable.Tests.fsproj out-tests --fableLib out-lib --sourceMaps",
+    "build-tests-node": "node out-node/app.js ../../../../tests/Js/Main/Fable.Tests.fsproj out-tests --fableLib out-lib --sourceMaps",
     "tests": "npm run mocha -- out-tests --colors --reporter dot",
 
     "tsc": "node ../../../../node_modules/typescript/bin/tsc",
@@ -73,6 +77,7 @@
     "prof-preprocess": "node --prof-process --preprocess isolate-*.log > profile.v8log.json",
     "speedscope": "speedscope profile.v8log.json",
     "flamegraph": "perf script | ../../../../../FlameGraph/stackcollapse-perf.pl | ../../../../../FlameGraph/flamegraph.pl > perf.svg",
-    "trace": "node --trace-deopt out-node/app.js bench-compiler.fsproj out-node2 > deopt.log"
+    "trace-node": "node --trace-deopt out-node/app.js bench-compiler.fsproj out-node2 > deopt.log",
+    "trace-rust": "dotnet trace collect --duration 00:00:01:00 --format speedscope -- dotnet bin/Release/net6.0/bench-compiler.dll ../../../../tests/Rust/Fable.Tests.Rust.fsproj --outDir out-tests-rust --fableLib out-lib --lang Rust"
   }
 }


### PR DESCRIPTION
- Updated `fable-standalone` with language support.
- Removed `EscapeStringLiteral`, as language printers know best how to print their strings.