### PR TITLE
[Python] fixes python test wrt culture info

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fantomas-tool": {
-      "version": "4.6.0",
+      "version": "4.7.9",
       "commands": [
         "fantomas"
       ]

--- a/src/fable-library-py/fable_library/string.py
+++ b/src/fable-library-py/fable_library/string.py
@@ -205,6 +205,11 @@ def fs_format(str: str):
 
 
 def format(string: str, *args: Any) -> str:
+    if not string and args:
+        # Called with culture info
+        string = args[0]
+        args = args[1:]
+
     def match(m: Match[str]) -> str:
         idx, padLength, format, precision_, pattern = list(m.groups())
         rep = args[int(idx)]

--- a/src/fable-library/System.Text.fs
+++ b/src/fable-library/System.Text.fs
@@ -1,4 +1,5 @@
 namespace System.Text
+open System
 
 type StringBuilder(value: string, capacity: int) =
     let buf = ResizeArray<string>(capacity)
@@ -16,6 +17,7 @@ type StringBuilder(value: string, capacity: int) =
     member x.Append(cs: char[]) = buf.Add(System.String(cs)); x
     member x.Append(s: StringBuilder) = buf.Add(s.ToString()); x
     member x.AppendFormat(fmt: string, o: obj) = buf.Add(System.String.Format(fmt, o)); x
+    member x.AppendFormat(provider: IFormatProvider, fmt: string, o: obj) = buf.Add(System.String.Format(provider, fmt, o)); x
     member x.AppendLine() = buf.Add(System.Environment.NewLine); x
     member x.AppendLine(s: string) = buf.Add(s); buf.Add(System.Environment.NewLine); x
     override __.ToString() = System.String.Concat(buf)

--- a/tests/Python/TestString.fs
+++ b/tests/Python/TestString.fs
@@ -1,6 +1,8 @@
 module Fable.Tests.String
 
 open System
+open System.Globalization
+
 open Util.Testing
 
 #nowarn "44" // This construct is deprecated. Uri.EscapeUriString can corrupt the Uri string in some cases. (code 44)
@@ -148,9 +150,9 @@ let ``test sprintf integers with sign and padding works`` () =
 
 [<Fact>]
 let ``test String.Format combining padding and zeroes pattern works`` () =
-    String.Format("{0:++0.00++}", -5000.5657) |> equal "-++5000.57++"
-    String.Format("{0:000.00}foo", 5) |> equal "005.00foo"
-    String.Format("{0,-8:000.00}foo", 12.456) |> equal "012.46  foo"
+    String.Format(CultureInfo.InvariantCulture, "{0:++0.00++}", -5000.5657) |> equal "-++5000.57++"
+    String.Format(CultureInfo.InvariantCulture, "{0:000.00}foo", 5) |> equal "005.00foo"
+    String.Format(CultureInfo.InvariantCulture, "{0,-8:000.00}foo", 12.456) |> equal "012.46  foo"
 
 [<Fact>]
 let ``test StringBuilder works`` () =
@@ -193,7 +195,7 @@ let ``test StringBuilder.Append works with various overloads`` () =
                       .Append("bcd".ToCharArray())
                       .Append('/')
                       .Append(true)
-                      .Append(5.2)
+                      .AppendFormat(CultureInfo.InvariantCulture, "{0}", 5.2)
                       .Append(34)
     equal "aaabcd/true5.234" (builder.ToString().ToLower())
 


### PR DESCRIPTION
Fixes python tests to use invariant culture to not output floats with commas instead of dots for decimal separator. Please check it looks ok since it touches non-python code as well @alfonsogarciacaro 