### PR TITLE
[Python] enable more tests

### DIFF
--- a/src/Fable.Transforms/Python/Python.fs
+++ b/src/Fable.Transforms/Python/Python.fs
@@ -1,5 +1,5 @@
-/// Python AST based on https://docs.python.org/3/library/ast.html. Currently uses records instead of tagged unions to better match
-/// with the Python AST docs.
+// Python AST based on https://docs.python.org/3/library/ast.html. Currently uses records instead of tagged unions to
+// better match with the Python AST docs.
 namespace rec Fable.AST.Python
 
 // fsharplint:disable MemberNames InterfaceNames

--- a/src/Fable.Transforms/Python/PythonPrinter.fs
+++ b/src/Fable.Transforms/Python/PythonPrinter.fs
@@ -1,7 +1,6 @@
 // fsharplint:disable InterfaceNames
 module Fable.Transforms.PythonPrinter
 
-open System
 open Fable
 open Fable.AST
 open Fable.AST.Python
@@ -78,7 +77,7 @@ module PrinterExtensions =
 
                 if i >= args.Length - defaults.Length then
                     printer.Print("=")
-                    printer.Print(defaults.[i - (args.Length - defaults.Length)])
+                    printer.Print(defaults[i - (args.Length - defaults.Length)])
 
                 if i < args.Length - 1 then
                     printer.Print(", ")
@@ -161,7 +160,7 @@ module PrinterExtensions =
             | [] -> ()
             | xs ->
                 printer.Print("(")
-                printer.PrintCommaSeparatedList(cd.Bases)
+                printer.PrintCommaSeparatedList(xs)
                 printer.Print(")")
 
             printer.Print(":")
@@ -258,7 +257,7 @@ module PrinterExtensions =
             printer.Print("[")
 
             match node.Slice with
-            | Tuple ({ Elements = elems }) -> printer.PrintCommaSeparatedList(elems)
+            | Tuple { Elements = elems } -> printer.PrintCommaSeparatedList(elems)
             | _ -> printer.Print(node.Slice)
 
             printer.Print("]")
@@ -324,9 +323,9 @@ module PrinterExtensions =
                             // Remove whitespace in front of new lines,
                             // indent will be automatically applied
                             if printer.Column = 0 then
-                                subSegments.[i - 1].TrimStart()
+                                subSegments[ i - 1 ].TrimStart()
                             else
-                                subSegments.[i - 1]
+                                subSegments[i - 1]
 
                         if subSegment.Length > 0 then
                             printer.Print(subSegment)
@@ -351,14 +350,14 @@ module PrinterExtensions =
                     let i = int m.Groups.[1].Value
 
                     match node.Args.[i] with
-                    | Constant(value = :? bool as value) when value -> m.Groups.[2].Value
+                    | Constant(value = :? bool as value) when value -> m.Groups[2].Value
                     | _ -> m.Groups.[3].Value)
 
                 |> replace @"\{\{([^\}]*\$(\d+).*?)\}\}" (fun m ->
-                    let i = int m.Groups.[2].Value
+                    let i = int m.Groups[2].Value
 
                     match List.tryItem i node.Args with
-                    | Some _ -> m.Groups.[1].Value
+                    | Some _ -> m.Groups[1].Value
                     | None -> "")
 
                 // If placeholder is followed by !, emit string literals as JS: "let $0! = $1"
@@ -373,7 +372,7 @@ module PrinterExtensions =
 
             if matches.Count > 0 then
                 for i = 0 to matches.Count - 1 do
-                    let m = matches.[i]
+                    let m = matches[i]
 
                     let isSurroundedWithParens =
                         m.Index > 0
@@ -383,13 +382,13 @@ module PrinterExtensions =
 
                     let segmentStart =
                         if i > 0 then
-                            matches.[i - 1].Index + matches.[i - 1].Length
+                            matches[i - 1].Index + matches.[i - 1].Length
                         else
                             0
 
                     printSegment printer value segmentStart m.Index
 
-                    let argIndex = int m.Value.[1..]
+                    let argIndex = int m.Value[1..]
 
                     match List.tryItem argIndex node.Args with
                     | Some e when isSurroundedWithParens -> printer.Print(e)
@@ -552,8 +551,7 @@ module PrinterExtensions =
                     printer.Print("\"")
                     printer.Print(Naming.escapeString (fun _ -> false) value)
                     printer.Print("\"")
-                | :? bool as value ->
-                    printer.Print(if value then "True" else "False")
+                | :? bool as value -> printer.Print(if value then "True" else "False")
                 | _ -> printer.Print(string value)
 
             | IfExp ex -> printer.Print(ex)
@@ -669,7 +667,7 @@ module PrinterExtensions =
 
         member printer.PrintList(nodes: 'a list, printNode: Printer -> 'a -> unit, printSeparator: Printer -> unit) =
             for i = 0 to nodes.Length - 1 do
-                printNode printer nodes.[i]
+                printNode printer nodes[i]
 
                 if i < nodes.Length - 1 then
                     printSeparator printer
@@ -758,8 +756,7 @@ let printLine (printer: Printer) (line: string) =
     printer.Print(line)
     printer.PrintNewLine()
 
-let isEmpty (program: Module): bool =
-    false //TODO: determine if printer will not print anything
+let isEmpty (program: Module) : bool = false //TODO: determine if printer will not print anything
 
 let run writer (program: Module) : Async<unit> =
     async {
@@ -771,12 +768,12 @@ let run writer (program: Module) : Async<unit> =
             |> List.splitWhile (function
                 | Import _
                 | ImportFrom _ -> true
-                | Expr ({Value=Expression.Emit(_)}) -> true
+                | Expr { Value = Expression.Emit _ } -> true
                 | _ -> false)
 
         for decl in imports do
             match decl with
-            | ImportFrom ({ Module = Some(Identifier path) } as info) ->
+            | ImportFrom ({ Module = Some (Identifier path) } as info) ->
                 let path = printer.MakeImportPath(path)
                 ImportFrom { info with Module = Some(Identifier path) }
             | decl -> decl

--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -1898,7 +1898,7 @@ let resizeArrays (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (this
         Helper.LibCall(com, "array", "removeAllInPlace", t, [ arg; ar ], ?loc = r)
         |> Some
     | "FindIndex", Some ar, [ arg ] ->
-        Helper.LibCall(com, "array", "find_index", t, [ arg; ar ], ?loc = r)
+        Helper.LibCall(com, "resize_array", "find_index", t, [ arg; ar ], ?loc = r)
         |> Some
     | "FindLastIndex", Some ar, [ arg ] ->
         Helper.LibCall(com, "array", "findLastIndex", t, [ arg; ar ], ?loc = r)
@@ -1925,9 +1925,7 @@ let resizeArrays (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (this
         Helper.LibCall(com, "Option", "defaultArg", t, [ opt; defaultof com ctx t ], ?loc = r)
         |> Some
     | "Exists", Some ar, [ arg ] ->
-        let left = Helper.InstanceCall(ar, "index", Number(Int32, NumberInfo.Empty), [ arg ], ?loc = r)
-
-        makeEqOp r left (makeIntConst -1) BinaryGreater
+        Helper.LibCall(com, "resize_array", "exists", t, [ arg; ar ], ?loc = r)
         |> Some
     | "FindLast", Some ar, [ arg ] ->
         let opt = Helper.LibCall(com, "array", "tryFindBack", t, [ arg; ar ], ?loc = r)
@@ -1958,10 +1956,10 @@ let resizeArrays (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (this
         Helper.InstanceCall(ar, "insert", t, [ idx; arg ], ?loc = r)
         |> Some
     | "InsertRange", Some ar, [ idx; arg ] ->
-        Helper.LibCall(com, "array", "insertRangeInPlace", t, [ idx; arg; ar ], ?loc = r)
+        Helper.LibCall(com, "array", "insert_range_in_place", t, [ idx; arg; ar ], ?loc = r)
         |> Some
     | "RemoveRange", Some ar, args ->
-        Helper.LibCall(com, "array", "remove_many_at", t, args @ [ ar ], ?loc = r)
+        Helper.LibCall(com, "resize_array", "remove_range", t, args @ [ar], ?loc = r)
         |> Some
     | "RemoveAt", Some ar, [ idx ] ->
         Helper.InstanceCall(ar, "pop", t, [ idx ], ?loc = r)

--- a/src/fable-library-py/fable_library/Native.fs
+++ b/src/fable-library-py/fable_library/Native.fs
@@ -109,7 +109,7 @@ module Helpers =
     // Inlining in combination with dynamic application may cause problems with uncurrying
     // Using Emit keeps the argument signature. Note: Python cannot take an argument here.
     [<Emit("$1.sort()")>]
-    let sortInPlaceWithImpl (comparer: 'T -> 'T -> int) (array: 'T []) : unit = nativeOnly //!!array?sort(comparer)
+    let sortInPlaceWithImpl (comparer: 'T -> 'T -> int) (array: 'T []) : unit = nativeOnly
 
     let copyToTypedArray (src: 'T []) (srci: int) (trg: 'T []) (trgi: int) (cnt: int) : unit =
         let diff = trgi - srci

--- a/src/fable-library-py/fable_library/resize_array.py
+++ b/src/fable-library-py/fable_library/resize_array.py
@@ -1,0 +1,21 @@
+from typing import Any, Callable, TypeVar, List
+
+_T = TypeVar("_T")
+
+
+def exists(predicate: Callable[[_T], bool], xs: List[_T]) -> bool:
+    for x in xs:
+        if predicate(x):
+            return True
+    return False
+
+
+def find_index(predicate: Callable[[_T], bool], xs: List[_T]) -> int:
+    for i, x in enumerate(xs):
+        if predicate(x):
+            return i
+    return -1
+
+
+def remove_range(start: int, count: int, xs: List[Any]) -> None:
+    del xs[start : start + count]

--- a/src/fable-library-py/fable_library/types.py
+++ b/src/fable-library-py/fable_library/types.py
@@ -233,7 +233,7 @@ def to_string(x: Union_[Iterable[Any], Any], call_stack: int = 0) -> str:
 
 
 class Exception(Exception):
-    def __init__(self, msg: Optional[str] = None):
+    def __init__(self, msg: str = "") -> None:
         self.msg = msg
 
     def __eq__(self, other: Any) -> bool:
@@ -245,9 +245,12 @@ class Exception(Exception):
 
         return self.msg == other.msg
 
+    def __str__(self) -> str:
+        return self.msg
+
 
 class FSharpException(Exception, IComparable):
-    def __init__(self):
+    def __init__(self) -> None:
         self.Data0: Any = None
 
     def __str__(self) -> str:

--- a/tests/Python/TestConvert.fs
+++ b/tests/Python/TestConvert.fs
@@ -240,21 +240,21 @@ let ``test System.Int64.ToString works`` () =
 
 [<Fact>]
 let ``test System.Int64.ToString 'd' works`` () =
-    (5592405L).ToString("d") |> equal "5592405"
-    (5592405L).ToString("d10") |> equal "0005592405"
+    5592405L.ToString("d") |> equal "5592405"
+    5592405L.ToString("d10") |> equal "0005592405"
 
 [<Fact>]
 let ``test System.Int64.ToString 'x' works`` () =
-    (5592405L).ToString("x") |> equal "555555"
-    (5592405L).ToString("x10") |> equal "0000555555"
+    5592405L.ToString("x") |> equal "555555"
+    5592405L.ToString("x10") |> equal "0000555555"
 
 [<Fact>]
 let ``test System.BigInt.ToString works`` () =
-    (5592405I).ToString() |> equal "5592405"
+    5592405I.ToString() |> equal "5592405"
 
 [<Fact>]
 let ``test System.Decimal.ToString works`` () =
-    (5592405M).ToString() |> equal "5592405"
+    5592405M.ToString() |> equal "5592405"
 
 [<Fact>]
 let ``test System.Convert.ToSByte works`` () =

--- a/tests/Python/TestDictionary.fs
+++ b/tests/Python/TestDictionary.fs
@@ -51,7 +51,6 @@ let ``test Dictionary creation from IDictionary works`` () =
     equal 10 idic.Count
     equal 11 dic.Count
 
-(*
 [<Fact>]
 let ``test Dictionaries with IEqualityComparer work`` () =
     let x = MyRefType(4)
@@ -71,7 +70,6 @@ let ``test Dictionaries with IEqualityComparer work`` () =
     dic2.ContainsKey(x) |> equal true
     dic2.ContainsKey(y) |> equal true
     dic2.ContainsKey(z) |> equal false
-*)
 
 [<Fact>]
 let ``test Interface IDictionary iteration works`` () =

--- a/tests/Python/TestResizeArray.fs
+++ b/tests/Python/TestResizeArray.fs
@@ -211,17 +211,14 @@ let ``test ResizeArray.RemoveAll works`` () =
     System.Predicate<_> (fun x -> x = "ab") |> li.RemoveAll |> equal 0
     li.[0] |> equal "ch"
 
-
-(*
-
 [<Fact>]
 let ``test ResizeArray.RemoveRange works`` () =
     let xs = ResizeArray<int>()
     for x in [1 .. 5] do xs.Add(x)
     xs.RemoveRange(1, 2) // [1;2;3;4;5] -> [1;4;5]
-    equal 1 xs.[0]
-    equal 4 xs.[1]
-    equal 5 xs.[2]
+    equal 1 xs[0]
+    equal 4 xs[1]
+    equal 5 xs[2]
 
 [<Fact>]
 let ``test ResizeArray.Exists works`` () =
@@ -234,7 +231,6 @@ let ``test ResizeArray.Exists works`` () =
     xs.Exists (fun a -> a < 1) |> equal false
     xs.Exists (fun a -> a = 3) |> equal true
 
-*)
 [<Fact>]
 let ``test ResizeArray.RemoveAt works`` () =
     let li = ResizeArray<_>()
@@ -247,7 +243,6 @@ let ``test ResizeArray.Insert works`` () =
     li.Add(1.); li.Add(2.); li.Add(3.); li.Add(4.); li.Add(5.)
     li.Insert(2, 8.)
     equal 8. li.[2]
-(*
 [<Fact>]
 let ``test ResizeArray.ReverseInPlace works`` () =
     let li = ResizeArray<_>()
@@ -265,6 +260,7 @@ let ``test ResizeArray.SortInPlace works`` () =
     li2.Sort()
     equal 2 li2.[1]
 
+(*
 [<Fact>]
 let ``test ResizeArray.SortInPlaceWith works`` () =
     let li = ResizeArray<_>()

--- a/tests/Python/TestSeq.fs
+++ b/tests/Python/TestSeq.fs
@@ -764,10 +764,10 @@ let ``test Seq.distinctBy works on infinite sequences`` () =
         |> Seq.take 5
     xs |> Seq.toList |> equal [1; 5; 10; 15; 20]
 
-// [<Fact>]
-// let ``test Seq.groupBy works`` () =
-//     let xs = [1; 2; 3; 4]
-//     let ys = xs |> Seq.groupBy (fun x -> x % 2)
-//     ys |> Seq.length |> equal 2
-//     ys |> Seq.iter (fun (k,v) ->
-//         v |> Seq.exists (fun x -> x % 2 <> k) |> equal false)
+[<Fact>]
+let ``test Seq.groupBy works`` () =
+     let xs = [1; 2; 3; 4]
+     let ys = xs |> Seq.groupBy (fun x -> x % 2)
+     ys |> Seq.length |> equal 2
+     ys |> Seq.iter (fun (k,v) ->
+         v |> Seq.exists (fun x -> x % 2 <> k) |> equal false)

--- a/tests/Python/TestType.fs
+++ b/tests/Python/TestType.fs
@@ -971,7 +971,6 @@ let ``test Custom F# exceptions work`` () =
     | ex -> (false, "unknown")
     |> equal (true, "ERROR!!")
 
-(* TODO
 [<Fact>]
 let ``test Custom exceptions work`` () =
     try
@@ -980,7 +979,7 @@ let ``test Custom exceptions work`` () =
     | :? MyEx2 as ex -> (box ex :? Exception, ex.Message, ex.Code)
     | ex -> (false, "unknown", 0.)
     |> equal (true, "Code: 5", 5.5)
-*)
+
 [<Fact>]
 let ``test reraise works`` () =
     try

--- a/tests/Python/TestUnionType.fs
+++ b/tests/Python/TestUnionType.fs
@@ -198,7 +198,6 @@ let ``test Erased union type testing works`` () =
     "HELLO" |> Wrapper |> U3.Case3 |> toString |> equal "OLLEH"
 #endif
 
-// FIXME:
 [<Fact>]
 let ``test Equality works in filter`` () =
     let original = [| { Name = "1"; Case = MyUnion3.Case1 } ; { Name = "2"; Case = MyUnion3.Case1 }; { Name = "3"; Case = MyUnion3.Case2 }; { Name = "4"; Case = MyUnion3.Case3 } |]


### PR DESCRIPTION
Enable previously disable tests. They run now thanks to Array and ResizeArray fixes. Some ResizeArray functions where mapped to Array which is not always compatible, i.e throws exception instead of returning -1 etc.