### PR TITLE
Generate Python data classes

### DIFF
--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -3275,7 +3275,11 @@ module Util =
             | _ -> body
 
         let dataClass = com.GetImportExpr(ctx, "dataclasses", "dataclass")
-        Statement.classDef (name, body = classBody, decoratorList = [ dataClass ], bases=bases @ generics)
+        let decorators = [
+            Expression.call(dataClass, kw=[Keyword.keyword(Identifier "eq", Expression.constant false)
+                                           Keyword.keyword(Identifier "repr", Expression.constant false)])
+        ]
+        Statement.classDef (name, body = classBody, decoratorList = decorators, bases=bases @ generics)
 
     let declareClassType
         (com: IPythonCompiler)
@@ -3356,7 +3360,7 @@ module Util =
         let slotMembers = createSlotsForRecordType com ctx ent
 
         let typeDeclaration =
-            match ent.IsFSharpRecord || Helpers.hasAttribute Atts.pyDataClassAttr ent with
+            match ent.IsFSharpRecord with
             | true -> declareDataClassType com ctx ent entName consArgs isOptional consBody baseExpr classMembers slotMembers
             | false -> declareClassType com ctx ent entName consArgs isOptional consBody baseExpr classMembers slotMembers
 

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -3608,14 +3608,14 @@ module Util =
 
         declareType com ctx ent entName args isOptional body baseExpr classMembers
 
-    let transformClassWithImplicitConstructor
+    let transformClassWithExplicitConstructor
         (com: IPythonCompiler)
         ctx
         (classDecl: Fable.ClassDecl)
         (classMembers: Statement list)
         (cons: Fable.MemberDecl)
         =
-        // printfn "transformClassWithImplicitConstructor: %A" classDecl
+        // printfn "transformClassWithExplicitConstructor: %A" classDecl
         let classEnt = com.GetEntity(classDecl.Entity)
         let classIdent = Expression.name (com.GetIdentifier(ctx, classDecl.Name))
 
@@ -3804,7 +3804,7 @@ module Util =
             | ent, _ when ent.IsFSharpUnion -> transformUnion com ctx ent decl.Name classMembers
             | _, Some cons ->
                 withCurrentScope ctx cons.UsedNames
-                <| fun ctx -> transformClassWithImplicitConstructor com ctx decl classMembers cons
+                <| fun ctx -> transformClassWithExplicitConstructor com ctx decl classMembers cons
             | _, None -> transformClassWithCompilerGeneratedConstructor com ctx ent decl.Name classMembers
 
     let transformTypeVars (com: IPythonCompiler) ctx (typeVars: HashSet<string>) =

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -497,7 +497,7 @@ module Reflection =
                     | None -> warnAndEvalToFalse ent.FullName, []
 
 module Helpers =
-    /// Returns true if type can be None in Python
+    /// Returns true if the first field type can be None in Python
     let isOptional (fields: Fable.Ident []) =
         if fields.Length < 1 then
             false
@@ -560,6 +560,12 @@ module Helpers =
             else
                 Some stmt
         | _ -> Some stmt
+
+    let hasAttribute fullName (ent: Fable.Entity) =
+        ent.Attributes |> Seq.exists (fun att -> att.Entity.FullName = fullName)
+
+    let hasInterface fullName (ent: Fable.Entity) =
+        ent |> FSharp2Fable.Util.hasInterface fullName
 
 // https://www.python.org/dev/peps/pep-0484/
 module Annotation =
@@ -736,9 +742,9 @@ module Annotation =
         | Fable.List genArg -> fableModuleTypeHint com ctx "list" "FSharpList" [ genArg ] repeatedGenerics
         | Replacements.Util.Builtin kind -> makeBuiltinTypeAnnotation com ctx kind repeatedGenerics
         | Fable.AnonymousRecordType (_, genArgs, _) ->
-            let value = Expression.name ("dict")
+            let value = Expression.name "dict"
             let any, stmts = stdlibModuleTypeHint com ctx "typing" "Any" []
-            Expression.subscript (value, Expression.tuple ([ Expression.name "str"; any ])), stmts
+            Expression.subscript (value, Expression.tuple [ Expression.name "str"; any ]), stmts
         | Fable.DeclaredType (entRef, genArgs) -> makeEntityTypeAnnotation com ctx entRef genArgs repeatedGenerics
         | _ -> stdlibModuleTypeHint com ctx "typing" "Any" []
 
@@ -835,7 +841,6 @@ module Annotation =
             fableModuleAnnotation com ctx "util" "IComparable" [ resolved ], stmts
         | Types.comparer, _ ->
             let resolved, stmts = resolveGenerics com ctx genArgs repeatedGenerics
-
             fableModuleAnnotation com ctx "util" "IComparer" resolved, stmts
         | Types.equalityComparer, _ ->
             let resolved, stmts = stdlibModuleTypeHint com ctx "typing" "Any" []
@@ -855,12 +860,10 @@ module Annotation =
             fableModuleAnnotation com ctx "util" "IEnumerable" [ resolved ], stmts
         | Types.ienumerableGeneric, _ ->
             let resolved, stmts = resolveGenerics com ctx genArgs repeatedGenerics
-
             fableModuleAnnotation com ctx "util" "IEnumerable" resolved, stmts
         | Types.icollection, _
         | Types.icollectionGeneric, _ ->
             let resolved, stmts = resolveGenerics com ctx genArgs repeatedGenerics
-
             fableModuleAnnotation com ctx "util" "ICollection" resolved, stmts
         | Types.idisposable, _ -> libValue com ctx "util" "IDisposable", []
         | Types.iobserverGeneric, _ ->
@@ -948,7 +951,14 @@ module Annotation =
         let args', body' = com.TransformFunction(ctx, name, args, body, repeatedGenerics)
         let returnType, stmts = typeAnnotation com ctx (Some repeatedGenerics) body.Type
 
-        args', stmts @ body', returnType
+        // If the only argument is generic, then we make the return type optional as well
+        let returnType' =
+            match args, body.Type with
+            | [ {Type=Fable.GenericParam(name=x)} ], Fable.GenericParam(name=y) when x = y && Set.contains x repeatedGenerics ->
+                stdlibModuleAnnotation com ctx "typing" "Optional" [ returnType ]
+            | _ -> returnType
+        
+        args', stmts @ body', returnType'
 
 module Util =
     open Lib
@@ -1446,7 +1456,7 @@ module Util =
 
         let func = makeFunction name (args, body, decoratorList, returnType)
 
-        Expression.name (name), [ func ]
+        Expression.name name, [ func ]
 
     let optimizeTailCall (com: IPythonCompiler) (ctx: Context) range (tc: ITailCallOpportunity) args =
         let rec checkCrossRefs tempVars allArgs =
@@ -1627,7 +1637,7 @@ module Util =
 
     let enumerator2iterator com ctx =
         let enumerator =
-            Expression.call (get com ctx None (Expression.identifier ("self")) "GetEnumerator" false, [])
+            Expression.call (get com ctx None (Expression.identifier "self") "GetEnumerator" false, [])
 
         [ Statement.return' (libCall com ctx None "util" "toIterator" [ enumerator ]) ]
 
@@ -3044,7 +3054,7 @@ module Util =
                     let limit = Expression.binOp (limit, Sub, Expression.constant 1) // Python `range` has exclusive end.
                     limit, -1
 
-            let step = Expression.constant (step)
+            let step = Expression.constant step
 
             let iter =
                 Expression.call (Expression.name (Identifier "range"), args = [ start; limit; step ])
@@ -3230,6 +3240,43 @@ module Util =
                 prop)
             |> Seq.toArray
 
+    let declareDataClassType
+        (com: IPythonCompiler)
+        (ctx: Context)
+        (ent: Fable.Entity)
+        (entName: string)
+        (consArgs: Arguments)
+        (isOptional: bool)
+        (consBody: Statement list)
+        (baseExpr: Expression option)
+        (classMembers: Statement list)
+        slotMembers
+        =
+        let name = com.GetIdentifier(ctx, entName)
+        let props =
+            consArgs.Args
+            |> List.map (fun arg ->
+                let any _ = stdlibModuleAnnotation com ctx "typing" "Any" []
+                let annotation = arg.Annotation |> Option.defaultWith any
+                Statement.assign (Expression.name arg.Arg, annotation=annotation))
+
+        let generics = makeEntityTypeParamDecl com ctx ent
+        let bases =
+            baseExpr
+            |> Option.toList
+
+        let classBody =
+            let body =
+                [ yield! props
+                  yield! classMembers ]
+
+            match body with
+            | [] -> [ Statement.ellipsis ]
+            | _ -> body
+
+        let dataClass = com.GetImportExpr(ctx, "dataclasses", "dataclass")
+        Statement.classDef (name, body = classBody, decoratorList = [ dataClass ], bases=bases @ generics)
+
     let declareClassType
         (com: IPythonCompiler)
         (ctx: Context)
@@ -3255,7 +3302,7 @@ module Util =
                   yield! classMembers ]
 
             match body with
-            | [] -> [ Pass ]
+            | [] -> [ Statement.ellipsis ]
             | _ -> body
 
         let interfaces =
@@ -3278,7 +3325,6 @@ module Util =
         Statement.classDef (name, body = classBody, bases = bases @ generics)
 
     let createSlotsForRecordType (com: IPythonCompiler) ctx (classEnt: Fable.Entity) =
-
         let strFromIdent (ident: Identifier) = ident.Name
 
         if classEnt.IsValueType then
@@ -3310,7 +3356,9 @@ module Util =
         let slotMembers = createSlotsForRecordType com ctx ent
 
         let typeDeclaration =
-            declareClassType com ctx ent entName consArgs isOptional consBody baseExpr classMembers slotMembers
+            match ent.IsFSharpRecord || Helpers.hasAttribute Atts.pyDataClassAttr ent with
+            | true -> declareDataClassType com ctx ent entName consArgs isOptional consBody baseExpr classMembers slotMembers
+            | false -> declareClassType com ctx ent entName consArgs isOptional consBody baseExpr classMembers slotMembers
 
         let reflectionDeclaration, stmts =
             let ta = fableModuleAnnotation com ctx "Reflection" "TypeInfo" []
@@ -3385,7 +3433,7 @@ module Util =
               elif isGetter then
                   Expression.name "property"
               else
-                  Expression.name ($"{memb.Name}.setter") ]
+                  Expression.name $"{memb.Name}.setter" ]
 
         let args, body, returnType =
             getMemberArgsAndBody com ctx (Attached isStatic) false memb.Args memb.Body
@@ -3632,8 +3680,7 @@ module Util =
                       |> Naming.toSnakeCase
                       |> Helpers.clean
 
-                  com.GetImportExpr(ctx, "abc", "abstractmethod")
-                  |> ignore
+                  let abstractMethod = com.GetImportExpr(ctx, "abc", "abstractmethod")
 
                   let decorators =
                       [ if memb.IsValue || memb.IsGetter then
@@ -3641,7 +3688,7 @@ module Util =
                         if memb.IsSetter then
                             Expression.name ($"{name}.setter")
 
-                        Expression.name "abstractmethod" ] // Must be after @property
+                        abstractMethod ] // Must be after @property
 
                   let name = com.GetIdentifier(ctx, name)
 

--- a/src/Fable.Transforms/Python/Prelude.fs
+++ b/src/Fable.Transforms/Python/Prelude.fs
@@ -194,7 +194,12 @@ module Naming =
            | Naming.StaticMemberPart (s, i) -> printPart sanitize "_" s i
            | Naming.NoMemberPart -> "")
 
-    let sanitizeIdent conflicts name part =
+    let sanitizeIdent conflicts (name: string) part =
+        let name =
+            if name.EndsWith("@") then
+                $"_{name.Substring(0, name.Length - 1)}"
+            else
+                name
         // Replace Forbidden Chars
         buildName sanitizeIdentForbiddenChars name part
         |> checkPyKeywords

--- a/src/Fable.Transforms/Python/PythonPrinter.fs
+++ b/src/Fable.Transforms/Python/PythonPrinter.fs
@@ -118,7 +118,7 @@ module PrinterExtensions =
 
         member printer.Print(assign: AnnAssign) =
             printer.Print(assign.Target)
-            printer.Print(" : ")
+            printer.Print(": ")
             printer.Print(assign.Annotation)
 
             match assign.Value with
@@ -152,6 +152,11 @@ module PrinterExtensions =
             printer.PopIndentation()
 
         member printer.Print(cd: ClassDef) =
+            for deco in cd.DecoratorList do
+                printer.Print("@")
+                printer.Print(deco)
+                printer.PrintNewLine()
+
             let (Identifier name) = cd.Name
             printer.Print("class ", ?loc = cd.Loc)
             printer.Print(name)
@@ -168,8 +173,7 @@ module PrinterExtensions =
             printer.PushIndentation()
             match cd.Body with
             | [] -> printer.PrintStatements([ Statement.ellipsis ])
-            | body ->
-                printer.PrintStatements(body)
+            | body -> printer.PrintStatements(body)
             printer.PopIndentation()
 
         member printer.Print(ifElse: If) =

--- a/src/fable-library-py/fable_library/reflection.py
+++ b/src/fable-library-py/fable_library/reflection.py
@@ -4,7 +4,7 @@ import functools
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union, cast
 
-from .types import FSharpRef, Record
+from .types import FSharpRef, Record, Array
 from .types import Union as FsUnion
 from .util import combine_hash_codes, equal_arrays_with
 
@@ -105,7 +105,9 @@ def array_type(generic: TypeInfo) -> TypeInfo:
     return TypeInfo(generic.fullname + "[]", [generic])
 
 
-def enum_type(fullname: str, underlyingType: TypeInfo, enumCases: List[EnumCase]) -> TypeInfo:
+def enum_type(
+    fullname: str, underlyingType: TypeInfo, enumCases: List[EnumCase]
+) -> TypeInfo:
     return TypeInfo(fullname, [underlyingType], None, None, None, None, enumCases)
 
 
@@ -139,7 +141,9 @@ def equals(t1: TypeInfo, t2: TypeInfo) -> bool:
             lambda kv1, kv2: kv1[0] == kv2[0] and equals(kv1[1], kv2[1]),
         )
 
-    return t1.fullname == t2.fullname and equal_arrays_with(t1.generics, t2.generics, equals)
+    return t1.fullname == t2.fullname and equal_arrays_with(
+        t1.generics, t2.generics, equals
+    )
 
 
 def is_generic_type(t: TypeInfo) -> bool:
@@ -147,7 +151,11 @@ def is_generic_type(t: TypeInfo) -> bool:
 
 
 def get_generic_type_definition(t: TypeInfo):
-    return t if t.generics is None else TypeInfo(t.fullname, list(map(lambda _: obj_type, t.generics)))
+    return (
+        t
+        if t.generics is None
+        else TypeInfo(t.fullname, list(map(lambda _: obj_type, t.generics)))
+    )
 
 
 def get_generics(t: TypeInfo) -> List[TypeInfo]:
@@ -207,7 +215,9 @@ def is_enum(t: TypeInfo) -> bool:
 
 
 def is_subclass_of(t1: TypeInfo, t2: TypeInfo) -> bool:
-    return t1.parent is not None and ((t1.parent == t2) or is_subclass_of(t1.parent, t2))
+    return t1.parent is not None and (
+        (t1.parent == t2) or is_subclass_of(t1.parent, t2)
+    )
 
 
 def is_erased_to_number(t: TypeInfo) -> bool:
@@ -239,7 +249,7 @@ def is_instance_of_type(t: TypeInfo, o: Any) -> bool:
     if callable(o):
         return is_function(t)
 
-    return t.construct is not None and isinstance(o, t.construct)
+    return t.construct is not None
 
 
 def is_record(t: Any) -> bool:
@@ -374,8 +384,8 @@ def get_record_field(v: Any, field: FieldInfo) -> Any:
     return getattr(v, field[0])
 
 
-def get_tuple_fields(v: Any) -> List:
-    return v
+def get_tuple_fields(v: Tuple[Any, ...]) -> Array[Any]:
+    return list(v)
 
 
 def get_tuple_field(v: Tuple[Any, ...], i: int) -> Any:
@@ -385,7 +395,9 @@ def get_tuple_field(v: Tuple[Any, ...], i: int) -> Any:
 def make_record(t: TypeInfo, values: List[Any]) -> Dict[str, Any]:
     fields = get_record_elements(t)
     if len(fields) != len(values):
-        raise ValueError(f"Expected an array of length {len(fields)} but got {len(values)}")
+        raise ValueError(
+            f"Expected an array of length {len(fields)} but got {len(values)}"
+        )
 
     if t.construct is not None:
         return t.construct(*values)
@@ -406,9 +418,15 @@ def make_tuple(values: List[Any], _t: TypeInfo) -> Tuple[Any, ...]:
 def make_union(uci: CaseInfo, values: List[Any]) -> Any:
     expectedLength = len(uci.fields or [])
     if len(values) != expectedLength:
-        raise ValueError(f"Expected an array of length {expectedLength} but got {len(values)}")
+        raise ValueError(
+            f"Expected an array of length {expectedLength} but got {len(values)}"
+        )
 
-    return uci.declaringType.construct(uci.tag, *values) if uci.declaringType.construct else {}
+    return (
+        uci.declaringType.construct(uci.tag, *values)
+        if uci.declaringType.construct
+        else {}
+    )
 
 
 def get_union_cases(t: TypeInfo) -> List[CaseInfo]:

--- a/src/fable-library-py/fable_library/reflection.py
+++ b/src/fable-library-py/fable_library/reflection.py
@@ -249,7 +249,7 @@ def is_instance_of_type(t: TypeInfo, o: Any) -> bool:
     if callable(o):
         return is_function(t)
 
-    return t.construct is not None
+    return t.construct is not None and isinstance(o, t.construct)
 
 
 def is_record(t: Any) -> bool:

--- a/src/fable-library-py/fable_library/task.py
+++ b/src/fable-library-py/fable_library/task.py
@@ -4,9 +4,10 @@ This module implements .NET
 [tasks](https://docs.microsoft.com/en-us/dotnet/standard/async-in-depth)
 using Python async / await.
 """
+from __future__ import annotations
 import asyncio
 from asyncio import AbstractEventLoop, Future
-from typing import TYPE_CHECKING, Any, Awaitable, Generic, TypeVar
+from typing import Any, Awaitable, Generic, TypeVar
 
 _T = TypeVar("_T")
 
@@ -16,10 +17,7 @@ class TaskCompletionSource(Generic[_T]):
 
     def __init__(self) -> None:
         self.loop: AbstractEventLoop = asyncio.get_event_loop()
-        if TYPE_CHECKING:
-            self.future: Future[_T] = self.loop.create_future()
-        else:
-            self.future: Future = self.loop.create_future()
+        self.future: Future[_T] = self.loop.create_future()
 
     def SetResult(self, value: _T) -> None:
         """Set result.

--- a/src/fable-library-py/fable_library/types.py
+++ b/src/fable-library-py/fable_library/types.py
@@ -179,12 +179,6 @@ def record_get_hashcode(self: Record) -> int:
 class Record(IComparable):
     __slots__: List[str]
 
-    def __str__(self) -> str:
-        return record_to_string(self)
-
-    def __repr__(self) -> str:
-        return str(self)
-
     def GetHashCode(self) -> int:
         return record_get_hashcode(self)
 
@@ -193,6 +187,12 @@ class Record(IComparable):
 
     def CompareTo(self, other: Record) -> int:
         return record_compare_to(self, other)
+
+    def __str__(self) -> str:
+        return record_to_string(self)
+
+    def __repr__(self) -> str:
+        return str(self)
 
     def __lt__(self, other: Any) -> bool:
         return True if self.CompareTo(other) == -1 else False

--- a/src/fable-library-py/fable_library/util.py
+++ b/src/fable-library-py/fable_library/util.py
@@ -544,7 +544,7 @@ def get_enumerator(o: Iterable[Any]) -> Enumerator[Any]:
     if attr:
         return attr()
     elif isinstance(o, dict):
-        # Dictionaries should return produce tuples
+        # Dictionaries should produce tuples
         return Enumerator(iter(cast(Any, o.items())))
     else:
         return Enumerator(iter(o))


### PR DESCRIPTION
- Use Python data-classes https://docs.python.org/3/library/dataclasses.html instead of plain classes for Records. This is needed for interoperability with libraries such as e.g Pydantic that uses data-classes for serialization, validation, database-models, etc.
- Fix return type of single generic parameters (needs to be optional in case of unit arguments.

TODO: see if we can use dataclasses for normal classes annotated with e.g DataClass attribute.