### PR TITLE
[Rust] Lrc - Abstracting over Rc and Arc using feature

### DIFF
--- a/src/Fable.Core/Fable.Core.Rust.fs
+++ b/src/Fable.Core/Fable.Core.Rust.fs
@@ -22,8 +22,9 @@ type InnerAttrAttribute private (name: string, value: string option, items: stri
 
 //Rc/Arc control
 type PointerType =
-    | Rc = 0
-    | Arc = 1
+    | Lrc = 0
+    | Rc = 1
+    | Arc = 2
 
 // Rust - Defines the pointer type that is to be used to wrap the object (Rc/Arc)
 type ReferenceTypeAttribute(pointerType: PointerType) =

--- a/src/fable-library-rust/src/Async.rs
+++ b/src/fable-library-rust/src/Async.rs
@@ -301,6 +301,7 @@ pub mod TaskBuilder_ {
     use std::{sync::Arc, rc::Rc};
 
     use super::Task_::Task_1;
+    use super::super::Native_::Lrc;
 
     pub struct TaskBuilder {}
 
@@ -311,7 +312,7 @@ pub mod TaskBuilder_ {
         }
     }
 
-    pub fn new() -> Rc<TaskBuilder> {
-        Rc::from(TaskBuilder {})
+    pub fn new() -> Lrc<TaskBuilder> {
+        Lrc::from(TaskBuilder {})
     }
 }

--- a/src/fable-library-rust/src/Native.rs
+++ b/src/fable-library-rust/src/Native.rs
@@ -18,13 +18,18 @@ pub mod Native_ {
     pub type Set_1<T> = Option<Rc<crate::Set_::SetTree_1<T>>>;
     pub type Map_2<K, V> = Option<Rc<crate::Map_::MapTree_2<K, V>>>;
 
+    #[cfg(not(futures))]
+    pub type Lrc<T> = Rc<T>;
+    #[cfg(futures)]
+    pub type Lrc<T> = Arc<T>;
+
     // TODO: use these types in generated code
-    pub type string = Rc<str>;
-    pub type seq<T> = Rc<dyn crate::Interfaces_::IEnumerable_1<T>>;
-    pub type RefCell<T> = Rc<MutCell<T>>;
-    pub type Array<T> = Rc<MutCell<Vec<T>>>;
-    pub type HashSet_1<T> = Rc<MutCell<HashSet<T>>>;
-    pub type HashMap_2<K, V> = Rc<MutCell<HashMap<K, V>>>;
+    pub type string = Lrc<str>;
+    pub type seq<T> = Lrc<dyn crate::Interfaces_::IEnumerable_1<T>>;
+    pub type RefCell<T> = Lrc<MutCell<T>>;
+    pub type Array<T> = Lrc<MutCell<Vec<T>>>;
+    pub type HashSet_1<T> = Lrc<MutCell<HashSet<T>>>;
+    pub type HashMap_2<K, V> = Lrc<MutCell<HashMap<K, V>>>;
 
     use core::cmp::Ordering;
     use core::fmt::Debug;
@@ -40,7 +45,7 @@ pub mod Native_ {
         Default::default()
     }
 
-    pub fn comparer<T: Clone>(comp: Rc<impl Fn(T, T) -> i32>) -> impl Fn(&T, &T) -> Ordering {
+    pub fn comparer<T: Clone>(comp: Lrc<impl Fn(T, T) -> i32>) -> impl Fn(&T, &T) -> Ordering {
         move |x, y| match comp(x.clone(), y.clone()) {
             i if i < 0 => Ordering::Less,
             i if i > 0 => Ordering::Greater,
@@ -53,8 +58,8 @@ pub mod Native_ {
     // -----------------------------------------------------------
 
     #[inline]
-    pub fn mkRef<T>(x: T) -> Rc<T> {
-        Rc::from(x)
+    pub fn mkRef<T>(x: T) -> Lrc<T> {
+        Lrc::from(x)
     }
 
     #[inline]
@@ -63,7 +68,7 @@ pub mod Native_ {
     }
 
     #[inline]
-    pub fn mkRefMut<T: Clone>(x: T) -> Rc<MutCell<T>> {
+    pub fn mkRefMut<T: Clone>(x: T) -> Lrc<MutCell<T>> {
         mkRef(mkMut(x))
     }
 

--- a/src/fable-library-rust/src/Native.rs
+++ b/src/fable-library-rust/src/Native.rs
@@ -14,14 +14,14 @@ pub mod Native_ {
     pub use super::Mutable::*;
     pub use super::Lazy::*;
 
-    pub type List_1<T> = Option<Rc<crate::List_::Node_1<T>>>;
-    pub type Set_1<T> = Option<Rc<crate::Set_::SetTree_1<T>>>;
-    pub type Map_2<K, V> = Option<Rc<crate::Map_::MapTree_2<K, V>>>;
-
-    #[cfg(not(futures))]
+    #[cfg(not(feature = "futures"))]
     pub type Lrc<T> = Rc<T>;
-    #[cfg(futures)]
+    #[cfg(feature = "futures")]
     pub type Lrc<T> = Arc<T>;
+
+    pub type List_1<T> = Option<Lrc<crate::List_::Node_1<T>>>;
+    pub type Set_1<T> = Option<Lrc<crate::Set_::SetTree_1<T>>>;
+    pub type Map_2<K, V> = Option<Lrc<crate::Map_::MapTree_2<K, V>>>;
 
     // TODO: use these types in generated code
     pub type string = Lrc<str>;

--- a/src/fable-library-rust/src/String.rs
+++ b/src/fable-library-rust/src/String.rs
@@ -8,7 +8,7 @@ pub mod String_ {
     // -----------------------------------------------------------
 
     pub fn string(s: &str) -> string {
-        Rc::from(s)
+        Lrc::from(s)
     }
 
     pub fn fromCharCode(code: u32) -> char {
@@ -351,42 +351,42 @@ pub mod String_ {
     // String module
     // -----------------------------------------------------------
 
-    pub fn collect(mapping: Rc<impl Fn(char) -> string>, s: string) -> string {
+    pub fn collect(mapping: Lrc<impl Fn(char) -> string>, s: string) -> string {
         let v: Vec<string> = s.chars().map(|c| mapping(c)).collect();
         string(&v.concat())
     }
 
-    pub fn exists(predicate: Rc<impl Fn(char) -> bool>, s: string) -> bool {
+    pub fn exists(predicate: Lrc<impl Fn(char) -> bool>, s: string) -> bool {
         s.chars().any(|c| predicate(c))
     }
 
-    pub fn filter(predicate: Rc<impl Fn(char) -> bool>, s: string) -> string {
+    pub fn filter(predicate: Lrc<impl Fn(char) -> bool>, s: string) -> string {
         string(&s.chars().filter(|c| predicate(*c)).collect::<String>())
     }
 
-    pub fn forAll(predicate: Rc<impl Fn(char) -> bool>, s: string) -> bool {
+    pub fn forAll(predicate: Lrc<impl Fn(char) -> bool>, s: string) -> bool {
         s.chars().all(|c| predicate(c))
     }
 
-    pub fn init(count: i32, initializer: Rc<impl Fn(i32) -> string>) -> string {
+    pub fn init(count: i32, initializer: Lrc<impl Fn(i32) -> string>) -> string {
         let v: Vec<string> = (0..count).map(|i| initializer(i)).collect();
         string(&v.concat())
     }
 
-    pub fn iter(action: Rc<impl Fn(char) -> ()>, s: string) -> () {
+    pub fn iter(action: Lrc<impl Fn(char) -> ()>, s: string) -> () {
         s.chars().for_each(|c| action(c))
     }
 
-    pub fn iteri(action: Rc<impl Fn(i32, char) -> ()>, s: string) -> () {
+    pub fn iteri(action: Lrc<impl Fn(i32, char) -> ()>, s: string) -> () {
         let mut i: i32 = -1;
         s.chars().for_each(|c| { i += 1; action(i, c) })
     }
 
-    pub fn map(mapping: Rc<impl Fn(char) -> char>, s: string) -> string {
+    pub fn map(mapping: Lrc<impl Fn(char) -> char>, s: string) -> string {
         string(&s.chars().map(|c| mapping(c)).collect::<String>())
     }
 
-    pub fn mapi(mapping: Rc<impl Fn(i32, char) -> char>, s: string) -> string {
+    pub fn mapi(mapping: Lrc<impl Fn(i32, char) -> char>, s: string) -> string {
         let mut i: i32 = -1;
         string(&s.chars().map(|c| { i += 1; mapping(i, c) }).collect::<String>())
     }

--- a/tests/Rust/tests/src/InteropTests.fs
+++ b/tests/Rust/tests/src/InteropTests.fs
@@ -10,7 +10,7 @@ module Subs =
     [<Emit("$0 * $1")>]
     let mul a b = nativeOnly
 
-    [<Emit("{ let mut v = std::vec::Vec::new(); v.append(&mut vec![$0,$1]); Rc::from(MutCell::from(v)) }")>]
+    [<Emit("{ let mut v = std::vec::Vec::new(); v.append(&mut vec![$0,$1]); std::rc::Rc::from(MutCell::from(v)) }")>]
     let fixedVec a b = nativeOnly
 
     //doesn't currently work, but would be preferred
@@ -23,11 +23,11 @@ module Subs =
     let private _import_MutCell () = let mutable _x = 0 in ()
 
     module Vec =
-        [<Emit("Rc<MutCell<Vec<$0>>>")>]
+        [<Emit("std::rc::Rc<MutCell<Vec<$0>>>")>]
         type VecT<'a> =
             [<Emit("$0.get_mut().push($1)")>]
             abstract Push: 'a -> unit
-        [<Emit("Rc::from(MutCell::from(std::vec::Vec::new()))")>]
+        [<Emit("std::rc::Rc::from(MutCell::from(std::vec::Vec::new()))")>]
         let create (): VecT<'a> = nativeOnly
         [<Emit("$1.get_mut().push($0)")>]
         let push (item: 'a) (vec: VecT<'a>) = nativeOnly


### PR DESCRIPTION
* Create an alias Lrc which is able to represent a Rc or an Arc depending on the feature switch "futures"
* Add Lrc as a explicit concept in transforms
* Tweak libs to redirect onto Lrc where manually hard-coded

### Testing:
* Run tests on futures (this is the default in CI) - Call sites correctly represent Arc all the way down
* Run tests on no futures + comment out async tests - Call sites correctly represent Rc

### Further things that still need looking at
* Is 1 feature switch sufficient granularity? (simplest user experience but less control)
* Add a new test-rust-something and push feature on-off to cargo run call. Conditionally enable "futures" feature switch for lib. Adjust CI so that it can be run for both modes
* MutCell