### PR TITLE
[Python] Fix array typing

### DIFF
--- a/src/fable-library-py/fable_library/types.py
+++ b/src/fable-library-py/fable_library/types.py
@@ -4,7 +4,6 @@ import array
 from abc import abstractmethod
 from typing import (
     Any,
-    ByteString,
     Callable,
     Generic,
     Iterable,
@@ -347,7 +346,7 @@ class float32(float):
     __slots__ = ()
 
 
-float = float
+float = float  # use native float for float64
 
 
 def Int8Array(lst: List[int]):
@@ -382,7 +381,7 @@ def Float64Array(lst: List[float]) -> MutableSequence[float]:
     return array.array("d", lst)
 
 
-Array = Union_[List[_T], MutableSequence[_T], ByteString]
+Array = MutableSequence[_T]
 
 
 def is_exception(x: Any):

--- a/tests/Python/TestQueue.fs
+++ b/tests/Python/TestQueue.fs
@@ -162,7 +162,6 @@ let ``test Dequeue throws on empty queue`` () =
         | _ -> true
     ) |> equal true
 
-(* TODO
 [<Fact>]
 let ``test Clear queue removes all entries`` () =
     let q = Queue([1;2;3;4])
@@ -172,7 +171,7 @@ let ``test Clear queue removes all entries`` () =
     q.Clear()
 
     q.Count |> equal(0)
-*)
+
 [<Fact>]
 let ``test Contains finds entries in queue`` () =
     let q = Queue([1;2;3;4])


### PR DESCRIPTION
Simplify array type on Python to be `abc.MutableSequence`. 