### PR TITLE
[Python] fix math imports

### DIFF
--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -876,6 +876,9 @@ module Annotation =
             let resolved, stmts = resolveGenerics com ctx genArgs repeatedGenerics
             fableModuleAnnotation com ctx "event" "IEvent_2" resolved, stmts
         | Types.cancellationToken, _ -> libValue com ctx "async_builder" "CancellationToken", []
+        | Types.mailboxProcessor, _ ->
+            let resolved, stmts = resolveGenerics com ctx genArgs repeatedGenerics
+            fableModuleAnnotation com ctx "mailbox_processor" "MailboxProcessor" resolved, stmts
         | _ ->
             let ent = com.GetEntity(entRef)
 

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -1419,7 +1419,7 @@ module Util =
             let ident =
                 name
                 |> Option.map Identifier
-                |> Option.defaultWith (fun _ -> Helpers.getUniqueIdentifier "arrow")
+                |> Option.defaultWith (fun _ -> Helpers.getUniqueIdentifier "_arrow")
 
             let func =
                 Statement.functionDef (name = ident, args = args, body = body, returns = returnType)
@@ -1442,7 +1442,7 @@ module Util =
         let name =
             name
             |> Option.map (fun name -> com.GetIdentifier(ctx, name))
-            |> Option.defaultValue (Helpers.getUniqueIdentifier "expr")
+            |> Option.defaultValue (Helpers.getUniqueIdentifier "_expr")
 
         let func = makeFunction name (args, body, decoratorList, returnType)
 
@@ -2660,7 +2660,7 @@ module Util =
                     stmts @ exprAsStatement ctx expr)
             |> transformBody com ctx None
 
-        let name = Helpers.getUniqueIdentifier "expr"
+        let name = Helpers.getUniqueIdentifier "_expr"
 
         let func =
             Statement.functionDef (name = name, args = Arguments.arguments [], body = body)
@@ -2682,7 +2682,7 @@ module Util =
                 else
                     exprAsStatement ctx expr)
 
-        let name = Helpers.getUniqueIdentifier "expr"
+        let name = Helpers.getUniqueIdentifier "_expr"
 
         let func =
             Statement.functionDef (name = name, args = Arguments.arguments [], body = body)

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -953,15 +953,7 @@ module Util =
     open Annotation
 
     let getIdentifier (com: IPythonCompiler) (ctx: Context) (name: string) =
-        let name =
-            match name with
-            //| "this" -> "self"
-            | "math"
-            | "Math" ->
-                com.GetImportExpr(ctx, "math") |> ignore
-                "math"
-            | _ -> Helpers.clean name
-
+        let name = Helpers.clean name
         Identifier name
 
     let (|TransformExpr|) (com: IPythonCompiler) ctx e : Expression * Statement list = com.TransformAsExpr(ctx, e)

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -3657,7 +3657,7 @@ module Util =
 
                   let returnType, _ = typeAnnotation com ctx None memb.ReturnParameter.Type
 
-                  let body = [ Statement.expr (Expression.name "...") ]
+                  let body = [ Statement.ellipsis ]
                   Statement.functionDef (name, args, body, returns = returnType, decoratorList = decorators)
 
               if members.IsEmpty then Statement.Pass ]

--- a/src/Fable.Transforms/Python/Python.fs
+++ b/src/Fable.Transforms/Python/Python.fs
@@ -756,12 +756,15 @@ type AST =
 
 [<AutoOpen>]
 module PythonExtensions =
+    let [<Literal>] Ellipsis = "..."
+
     type Statement with
 
         static member break'() : Statement = Break
         static member continue' ?loc : Statement = Continue
         static member import(names) : Statement = Import { Names = names }
         static member expr(value) : Statement = { Expr.Value = value } |> Expr
+        static member ellipsis : Statement = Statement.expr(Expression.ellipsis)
 
         static member raise(value) : Statement =
             { Exception = value; Cause = None } |> Raise
@@ -890,8 +893,8 @@ module PythonExtensions =
             |> Compare
 
         static member none = Expression.name (Identifier(name = "None"))
-
         static member any = Expression.name (Identifier(name = "Any"))
+        static member ellipsis = Expression.name (Identifier(name = Ellipsis))
 
         static member attribute(value, attr, ?ctx) : Expression =
             { Value = value

--- a/src/Fable.Transforms/Python/PythonPrinter.fs
+++ b/src/Fable.Transforms/Python/PythonPrinter.fs
@@ -166,7 +166,10 @@ module PrinterExtensions =
             printer.Print(":")
             printer.PrintNewLine()
             printer.PushIndentation()
-            printer.PrintStatements(cd.Body)
+            match cd.Body with
+            | [] -> printer.PrintStatements([ Statement.ellipsis ])
+            | body ->
+                printer.PrintStatements(body)
             printer.PopIndentation()
 
         member printer.Print(ifElse: If) =

--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -1275,7 +1275,7 @@ let fsFormat (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr op
 let operators (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr option) (args: Expr list) =
     let math r t (args: Expr list) argTypes methName =
         let meth = Naming.lowerFirst methName
-        Helper.GlobalCall("math", t, args, argTypes, memb=meth, ?loc = r)
+        Helper.ImportedCall("math", meth, t, args, argTypes, ?loc = r)
 
     match i.CompiledName, args with
     | ("DefaultArg" | "DefaultValueArg"), [opt; defValue] ->
@@ -1437,7 +1437,7 @@ let operators (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr o
                 | _ -> "long"
             Helper.LibCall(com, modName, "abs", t, args, i.SignatureArgTypes, ?thisArg=thisArg, ?loc=r) |> Some
         | _ ->
-            math r t args i.SignatureArgTypes i.CompiledName
+            Helper.GlobalCall("abs", t, args, [ t ], ?loc = r)
             |> Some
     | "Acos", _
     | "Asin", _

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -103,6 +103,7 @@ module Types =
     let [<Literal>] fsharpMap = "Microsoft.FSharp.Collections.FSharpMap`2"
     let [<Literal>] fsharpSet = "Microsoft.FSharp.Collections.FSharpSet`1"
     let [<Literal>] fsharpAsyncGeneric = "Microsoft.FSharp.Control.FSharpAsync`1"
+    let [<Literal>] mailboxProcessor = "Microsoft.FSharp.Control.FSharpMailboxProcessor`1"
     let [<Literal>] taskBuilder = "Microsoft.FSharp.Control.TaskBuilder"
     let [<Literal>] taskBuilderModule = "Microsoft.FSharp.Control.TaskBuilderModule"
     let [<Literal>] task = "System.Threading.Tasks.Task"


### PR DESCRIPTION
- Remove legacy math handling in Fable2Python and fixes stuff in Replacements instead.
- Use ellipsis on empty class body
- Make generated arrow functions private