### PR TITLE
Rust - more collection interop improvements

### DIFF
--- a/src/fable-library-rust/src/Interop.rs
+++ b/src/fable-library-rust/src/Interop.rs
@@ -1,11 +1,17 @@
 pub mod ListExt {
     // use std::ops::Deref;
-    use crate::List_::{List, cons, mkList};
-    use crate::Native_::{seq_as_iter};
-    use crate::Seq_::{ofList};
+    use crate::List_::{cons, mkList, reverse, List};
+    use crate::Native_::seq_as_iter;
+    use crate::Seq_::ofList;
 
     impl<T: Clone> List<T> {
-        pub fn iter(&self) -> impl Iterator<Item = T> {
+        //todo - non-consuming iter by ref
+        // pub fn iter<'a>(&self) -> impl Iterator<Item = & 'a T> {
+        //     let s = ofList(self.clone());
+        //     seq_as_iter(&s)
+        // }
+
+        pub fn into_iter(&self) -> impl Iterator<Item = T> {
             let s = ofList(self.clone());
             seq_as_iter(&s)
         }
@@ -29,9 +35,29 @@ pub mod ListExt {
         }
     }
 
+    impl<T: Clone> FromIterator<T> for List<T> {
+        fn from_iter<U: IntoIterator<Item = T>>(iter: U) -> Self {
+            let mut lst: List<T> = mkList(None);
+            for (i, item) in iter.into_iter().enumerate() {
+                lst = cons(item, lst);
+            }
+            reverse(lst)
+        }
+    }
+
+    impl<'a, T: Clone> FromIterator<&'a T> for List<T> {
+        fn from_iter<U: IntoIterator<Item = &'a T>>(iter: U) -> Self {
+            let mut lst: List<T> = mkList(None);
+            for (i, item) in iter.into_iter().enumerate() {
+                lst = cons(item.clone(), lst);
+            }
+            reverse(lst)
+        }
+    }
+
     impl<T: Clone> Into<Vec<T>> for List<T> {
         fn into(self) -> Vec<T> {
-            self.iter().collect()
+            self.into_iter().collect()
         }
     }
 }
@@ -79,11 +105,17 @@ pub mod ArrayExt {
 
 pub mod SetExt {
     // use std::ops::Deref;
-    use crate::Native_::{seq_as_iter};
-    use crate::Set_::{Set, add, empty, toSeq};
+    use crate::Native_::seq_as_iter;
+    use crate::Set_::{add, empty, toSeq, Set};
 
     impl<T: Clone + PartialOrd> Set<T> {
-        pub fn iter(&self) -> impl Iterator<Item = T> {
+        //todo - non-consuming iter by ref
+        // pub fn iter<'a>(&self) -> impl Iterator<Item = & 'a T> {
+        //     let s = toSeq(self.clone());
+        //     seq_as_iter(&s)
+        // }
+
+        pub fn into_iter(&self) -> impl Iterator<Item = T> {
             let s = toSeq(self.clone());
             seq_as_iter(&s)
         }
@@ -109,20 +141,36 @@ pub mod SetExt {
         }
     }
 
+    impl<T: Clone + PartialOrd> FromIterator<T> for Set<T> {
+        fn from_iter<U: IntoIterator<Item = T>>(iter: U) -> Self {
+            let mut set = empty();
+            for v in iter.into_iter() {
+                set = add(v, set);
+            }
+            set
+        }
+    }
+
     impl<T: Clone + PartialOrd> Into<Vec<T>> for Set<T> {
         fn into(self) -> Vec<T> {
-            self.iter().collect()
+            self.into_iter().collect()
         }
     }
 }
 
 pub mod MapExt {
     // use std::ops::Deref;
-    use crate::Map_::{Map, add, empty, iterate, toSeq};
-    use crate::Native_::{seq_as_iter};
+    use crate::Map_::{add, empty, iterate, toSeq, Map};
+    use crate::Native_::seq_as_iter;
 
     impl<K: Clone + PartialOrd, V: Clone> Map<K, V> {
-        pub fn iter(&self) -> impl Iterator<Item = (K, V)> {
+        //todo - non-consuming iter by ref
+        // pub fn iter<'a>(&self) -> impl Iterator<Item = (& 'a K, & 'a V)> {
+        //     let s = toSeq(self.clone());
+        //     seq_as_iter(&s).map(|kvp| kvp.as_ref().clone())
+        // }
+
+        pub fn into_iter(&self) -> impl Iterator<Item = (K, V)> {
             let s = toSeq(self.clone());
             seq_as_iter(&s).map(|kvp| kvp.as_ref().clone())
         }
@@ -138,9 +186,19 @@ pub mod MapExt {
         }
     }
 
+    impl<K: Clone + PartialOrd, V: Clone> FromIterator<(K, V)> for Map<K, V> {
+        fn from_iter<U: IntoIterator<Item = (K, V)>>(iter: U) -> Self {
+            let mut map: Map<K, V> = empty();
+            for (k, v) in iter.into_iter() {
+                map = add(k, v.clone(), map);
+            }
+            map
+        }
+    }
+
     impl<K: Clone + PartialOrd, V: Clone> Into<Vec<(K, V)>> for Map<K, V> {
         fn into(self) -> Vec<(K, V)> {
-            self.iter().collect()
+            self.into_iter().collect()
         }
     }
 }

--- a/tests/Rust/tests/src/ExtInteropTests.rs
+++ b/tests/Rust/tests/src/ExtInteropTests.rs
@@ -1,6 +1,7 @@
 pub mod ExtInteropTests {
     pub mod ListTests {
-        use fable_library_rust::List_::{List, cons, singleton};
+        use fable_library_rust::List_::{cons, singleton, List};
+        use fable_library_rust::String_::string;
 
         #[test]
         pub fn can_interop_between_list_and_vec() {
@@ -17,8 +18,24 @@ pub mod ExtInteropTests {
         #[test]
         pub fn can_iter() {
             let lst = List::from(&vec![1, 2, 3]);
-            let res: Vec<i32> = lst.iter().map(|x|x+1).collect();
+            let res: Vec<i32> = lst.into_iter().map(|x| x + 1).collect();
             assert_eq!(res, vec![2, 3, 4]);
+        }
+
+        #[test]
+        pub fn can_collect_while_consuming() {
+            let raw = vec![1, 2, 3];
+            let expected = List::from(&raw);
+            let res: List<i32> = raw.into_iter().collect();
+            assert_eq!(res, expected);
+        }
+
+        #[test]
+        pub fn can_collect() {
+            let raw = vec![1, 2, 3];
+            let expected = List::from(&raw);
+            let res: List<i32> = raw.iter().collect();
+            assert_eq!(res, expected);
         }
     }
 
@@ -47,11 +64,23 @@ pub mod ExtInteropTests {
             let tgt: Vec<i32> = set.clone().into();
             assert_eq!(raw, tgt);
         }
+
+        #[test]
+        pub fn can_collect_while_consuming() {
+            let raw = vec![1, 2, 3];
+            let expected = Set::from(&raw);
+            let res: Set<i32> = raw.into_iter().collect();
+            // todo - equality not working, so have to convert back to vec to check. Perhaps because of SetTree [<NoEquality; NoComparison>] ?
+            //assert_eq!(res, expected);
+            let res: Vec<i32> = res.into();
+            let expected: Vec<i32> = expected.into();
+            assert_eq!(res, expected);
+        }
     }
 
     pub mod MapTests {
         use fable_library_rust::Map_::Map;
-        use fable_library_rust::Native_::Lrc;
+        use fable_library_rust::Native_::{string, Lrc};
         use fable_library_rust::String_::string;
 
         #[test]
@@ -67,8 +96,20 @@ pub mod ExtInteropTests {
         pub fn can_iter() {
             let raw = vec![(string("a"), 1), (string("b"), 2), (string("c"), 3)];
             let map = Map::from(&raw);
-            let res: Vec<i32> = map.iter().map(|(a, b)|b + 1).collect();
+            let res: Vec<i32> = map.into_iter().map(|(a, b)| b + 1).collect();
             assert_eq!(res, vec![2, 3, 4]);
+        }
+
+        #[test]
+        pub fn can_collect_while_consuming() {
+            let raw = vec![(string("a"), 1), (string("b"), 2), (string("c"), 3)];
+            let expected: Map<string, i32> = Map::from(&raw);
+            let res: Map<string, i32> = raw.into_iter().collect();
+            // todo - equality not working, so have to convert back to vec to check. Perhaps because of MapTree [<NoEquality; NoComparison>] ?
+            //assert_eq!(res, expected);
+            let expected: Vec<(string, i32)> = expected.into();
+            let res: Vec<(string, i32)> = res.into();
+            assert_eq!(res, expected)
         }
     }
 }


### PR DESCRIPTION
Couple of little improvements in an attempt to better standardize the Rust interface.

* Added implementations of ```FromIterator```, so a user can directly collect an iterator into an F# collection.
* Renamed iter to from_iter so that it more accurately reflects Rust conventions. A rust user expects ```iter``` to emit references, and ```into_iter``` to emit values (and consume the underlying object). Currently we can only emit values, so ```into_iter``` is implemented, and ```iter``` is a commented out placeholder with the correct interface. This is still not entirely accurate because into_iter will also consume the underlying collection, which is not feasible when you are working with Rc shared types. I personally feel this combination is the closest match to Rust expectations but happy to discuss/iterate where required.

On a side note I noticed equality does not work for Map and Set, which was a little unexpected since this works in .Net. I am worried this will break equality on model hierarchies where Sets/Maps/Lists are used as properties. I think this is to do with the SetTree and MapTree type being marked as such. Is it possible to do anything about this? You can see this in the tests, which have had to convert back to vec to check the result.