### PR TITLE
[Python] Relax identifier checking to accept unicode chars

### DIFF
--- a/src/Fable.Transforms/Python/Prelude.fs
+++ b/src/Fable.Transforms/Python/Prelude.fs
@@ -7,7 +7,8 @@ module Naming =
     open Fable.Core
     open System.Text.RegularExpressions
 
-    let [<Literal>] sitePackages = "site-packages"
+    [<Literal>]
+    let sitePackages = "site-packages"
 
     let lowerFirst (s: string) =
         s.Substring(0, 1).ToLowerInvariant()
@@ -134,13 +135,10 @@ module Naming =
         check originalName 0
 
     let isIdentChar index (c: char) =
-        let code = int c
-
-        c = '_'
-        || (65 <= code && code <= 90) // a-z
-        || (97 <= code && code <= 122) // A-Z
         // Digits are not allowed in first position, see #1397
-        || (index > 0 && 48 <= code && code <= 57) // 0-9
+        c = '_'
+        || Char.IsLetter(c)
+        || Char.IsDigit(c) && index > 0
 
     let hasIdentForbiddenChars (ident: string) =
         let mutable found = false

--- a/tests/Python/TestMisc.fs
+++ b/tests/Python/TestMisc.fs
@@ -1306,6 +1306,7 @@ let ``test Accessing union tags `` () =
 
 type Type1 = { t1: string }
 
+[<Fact>]
 let ``test conditional expressions`` () = // See #2782
     let test (u2: U2<string, Type1>) =       
         match u2 with
@@ -1314,3 +1315,11 @@ let ``test conditional expressions`` () = // See #2782
         | _ -> ""
 
     equal(test (U2.Case1 "x"), "x")
+
+type Æøå =
+    | Union1 of string
+    
+[<Fact>]
+let ``test unicode chars in identifiers are preserved`` () =
+    let x = typeof<Æøå>.FullName
+    x.Replace("+", ".") |> equal "Fable.Tests.Misc.Æøå"


### PR DESCRIPTION
Fixes #2964