### PR TITLE
[Python] Revert python packages

### DIFF
--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -128,30 +128,7 @@ module private Util =
                 match cliArgs.OutDir with
                 | Some outDir -> outDir
                 | None -> IO.Path.GetDirectoryName cliArgs.ProjectFile
-
-            let absPath =
-                let absPath = Imports.getTargetAbsolutePath pathResolver file projDir outDir
-                let fileName = IO.Path.GetFileName(file)
-
-                // Make sure all packages and modules (subdirs) we create within outDir are lower case (PEP8)
-                let modules =
-                    absPath.Substring(outDir.Length, absPath.Length-outDir.Length-fileName.Length)
-                        .Trim([|'/'|])
-                        .ToLowerInvariant()
-                        .Split([|'/'|])
-
-                // Generate Python snake_case module within the kebab-case package
-                let modules =
-                    match Array.toList modules with
-                    | Naming.fableModules :: package :: modules ->
-                        let packageModule = package.Replace("-", "_")
-                        Naming.fableModules :: package :: packageModule :: modules
-                    | modules -> modules
-                    |> List.toArray
-                    |> IO.Path.Join
-
-                IO.Path.Join(outDir, modules, fileName)
-
+            let absPath = Imports.getTargetAbsolutePath pathResolver file projDir outDir
             Path.ChangeExtension(absPath, fileExt)
         | lang ->
             let changeExtension path fileExt =

--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -128,7 +128,19 @@ module private Util =
                 match cliArgs.OutDir with
                 | Some outDir -> outDir
                 | None -> IO.Path.GetDirectoryName cliArgs.ProjectFile
-            let absPath = Imports.getTargetAbsolutePath pathResolver file projDir outDir
+            let absPath =
+                let absPath = Imports.getTargetAbsolutePath pathResolver file projDir outDir
+                let fileName = IO.Path.GetFileName(file)
+
+                // Make sure all packages and modules (subdirs) we create within outDir are lower case (PEP8)
+                let modules =
+                    absPath.Substring(outDir.Length, absPath.Length-outDir.Length-fileName.Length)
+                        .Trim([|'/'|])
+                        .ToLowerInvariant()
+                        .Split([|'/'|])
+                    |> IO.Path.Join
+
+                IO.Path.Join(outDir, modules, fileName)
             Path.ChangeExtension(absPath, fileExt)
         | lang ->
             let changeExtension path fileExt =

--- a/src/Fable.Cli/Pipeline.fs
+++ b/src/Fable.Cli/Pipeline.fs
@@ -185,13 +185,13 @@ module Python =
                             parts
                             |> Array.choose (fun part ->
                                 i <- i + 1
-                                if part = "." then None
-                                elif part = ".." then Some ""
-                                elif i = parts.Length - 1 then Some(normalizeFileName part)
-                                else Some part // TODO: normalize also dir names?
+                                if part = "." then if i = 0 && isLibrary then Some("") else None
+                                elif part = ".." then None
+                                elif part = Naming.fableModules then None
+                                else Some(normalizeFileName part)
                             )
                             |> String.concat "."
-                        if isLibrary then "." + path else path
+                        path
                 else path
 
     // Writes __init__ files to all directories. This mailbox serializes and dedups.

--- a/src/Fable.Cli/Pipeline.fs
+++ b/src/Fable.Cli/Pipeline.fs
@@ -185,13 +185,13 @@ module Python =
                             parts
                             |> Array.choose (fun part ->
                                 i <- i + 1
-                                if part = "." then if i = 0 && isLibrary then Some("") else None
-                                elif part = ".." then None
-                                elif part = Naming.fableModules then None
-                                else Some(normalizeFileName part)
+                                if part = "." then None
+                                elif part = ".." then Some ""
+                                elif i = parts.Length - 1 then Some(normalizeFileName part)
+                                else Some part // TODO: normalize also dir names?
                             )
                             |> String.concat "."
-                        path
+                        if isLibrary then "." + path else path
                 else path
 
     // Writes __init__ files to all directories. This mailbox serializes and dedups.

--- a/src/Fable.Cli/ProjectCracker.fs
+++ b/src/Fable.Cli/ProjectCracker.fs
@@ -505,7 +505,7 @@ let getFableLibraryPath (opts: CrackerOptions) =
     | None ->
         let buildDir, libDir =
             match opts.FableOptions.Language with
-            | Python -> "fable-library-py", "fable-library"
+            | Python -> "fable-library-py/fable_library", "fable_library"
             | Dart -> "fable-library-dart", "fable_library"
             | Rust -> "fable-library-rust", "fable-library-rust"
             | _ -> "fable-library", "fable-library" + "." + Literals.VERSION
@@ -537,19 +537,11 @@ let copyFableLibraryAndPackageSourcesPy (opts: CrackerOptions) (pkgs: FablePacka
         pkgs |> List.map (fun pkg ->
             let sourceDir = IO.Path.GetDirectoryName(pkg.FsprojPath)
             let targetDir =
-                let name = Naming.applyCaseRule Core.CaseRules.KebabCase pkg.Id
-                IO.Path.Combine(opts.FableModulesDir, name.Replace(".", "-"))
+                let name = Naming.applyCaseRule Core.CaseRules.SnakeCase pkg.Id
+                IO.Path.Combine(opts.FableModulesDir, name.Replace(".", "_"))
             copyDirIfDoesNotExist false sourceDir targetDir
             { pkg with FsprojPath = IO.Path.Combine(targetDir, IO.Path.GetFileName(pkg.FsprojPath)) })
-    let packages =
-        pkgRefs
-        |> List.map (fun pkg ->
-            Naming.applyCaseRule Core.CaseRules.KebabCase (pkg.Id.Replace(".", "-")))
-        |> List.append ["fable-library"]
-        |> List.map (fun name -> $"-e ./fable_modules/{name}")
 
-    // Store all packages used for easy installation using `pip install -r requirements.txt`
-    IO.File.WriteAllLines(IO.Path.Combine(opts.FableModulesDir, "requirements.txt"), packages)
     getFableLibraryPath opts, pkgRefs
 
 // See #1455: F# compiler generates *.AssemblyInfo.fs in obj folder, but we don't need it

--- a/src/Fable.Transforms/Python/PythonPrinter.fs
+++ b/src/Fable.Transforms/Python/PythonPrinter.fs
@@ -768,7 +768,7 @@ let run writer (program: Module) : Async<unit> =
 
         let imports, restDecls =
             program.Body
-            |> List.partition (function
+            |> List.splitWhile (function
                 | Import _
                 | ImportFrom _ -> true
                 | Expr ({Value=Expression.Emit(_)}) -> true

--- a/src/Fable.Transforms/Python/PythonPrinter.fs
+++ b/src/Fable.Transforms/Python/PythonPrinter.fs
@@ -768,9 +768,10 @@ let run writer (program: Module) : Async<unit> =
 
         let imports, restDecls =
             program.Body
-            |> List.splitWhile (function
+            |> List.partition (function
                 | Import _
                 | ImportFrom _ -> true
+                | Expr ({Value=Expression.Emit(_)}) -> true
                 | _ -> false)
 
         for decl in imports do


### PR DESCRIPTION
Revert the latest python package generation changes until we can find a better solution (if any) for handling this. Instead we remove `fable_modules` from the import paths and add that path as the first statement. This makes it more flexible for library writers to use a pre-compiled fable-library instead of bundling the code.