### PR TITLE
fix: standalone import path for Python

### DIFF
--- a/src/fable-standalone/src/Worker/Worker.fs
+++ b/src/fable-standalone/src/Worker/Worker.fs
@@ -50,7 +50,7 @@ type SourceWriter(sourceMaps: bool, language: string) =
         member _.Write(str) = async { return sb.Append(str) |> ignore }
         member _.MakeImportPath(path) =
             match language with
-            | "Python" -> path.Replace("/", ".").Replace("-", "_").Replace(".py", "")
+            | "Python" -> path.Replace("/", ".").Replace("-", "_").Replace(".py", "").ToLowerInvariant()
             | _ -> path
         member _.AddSourceMapping(mapping) = ()
         member _.Dispose() = ()


### PR DESCRIPTION
Fixes #2977 

@alfonsogarciacaro I decided to go with @ncave suggestion since changing `getLibPath` to use dots (`.`) broke PythonWriter in the CLI that uses stuff like `Imports.getImportPath` etc.