### PR TITLE
Rust - implement unsafe-cells feature switch + Monitor

### DIFF
--- a/src/Fable.Transforms/Rust/Fable2Rust.fs
+++ b/src/Fable.Transforms/Rust/Fable2Rust.fs
@@ -562,6 +562,9 @@ module TypeInfo =
     let transformTaskBuilderType com ctx: Rust.Ty =
         transformImportType com ctx [] "TaskBuilder" "TaskBuilder"
 
+    let transformThreadType com ctx: Rust.Ty = //todo - compiler does not seem to recognise System.Threading.Thread
+        transformImportType com ctx [] "Thread" "Thread"
+
     let transformTupleType com ctx isStruct genArgs: Rust.Ty =
         genArgs
         |> List.map (transformType com ctx)
@@ -798,6 +801,7 @@ module TypeInfo =
             | Replacements.Util.IsEntity (Types.taskGeneric) (_, [t]) -> transformTaskType com ctx t
             | Replacements.Util.IsEntity (Types.taskBuilder) (_, []) -> transformTaskBuilderType com ctx
             | Replacements.Util.IsEntity (Types.taskBuilderModule) (_, []) -> transformTaskBuilderType com ctx
+            | Replacements.Util.IsEntity (Types.thread) (_, []) -> transformThreadType com ctx
             | Replacements.Util.IsEnumerator (entRef, genArgs) ->
                 // get IEnumerator interface from enumerator object
                 match tryFindInterface com Types.ienumeratorGeneric entRef with

--- a/src/Fable.Transforms/Rust/Replacements.fs
+++ b/src/Fable.Transforms/Rust/Replacements.fs
@@ -2598,11 +2598,13 @@ let taskBuilderB (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Exp
     | _, "Bind", _ -> Helper.LibCall(com, "Task", "bind", t, args, i.SignatureArgTypes, ?loc=r) |> Some
     | _, "Return", _ -> Helper.LibCall(com, "Task", "r_return", t, args, i.SignatureArgTypes, ?loc=r) |> Some
     | _, "Delay", _ -> Helper.LibCall(com, "Task", "delay", t, args, i.SignatureArgTypes, ?loc=r) |> Some
+    | _, "Zero", _ -> Helper.LibCall(com, "Task", "zero", t, args, i.SignatureArgTypes, ?loc=r) |> Some
     | _ -> None
 
 let taskBuilderHP (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr option) (args: Expr list) =
     match thisArg, i.CompiledName, args with
     | _, "TaskBuilderBase.Bind", _ -> Helper.LibCall(com, "Task", "bind", t, args, i.SignatureArgTypes, ?loc=r) |> Some
+    | _, "TaskBuilderBase.Zero", _ -> Helper.LibCall(com, "Task", "zero", t, args, i.SignatureArgTypes, ?loc=r) |> Some
     | Some x, meth, _ -> Helper.InstanceCall(x, meth, t, args, i.SignatureArgTypes, ?loc=r) |> Some
     | None, meth, _ -> Helper.LibCall(com, "TaskBuilder", Naming.lowerFirst meth, t, args, i.SignatureArgTypes, ?loc=r) |> Some
 

--- a/src/Fable.Transforms/Rust/Replacements.fs
+++ b/src/Fable.Transforms/Rust/Replacements.fs
@@ -2412,7 +2412,8 @@ let cancels (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr opt
 
 let monitor (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr option) (args: Expr list) =
     match i.CompiledName with
-    | "Enter" | "Exit" -> Null Type.Unit |> makeValue r |> Some
+    | "Enter" -> Helper.LibCall(com, "Monitor", "enter", t, args, ?loc=r) |> Some
+    | "Exit" -> Helper.LibCall(com, "Monitor", "exit", t, args, ?loc=r) |> Some
     | _ -> None
 
 let tasks com (ctx: Context) r t (i: CallInfo) (thisArg: Expr option) (args: Expr list) =
@@ -2423,6 +2424,16 @@ let tasks com (ctx: Context) r t (i: CallInfo) (thisArg: Expr option) (args: Exp
         Helper.LibCall(com, "Task", "from_result", tType, args, ?loc=r) |> Some
     | Some x, "get_Result", _ ->
         Helper.InstanceCall(x, "get_result", t, args, i.SignatureArgTypes, ?loc=r) |> Some
+    | _ -> None
+
+let threads com (ctx: Context) r t (i: CallInfo) (thisArg: Expr option) (args: Expr list) =
+    match thisArg, i.CompiledName, i.GenericArgs with
+    | _, "Thread", [tType] ->
+        Helper.LibCall(com, "Thread", "new", tType, args, ?loc=r) |> Some
+    | Some x, "Start", [] ->
+        Helper.InstanceCall(x, "start", t, args, i.SignatureArgTypes, ?loc=r) |> Some
+    | Some x, "Join", [] ->
+        Helper.InstanceCall(x, "join", t, args, i.SignatureArgTypes, ?loc=r) |> Some
     | _ -> None
 
 let activator (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr option) (args: Expr list) =
@@ -2559,13 +2570,16 @@ let mailbox (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr opt
 
 let asyncBuilder (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr option) (args: Expr list) =
     match thisArg, i.CompiledName, args with
-    | _, "Singleton", _ -> makeImportLib com t "singleton" "AsyncBuilder" |> Some
+    | _, "Singleton", _ ->
+        Some (Value (UnitConstant, r))
+        //makeImportLib com t "singleton" "AsyncBuilder" |> Some
     // For Using we need to cast the argument to IDisposable
     | Some x, "Using", [arg; f] ->
         Helper.InstanceCall(x, "Using", t, [arg; f], i.SignatureArgTypes, ?loc=r) |> Some
     | _, "Delay", _ -> Helper.LibCall(com, "AsyncBuilder", "delay", t, args, i.SignatureArgTypes, ?loc=r) |> Some
     | _, "Bind", _ -> Helper.LibCall(com, "AsyncBuilder", "bind", t, args, i.SignatureArgTypes, ?loc=r) |> Some
     | _, "Return", _ -> Helper.LibCall(com, "AsyncBuilder", "r_return", t, args, i.SignatureArgTypes, ?loc=r) |> Some
+    | _, "Zero", _ -> Helper.LibCall(com, "AsyncBuilder", "zero", t, args, i.SignatureArgTypes, ?loc=r) |> Some
     | Some x, meth, _ -> Helper.InstanceCall(x, meth, t, args, i.SignatureArgTypes, ?loc=r) |> Some
     | None, meth, _ -> Helper.LibCall(com, "AsyncBuilder", Naming.lowerFirst meth, t, args, i.SignatureArgTypes, ?loc=r) |> Some
 
@@ -2912,6 +2926,7 @@ let private replacedModules =
     "System.Threading.Monitor", monitor
     Types.task, tasks
     Types.taskGeneric, tasks
+    Types.thread, threads
     "System.Threading.Tasks.TaskCompletionSource`1", tasks
     "System.Runtime.CompilerServices.TaskAwaiter`1", tasks
     "System.Activator", activator

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -106,6 +106,7 @@ module Types =
     let [<Literal>] taskBuilderModule = "Microsoft.FSharp.Control.TaskBuilderModule"
     let [<Literal>] task = "System.Threading.Tasks.Task"
     let [<Literal>] taskGeneric = "System.Threading.Tasks.Task`1"
+    let [<Literal>] thread = "System.Threading.Thread.Thread"
     let [<Literal>] cancellationToken = "System.Threading.CancellationToken"
     let [<Literal>] ienumerableGeneric = "System.Collections.Generic.IEnumerable`1"
     let [<Literal>] ienumerable = "System.Collections.IEnumerable"

--- a/src/fable-library-rust/Cargo.toml
+++ b/src/fable-library-rust/Cargo.toml
@@ -3,6 +3,10 @@ name = "fable_library_rust"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+futures = ["dep:futures"]
+unsafe-cells = []
+
 [dependencies]
 futures = { version = "0.3.21", features = ["executor", "thread-pool"], optional = true }
 startup = { version = "0.1.1" }

--- a/src/fable-library-rust/src/Async.rs
+++ b/src/fable-library-rust/src/Async.rs
@@ -290,6 +290,10 @@ pub mod Task_ {
         Arc::from(t)
     }
 
+    pub fn zero() -> Arc<Task<()>> {
+        r_return(())
+    }
+
     pub fn from_result<T: Clone + Send>(t: T) -> Arc<Task<T>> {
         let t = Task { result: Arc::from(RwLock::from(TaskState::Complete(t))) };
         Arc::from(t)

--- a/src/fable-library-rust/src/Async.rs
+++ b/src/fable-library-rust/src/Async.rs
@@ -2,29 +2,34 @@
 
 #[cfg(feature = "futures")]
 pub mod Async_ {
-    use std::future::{self, Future, ready};
+    use std::future::{self, ready, Future};
     use std::pin::Pin;
-    use std::sync::{Arc};
+    use std::sync::Arc;
     use std::thread;
     use std::time::Duration;
 
-    use futures::FutureExt;
     use futures::executor::{self, LocalPool};
     use futures::lock::Mutex;
+    use futures::FutureExt;
 
     use super::Task_::Task;
 
     pub struct Async<T: Sized + Send + Sync> {
-        pub future: Arc<Mutex<Pin<Box<dyn Future<Output = T> + Send + Sync>>>>
+        pub future: Arc<Mutex<Pin<Box<dyn Future<Output = T> + Send + Sync>>>>,
     }
 
-    impl <T: Clone + Send + Sync> Future for &Async<T> {
+    impl<T: Clone + Send + Sync> Future for &Async<T> {
         type Output = T;
 
-        fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> std::task::Poll<Self::Output> {
-            let p = self.future.try_lock()
-                .map(|mut f|f.poll_unpin(cx))
-                .unwrap_or_else(||{
+        fn poll(
+            self: Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Self::Output> {
+            let p = self
+                .future
+                .try_lock()
+                .map(|mut f| f.poll_unpin(cx))
+                .unwrap_or_else(|| {
                     //Again blocking wait, not good
                     thread::sleep(Duration::from_millis(10));
                     cx.waker().wake_by_ref();
@@ -57,46 +62,62 @@ pub mod Async_ {
 
     pub fn awaitTask<T: Clone + Send + Sync + 'static>(a: Arc<Task<T>>) -> Arc<Async<T>> {
         let fut = async move { (&*a).await };
-        let a: Pin<Box<dyn Future<Output=T> + Send + Sync + 'static>> = Box::pin(fut);
-        Arc::from(Async{ future: Arc::from(Mutex::from(a)) })
+        let a: Pin<Box<dyn Future<Output = T> + Send + Sync + 'static>> = Box::pin(fut);
+        Arc::from(Async {
+            future: Arc::from(Mutex::from(a)),
+        })
     }
 }
 
 #[cfg(feature = "futures")]
 pub mod AsyncBuilder_ {
-    use std::{sync::Arc, pin::Pin, future::{Future, ready}};
+    use std::{
+        future::{ready, Future},
+        pin::Pin,
+        sync::Arc,
+    };
 
     use futures::lock::Mutex;
 
     use super::Async_::Async;
 
-    pub fn delay<T: Send + Sync>(binder: Arc<impl Fn() -> Arc<Async<T>> + 'static>) -> Arc<Async<T>> {
+    pub fn delay<T: Send + Sync>(
+        binder: Arc<impl Fn() -> Arc<Async<T>> + 'static>,
+    ) -> Arc<Async<T>> {
         let pr = binder();
-        Arc::from(Async {future: pr.future.clone()})
+        Arc::from(Async {
+            future: pr.future.clone(),
+        })
     }
 
-    pub fn bind<T: Clone  + Send + Sync + 'static, U: Clone  + Send + Sync + 'static>(
+    pub fn bind<T: Clone + Send + Sync + 'static, U: Clone + Send + Sync + 'static>(
         opt: Arc<Async<T>>,
-        binder: Arc<impl Fn(T) -> Arc<Async<U>> + Send + Sync + 'static>
-    ) -> Arc<Async<U>>
-    {
-        let next =
-            async move {
-                let mut m = opt.future.lock().await;
-                let m = m.as_mut().await;
-                let nextAsync = binder(m);
-                let mut next = nextAsync.future.lock().await;
-                next.as_mut().await
-            };
+        binder: Arc<impl Fn(T) -> Arc<Async<U>> + Send + Sync + 'static>,
+    ) -> Arc<Async<U>> {
+        let next = async move {
+            let mut m = opt.future.lock().await;
+            let m = m.as_mut().await;
+            let nextAsync = binder(m);
+            let mut next = nextAsync.future.lock().await;
+            next.as_mut().await
+        };
 
-        let b :Pin<Box<dyn Future<Output=U> + Send + Sync + 'static>> = Box::pin(next);
-        Arc::from(Async { future: Arc::from(Mutex::from(b)) })
+        let b: Pin<Box<dyn Future<Output = U> + Send + Sync + 'static>> = Box::pin(next);
+        Arc::from(Async {
+            future: Arc::from(Mutex::from(b)),
+        })
     }
 
-    pub fn r_return<T: Send + Sync + 'static>(item: T) -> Arc<Async<T>>{
+    pub fn r_return<T: Send + Sync + 'static>(item: T) -> Arc<Async<T>> {
         let r = ready(item);
-        let b :Pin<Box<dyn Future<Output=T> + Send + Sync + 'static>> = Box::pin(r);
-        Arc::from(Async { future: Arc::from(Mutex::from(b)) })
+        let b: Pin<Box<dyn Future<Output = T> + Send + Sync + 'static>> = Box::pin(r);
+        Arc::from(Async {
+            future: Arc::from(Mutex::from(b)),
+        })
+    }
+
+    pub fn zero() -> Arc<Async<()>> {
+        r_return(())
     }
 }
 
@@ -107,7 +128,7 @@ pub mod ThreadPool {
     use futures::executor::ThreadPool;
 
     static mut POOL: Option<RwLock<ThreadPool>> = None;
-    pub fn try_init_and_get_pool() -> & 'static RwLock<ThreadPool> {
+    pub fn try_init_and_get_pool() -> &'static RwLock<ThreadPool> {
         unsafe {
             if POOL.is_none() {
                 let pool = ThreadPool::new().unwrap();
@@ -120,21 +141,72 @@ pub mod ThreadPool {
 }
 
 #[cfg(feature = "futures")]
-pub mod Task_ {
-    use std::{sync::{Arc, RwLock}, thread::{self, JoinHandle}, time::Duration, task::Poll, pin::Pin};
+pub mod Monitor_ {
+    use std::{
+        any::Any,
+        collections::HashSet,
+        sync::{Arc, Mutex, RwLock, Weak},
+        thread,
+        time::Duration,
+    };
 
-    use futures::{FutureExt, Future};
+    use crate::Native_::Lrc;
+
+    static mut LOCKS: Option<Mutex<HashSet<usize>>> = None;
+    fn try_init_and_get_locks() -> &'static Mutex<HashSet<usize>> {
+        unsafe {
+            let hs = HashSet::new();
+            if LOCKS.is_none() {
+                LOCKS = Some(Mutex::new(hs));
+            }
+
+            LOCKS.as_ref().unwrap()
+        }
+    }
+
+    pub fn enter<T>(o: Lrc<T>) {
+        let p = Arc::<T>::as_ptr(&o) as usize;
+        loop {
+            let otherHasLock = try_init_and_get_locks().lock().unwrap().get(&p).is_some();
+            if otherHasLock {
+                thread::sleep(Duration::from_millis(10));
+            } else {
+                try_init_and_get_locks().lock().unwrap().insert(p);
+                return
+            }
+        }
+    }
+
+    pub fn exit<T>(o: Lrc<T>) {
+        let p = Arc::<T>::as_ptr(&o) as usize;
+        let hasRemoved = try_init_and_get_locks().lock().unwrap().remove(&p);
+        if(!hasRemoved){
+            panic!("Not removed {}", p)
+        }
+    }
+}
+
+#[cfg(feature = "futures")]
+pub mod Task_ {
+    use std::{
+        pin::Pin,
+        sync::{Arc, RwLock},
+        task::Poll,
+        thread::{self, JoinHandle},
+        time::Duration,
+    };
+
+    use futures::{Future, FutureExt};
 
     use super::ThreadPool::try_init_and_get_pool;
 
     pub enum TaskState<T: Sized + Clone + Send> {
         New(Pin<Box<dyn Future<Output = T> + Send + Sync>>),
         Running,
-        Complete(T)
+        Complete(T),
     }
 
-    impl <T: Sized + Clone + Send + 'static> TaskState<T> {
-
+    impl<T: Sized + Clone + Send + 'static> TaskState<T> {
         pub fn is_new(&self) -> bool {
             match self {
                 TaskState::New(_) => true,
@@ -173,10 +245,13 @@ pub mod Task_ {
         result: Arc<RwLock<TaskState<T>>>,
     }
 
-    impl <T: Clone + Send + Sync> Future for &Task<T> {
+    impl<T: Clone + Send + Sync> Future for &Task<T> {
         type Output = T;
 
-        fn poll(self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> std::task::Poll<Self::Output> {
+        fn poll(
+            self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Self::Output> {
             //eprintln!("{:?} Polling task for result", thread::current().id());
             let m = self.result.read().unwrap();
 
@@ -186,8 +261,8 @@ pub mod Task_ {
                     //eprintln!("{:?} poll: task is new, waking up", thread::current().id());
                     cx.waker().wake_by_ref();
                     Poll::Pending
-                },
-                TaskState::Running  => {
+                }
+                TaskState::Running => {
                     //eprintln!("{:?} poll: pending, nothing to do", thread::current().id());
 
                     //todo - this is no good as it blocks the thread. It needs to be non-blocking and delegate out
@@ -195,25 +270,29 @@ pub mod Task_ {
                     cx.waker().wake_by_ref();
 
                     Poll::Pending
-                },
+                }
                 TaskState::Complete(res) => {
                     //eprintln!("{:?} Poll succeeded", thread::current().id());
                     Poll::Ready(res.clone())
-                },
+                }
             }
         }
     }
 
-    impl <T: Clone + Send + Sync + 'static> Task<T>{
+    impl<T: Clone + Send + Sync + 'static> Task<T> {
         pub fn new(fut: impl Future<Output = T> + Send + Sync + 'static) -> Task<T> {
-            Task { result: Arc::from(RwLock::from(TaskState::New(Box::pin(fut)))) }
+            Task {
+                result: Arc::from(RwLock::from(TaskState::New(Box::pin(fut)))),
+            }
         }
 
         pub fn from_result(value: T) -> Task<T> {
-            Task { result: Arc::from(RwLock::from(TaskState::Complete(value))) }
+            Task {
+                result: Arc::from(RwLock::from(TaskState::Complete(value))),
+            }
         }
 
-        pub fn set_result(&self, value: T){
+        pub fn set_result(&self, value: T) {
             let mut m = self.result.write().unwrap();
             //eprintln!("{:?} set task result", thread::current().id());
             (*m) = TaskState::Complete(value);
@@ -240,7 +319,7 @@ pub mod Task_ {
 
         pub fn start(t: Arc<Task<T>>) {
             if !t.result.read().unwrap().is_new() {
-                return
+                return;
             }
             let ts = t.result.write().unwrap().replace(TaskState::Running);
             match ts {
@@ -258,29 +337,30 @@ pub mod Task_ {
         }
     }
 
-    pub fn bind<T: Clone  + Send + Sync + 'static, U: Clone  + Send + Sync + 'static>(
+    pub fn bind<T: Clone + Send + Sync + 'static, U: Clone + Send + Sync + 'static>(
         opt: Arc<Task<T>>,
-        binder: Arc<impl Fn(T) -> Arc<Task<U>> + Send + Sync + 'static>
-                         ) -> Arc<Task<U>> {
-        let next =
-            async move {
-                //eprintln!("{:?} begin await source fut", thread::current().id());
-                let m = opt.as_ref().await;
-                //eprintln!("{:?} awaiting source future success", thread::current().id());
-                let nextAsync = binder(m);
-                if nextAsync.is_new() {
-                    Task::start(nextAsync.clone());
-                }
-                let next = nextAsync.as_ref().await;
-                //eprintln!("{:?} setting result", thread::current().id());
-                next
-            };
+        binder: Arc<impl Fn(T) -> Arc<Task<U>> + Send + Sync + 'static>,
+    ) -> Arc<Task<U>> {
+        let next = async move {
+            //eprintln!("{:?} begin await source fut", thread::current().id());
+            let m = opt.as_ref().await;
+            //eprintln!("{:?} awaiting source future success", thread::current().id());
+            let nextAsync = binder(m);
+            if nextAsync.is_new() {
+                Task::start(nextAsync.clone());
+            }
+            let next = nextAsync.as_ref().await;
+            //eprintln!("{:?} setting result", thread::current().id());
+            next
+        };
 
         let task = Task::new(next);
         Arc::from(task)
     }
 
-    pub fn delay<T: Clone + Send + Sync>(binder: Arc<impl Fn() -> Arc<Task<T>> + 'static>) -> Arc<Task<T>> {
+    pub fn delay<T: Clone + Send + Sync>(
+        binder: Arc<impl Fn() -> Arc<Task<T>> + 'static>,
+    ) -> Arc<Task<T>> {
         let pr = binder();
         pr
     }
@@ -295,17 +375,19 @@ pub mod Task_ {
     }
 
     pub fn from_result<T: Clone + Send>(t: T) -> Arc<Task<T>> {
-        let t = Task { result: Arc::from(RwLock::from(TaskState::Complete(t))) };
+        let t = Task {
+            result: Arc::from(RwLock::from(TaskState::Complete(t))),
+        };
         Arc::from(t)
     }
 }
 
 #[cfg(feature = "futures")]
 pub mod TaskBuilder_ {
-    use std::{sync::Arc, rc::Rc};
+    use std::{rc::Rc, sync::Arc};
 
-    use super::Task_::Task;
     use super::super::Native_::Lrc;
+    use super::Task_::Task;
 
     pub struct TaskBuilder {}
 

--- a/src/fable-library-rust/src/Mutable.rs
+++ b/src/fable-library-rust/src/Mutable.rs
@@ -148,3 +148,14 @@ impl<T> Index<i32> for MutCell<Vec<T>> {
         &self.get_mut()[idx as usize]
     }
 }
+
+
+// In .NET, thread safety is not guaranteed, and it is expected that a user handles this themselves via constructs such as
+// System.Threading.Monitor or lock.
+// In order to allow this pattern, Send and Sync guards must be removed, which is why it is behind an "unsafe" feature switch.
+// Use at your own risk!
+#[cfg(feature = "unsafe-cells")]
+unsafe impl <T> Send for MutCell<T> {}
+
+#[cfg(feature = "unsafe-cells")]
+unsafe impl <T> Sync for MutCell<T> {}

--- a/tests/Rust/Cargo.toml
+++ b/tests/Rust/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-futures = ["fable_library_rust/futures"]
+futures = ["fable_library_rust/futures", "fable_library_rust/unsafe-cells"]
 # default = ["futures"] # Uncomment when attempting to debug/use rust analyzer to switch to futures mode
 
 [dependencies]

--- a/tests/Rust/tests/src/AsyncTests.fs
+++ b/tests/Rust/tests/src/AsyncTests.fs
@@ -80,3 +80,67 @@ let shouldExecuteTask () =
         return a + b
     }
     comp.Result |> equal 3
+
+
+[<Fact>]
+let shouldExecuteMutationOnTask () =
+    let a = Task.FromResult 0
+    let mutable x = 0
+    let comp = task {
+        let! _ = a
+        x <- x + 1
+    }
+    do comp.Result
+    x |> equal 1
+
+// [<Fact>]
+// let ``should execute mutation on thread unsafe`` () =
+//     let mutable x = 1
+//     let t = new System.Threading.Thread(fun () -> x <- x + 1)
+//     t.Start()
+//     t.Join()
+//     x |> equal 2
+
+// module Monitor =
+//     [<Fact>]
+//     let monitorShouldWorkWithSystemObj () =
+//         let o = new System.Object()
+//         System.Threading.Monitor.Enter(o)
+//         System.Threading.Monitor.Exit(o)
+
+//     type Data = {
+//         x: string //deliberately use reference type to confirm nested Lrc
+//     }
+
+//     [<Fact>]
+//     let monitorShouldWorkWithT () =
+//         let o = { x = "test" }
+//         System.Threading.Monitor.Enter(o)
+//         System.Threading.Monitor.Exit(o)
+//     [<Fact>]
+//     let ``For monitor - Should block on thread until lock has been released`` () =
+//         let mutable events = []
+//         let o = new System.Object()
+//         System.Threading.Monitor.Enter(o)
+//         let t1 = new System.Threading.Thread(fun () -> lock o (fun () -> events <- 1::events))
+//         t1.Start()
+//         System.Threading.Thread.Sleep(100);
+
+//         events <- 2::events
+//         System.Threading.Monitor.Exit(o)
+
+//         t1.Join()
+//         events |> equal [1; 2]
+
+//[<Fact>]
+// let testShouldMutateAndLock () =
+//     let o = new System.Object()
+//     let mutable x = 1
+//     let lazyGet = async { return 1 }
+//     let comp = async {
+//         let! _ = lazyGet
+//         lock o (fun () -> x <- x + 1)
+//     }
+//     let t = Async.StartAsTask comp
+//     do t.Result
+//     x |> equal 2


### PR DESCRIPTION
Folowing on from https://github.com/fable-compiler/Fable/issues/2916 and https://github.com/fable-compiler/Fable/issues/2916#issuecomment-1196939666 this moves threading forward a bit:

* unsafe-cells feature switch - turns on Send and Sync for MutCell
* Add test for mutating declared on another thread
* Implement Monitor
* Added some tests for above
* Added placeholders for the next steps - full locks + Thread etc