### PR TITLE
Rust - represent self as a Lrc<T> for method calls using double pointer indirection

### DIFF
--- a/src/Fable.Transforms/Rust/Fable2Rust.fs
+++ b/src/Fable.Transforms/Rust/Fable2Rust.fs
@@ -3599,7 +3599,6 @@ module Util =
                         let genArgTys = genArgs |> transformGenArgs com ctx
                         let bounds = mkTypeTraitGenericBound [entName] genArgTys
                         let ty = mkTraitTy [bounds]
-                        let ety = com.GetEntity(tEntRef)
                         ty
                     let genArgs = getEntityGenArgs tEnt
                     let nameParts =

--- a/src/Fable.Transforms/Rust/Fable2Rust.fs
+++ b/src/Fable.Transforms/Rust/Fable2Rust.fs
@@ -428,6 +428,13 @@ module TypeInfo =
             | ent ->
                 if ent.IsValueType then None else Some Lrc
 
+    let shouldBeDoubleWrapped (com: IRustCompiler) typ=
+        match typ with
+        | Fable.DeclaredType(entRef, _) ->
+            let ent = com.GetEntity(entRef)
+            ent.IsInterface && not ent.IsValueType
+        | _ -> false
+
     let isCloneableType (com: IRustCompiler) typ =
         match typ with
         | Fable.String
@@ -980,7 +987,7 @@ module Util =
     let transformIdentGet com ctx r (ident: Fable.Ident) =
         let expr = transformIdent com ctx r ident
         if ident.IsThisArgument then
-            expr |> makeClone |> makeLrcValue
+            expr |> makeClone
         elif ident.IsMutable && not (isInRefType com ident.Type) then
             expr |> mutableGet
         else
@@ -1257,6 +1264,10 @@ module Util =
         | _, Fable.GenericParam(name, _isMeasure, _constraints) ->
             makeCall [name; "from"] None [expr] // e.g. T::from(value)
         // casts to interface
+        | Replacements.Util.IsEntity (Types.dictionary) _, Replacements.Util.IsEntity (Types.idictionary) _ ->
+            expr |> makeClone |> mkCastExpr ty
+        | t1, t2 when not (shouldBeDoubleWrapped com t1) && shouldBeDoubleWrapped com t2 ->
+            expr |> makeClone |> makeNewLrcValue |> mkCastExpr ty
         | _, t when isInterface com t ->
             expr |> makeClone |> mkCastExpr ty
         // TODO: other casts?
@@ -1307,6 +1318,9 @@ module Util =
     let makeCall pathNames genArgs (args: Rust.Expr list) =
         let callee = mkGenericPathExpr pathNames genArgs
         mkCallExpr callee args
+
+    let makeNewLrcValue (value: Rust.Expr) =
+        makeCall ["Lrc";"new"] None [value]
 
     let makeLrcValue (value: Rust.Expr) =
         makeCall ["Lrc";"from"] None [value]
@@ -3539,19 +3553,36 @@ module Util =
             if Set.isEmpty nonInterfaceMembersSet then
                 []
             else
-                let assocItems = [
-                    let membersNotDeclared =
-                        decl.AttachedMembers |> List.filter (fun m ->
-                            Set.contains m.Name nonInterfaceMembersSet)
-                    for m in membersNotDeclared ->
-                        let isFluent = isFluentMemberBody m.Body
-                        let fnDecl = transformFunctionDecl com ctx isFluent m.Args m.Body.Type
-                        let generics = makeGenerics com ctx [] //TODO: add generics?
-                        let fnKind = mkFnKind DEFAULT_FN_HEADER fnDecl generics None
-                        mkFnAssocItem [] m.Name fnKind
-                ]
-                let generics = getEntityGenArgs ent |> makeGenerics com ctx
-                let traitItem = mkTraitItem [] (entName + "Methods") assocItems [] generics
+                // let statics =
+                //     let assocItems = [
+                //         let membersNotDeclared =
+                //             decl.AttachedMembers |> List.filter (fun m ->
+                //                 let isStatic = m.Args |> List.exists (fun q -> q.IsThisArgument) |> not
+                //                 Set.contains m.Name nonInterfaceMembersSet && isStatic)
+                //         for m in membersNotDeclared ->
+                //             let isFluent = isFluentMemberBody m.Body
+                //             let fnDecl = transformFunctionDecl com ctx isFluent m.Args m.Body.Type
+                //             let generics = makeGenerics com ctx [] //TODO: add generics?
+                //             let fnKind = mkFnKind DEFAULT_FN_HEADER fnDecl generics None
+                //             mkFnAssocItem [] m.Name fnKind
+                //     ]
+                //     let generics = getEntityGenArgs ent |> makeGenerics com ctx
+                //     mkTraitItem [] (entName) assocItems [] generics
+                let traitItem =
+                    let assocItems = [
+                        let membersNotDeclared =
+                            decl.AttachedMembers |> List.filter (fun m ->
+                                let isNotStatic = m.Args |> List.exists (fun q -> q.IsThisArgument)
+                                Set.contains m.Name nonInterfaceMembersSet && isNotStatic)
+                        for m in membersNotDeclared ->
+                            let isFluent = isFluentMemberBody m.Body
+                            let fnDecl = transformFunctionDecl com ctx isFluent m.Args m.Body.Type
+                            let generics = makeGenerics com ctx [] //TODO: add generics?
+                            let fnKind = mkFnKind DEFAULT_FN_HEADER fnDecl generics None
+                            mkFnAssocItem [] m.Name fnKind
+                    ]
+                    let generics = getEntityGenArgs ent |> makeGenerics com ctx
+                    mkTraitItem [] (entName + "Methods") assocItems [] generics
                 [traitItem |> mkPublicItem]
 
         let traitsToRender =
@@ -3564,22 +3595,47 @@ module Util =
             traitsToRender
             |> List.collect (fun (isNonInterface, tMethods, tEntRef) ->
                 let tEnt = com.GetEntity(tEntRef)
+                let memberItemsStatic =
+                    decl.AttachedMembers
+                    |> List.filter (fun m ->
+                        let isDynamic = m.Args |> List.exists (fun q -> q.IsThisArgument)
+                        tMethods |> Set.contains m.Name && not isDynamic)
+                    |> List.map (makeMemberItem ctx)
                 let memberItems =
                     decl.AttachedMembers
-                    |> List.filter (fun m -> tMethods |> Set.contains m.Name)
+                    |> List.filter (fun m ->
+                        let isDynamic = m.Args |> List.exists (fun q -> q.IsThisArgument)
+                        tMethods |> Set.contains m.Name && isDynamic)
                     |> List.map (makeMemberItem ctx)
-                if List.isEmpty memberItems then
-                    []
-                else
+
+                let implItemStatic =
                     let ty =
                         let genArgs = getEntityGenArgs ent
                         let genArgTys = genArgs |> transformGenArgs com ctx
                         let bounds = mkTypeTraitGenericBound [entName] genArgTys
                         let ty = mkTraitTy [bounds]
-                        // TODO: Wrapping the impl block in a Lrc breaks casting (see IEnumerable), because it no longer implements the interface for T but for Lrc<T>
-                        // let entTyp = Fable.DeclaredType(entRef, genArgs)
-                        // maybeWrapInPtrTy com ctx entTyp ty
+                        let ety = com.GetEntity(tEntRef)
                         ty
+                    let genArgs = getEntityGenArgs tEnt
+                    let nameParts =
+                        if isNonInterface then tEntRef.FullName
+                        else getInterfaceEntityName com ctx tEntRef
+                        |> splitFullName
+                    let path =
+                        let genArgTys = genArgs |> List.map (transformType com ctx)
+                        mkGenericPath nameParts (mkGenericTypeArgs genArgTys)
+                    let generics = genArgs |> makeGenerics com ctx
+                    mkImplItem [] "" ty generics memberItemsStatic None
+                let implItem =
+                    let ty =
+                        let genArgs = getEntityGenArgs ent
+                        let genArgTys = genArgs |> transformGenArgs com ctx
+                        let bounds = mkTypeTraitGenericBound [entName] genArgTys
+                        let ty = mkTraitTy [bounds]
+                        let ety = com.GetEntity(tEntRef)
+                        if not ety.IsValueType then
+                            makeLrcTy com ctx ty
+                        else ty
                     let genArgs = getEntityGenArgs tEnt
                     let nameParts =
                         if isNonInterface then tEntRef.FullName + "Methods"
@@ -3590,8 +3646,8 @@ module Util =
                         mkGenericPath nameParts (mkGenericTypeArgs genArgTys)
                     let generics = genArgs |> makeGenerics com ctx
                     let ofTrait = mkTraitRef path |> Some
-                    let implItem = mkImplItem [] "" ty generics memberItems ofTrait
-                    [implItem]
+                    mkImplItem [] "" ty generics memberItems ofTrait
+                [implItemStatic; implItem] // todo only render if it has 1 or more item
             )
 
         ctorImpls @ nonInterfaceMembersTrait @ memberTraitImpls

--- a/src/Fable.Transforms/Rust/Fable2Rust.fs
+++ b/src/Fable.Transforms/Rust/Fable2Rust.fs
@@ -428,7 +428,7 @@ module TypeInfo =
             | ent ->
                 if ent.IsValueType then None else Some Lrc
 
-    let shouldBeDoubleWrapped (com: IRustCompiler) typ=
+    let shouldBeDyn (com: IRustCompiler) typ=
         match typ with
         | Fable.DeclaredType(entRef, _) ->
             let ent = com.GetEntity(entRef)
@@ -1265,8 +1265,8 @@ module Util =
             makeCall [name; "from"] None [expr] // e.g. T::from(value)
         // casts to interface
         | Replacements.Util.IsEntity (Types.dictionary) _, Replacements.Util.IsEntity (Types.idictionary) _ ->
-            expr |> makeClone |> mkCastExpr ty
-        | t1, t2 when not (shouldBeDoubleWrapped com t1) && shouldBeDoubleWrapped com t2 ->
+            expr
+        | t1, t2 when not (shouldBeDyn com t1) && shouldBeDyn com t2 ->
             expr |> makeClone |> makeNewLrcValue |> mkCastExpr ty
         | _, t when isInterface com t ->
             expr |> makeClone |> mkCastExpr ty
@@ -3553,21 +3553,6 @@ module Util =
             if Set.isEmpty nonInterfaceMembersSet then
                 []
             else
-                // let statics =
-                //     let assocItems = [
-                //         let membersNotDeclared =
-                //             decl.AttachedMembers |> List.filter (fun m ->
-                //                 let isStatic = m.Args |> List.exists (fun q -> q.IsThisArgument) |> not
-                //                 Set.contains m.Name nonInterfaceMembersSet && isStatic)
-                //         for m in membersNotDeclared ->
-                //             let isFluent = isFluentMemberBody m.Body
-                //             let fnDecl = transformFunctionDecl com ctx isFluent m.Args m.Body.Type
-                //             let generics = makeGenerics com ctx [] //TODO: add generics?
-                //             let fnKind = mkFnKind DEFAULT_FN_HEADER fnDecl generics None
-                //             mkFnAssocItem [] m.Name fnKind
-                //     ]
-                //     let generics = getEntityGenArgs ent |> makeGenerics com ctx
-                //     mkTraitItem [] (entName) assocItems [] generics
                 let traitItem =
                     let assocItems = [
                         let membersNotDeclared =

--- a/tests/Rust/tests/src/ClassTests.fs
+++ b/tests/Rust/tests/src/ClassTests.fs
@@ -128,7 +128,6 @@ let ``Class fluent/builder internal clone pattern should work`` () =
 let ``Class fluent/builder should be sharing same reference and not cloning when returning this`` () =
     let a = FluentA(1);
     let b = a.Add1().Add1();
-    // Does not yet work - Requires this to be Lrc<T> and not T when implementing TypeMethods
     a.X |> equal 3
     b.X |> equal 3
 

--- a/tests/Rust/tests/src/ClassTests.fs
+++ b/tests/Rust/tests/src/ClassTests.fs
@@ -129,7 +129,7 @@ let ``Class fluent/builder should be sharing same reference and not cloning when
     let a = FluentA(1);
     let b = a.Add1().Add1();
     // Does not yet work - Requires this to be Lrc<T> and not T when implementing TypeMethods
-    //a.X |> equal 3
+    a.X |> equal 3
     b.X |> equal 3
 
 [<Fact>]


### PR DESCRIPTION
Following on from https://github.com/fable-compiler/Fable/pull/2981#discussion_r928690837 this implements class method traits as Lrc<T>, thus allowing self to be of type ```&Lrc<T>``` and ```not &T```. This is done by double pointer indirection ```Lrc<dyn Lrc<YourStruct>>```, which is not ideal, but currently the only seemingly practical way to achieve this dynamic dispatch approach in Rust. This is important because it allows self/this to be correctly cloned, preserving underlying referential integrity. This is required for fluent/builder patterns when internal mutability is present, and it can not be reasoned which reference a user will potentially pass over to another area of the program after configuration.

![image](https://user-images.githubusercontent.com/1506553/181067508-47e01687-6337-4551-a93d-339323c7845a.png)


Changes
* Add concept of dynamic - Currently this is just anything expressed through its interface, but in theory you could use this to cast between instances of concrete classes too, but it is kind of an all or nothing approach. For flat hierarchies perhaps this could just be optimized out.
* Split out static methods so they no longer get rendered into the Methods trait. They now get rendered straight into the root type, so they can correctly be referenced by static name.
* Something weird with dictionaries, they are not a single struct that implements a methods trait, so casting causes problems. Will likely need an explicit workaround? For now I have deduced that it is safe to do absolutely nothing, so this should hopefully suffice for now.

The trait gen code is copy pasted, so there are some obvious refactor opportunities here! Apologies, I will come back to this.