### PR TITLE
[Rust] Initial no_std support

### DIFF
--- a/src/Fable.Transforms/Rust/Replacements.fs
+++ b/src/Fable.Transforms/Rust/Replacements.fs
@@ -103,8 +103,7 @@ let toString com (ctx: Context) r (args: Expr list) =
         //     Helper.InstanceCall(head, "toString", String, [], ?loc=r)
         // | DeclaredType(ent, _) ->
         | _ ->
-            let s = Helper.InstanceCall(head, "to_string", String, [])
-            Helper.LibCall(com, "String", "string", String, [makeRef s])
+            Helper.LibCall(com, "String", "toString", String, [makeRef head])
 
 let getParseParams (kind: NumberKind) =
     let isFloatOrDecimal, numberModule, unsigned, bitsize =
@@ -446,7 +445,7 @@ let equals (com: ICompiler) ctx r (left: Expr) (right: Expr) =
         makeEqOp r left right BinaryEqual
 
 let objectEquals (com: ICompiler) ctx r (left: Expr) (right: Expr) =
-    // TODO: reference equality
+    // reference equality actually happens in Fable2Rust.transformOperation
     TypeCast(right, left.Type) |> equals com ctx r left
 
 let structEquals (com: ICompiler) ctx r (left: Expr) (right: Expr) =
@@ -2163,7 +2162,7 @@ let objects (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr opt
     match i.CompiledName, thisArg, args with
     | ".ctor", _, _ -> typedObjExpr t [] |> Some
     | "ToString", Some arg, _ -> toString com ctx r [arg] |> Some
-    | "ReferenceEquals", _, [left; right] -> makeEqOp r left right BinaryEqual |> Some
+    | "ReferenceEquals", None, [arg1; arg2]
     | "Equals", Some arg1, [arg2]
     | "Equals", None, [arg1; arg2] -> objectEquals com ctx r arg1 arg2 |> Some
     | "GetHashCode", Some arg, _ -> identityHash com r arg |> Some

--- a/src/fable-library-rust/Cargo.toml
+++ b/src/fable-library-rust/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [features]
 atomic = []
+no_std = ["dep:hashbrown"]
 threaded = ["atomic", "dep:futures"]
 guid = ["dep:uuid"]
 date = ["dep:chrono"]
@@ -12,6 +13,7 @@ default = ["guid", "date"]
 
 [dependencies]
 startup = { version = "0.1.1" }
+hashbrown = { version = "0.12", optional = true }
 rust_decimal = { version = "1.25.0", features = ["maths"], default-features = false }
 futures = { version = "0.3.21", features = ["executor", "thread-pool"], optional = true }
 uuid = { version = "1.1.2", features = ["v4"], default-features = false, optional = true }

--- a/src/fable-library-rust/src/Async.rs
+++ b/src/fable-library-rust/src/Async.rs
@@ -71,11 +71,9 @@ pub mod Async_ {
 
 #[cfg(feature = "threaded")]
 pub mod AsyncBuilder_ {
-    use std::{
-        future::{ready, Future},
-        pin::Pin,
-        sync::Arc,
-    };
+    use std::future::{ready, Future};
+    use std::pin::Pin;
+    use std::sync::Arc;
 
     use futures::lock::Mutex;
 
@@ -142,13 +140,11 @@ pub mod ThreadPool {
 
 #[cfg(feature = "threaded")]
 pub mod Monitor_ {
-    use std::{
-        any::Any,
-        collections::HashSet,
-        sync::{Arc, Mutex, RwLock, Weak},
-        thread,
-        time::Duration,
-    };
+    use std::any::Any;
+    use std::collections::HashSet;
+    use std::sync::{Arc, Mutex, RwLock, Weak};
+    use std::thread;
+    use std::time::Duration;
 
     use crate::Native_::Lrc;
 
@@ -197,13 +193,11 @@ pub mod Monitor_ {
 
 #[cfg(feature = "threaded")]
 pub mod Task_ {
-    use std::{
-        pin::Pin,
-        sync::{Arc, RwLock},
-        task::Poll,
-        thread::{self, JoinHandle},
-        time::Duration,
-    };
+    use std::pin::Pin;
+    use std::sync::{Arc, RwLock};
+    use std::task::Poll;
+    use std::thread::{self, JoinHandle};
+    use std::time::Duration;
 
     use futures::{Future, FutureExt};
 
@@ -245,7 +239,7 @@ pub mod Task_ {
         }
 
         pub fn replace(&mut self, next: TaskState<T>) -> TaskState<T> {
-            std::mem::replace(self, next)
+            core::mem::replace(self, next)
         }
     }
 
@@ -393,8 +387,7 @@ pub mod Task_ {
 
 #[cfg(feature = "threaded")]
 pub mod TaskBuilder_ {
-    use std::{rc::Rc, sync::Arc};
-
+    use std::sync::Arc;
     use super::super::Native_::Lrc;
     use super::Task_::Task;
 
@@ -414,7 +407,8 @@ pub mod TaskBuilder_ {
 
 #[cfg(feature = "threaded")]
 pub mod Thread_ {
-    use std::{thread, time::Duration};
+    use std::thread;
+    use std::time::Duration;
 
     use crate::Native_::{Lrc, MutCell};
 

--- a/src/fable-library-rust/src/Decimal.rs
+++ b/src/fable-library-rust/src/Decimal.rs
@@ -1,8 +1,8 @@
 #![allow(non_snake_case)]
 
 pub mod Decimal_ {
-    use crate::Native_::{array, Array, Lrc, RefCell};
-    use crate::String_::{string};
+    use crate::Native_::{array, Array, Lrc, RefCell, Vec};
+    use crate::String_::{string, toString as toString_1};
 
     use rust_decimal::prelude::*;
     pub use rust_decimal::Decimal as decimal;
@@ -55,11 +55,11 @@ pub mod Decimal_ {
     pub fn toBoolean (x: Decimal) -> bool { !x.is_zero() }
 
     pub fn toChar (x: Decimal) -> char {
-        std::char::from_u32(x.to_u32().unwrap()).unwrap()
+        core::char::from_u32(x.to_u32().unwrap()).unwrap()
     }
 
     pub fn toString (x: Decimal) -> string {
-        string(&x.to_string())
+        toString_1(&x)
     }
 
     pub fn tryParse(s: string, res: &RefCell<Decimal>) -> bool {
@@ -115,7 +115,7 @@ pub mod Decimal_ {
         let scale = du.scale as i32;
         let signExp =
             if du.negative { -(scale << 16) } else { scale << 16 };
-        array(vec![low, mid, high, signExp])
+        array(Vec::from([low, mid, high, signExp]))
     }
 
     pub fn round(x: Decimal) -> Decimal { x.round() }

--- a/src/fable-library-rust/src/Guid.rs
+++ b/src/fable-library-rust/src/Guid.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "guid")]
 pub mod Guid_ {
-    use crate::{Native_::Lrc, String_::string};
+    use crate::Native_::{Lrc};
+    use crate::String_::{string, toString};
     use uuid::{Uuid};
 
     #[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
@@ -8,7 +9,7 @@ pub mod Guid_ {
 
     impl core::fmt::Display for Guid {
         fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-            write!(f, "{}", self.0.to_string())
+            write!(f, "{}", toString(&self.0))
         }
     }
 

--- a/src/fable-library-rust/src/Interop.rs
+++ b/src/fable-library-rust/src/Interop.rs
@@ -1,7 +1,7 @@
 pub mod ListExt {
-    // use std::ops::Deref;
+    // use core::ops::Deref;
     use crate::List_::{cons, mkList, reverse, List};
-    use crate::Native_::seq_to_iter;
+    use crate::Native_::{seq_to_iter, Vec};
     use crate::Seq_::ofList;
 
     impl<T: Clone> List<T> {
@@ -63,8 +63,8 @@ pub mod ListExt {
 }
 
 pub mod ArrayExt {
-    // use std::ops::Deref;
-    use crate::Native_::{self, array};
+    // use core::ops::Deref;
+    use crate::Native_::{self, array, Vec};
 
     #[derive(Clone, Debug, PartialEq, PartialOrd)]
     pub struct Array<T: Clone + 'static>(Native_::Array<T>);
@@ -104,8 +104,8 @@ pub mod ArrayExt {
 }
 
 pub mod SetExt {
-    // use std::ops::Deref;
-    use crate::Native_::seq_to_iter;
+    // use core::ops::Deref;
+    use crate::Native_::{seq_to_iter, Vec};
     use crate::Set_::{add, empty, equals, toSeq, Set};
 
     impl<T: Clone + PartialOrd> Set<T> {
@@ -165,9 +165,9 @@ pub mod SetExt {
 }
 
 pub mod MapExt {
-    // use std::ops::Deref;
+    // use core::ops::Deref;
     use crate::Map_::{add, empty, equals, iterate, toSeq, Map};
-    use crate::Native_::seq_to_iter;
+    use crate::Native_::{seq_to_iter, Vec};
 
     impl<K: Clone + PartialOrd, V: Clone> Map<K, V> {
         //todo - non-consuming iter by ref

--- a/src/fable-library-rust/src/String.rs
+++ b/src/fable-library-rust/src/String.rs
@@ -1,7 +1,7 @@
 #![allow(non_snake_case)]
 
 pub mod String_ {
-    use crate::Native_::{Array, Lrc, array};
+    use crate::Native_::{Array, Lrc, String, ToString, Vec, array};
 
     // -----------------------------------------------------------
     // Strings
@@ -11,6 +11,10 @@ pub mod String_ {
 
     pub fn string(s: &str) -> string {
         Lrc::from(s)
+    }
+
+    pub fn toString<T: ToString>(o: &T) -> string {
+        string(&o.to_string())
     }
 
     pub fn toInt8 (s: string) -> i8 { s.parse::<i8>().unwrap() }
@@ -187,6 +191,10 @@ pub mod String_ {
                 substring2(s, start, count)
             },
         }
+    }
+
+    pub fn append(s1: string, s2: string) -> string {
+        string(&[s1.as_ref(), s2.as_ref()].concat())
     }
 
     pub fn insert(s: string, i: i32, v: string) -> string {

--- a/tests/Rust/tests/src/ClassTests.fs
+++ b/tests/Rust/tests/src/ClassTests.fs
@@ -121,12 +121,12 @@ let ``Class methods and props work`` () =
     b.A |> equal 7
     a.B |> equal 1
 
-// [<Fact>]
-// let ``Class reference equality works`` () =
-//     let a = NTest(1, 2)
-//     let b = NTest(3, 4)
-//     (a = a) |> equal true
-//     (a = b) |> equal false
+[<Fact>]
+let ``Class reference equality works`` () =
+    let a = NTest(1, 2)
+    let b = NTest(1, 2)
+    (a = a) |> equal true
+    (a = b) |> equal false
 
 [<Fact>]
 let ``Class methods and props work II`` () =


### PR DESCRIPTION
- Added object reference equality.
- Changed string concatenation.
- Changed module let bindings to not use `thread_local`.
- Added initial `no_std` support.