### PR TITLE
[Python] Use --fableLib to choose between embedded or site-packages

### DIFF
--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -138,6 +138,15 @@ module private Util =
                         .Trim([|'/'|])
                         .ToLowerInvariant()
                         .Split([|'/'|])
+
+                // When building packages we generate Python snake_case module within the kebab-case package
+                let modules =
+                    match Array.toList modules, cliArgs.FableLibraryPath with
+                    | Naming.fableModules :: package :: modules, Some PY.Naming.sitePackages ->
+                        let packageModule = package.Replace("-", "_")
+                        Naming.fableModules :: package :: packageModule :: modules
+                    | modules, _ -> modules
+                    |> List.toArray
                     |> IO.Path.Join
 
                 IO.Path.Join(outDir, modules, fileName)

--- a/src/Fable.Cli/ProjectCracker.fs
+++ b/src/Fable.Cli/ProjectCracker.fs
@@ -505,7 +505,10 @@ let getFableLibraryPath (opts: CrackerOptions) =
     | None ->
         let buildDir, libDir =
             match opts.FableOptions.Language with
-            | Python -> "fable-library-py/fable_library", "fable_library"
+            | Python ->
+                match opts.FableLib with
+                | Some PY.Naming.sitePackages -> "fable-library-py", "fable-library"
+                | _ -> "fable-library-py/fable_library", "fable_library"
             | Dart -> "fable-library-dart", "fable_library"
             | Rust -> "fable-library-rust", "fable-library-rust"
             | _ -> "fable-library", "fable-library" + "." + Literals.VERSION
@@ -537,8 +540,13 @@ let copyFableLibraryAndPackageSourcesPy (opts: CrackerOptions) (pkgs: FablePacka
         pkgs |> List.map (fun pkg ->
             let sourceDir = IO.Path.GetDirectoryName(pkg.FsprojPath)
             let targetDir =
-                let name = Naming.applyCaseRule Core.CaseRules.SnakeCase pkg.Id
-                IO.Path.Combine(opts.FableModulesDir, name.Replace(".", "_"))
+                match opts.FableLib with
+                | Some PY.Naming.sitePackages ->
+                    let name = Naming.applyCaseRule Core.CaseRules.KebabCase pkg.Id
+                    IO.Path.Combine(opts.FableModulesDir, name.Replace(".", "-"))
+                | _ ->
+                    let name = Naming.applyCaseRule Core.CaseRules.SnakeCase pkg.Id
+                    IO.Path.Combine(opts.FableModulesDir, name.Replace(".", "_"))
             copyDirIfDoesNotExist false sourceDir targetDir
             { pkg with FsprojPath = IO.Path.Combine(targetDir, IO.Path.GetFileName(pkg.FsprojPath)) })
 

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -178,7 +178,6 @@ module Reflection =
                 |> List.map (fun fi ->
                     Expression.tuple [ fi.Name |> Expression.constant
                                        let expr, _stmts = transformTypeInfo com ctx r genMap fi.FieldType
-
                                        expr ])
                 |> Expression.list)
             |> Seq.toList
@@ -3783,15 +3782,7 @@ module Util =
               | None ->
                   // Do not put multiple imports on a single line. flake8(E401)
                   for alias in aliases do
-                      if alias.Name.Name = "sys"
-                         && com.OutputType = OutputType.Exe then
-                          yield!
-                              [ Statement.import [ alias ]
-                                Statement.expr (
-                                    Expression.emit "sys.path.append(os.path.join(os.path.dirname(__file__), \"fable_modules\"))"
-                                ) ]
-                      else
-                          Statement.import [ alias ] ]
+                        Statement.import [ alias ] ]
 
     let getIdentForImport (ctx: Context) (moduleName: string) (name: string option) =
         // printfn "getIdentForImport: %A" (moduleName, name)
@@ -3950,10 +3941,6 @@ module Compiler =
               OptimizeTailCall = fun () -> ()
               ScopedTypeParams = Set.empty
               TypeParamsScope = 0 }
-
-        if com.OutputType = OutputType.Exe then
-            com.GetImportExpr(ctx, "os") |> ignore
-            com.GetImportExpr(ctx, "sys") |> ignore
 
         //printfn "file: %A" file.Declarations
         let rootDecls = List.collect (transformDeclaration com ctx) file.Declarations

--- a/src/Fable.Transforms/Python/Prelude.fs
+++ b/src/Fable.Transforms/Python/Prelude.fs
@@ -7,6 +7,8 @@ module Naming =
     open Fable.Core
     open System.Text.RegularExpressions
 
+    let [<Literal>] sitePackages = "site-packages"
+
     let lowerFirst (s: string) =
         s.Substring(0, 1).ToLowerInvariant()
         + s.Substring(1)


### PR DESCRIPTION
Enable the use of `--fableLib site-packages` command line option to generate absolute references to `fable_library` and generate packages within `fable_modules`. Default is to generate embedded modules including `fable_library` within `fable_modules`

PS: for `site-packages` option to work, one would have to use a package manager like Poetry. This might be a better option for larger projects. For smaller projects the default "embedded similar to JS is preferred.