### PR TITLE
[Python] typing fixes

### DIFF
--- a/src/Fable.Transforms/Python/PythonPrinter.fs
+++ b/src/Fable.Transforms/Python/PythonPrinter.fs
@@ -559,6 +559,12 @@ module PrinterExtensions =
                     printer.Print("\"")
                     printer.Print(Naming.escapeString (fun _ -> false) value)
                     printer.Print("\"")
+                | :? float as value ->
+                    let value = string value
+                    printer.Print(value)
+                    // Print with at least one decimal place
+                    if value.IndexOf(".") = -1 && not (value.Contains("E")) then
+                        printer.Print(".0")
                 | :? bool as value -> printer.Print(if value then "True" else "False")
                 | _ -> printer.Print(string value)
 

--- a/src/Fable.Transforms/Python/README.md
+++ b/src/Fable.Transforms/Python/README.md
@@ -10,7 +10,7 @@ Python source code.
 | List (F#)    |     List.fs      | F# immutable list                                                                 |
 | ResizeArray  |      `list`      | Python [list](https://docs.python.org/3/library/stdtypes.html#typesseq-list)      |
 | Map          |      Map.fs      | F# immutable map                                                                  |
-| Record       |     types.py     | dataclasses.dataclass                                                             |
+| Record       |     types.py     | dataclasses.dataclass decorated Record type                                       |
 | Option       |      Erased      | F# `None` will be translated to Python `None`                                     |
 | An. Record   |      `dict`      | Python [dict](https://docs.python.org/3/library/stdtypes.html#mapping-types-dict) |
 | dict         |      `dict`      |                                                                                   |

--- a/src/fable-library-py/fable_library/numeric.py
+++ b/src/fable-library-py/fable_library/numeric.py
@@ -32,7 +32,7 @@ def to_exponential(x: float, dp: Optional[int] = None) -> str:
 
 
 def to_hex(x: int) -> str:
-    def rshift(val, n):
+    def rshift(val: int, n: int) -> int:
         sign = 0x10000000000000000 if isinstance(val, int64) else 0x100000000
         return val >> n if val >= 0 else (val + sign) >> n
 

--- a/src/fable-library-py/fable_library/string.py
+++ b/src/fable-library-py/fable_library/string.py
@@ -15,6 +15,7 @@ from typing import (
     Pattern,
     TypeVar,
     Union,
+    cast,
     overload,
 )
 
@@ -90,7 +91,7 @@ def format_replacement(
     flags = flags or ""
     format = format or ""
 
-    if isinstance(rep, int):
+    if isinstance(rep, (int, float)):
         if format not in ["x", "X"]:
             if rep < 0:
                 rep = rep * -1
@@ -102,25 +103,11 @@ def format_replacement(
                     sign = "+"
 
         if format == "x":
-            rep = to_hex(rep)
+            rep = to_hex(cast(int, rep))
         elif format == "X":
-            rep = to_hex(rep).upper()
-        else:  # AOid
-            rep = to_string(rep)
-
-    elif isinstance(rep, float):
-        if rep < 0:
-            rep = rep * -1
-            sign = "-"
-        else:
-            if flags.find(" ") >= 0:
-                sign = " "
-            elif flags.find("+") >= 0:
-                sign = "+"
-
-        precision = None if precision is None else int(precision)
+            rep = to_hex(cast(int, rep)).upper()
         if format in ("f", "F"):
-            precision = precision if precision is not None else 6
+            precision = int(precision) if precision is not None else 6
             rep = to_fixed(rep, precision)
         elif format in ("g", "G"):
             rep = (

--- a/src/fable-library-py/fable_library/util.py
+++ b/src/fable-library-py/fable_library/util.py
@@ -132,8 +132,9 @@ class IComparer(Generic[_T_in], Protocol):
     https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.icomparer-1
     """
 
+    @property
     @abstractmethod
-    def Compare(self, y: _T_in) -> int:
+    def Compare(self) -> Callable[[_T_in, _T_in], int]:
         ...
 
 


### PR DESCRIPTION
- Compiles int32 to Python native int for less noise
- Fixes float constants without decimals e. `1.` to be printed as `1.0` in Python
- Fixed union indices to be ints, not floats (or they would now get a decimal)