### PR TITLE
Rust - union fix for import prefixes

### DIFF
--- a/tests/Rust/Fable.Tests.Rust.fsproj
+++ b/tests/Rust/Fable.Tests.Rust.fsproj
@@ -19,6 +19,7 @@
     <Compile Include="tests/common/Util.fs" />
     <Compile Include="tests/common/Interfaces.fs" />
     <Compile Include="tests/common/Records.fs" />
+    <Compile Include="tests/common/Unions.fs" />
     <Compile Include="tests/src/AnonRecordTests.fs" />
     <!-- <Compile Include="tests/src/ApplicativeTests.fs" /> -->
     <Compile Include="tests/src/ArithmeticTests.fs" />

--- a/tests/Rust/tests/common/Unions.fs
+++ b/tests/Rust/tests/common/Unions.fs
@@ -1,0 +1,9 @@
+module Common.Unions
+
+type MyUnion =
+    | A of int
+    | B of string
+
+module MyUnion =
+    let createA i =
+        A i

--- a/tests/Rust/tests/src/UnionTests.fs
+++ b/tests/Rust/tests/src/UnionTests.fs
@@ -126,6 +126,13 @@ let ``Multi-case Union with wrapped type works`` () =
     let res = match b with DeepWrappedB s -> s + " world" | _ -> ""
     res |> equal "hello world"
 
+[<Fact>]
+let ``Should correctly import union in other file and allow creation`` =
+    let r = Common.Unions.MyUnion.A 1
+    let expected = Common.Unions.MyUnion.createA 1
+    r |> equal expected
+
+
 let matchStringWhenStringNotHello = function
     | DeepWrappedB s when s <> "hello" -> "not hello"
     | _ -> "hello"


### PR DESCRIPTION
Following on from the alpha 20 release (many thanks @dbrattli) I unfortunately uncovered another dealbreaker for Rust, which is identical to #3032 but for Unions this time.

I have fixed this using the same pattern as for #3034, but there are some subtleties around built in unions etc, so had to move a couple of things around a little.

There is also a new test to cover the cross-file import scenario.