### PR TITLE
Rust - Double prefix fix for NewRecord #3032

### DIFF
--- a/src/Fable.Transforms/Rust/Fable2Rust.fs
+++ b/src/Fable.Transforms/Rust/Fable2Rust.fs
@@ -1495,7 +1495,8 @@ module Util =
                     else expr
                 mkExprField attrs fi.Name expr false false)
         let genArgs = transformGenArgs com ctx genArgs
-        let path = makeFullNamePath ent.FullName genArgs
+        let entNs, entName = splitNameSpace ent.FullName
+        let path = makeFullNamePath entName genArgs
         let expr = mkStructExpr path fields // TODO: range
         if ent.IsValueType
         then expr

--- a/src/Fable.Transforms/Rust/Fable2Rust.fs
+++ b/src/Fable.Transforms/Rust/Fable2Rust.fs
@@ -1495,7 +1495,8 @@ module Util =
                     else expr
                 mkExprField attrs fi.Name expr false false)
         let genArgs = transformGenArgs com ctx genArgs
-        let entNs, entName = splitNameSpace ent.FullName
+
+        let entName = getEntityFullName com ctx entRef
         let path = makeFullNamePath entName genArgs
         let expr = mkStructExpr path fields // TODO: range
         if ent.IsValueType
@@ -3006,7 +3007,7 @@ module Util =
                 | Fable.DeclaredType(entRef, _) ->
                     let ent = com.GetEntity(entRef)
                     if ent.IsInterface then
-                        let entNs, entName = splitNameSpace ent.FullName
+                        let entName = getEntityFullName com ctx entRef
                         // todo - check with actual import ident, which may be aliased differently
                         [ makeGenBound [entName] [] ]
                     else []

--- a/src/Fable.Transforms/Rust/Fable2Rust.fs
+++ b/src/Fable.Transforms/Rust/Fable2Rust.fs
@@ -1495,7 +1495,6 @@ module Util =
                     else expr
                 mkExprField attrs fi.Name expr false false)
         let genArgs = transformGenArgs com ctx genArgs
-
         let entName = getEntityFullName com ctx entRef
         let path = makeFullNamePath entName genArgs
         let expr = mkStructExpr path fields // TODO: range
@@ -3008,7 +3007,6 @@ module Util =
                     let ent = com.GetEntity(entRef)
                     if ent.IsInterface then
                         let entName = getEntityFullName com ctx entRef
-                        // todo - check with actual import ident, which may be aliased differently
                         [ makeGenBound [entName] [] ]
                     else []
                 | _ -> []

--- a/tests/Rust/Fable.Tests.Rust.fsproj
+++ b/tests/Rust/Fable.Tests.Rust.fsproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <Compile Include="tests/common/Util.fs" />
     <Compile Include="tests/common/Interfaces.fs" />
+    <Compile Include="tests/common/Records.fs" />
     <Compile Include="tests/src/AnonRecordTests.fs" />
     <Compile Include="tests/src/ArithmeticTests.fs" />
     <Compile Include="tests/src/ArrayTests.fs" />

--- a/tests/Rust/tests/common/Records.fs
+++ b/tests/Rust/tests/common/Records.fs
@@ -1,8 +1,9 @@
 module Common.Records
 
-type ImportTestRecord = {
+//This deliberately has the same name as in RecordsTests to ensure a collision
+type MyRecord = {
     a: int
 }
 
-module ImportTestRecord = 
+module MyRecord = 
     let create a = { a = a }

--- a/tests/Rust/tests/common/Records.fs
+++ b/tests/Rust/tests/common/Records.fs
@@ -1,0 +1,8 @@
+module Common.Records
+
+type ImportTestRecord = {
+    a: int
+}
+
+module ImportTestRecord = 
+    let create a = { a = a }

--- a/tests/Rust/tests/src/RecordTests.fs
+++ b/tests/Rust/tests/src/RecordTests.fs
@@ -178,6 +178,12 @@ let ``Box record fields works`` () =
     let y = x |> add1Box
     y.a |> equal 2
 
+[<Fact>]
+let ``Should correctly import record in other file and allow creation`` = 
+    let r = { Common.Records.ImportTestRecord.a = 1}
+    let expected = Common.Records.ImportTestRecord.create 1
+    r |> equal expected
+
 #if FABLE_COMPILER
 open Fable.Core
 

--- a/tests/Rust/tests/src/RecordTests.fs
+++ b/tests/Rust/tests/src/RecordTests.fs
@@ -180,8 +180,8 @@ let ``Box record fields works`` () =
 
 [<Fact>]
 let ``Should correctly import record in other file and allow creation`` = 
-    let r = { Common.Records.ImportTestRecord.a = 1}
-    let expected = Common.Records.ImportTestRecord.create 1
+    let r = { Common.Records.MyRecord.a = 1}
+    let expected = Common.Records.MyRecord.create 1
     r |> equal expected
 
 #if FABLE_COMPILER


### PR DESCRIPTION
Failing scenario + fix for #3032 