### PR TITLE
Rust - More work on collection interop (Set, List, Map)

### DIFF
--- a/src/fable-library-rust/src/Interop.rs
+++ b/src/fable-library-rust/src/Interop.rs
@@ -5,7 +5,7 @@ pub mod ListExt {
 
     use super::super::List_;
     use crate::{
-        List_::{cons, iterate, singleton, mkList},
+        List_::{cons, iterate, mkList, singleton},
         Native_::{List_1, Lrc, MutCell},
     };
 
@@ -47,7 +47,7 @@ pub mod ListExt {
     }
 }
 
-pub mod Array {
+pub mod ArrayExt {
     use std::ops::Deref;
 
     use crate::{
@@ -92,8 +92,55 @@ pub mod Array {
     }
 }
 
-pub mod Seq {}
+pub mod SeqExt {}
 
-pub mod Set {}
+pub mod SetExt {
+    use std::ops::Deref;
 
-pub mod Map {}
+    use super::super::Set_;
+    use crate::{
+        Native_::{Lrc, MutCell, self},
+        Set_::{iterate, empty}
+    };
+
+    type Set<T> = Set_::Set_1<T>;
+
+    impl<T: Clone + PartialOrd> From<Vec<T>> for Set<T> {
+        fn from(vec: Vec<T>) -> Self {
+            let mut set = empty();
+            for v in vec.iter() {
+                set = Set_::add(v.clone(), set);
+            }
+            set
+        }
+    }
+
+    impl<T: Clone + PartialOrd> From<&Vec<T>> for Set<T> {
+        fn from(vec: &Vec<T>) -> Self {
+            let mut set = empty();
+            for v in vec.iter() {
+                set = Set_::add(v.clone(), set);
+            }
+            set
+        }
+    }
+
+    impl<T: Clone> Into<Vec<T>> for Set<T> {
+        fn into(self) -> Vec<T> {
+            let vec = Lrc::from(MutCell::from(Vec::new()));
+            iterate(
+                Lrc::from({
+                    let vec = vec.clone();
+                    move |item: T| {
+                        let rawVec = vec.get_mut();
+                        rawVec.push(item.clone());
+                    }
+                }),
+                self,
+            );
+            vec.get()
+        }
+    }
+}
+
+pub mod MapExt {}

--- a/src/fable-library-rust/src/Interop.rs
+++ b/src/fable-library-rust/src/Interop.rs
@@ -1,38 +1,31 @@
 use crate::Native_::List_1;
 
-pub mod List {
+pub mod ListExt {
     use std::ops::Deref;
 
     use super::super::List_;
     use crate::{
-        List_::{cons, iterate, singleton},
+        List_::{cons, iterate, singleton, mkList},
         Native_::{List_1, Lrc, MutCell},
     };
 
-    #[derive(Clone, Debug, PartialEq, PartialOrd)]
-    pub struct List<T: Clone + 'static>(List_1<T>);
+    type List<T> = List_1<T>;
 
-    impl <T: Clone> Deref for List<T> {
-        type Target = List_1<T>;
+    impl<T: Clone> Deref for List<T> {
+        type Target = Option<Lrc<crate::List_::Node_1<T>>>;
 
         fn deref(&self) -> &Self::Target {
-            &self.0
+            &self.item
         }
     }
 
-    impl <T: Clone> From<List_1<T>> for List<T> {
-        fn from(lst: List_1<T>) -> Self {
-            List(lst)
-        }
-    }
-
-    impl <T: Clone> From<&Vec<T>> for List<T> {
+    impl<T: Clone> From<&Vec<T>> for List<T> {
         fn from(vec: &Vec<T>) -> Self {
-            let mut lst: List_1<T> = None;
+            let mut lst: List<T> = mkList(None);
             for (i, item) in vec.iter().rev().enumerate() {
                 lst = cons(item.clone(), lst);
             }
-            List(lst)
+            lst
         }
     }
 
@@ -47,7 +40,7 @@ pub mod List {
                         rawVec.push(item.clone());
                     }
                 }),
-                self.0,
+                self,
             );
             vec.get()
         }
@@ -65,7 +58,7 @@ pub mod Array {
     #[derive(Clone, Debug, PartialEq, PartialOrd)]
     pub struct Array<T: Clone + 'static>(Native_::Array<T>);
 
-    impl <T: Clone> Deref for Array<T> {
+    impl<T: Clone> Deref for Array<T> {
         type Target = Native_::Array<T>;
 
         fn deref(&self) -> &Self::Target {
@@ -73,19 +66,19 @@ pub mod Array {
         }
     }
 
-    impl <T: Clone> From<Native_::Array<T>> for Array<T> {
+    impl<T: Clone> From<Native_::Array<T>> for Array<T> {
         fn from(arr: Native_::Array<T>) -> Self {
             Array(arr)
         }
     }
 
-    impl <T: Clone> From<Vec<T>> for Array<T> {
+    impl<T: Clone> From<Vec<T>> for Array<T> {
         fn from(vec: Vec<T>) -> Self {
             Array(Lrc::from(MutCell::from(vec)))
         }
     }
 
-    impl <T: Clone> From<&Vec<T>> for Array<T> {
+    impl<T: Clone> From<&Vec<T>> for Array<T> {
         fn from(vec: &Vec<T>) -> Self {
             let vecNew: Vec<T> = vec.iter().map(|item| item.clone()).collect();
             Array(Lrc::from(MutCell::from(vecNew)))

--- a/src/fable-library-rust/src/Interop.rs
+++ b/src/fable-library-rust/src/Interop.rs
@@ -99,8 +99,8 @@ pub mod SetExt {
 
     use super::super::Set_;
     use crate::{
-        Native_::{Lrc, MutCell, self},
-        Set_::{iterate, empty}
+        Native_::{self, Lrc, MutCell},
+        Set_::{empty, iterate},
     };
 
     type Set<T> = Set_::Set_1<T>;
@@ -143,4 +143,41 @@ pub mod SetExt {
     }
 }
 
-pub mod MapExt {}
+pub mod MapExt {
+    use std::ops::Deref;
+
+    use super::super::Map_;
+    use crate::{
+        Map_::{empty, iterate},
+        Native_::{List_1, Lrc, MutCell},
+    };
+
+    type Map_2<K, V> = Map_::Map_2<K, V>;
+
+    impl<K: Clone + PartialOrd, V: Clone + PartialOrd> From<&Vec<(K, V)>> for Map_2<K, V> {
+        fn from(vec: &Vec<(K, V)>) -> Self {
+            let mut map: Map_2<K, V> = empty();
+            for (i, (k, v)) in vec.iter().rev().enumerate() {
+                map = Map_::add(k.clone(), v.clone(), map);
+            }
+            map
+        }
+    }
+
+    impl<K: Clone + PartialOrd, V: Clone + PartialOrd> Into<Vec<(K, V)>> for Map_2<K, V> {
+        fn into(self) -> Vec<(K, V)> {
+            let vec = Lrc::from(MutCell::from(Vec::new()));
+            iterate(
+                Lrc::from({
+                    let vec = vec.clone();
+                    move |k: K, v: V| {
+                        let rawVec = vec.get_mut();
+                        rawVec.push((k.clone(), v.clone()));
+                    }
+                }),
+                self,
+            );
+            vec.get()
+        }
+    }
+}

--- a/src/fable-library-rust/src/Interop.rs
+++ b/src/fable-library-rust/src/Interop.rs
@@ -6,12 +6,13 @@ pub mod ListExt {
     use super::super::List_;
     use crate::{
         List_::{cons, iterate, mkList, singleton},
-        Native_::{List_1, Lrc, MutCell, seq_as_iter}, Seq_,
+        Native_::{seq_as_iter, List_1, Lrc, MutCell},
+        Seq_,
     };
 
     type List<T> = List_1<T>;
 
-    impl <T: Clone> List<T>{
+    impl<T: Clone> List<T> {
         pub fn iter(&self) -> impl Iterator<Item = T> {
             let s = Seq_::ofList(self.clone());
             seq_as_iter(&s)
@@ -39,18 +40,7 @@ pub mod ListExt {
 
     impl<T: Clone> Into<Vec<T>> for List<T> {
         fn into(self) -> Vec<T> {
-            let vec = Lrc::from(MutCell::from(Vec::new()));
-            iterate(
-                Lrc::from({
-                    let vec = vec.clone();
-                    move |item: T| {
-                        let rawVec = vec.get_mut();
-                        rawVec.push(item.clone());
-                    }
-                }),
-                self,
-            );
-            vec.get()
+            self.iter().collect()
         }
     }
 }
@@ -113,9 +103,7 @@ pub mod SetExt {
 
     type Set<T> = Set_::Set_1<T>;
 
-    impl <T: Clone> Set<T>{
-
-    }
+    impl<T: Clone> Set<T> {}
 
     impl<T: Clone + PartialOrd> From<Vec<T>> for Set<T> {
         fn from(vec: Vec<T>) -> Self {
@@ -161,16 +149,17 @@ pub mod MapExt {
     use super::super::Map_;
     use crate::{
         Map_::{empty, iterate},
-        Native_::{List_1, Lrc, MutCell, seq_as_iter}, Seq_,
+        Native_::{seq_as_iter, List_1, Lrc, MutCell},
+        Seq_,
     };
 
     type Map_2<K, V> = Map_::Map_2<K, V>;
 
-    impl <K: Clone + PartialOrd, V: Clone> Map_2<K, V>{
+    impl<K: Clone + PartialOrd, V: Clone> Map_2<K, V> {
         pub fn iter(&self) -> impl Iterator<Item = (K, V)> {
             let s = Map_::toSeq(self.clone());
-            seq_as_iter(&s).map(|x|{
-                 //todo - these tuples should probably internally be represented as struct tuples in Map, so they an easily be destructured + more efficient for keyvalue
+            seq_as_iter(&s).map(|x| {
+                //todo - these tuples should probably internally be represented as struct tuples in Map, so they an easily be destructured + more efficient for keyvalue
                 let k = x.0.clone();
                 let v = x.1.clone();
                 (k, v)
@@ -190,18 +179,7 @@ pub mod MapExt {
 
     impl<K: Clone + PartialOrd, V: Clone> Into<Vec<(K, V)>> for Map_2<K, V> {
         fn into(self) -> Vec<(K, V)> {
-            let vec = Lrc::from(MutCell::from(Vec::new()));
-            iterate(
-                Lrc::from({
-                    let vec = vec.clone();
-                    move |k: K, v: V| {
-                        let rawVec = vec.get_mut();
-                        rawVec.push((k.clone(), v.clone()));
-                    }
-                }),
-                self,
-            );
-            vec.get()
+            self.iter().collect()
         }
     }
 }

--- a/src/fable-library-rust/src/List.fs
+++ b/src/fable-library-rust/src/List.fs
@@ -5,7 +5,6 @@ type Node<'T> = {
     mutable tail: Node<'T> option
 }
 
-//type List<'T> = Node<'T> option
 [<Struct>]
 type List<'t> = {
     item: Node<'t> option
@@ -53,7 +52,7 @@ let singleton (x: 'T) = //List.Cons(x, List.Empty)
     cons x (empty())
 
 let isEmpty (xs: 'T list) = //xs.IsEmpty
-    xs |> getRaw |> Option.isNone 
+    xs |> getRaw |> Option.isNone
 
 let head (xs: 'T list) = //xs.Head
     match xs |> getRaw with

--- a/src/fable-library-rust/src/List.fs
+++ b/src/fable-library-rust/src/List.fs
@@ -5,8 +5,15 @@ type Node<'T> = {
     mutable tail: Node<'T> option
 }
 
-type List<'T> = Node<'T> option
+//type List<'T> = Node<'T> option
+[<Struct>]
+type List<'t> = {
+    item: Node<'t> option
+}
 type 'T list = List<'T>
+let mkList item = { item = item }
+[<Fable.Core.Emit("$0.item")>] // otherwise Fable assumes conservatively the item must be cloned as owned.
+let getRaw lst = lst.item
 
 module SR =
     let indexOutOfBounds = "The index was outside the range of elements in the list."
@@ -21,11 +28,11 @@ module SR =
 let inline indexNotFound() = failwith SR.keyNotFoundAlt
 
 let inline private consNoTail (x: 'T): 'T list =
-    Some { head = x; tail = None }
+    Some { head = x; tail = None } |> mkList
 
 let private setConsTail (t: 'T list) (xs: 'T list) =
-    match xs with
-    | Some node -> node.tail <- t
+    match xs |> getRaw with
+    | Some node -> node.tail <- (getRaw t)
     | None -> ()
 
 let private appendConsNoTail (x: 'T) (xs: 'T list) =
@@ -37,33 +44,35 @@ let private appendConsNoTail (x: 'T) (xs: 'T list) =
 // TODO: there may be some class members here when those are supported
 
 let empty (): 'T list = //List.Empty
-    None
+    None |> mkList
 
 let cons (x: 'T) (xs: 'T list) = //List.Cons(x, xs)
-    Some { head = x; tail = xs }
+    Some { head = x; tail = xs |> getRaw } |> mkList
 
 let singleton (x: 'T) = //List.Cons(x, List.Empty)
     cons x (empty())
 
 let isEmpty (xs: 'T list) = //xs.IsEmpty
-    xs |> Option.isNone
+    xs |> getRaw |> Option.isNone 
 
 let head (xs: 'T list) = //xs.Head
-    match xs with
+    match xs |> getRaw with
     | Some node -> node.head
     | None -> invalidArg "list" SR.inputListWasEmpty
 
 let tryHead (xs: 'T list) = //xs.TryHead
-    match xs with
+    match xs |> getRaw with
     | Some node -> Some (node.head)
     | None -> None
 
 let tail (xs: 'T list) = //xs.Tail
-    match xs with
+    match xs |> getRaw with
     | Some node -> node.tail
     | None -> invalidArg "list" SR.inputListWasEmpty
+    |> mkList
 
 let length (xs: 'T list) = //xs.Length
+    let xs = getRaw xs
     let rec inner_loop i xs =
         match xs with
         | None -> i
@@ -71,12 +80,13 @@ let length (xs: 'T list) = //xs.Length
     inner_loop 0 xs
 
 let rec tryLast (xs: 'T list) =
+    let xs = getRaw xs
     match xs with
     | None -> None
     | Some node ->
-        if (isEmpty node.tail)
+        if (isEmpty (mkList node.tail))
         then Some (node.head)
-        else tryLast node.tail
+        else tryLast (mkList node.tail)
 
 let last (xs: 'T list) =
     match tryLast xs with
@@ -121,6 +131,7 @@ let fold (folder: 'State -> 'T -> 'State) (state: 'State) (xs: 'T list) =
     acc
 
 let reverse (xs: 'T list) =
+    let xs = xs
     fold (fun acc x -> cons x acc) (empty()) xs
 
 let foldBack (folder: 'T -> 'State -> 'State) (xs: 'T list) (state: 'State) =

--- a/src/fable-library-rust/src/Native.rs
+++ b/src/fable-library-rust/src/Native.rs
@@ -24,7 +24,7 @@ pub mod Native_ {
 
     pub type List_1<T> = crate::List_::List_1<T>;
     pub type Set_1<T> = crate::Set_::Set_1<T>;
-    pub type Map_2<K, V> = Option<Lrc<crate::Map_::MapTree_2<K, V>>>;
+    pub type Map_2<K, V> = crate::Map_::Map_2<K, V>;
 
     // TODO: use these types in generated code
     pub type string = Lrc<str>;

--- a/src/fable-library-rust/src/Native.rs
+++ b/src/fable-library-rust/src/Native.rs
@@ -22,7 +22,7 @@ pub mod Native_ {
     #[cfg(feature = "futures")]
     pub type Lrc<T> = Arc<T>;
 
-    pub type List_1<T> = Option<Lrc<crate::List_::Node_1<T>>>;
+    pub type List_1<T> = crate::List_::List_1<T>;
     pub type Set_1<T> = Option<Lrc<crate::Set_::SetTree_1<T>>>;
     pub type Map_2<K, V> = Option<Lrc<crate::Map_::MapTree_2<K, V>>>;
 

--- a/src/fable-library-rust/src/Native.rs
+++ b/src/fable-library-rust/src/Native.rs
@@ -23,7 +23,7 @@ pub mod Native_ {
     pub type Lrc<T> = Arc<T>;
 
     pub type List_1<T> = crate::List_::List_1<T>;
-    pub type Set_1<T> = Option<Lrc<crate::Set_::SetTree_1<T>>>;
+    pub type Set_1<T> = crate::Set_::Set_1<T>;
     pub type Map_2<K, V> = Option<Lrc<crate::Map_::MapTree_2<K, V>>>;
 
     // TODO: use these types in generated code

--- a/src/fable-library-rust/src/Set.fs
+++ b/src/fable-library-rust/src/Set.fs
@@ -25,7 +25,6 @@ type SetTree<'T> = {
 and [<Struct>]Set<'T> = {
     item: Option<SetTree<'T>>
 }
-type 'T list = List<'T>
 let mkSet item = { item = item }
 [<Fable.Core.Emit("$0.item")>] // otherwise Fable assumes conservatively the item must be cloned as owned.
 let getRaw lst = lst.item

--- a/src/fable-library-rust/src/Set.fs
+++ b/src/fable-library-rust/src/Set.fs
@@ -22,24 +22,31 @@ type SetTree<'T> = {
     Right: Set<'T>
 }
 
-and Set<'T> = Option<SetTree<'T>>
+and [<Struct>]Set<'T> = {
+    item: Option<SetTree<'T>>
+}
+type 'T list = List<'T>
+let mkSet item = { item = item }
+[<Fable.Core.Emit("$0.item")>] // otherwise Fable assumes conservatively the item must be cloned as owned.
+let getRaw lst = lst.item
+
 
 type 'T set = Set<'T>
 
-let empty: Set<'T> = None
+let empty: Set<'T> = { item = None }
 
-let isEmpty (s: Set<'T>) = s.IsNone
+let isEmpty (s: Set<'T>) = s.item.IsNone
 
 let mkSetTreeLeaf (key: 'T): Set<'T> =
-    Some { Key = key; Left = empty; Right = empty; Height = 1 }
+    Some { Key = key; Left = empty; Right = empty; Height = 1 } |> mkSet
 
 let mkSetTreeNode (key: 'T, left: Set<'T>, right: Set<'T>, height: int): Set<'T> =
-    Some { Key = key; Left = left; Right = right; Height = height }
+    Some { Key = key; Left = left; Right = right; Height = height } |> mkSet
 
 let singleton (value: 'T) = mkSetTreeLeaf value
 
 let rec countAux (s: Set<'T>) acc =
-    match s with
+    match s |> getRaw with
     | None -> acc
     | Some t ->
         if t.Height = 1 then
@@ -50,7 +57,7 @@ let rec countAux (s: Set<'T>) acc =
 let count s = countAux s 0
 
 let inline height (s: Set<'T>) =
-    match s with
+    match s |> getRaw with
     | None -> 0
     | Some t -> t.Height
 
@@ -70,27 +77,27 @@ let rebalance (t1: Set<'T>) v (t2: Set<'T>) =
     let t1h = height t1
     let t2h = height t2
     if t2h > t1h + tolerance then // right is heavier than left
-        let t2' = t2.Value
+        let t2' = t2.item.Value
         // one of the nodes must have height > height t1 + 1
         if height t2'.Left > t1h + 1 then  // balance left: combination
-            let t2l = t2'.Left.Value
+            let t2l = t2'.Left.item.Value
             mk (mk t1 v t2l.Left) t2l.Key (mk t2l.Right t2'.Key t2'.Right)
         else // rotate left
             mk (mk t1 v t2'.Left) t2'.Key t2'.Right
     else
         if t1h > t2h + tolerance then // left is heavier than right
-            let t1' = t1.Value
+            let t1' = t1.item.Value
             // one of the nodes must have height > height t2 + 1
             if height t1'.Right > t2h + 1 then
                 // balance right: combination
-                let t1r = t1'.Right.Value
+                let t1r = t1'.Right.item.Value
                 mk (mk t1'.Left t1'.Key t1r.Left) t1r.Key (mk t1r.Right v t2)
             else
                 mk t1'.Left t1'.Key (mk t1'.Right v t2)
         else mk t1 v t2
 
 let rec add k (s: Set<'T>): Set<'T> =
-    match s with
+    match s |> getRaw with
     | None -> mkSetTreeLeaf k
     | Some t ->
         let c = compare k t.Key
@@ -108,10 +115,10 @@ let rec balance (s1: Set<'T>) k (s2: Set<'T>) =
     // Given t1 < k < t2 where t1 and t2 are "balanced",
     // return a balanced tree for <t1, k, t2>.
     // Recall: balance means subtrees heights differ by at most "tolerance"
-    match s1 with
+    match s1 |> getRaw with
     | None -> add k s2 // drop t1 = empty
     | Some t1 ->
-        match s2 with
+        match s2 |> getRaw with
         | None -> add k s1 // drop t2 = empty
         | Some t2 ->
             if t1.Height = 1 then add k (add t1.Key s2)
@@ -137,7 +144,7 @@ let rec balance (s1: Set<'T>) k (s2: Set<'T>) =
 let rec split pivot (s: Set<'T>) =
     // Given a pivot and a set t
     // Return { x in t s.t. x < pivot }, pivot in t?, { x in t s.t. x > pivot }
-    match s with
+    match s |> getRaw with
     | None -> empty, false, empty
     | Some t ->
         if t.Height = 1 then
@@ -157,7 +164,7 @@ let rec split pivot (s: Set<'T>) =
                 balance t.Left t.Key t12Lo, havePivot, t12Hi
 
 let rec spliceOutSuccessor (s: Set<'T>) =
-    match s with
+    match s |> getRaw with
     | None -> failwith "internal error: Set.spliceOutSuccessor"
     | Some t ->
         if t.Height = 1 then t.Key, empty
@@ -166,7 +173,7 @@ let rec spliceOutSuccessor (s: Set<'T>) =
             else let k3, l' = spliceOutSuccessor t.Left in k3, mk l' t.Key t.Right
 
 let rec remove k (s: Set<'T>) =
-    match s with
+    match s |> getRaw with
     | None -> s
     | Some t ->
         let c = compare k t.Key
@@ -183,7 +190,7 @@ let rec remove k (s: Set<'T>) =
             else rebalance t.Left t.Key (remove k t.Right)
 
 let rec contains k (s: Set<'T>) =
-    match s with
+    match s |> getRaw with
     | None -> false
     | Some t ->
         let c = compare k t.Key
@@ -194,7 +201,7 @@ let rec contains k (s: Set<'T>) =
             else contains k t.Right
 
 let rec iterate f (s: Set<'T>) =
-    match s with
+    match s |> getRaw with
     | None -> ()
     | Some t ->
         if t.Height = 1 then f t.Key
@@ -202,7 +209,7 @@ let rec iterate f (s: Set<'T>) =
             iterate f t.Left; f t.Key; iterate f t.Right
 
 let rec foldBack f (s: Set<'T>) x =
-    match s with
+    match s |> getRaw with
     | None -> x
     | Some t ->
         if t.Height = 1 then f t.Key x
@@ -210,7 +217,7 @@ let rec foldBack f (s: Set<'T>) x =
             foldBack f t.Left (f t.Key (foldBack f t.Right x))
 
 let rec fold f x (s: Set<'T>) =
-    match s with
+    match s |> getRaw with
     | None -> x
     | Some t ->
         if t.Height = 1 then f x t.Key
@@ -223,7 +230,7 @@ let map mapping (s: Set<'T>) =
     fold (fun acc k -> add (mapping k) acc) empty s
 
 let rec forAll f (s: Set<'T>) =
-    match s with
+    match s |> getRaw with
     | None -> true
     | Some t ->
         if t.Height = 1 then f t.Key
@@ -231,7 +238,7 @@ let rec forAll f (s: Set<'T>) =
             f t.Key && forAll f t.Left && forAll f t.Right
 
 let rec exists f (s: Set<'T>) =
-    match s with
+    match s |> getRaw with
     | None -> false
     | Some t ->
         if t.Height = 1 then f t.Key
@@ -251,7 +258,7 @@ let isProperSuperset a b =
     isProperSubset b a
 
 let rec filterAux f (s: Set<'T>) acc =
-    match s with
+    match s |> getRaw with
     | None -> acc
     | Some t ->
         if t.Height = 1 then
@@ -263,10 +270,10 @@ let rec filterAux f (s: Set<'T>) acc =
 let filter f s = filterAux f s empty
 
 let rec diffAux (s: Set<'T>) (acc: Set<'T>) =
-    match acc with
+    match acc |> getRaw with
     | None -> acc
     | Some _acc ->
-        match s with
+        match s |> getRaw with
         | None -> acc
         | Some t ->
             if t.Height = 1 then remove t.Key acc
@@ -277,10 +284,10 @@ let difference a b = diffAux b a
 
 let rec union (s1: Set<'T>) (s2: Set<'T>) =
     // Perf: tried bruteForce for low heights, but nothing significant
-    match s1 with
+    match s1 |> getRaw with
     | None -> s2
     | Some t1 ->
-        match s2 with
+        match s2 |> getRaw with
         | None -> s1
         | Some t2 ->
             if t1.Height = 1 then add t1.Key s2
@@ -302,7 +309,7 @@ let unionMany (sets: seq<Set<'T>>) =
     Seq.fold union empty sets
 
 let rec intersectionAux b (s: Set<'T>) acc =
-    match s with
+    match s |> getRaw with
     | None -> acc
     | Some t ->
         if t.Height = 1 then
@@ -324,7 +331,7 @@ let partition1 f k (acc1, acc2) =
     else (acc1, add k acc2)
 
 let rec partitionAux f (s: Set<'T>) acc =
-    match s with
+    match s |> getRaw with
     | None -> acc
     | Some t ->
         if t.Height = 1 then partition1 f t.Key acc
@@ -336,7 +343,7 @@ let rec partitionAux f (s: Set<'T>) acc =
 let partition f s = partitionAux f s (empty, empty)
 
 let rec minimumElementAux (s: Set<'T>) n =
-    match s with
+    match s |> getRaw with
     | None -> n
     | Some t ->
         if t.Height = 1 then t.Key
@@ -344,7 +351,7 @@ let rec minimumElementAux (s: Set<'T>) n =
             minimumElementAux t.Left t.Key
 
 and minimumElementOpt (s: Set<'T>) =
-    match s with
+    match s |> getRaw with
     | None -> None
     | Some t ->
         if t.Height = 1 then Some t.Key
@@ -352,7 +359,7 @@ and minimumElementOpt (s: Set<'T>) =
             Some(minimumElementAux t.Left t.Key)
 
 and maximumElementAux (s: Set<'T>) n =
-    match s with
+    match s |> getRaw with
     | None -> n
     | Some t ->
         if t.Height = 1 then t.Key
@@ -360,7 +367,7 @@ and maximumElementAux (s: Set<'T>) n =
             maximumElementAux t.Right t.Key
 
 and maximumElementOpt (s: Set<'T>) =
-    match s with
+    match s |> getRaw with
     | None -> None
     | Some t ->
         if t.Height = 1 then Some t.Key
@@ -391,7 +398,7 @@ let rec collapseLHS (stack: Set<'T> list) =
     match stack with
     | [] -> []
     | s :: rest ->
-        match s with
+        match s |> getRaw with
         | None -> collapseLHS rest
         | Some t ->
             if t.Height = 1 then stack
@@ -406,7 +413,7 @@ let alreadyFinished() = failwith SR.enumerationAlreadyFinished
 let current (i: SetIterator<'T>) =
     if i.started then
         match i.stack with
-        | Some k :: _ -> k.Key
+        | { item = Some k } :: _ -> k.Key
         | _ -> alreadyFinished()
     else
         notStarted()
@@ -417,7 +424,7 @@ let unexpectedstateInSetTreeCompareStacks() = failwith "unexpected state in SetT
 let rec moveNext (i: SetIterator<'T>) =
     if i.started then
         match i.stack with
-        | Some t :: rest ->
+        | { item = Some t } :: rest ->
             if t.Height = 1 then
                 i.stack <- collapseLHS rest
                 not i.stack.IsEmpty

--- a/tests/Rust/tests/src/ExtInteropTests.rs
+++ b/tests/Rust/tests/src/ExtInteropTests.rs
@@ -15,6 +15,15 @@ pub mod ExtInteropTests {
             assert_eq!(lst, expectedLst);
             assert_eq!(raw, tgt);
         }
+
+        #[test]
+        pub fn can_iter() {
+            let lst = List_1::from(&vec![1, 2, 3]);
+
+            let res: Vec<i32> = lst.iter().map(|x|x+1).collect();
+
+            assert_eq!(res, vec![2, 3, 4]);
+        }
     }
 
     pub mod ArrayTests {
@@ -32,7 +41,7 @@ pub mod ExtInteropTests {
     }
 
     pub mod SetTests {
-        use fable_library_rust::{Set_::Set_1};
+        use fable_library_rust::Set_::Set_1;
         #[test]
         pub fn can_interop_between_set_and_vec() {
             //todo
@@ -45,7 +54,10 @@ pub mod ExtInteropTests {
     }
 
     pub mod MapTests {
-        use fable_library_rust::{Native_::{Map_2, Lrc}, String_::string};
+        use fable_library_rust::{
+            Native_::{Lrc, Map_2},
+            String_::string,
+        };
         #[test]
         pub fn can_interop_between_map_and_vec() {
             //todo
@@ -54,6 +66,15 @@ pub mod ExtInteropTests {
             let tgt: Vec<(Lrc<str>, i32)> = map.clone().into();
 
             assert_eq!(raw, tgt);
+        }
+
+        #[test]
+        pub fn can_iter() {
+            let raw = vec![(string("a"), 1), (string("b"), 2), (string("c"), 3)];
+            let map = Map_2::from(&raw);
+
+            let res: Vec<i32> = map.iter().map(|(a, b)|b + 1).collect();
+            assert_eq!(res, vec![2, 3, 4]);
         }
     }
 }

--- a/tests/Rust/tests/src/ExtInteropTests.rs
+++ b/tests/Rust/tests/src/ExtInteropTests.rs
@@ -1,24 +1,24 @@
 pub mod ExtInteropTests {
     pub mod ListTests {
         use fable_library_rust::{
-            List::*,
+            Native_::List_1,
             List_::{cons, singleton},
         };
         #[test]
         pub fn can_interop_between_list_and_vec() {
             //todo
             let raw = vec![1, 2, 3];
-            let lst = List::from(&vec![1, 2, 3]);
-            let tgt:Vec<i32> = lst.clone().into();
+            let lst = List_1::from(&vec![1, 2, 3]);
+            let tgt: Vec<i32> = lst.clone().into();
 
-            let expectedLst = List::from(cons(1, cons(2, singleton(3))));
-            assert_eq!(lst, expectedLst );
+            let expectedLst = List_1::from(cons(1, cons(2, singleton(3))));
+            assert_eq!(lst, expectedLst);
             assert_eq!(raw, tgt);
         }
     }
 
     pub mod ArrayTests {
-        use fable_library_rust::{Array::Array};
+        use fable_library_rust::Array::Array;
         #[test]
         pub fn can_interop_between_list_and_vec() {
             //todo

--- a/tests/Rust/tests/src/ExtInteropTests.rs
+++ b/tests/Rust/tests/src/ExtInteropTests.rs
@@ -1,8 +1,8 @@
 pub mod ExtInteropTests {
     pub mod ListTests {
         use fable_library_rust::{
-            Native_::List_1,
             List_::{cons, singleton},
+            Native_::List_1,
         };
         #[test]
         pub fn can_interop_between_list_and_vec() {
@@ -18,12 +18,29 @@ pub mod ExtInteropTests {
     }
 
     pub mod ArrayTests {
-        use fable_library_rust::Array::Array;
+        //Work in progress - Array needs a built in wrapper as first class citizen before this can be fleshed out
+        use fable_library_rust::ArrayExt::Array;
         #[test]
-        pub fn can_interop_between_list_and_vec() {
+        pub fn can_interop_between_array_and_vec() {
             //todo
             let raw = vec![1, 2, 3];
             let arr = Array::from(&vec![1, 2, 3]);
+            let tgt: Vec<i32> = arr.clone().into();
+
+            assert_eq!(raw, tgt);
+        }
+    }
+
+    pub mod SetTests {
+        use fable_library_rust::{
+            Set_::{Set_1},
+            Native_::List_1,
+        };
+        #[test]
+        pub fn can_interop_between_set_and_vec() {
+            //todo
+            let raw = vec![1, 2, 3];
+            let arr = Set_1::from(&vec![1, 2, 3]);
             let tgt: Vec<i32> = arr.clone().into();
 
             assert_eq!(raw, tgt);

--- a/tests/Rust/tests/src/ExtInteropTests.rs
+++ b/tests/Rust/tests/src/ExtInteropTests.rs
@@ -8,7 +8,7 @@ pub mod ExtInteropTests {
         pub fn can_interop_between_list_and_vec() {
             //todo
             let raw = vec![1, 2, 3];
-            let lst = List_1::from(&vec![1, 2, 3]);
+            let lst = List_1::from(&raw);
             let tgt: Vec<i32> = lst.clone().into();
 
             let expectedLst = cons(1, cons(2, singleton(3)));
@@ -24,7 +24,7 @@ pub mod ExtInteropTests {
         pub fn can_interop_between_array_and_vec() {
             //todo
             let raw = vec![1, 2, 3];
-            let arr = Array::from(&vec![1, 2, 3]);
+            let arr = Array::from(&raw);
             let tgt: Vec<i32> = arr.clone().into();
 
             assert_eq!(raw, tgt);
@@ -32,16 +32,26 @@ pub mod ExtInteropTests {
     }
 
     pub mod SetTests {
-        use fable_library_rust::{
-            Set_::{Set_1},
-            Native_::List_1,
-        };
+        use fable_library_rust::{Set_::Set_1};
         #[test]
         pub fn can_interop_between_set_and_vec() {
             //todo
             let raw = vec![1, 2, 3];
-            let arr = Set_1::from(&vec![1, 2, 3]);
-            let tgt: Vec<i32> = arr.clone().into();
+            let set = Set_1::from(&raw);
+            let tgt: Vec<i32> = set.clone().into();
+
+            assert_eq!(raw, tgt);
+        }
+    }
+
+    pub mod MapTests {
+        use fable_library_rust::{Native_::{Map_2, Lrc}, String_::string};
+        #[test]
+        pub fn can_interop_between_map_and_vec() {
+            //todo
+            let raw = vec![(string("a"), 1), (string("b"), 2), (string("c"), 3)];
+            let map = Map_2::from(&raw);
+            let tgt: Vec<(Lrc<str>, i32)> = map.clone().into();
 
             assert_eq!(raw, tgt);
         }

--- a/tests/Rust/tests/src/ExtInteropTests.rs
+++ b/tests/Rust/tests/src/ExtInteropTests.rs
@@ -11,7 +11,7 @@ pub mod ExtInteropTests {
             let lst = List_1::from(&vec![1, 2, 3]);
             let tgt: Vec<i32> = lst.clone().into();
 
-            let expectedLst = List_1::from(cons(1, cons(2, singleton(3))));
+            let expectedLst = cons(1, cons(2, singleton(3)));
             assert_eq!(lst, expectedLst);
             assert_eq!(raw, tgt);
         }


### PR DESCRIPTION
@ncave sorry I really am keeping you busy this week :) Following on from yesterday's discussion on zero cost wrappers, I wanted to get your input and be sure we are on the same page etc. I know we were going to defer the decision to add wrappers as first class citizens but it was a lot easier than I anticipated...

This implements List, Set, and Map as first class struct wrappers (zero cost as we covered yesterday). I have consequentially also adjusted the interop layer so you can now directly ```From``` and ```Into``` these types, which is a far more intuitive interop experience as everything is just available on the raw type. At the moment we obviously only support Vec, but you can see how this pattern can be extended to cover all sorts of useful things.

Additionally I also got carried away and supported iter, following on from your seq_as_iter helper. This is really handy because it means you can just collect into a vec after using built in Rust combinators, or even theoretically collect INTO a F# collection if we also implemented fromiterator..

These From and Into implementations are not supposed to be fast, they are just supposed to define the required interfaces and work. Optimization can come later.

**Following on from this**
* Array I am not so sure of, but I think the same pattern should work in theory.
* Who knows what we do with seq
* HashSet and Hashmap I guess need this treatment too. Meh, no rush :)
* Names are a little weird because they are ```List_```. Can we make them without the underscore - ```List```?
* Since our tuple Rc by default change, it is possible that some library types may want to use struct tuples under the hood for performance reasons, such as Map uses these in a few places. I didn't want to go changing too much at once so have left this for now.

Another interesting possibility for way down the road is that you could perhaps even "auto implement" from and into traits for any Fable generated types. The great thing is that tree shaking (when turned on) will throw out anything you are not using anyway, so the bloat is never paid at runtime in production (assuming everything is correctly configured).