### PR TITLE
[Rust] Made Async optional

### DIFF
--- a/src/fable-library-rust/Cargo.toml
+++ b/src/fable-library-rust/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-futures = { version = "0.3.21", features = ["executor", "thread-pool" ] }
+futures = { version = "0.3.21", features = ["executor", "thread-pool" ], optional = true }

--- a/src/fable-library-rust/src/Async.rs
+++ b/src/fable-library-rust/src/Async.rs
@@ -1,5 +1,6 @@
 #![allow(non_snake_case)]
 
+#[cfg(feature = "futures")]
 pub mod Async_ {
     use std::future::{self, Future, ready};
     use std::pin::Pin;
@@ -61,6 +62,7 @@ pub mod Async_ {
     }
 }
 
+#[cfg(feature = "futures")]
 pub mod AsyncBuilder_ {
     use std::{sync::Arc, pin::Pin, future::{Future, ready}};
 
@@ -98,6 +100,7 @@ pub mod AsyncBuilder_ {
     }
 }
 
+#[cfg(feature = "futures")]
 pub mod ThreadPool {
     use std::sync::RwLock;
 
@@ -116,6 +119,7 @@ pub mod ThreadPool {
     }
 }
 
+#[cfg(feature = "futures")]
 pub mod Task_ {
     use std::{sync::{Arc, RwLock}, thread::{self, JoinHandle}, time::Duration, task::Poll, pin::Pin};
 
@@ -292,6 +296,7 @@ pub mod Task_ {
     }
 }
 
+#[cfg(feature = "futures")]
 pub mod TaskBuilder_ {
     use std::{sync::Arc, rc::Rc};
 

--- a/tests/Rust/Cargo.toml
+++ b/tests/Rust/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-fable_library_rust = { path = "../../fable-library-rust" }
+fable_library_rust = { path = "../../fable-library-rust", features = ["futures"] }


### PR DESCRIPTION
- Made `Async` module optional to speed up compilation when not needed.
- It can be enabled by adding `features = ["futures"]` in `Cargo.toml` where needed, like this:
```toml
[dependencies]
fable_library_rust = { path = "../../fable-library-rust", features = ["futures"] }
```