### PR TITLE
Rust - more references

### DIFF
--- a/src/Fable.Transforms/Rust/AST/Rust.AST.Helpers.fs
+++ b/src/Fable.Transforms/Rust/AST/Rust.AST.Helpers.fs
@@ -887,7 +887,7 @@ module Exprs =
 
     //for debugging purposes - decorate any expr with some metadata
     let BLOCK_COMMENT_SUFFIX comment expr : Expr =
-        ExprKind.EmitExpression(sprintf "$0 /* %A */" comment, mkVec [expr])
+        ExprKind.EmitExpression(sprintf "($0 /* %A */)" comment, mkVec [expr])
         |> mkExpr
 
 [<AutoOpen>]

--- a/src/Fable.Transforms/Rust/Fable2Rust.fs
+++ b/src/Fable.Transforms/Rust/Fable2Rust.fs
@@ -1607,8 +1607,6 @@ module Util =
                 HasMultipleUses = true
                 UsageCount = 9999 }
         let isOnlyReference =
-            // if varAttrs.IsRef then false
-            // else
             match e with
             | Fable.Let _ -> true
             | Fable.Call _ ->

--- a/tests/Rust/tests/src/ByRefTests.fs
+++ b/tests/Rust/tests/src/ByRefTests.fs
@@ -9,6 +9,30 @@ type Obj = {
 
 let byrefIntFn (x: int inref) =
     x + 1
+let byrefObjFn (x: Obj inref) =
+    x.X + 1
+
+[<ByRef>]
+let byrefAttrRootObjDecFn (x: Obj) =
+    x.X + 1
+[<ByRef>]
+let byrefAttrRootIntFn (x: int) =
+    x + 1
+
+let byrefAttrIntFn ([<ByRef>] x: int) =
+    x + 1
+let byrefAttrObjFn ([<ByRef>] x: Obj) =
+    x.X + 1
+
+[<Fable.Core.Emit("byrefAttrRootIntFn(&$0)")>]
+let callByRefAttrRootIntFn i = i
+[<Fable.Core.Emit("byrefAttrIntFn(&$0)")>]
+let callByRefAttrIntFn i = i
+
+// the intent of doing this is that this will break if there is some regression that the parameters no longer are passed by ref
+let ensureIntRefsAreActuallyExpectedTypecheck () =
+    callByRefAttrRootIntFn 1 |> ignore
+    callByRefAttrIntFn 1 |> ignore
 
 [<Fact>]
 let ``pass int by ref works`` () =
@@ -16,8 +40,9 @@ let ``pass int by ref works`` () =
     byrefIntFn &a |> equal 2
     a |> equal 1 // a is not modified & prevent inlining
 
-let byrefObjFn (x: Obj inref) =
-    x.X + 1
+
+
+
 
 [<Fact>]
 let ``pass obj by ref works`` () =
@@ -27,10 +52,6 @@ let ``pass obj by ref works`` () =
     byrefObjFn &b |> equal 3
     a |> equal a //prevent inlining
 
-[<ByRef>]
-let byrefAttrRootObjDecFn (x: Obj) =
-    x.X + 1
-
 [<Fact>]
 let ``pass obj by ref using attr on fn works`` () =
     let a = { X = 1 }
@@ -39,10 +60,7 @@ let ``pass obj by ref using attr on fn works`` () =
     byrefAttrRootObjDecFn b |> equal 3
     a |> equal a //prevent inlining
 
-// // TODO: Use ByRef attr as Param not yet working
 
-let byrefAttrIntFn ([<ByRef>] x: int) =
-    x + 1
 
 [<Fact>]
 let ``pass int by ref using ByRef attr works`` () =
@@ -50,8 +68,7 @@ let ``pass int by ref using ByRef attr works`` () =
     byrefAttrIntFn a |> equal 2
     a |> equal 1 // a is not modified & prevent inlining
 
-let byrefAttrObjFn ([<ByRef>] x: Obj) =
-    x.X + 1
+
 
 [<Fact>]
 let ``pass obj by ref using ByRef attr works`` () =

--- a/tests/Rust/tests/src/ByRefTests.fs
+++ b/tests/Rust/tests/src/ByRefTests.fs
@@ -41,25 +41,25 @@ let ``pass obj by ref using attr on fn works`` () =
 
 // // TODO: Use ByRef attr as Param not yet working
 
-// let byrefAttrIntFn ([<ByRef>] x: int) =
-//     x + 1
+let byrefAttrIntFn ([<ByRef>] x: int) =
+    x + 1
 
-// [<Fact>]
-// let ``pass int by ref using ByRef attr works`` () =
-//     let a = 1
-//     byrefAttrIntFn a |> equal 2
-//     a |> equal 1 // a is not modified & prevent inlining
+[<Fact>]
+let ``pass int by ref using ByRef attr works`` () =
+    let a = 1
+    byrefAttrIntFn a |> equal 2
+    a |> equal 1 // a is not modified & prevent inlining
 
-// let byrefAttrObjFn ([<ByRef>] x: Obj) =
-//     x.X + 1
+let byrefAttrObjFn ([<ByRef>] x: Obj) =
+    x.X + 1
 
-// [<Fact>]
-// let ``pass obj by ref using ByRef attr works`` () =
-//     let a = { X = 1 }
-//     let b = { X = 2 }
-//     byrefAttrObjFn a |> equal 2
-//     byrefAttrObjFn b |> equal 3
-//     a |> equal a //prevent inlining
+[<Fact>]
+let ``pass obj by ref using ByRef attr works`` () =
+    let a = { X = 1 }
+    let b = { X = 2 }
+    byrefAttrObjFn a |> equal 2
+    byrefAttrObjFn b |> equal 3
+    a |> equal a //prevent inlining
 
 
 // // TODO: passing byref into inref not working yet


### PR DESCRIPTION
A couple more additions here

* ByRef Attr can now work at the param level, allowing pipelining and all the other normally non ref-friendly stuff whilst avoiding cloning - good for using structs etc in tight loops & ultimately just giving an end user more granular control.
* Did a refactor/rewrite of the reference handling to use the truth table approach. I am not sure it is conceptually any simpler but I feel it conveys the intent far better. I have diffed the output against existing and pretty much is identical. I noticed some of the rules such as the deref rule cannot currently work due to some edge cases in match statements, where the ident going into the match statement is incorrectly tracked as a ByRef ident (all internal match idents are ByRef, but not outside).

Let me know, happy to revisit, tweak etc