### PR TITLE
Rust - Units of measure progress

### DIFF
--- a/src/Fable.Transforms/Rust/Fable2Rust.fs
+++ b/src/Fable.Transforms/Rust/Fable2Rust.fs
@@ -504,13 +504,20 @@ module TypeInfo =
         let callee = transformImport com ctx r Fable.Any info genArgs
         Util.callFunction com ctx r callee args
 
+    let genArgsUnitsFilter = function
+        | Fable.Measure _ | Fable.GenericParam(_, true, _)
+        | Replacements.Util.IsEntity (Types.measureProduct2) _ -> false
+        | _ -> true
+
     let transformGenArgs com ctx genArgs: Rust.GenericArgs option =
         genArgs
+        |> List.filter genArgsUnitsFilter
         |> List.map (transformType com ctx)
         |> mkGenericTypeArgs
 
     let transformGenericType com ctx genArgs typeName: Rust.Ty =
         genArgs
+        |> List.filter genArgsUnitsFilter
         |> List.map (transformType com ctx)
         |> mkGenericTy (splitFullName typeName)
 
@@ -592,7 +599,7 @@ module TypeInfo =
         let inputs =
             match argTypes with
             | [Fable.Unit] -> []
-            | _ -> argTypes |> List.map (transformParamType com ctx)
+            | _ -> argTypes |> List.filter genArgsUnitsFilter |> List.map (transformParamType com ctx)
         let output =
             if returnType = Fable.Unit then VOID_RETURN_TY
             else
@@ -705,6 +712,10 @@ module TypeInfo =
         | ent when ent.IsInterface ->
             transformInterfaceType com ctx entRef genArgs
         | ent ->
+            let genArgs =
+                genArgs
+                |> List.zip ent.GenericParameters
+                |> List.choose (fun (p, a) -> if not p.IsMeasure then Some a else None)
             let genArgs = transformGenArgs com ctx genArgs
             let entName = getEntityFullName com ctx entRef
             makeFullNamePathTy entName genArgs
@@ -1019,7 +1030,7 @@ module Util =
 
     let getGenericParams (ctx: Context) (types: Fable.Type list) =
         let rec getGenParams = function
-            | Fable.GenericParam _ as p -> [p]
+            | Fable.GenericParam (_, false, _) as p -> [p]
             | t -> t.Generics |> List.collect getGenParams
         let mutable dedupSet = ctx.ScopedTypeParams
         types
@@ -3276,7 +3287,7 @@ module Util =
 
     let getMemberGenArgs (ent: Fable.MemberFunctionOrValue) =
         ent.GenericParameters
-        |> List.map (fun p -> Fable.Type.GenericParam(p.Name, p.IsMeasure, Seq.toList p.Constraints))
+        |> List.choose (fun p -> if not p.IsMeasure then Fable.Type.GenericParam(p.Name, p.IsMeasure, Seq.toList p.Constraints) |> Some else None)
 
     let getInterfaceMemberNamesSet (com: IRustCompiler) (entRef: Fable.EntityRef) =
         let ent = com.GetEntity(entRef)
@@ -3327,7 +3338,9 @@ module Util =
 
     let transformUnion (com: IRustCompiler) ctx (ent: Fable.Entity) =
         let entNameSpace, entName = splitNameSpace ent.FullName
-        let generics = getEntityGenArgs ent |> makeGenerics com ctx
+        let generics = getEntityGenArgs ent
+                        |> List.filter genArgsUnitsFilter
+                        |> makeGenerics com ctx
         let variants =
             ent.UnionCases |> Seq.map (fun uci ->
                 let name = uci.Name
@@ -3349,7 +3362,9 @@ module Util =
 
     let transformClass (com: IRustCompiler) ctx (ent: Fable.Entity) =
         let entNameSpace, entName = splitNameSpace ent.FullName
-        let generics = getEntityGenArgs ent |> makeGenerics com ctx
+        let generics = getEntityGenArgs ent
+                        |> List.filter genArgsUnitsFilter
+                        |> makeGenerics com ctx
         let isPublic = ent.IsFSharpRecord
         let fields =
             ent.FSharpFields |> Seq.map (fun field ->
@@ -3447,7 +3462,9 @@ module Util =
                     mkFnAssocItem [] fnName fnKind
                 )
             )
-        let generics = getEntityGenArgs ent |> makeGenerics com ctx
+        let generics = getEntityGenArgs ent
+                        |> List.filter genArgsUnitsFilter
+                        |> makeGenerics com ctx
         let entNameSpace, entName = splitNameSpace ent.FullName
         let traitItem = mkTraitItem [] entName assocItems [] generics
         [traitItem |> mkPublicItem]
@@ -3540,7 +3557,7 @@ module Util =
             if List.isEmpty ctorOrStaticOrObjectItems then
                 []
             else
-                let generics = genArgs |> makeGenerics com ctx
+                let generics = genArgs |> List.filter genArgsUnitsFilter |> makeGenerics com ctx
                 let implItem =
                     mkImplItem [] "" self_ty generics ctorOrStaticOrObjectItems None
                 [implItem]

--- a/src/Fable.Transforms/Rust/Fable2Rust.fs
+++ b/src/Fable.Transforms/Rust/Fable2Rust.fs
@@ -1503,6 +1503,10 @@ module Util =
                 let fieldName = field.Name |> sanitizeMember
                 mkExprField attrs fieldName expr false false
             )
+        let genArgs =
+            genArgs
+            |> List.zip ent.GenericParameters
+            |> List.choose (fun (p, a) -> if not p.IsMeasure then Some a else None)
         let genArgs = transformGenArgs com ctx genArgs
         let entName = getEntityFullName com ctx entRef
         let path = makeFullNamePath entName genArgs

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -129,6 +129,7 @@ module Types =
     let [<Literal>] printfModule = "Microsoft.FSharp.Core.PrintfModule"
     let [<Literal>] printfFormat = "Microsoft.FSharp.Core.PrintfFormat"
     let [<Literal>] createEvent = "Microsoft.FSharp.Core.CompilerServices.RuntimeHelpers.CreateEvent"
+    let [<Literal>] measureProduct2 = "Microsoft.FSharp.Core.CompilerServices.MeasureProduct`2"
 
     // Types compatible with Inject attribute (fable library)
     let [<Literal>] comparer = "System.Collections.Generic.IComparer`1"

--- a/tests/Rust/tests/src/ArithmeticTests.fs
+++ b/tests/Rust/tests/src/ArithmeticTests.fs
@@ -864,6 +864,13 @@ module UnitTests =
         static member inline ( + ) (Vector2(ax, ay), Vector2(bx, by)) = Vector2(ax + bx, ay + by)
         static member inline ( * ) (scalar, Vector2(x, y)) = Vector2(scalar * x, scalar * y)
 
+    [<Struct>]
+    type Vector2R<[<Measure>] 'u> = {
+        x: float32<'u>
+        y: float32<'u>
+    } with
+        static member inline ( + ) (a, b) = { x = a.x + b.x; y = a.y + b.y }
+
     let square (x: float<'a>) = x * x
     [<Fact>]
     let ``can square a unit`` () =
@@ -872,8 +879,15 @@ module UnitTests =
         dSquared |> equal 9.<m^2>
 
     [<Fact>]
-    let ``Can add two vectors with same units but remove generics in output`` () =
+    let ``Can add two union vectors with same units but remove generics in output`` () =
         let a = Vector2(2.<m>, 1.<m>)
         let b = Vector2(3.<m>, 2.<m>)
         let res = a + b
-        equal (Vector2(5.<m> ,3.<m>) )res
+        equal (Vector2(5.<m> ,3.<m>)) res
+
+    [<Fact>]
+    let ``Can add two record vectors with same units but remove generics in output`` () =
+        let a = { x = 2f<m>; y = 1f<m> }
+        let b = { x = 3f<m>; y = 1f<m> }
+        let res = a + b
+        equal { x = 5f<m>; y = 2f<m> } res

--- a/tests/Rust/tests/src/ArithmeticTests.fs
+++ b/tests/Rust/tests/src/ArithmeticTests.fs
@@ -855,3 +855,25 @@ let ``Long integers comparison works`` () =
 //     formatEuro 0.020M |> equal "0,02 €"
 //     formatEuro 0.20M |> equal "0,20 €"
 //     formatEuro 2.0M |> equal "2,00 €"
+
+module UnitTests =
+    type [<Measure>] m
+    type [<Measure>] s
+    type Vector2<[<Measure>] 'u> = Vector2 of x: float<'u> * y: float<'u> with
+
+        static member inline ( + ) (Vector2(ax, ay), Vector2(bx, by)) = Vector2(ax + bx, ay + by)
+        static member inline ( * ) (scalar, Vector2(x, y)) = Vector2(scalar * x, scalar * y)
+
+    let square (x: float<'a>) = x * x
+    [<Fact>]
+    let ``can square a unit`` () =
+        let d = 3.<m>
+        let dSquared = square d
+        dSquared |> equal 9.<m^2>
+
+    [<Fact>]
+    let ``Can add two vectors with same units but remove generics in output`` () =
+        let a = Vector2(2.<m>, 1.<m>)
+        let b = Vector2(3.<m>, 2.<m>)
+        let res = a + b
+        equal (Vector2(5.<m> ,3.<m>) )res


### PR DESCRIPTION
@ncave  hope you don't mind me getting ahead of this, but I figured I would get something working... 

This fixes some unexpected output when trying to use generics to express units of measure in unions and records. After [this](https://github.com/fable-compiler/Fable/issues/2703#issuecomment-1217388828) pointer from @alfonsogarciacaro I opted for erasing by default. We can perhaps revisit this in the future if we wanted to support something like [this pattern](https://yoric.github.io/post/uom.rs/) down the road.

* Measure's do not exist in Rust
* Remove ```[<Measure>]``` generic parameters from type declarations
* Remove ```[<Measure>]``` generic params from impl blocks
* Remove ```[<Measure>]``` from function signatures
* Add some basic tests for Vector2 (as Enum) 
* Add some basic tests for Vector2R as Struct

In order to do this I had to do some comparing with entity types, as a bunch of parameters were just coming through as Any. The only way I could discern if they could be thrown out or not was to go back to the entity, which was not that straight forward. Perhaps there may be more abstract ways we can deal with this down the road.

#### Newly discovered issue
Looks like something that has just not yet been implemented, but operator overloading generates the correct methods, however these are not correctly redirected. If I were to add two vectors for example with an overloaded operator, it will try to destructure the constituents and infer what an add looks like, without using the generated overload. This is perhaps best seen in the output of the new Vector tests.

#### Sidenote - Random Enum discovery 
So I did some digging and it turns out that for Enum's that have only 1 item are the size of the constituent item('s), as they do not need to store the enum index at all. This is really handy because in F# this pattern is very common thanks to some great writeups like [Scott Wlaschin's Designing with Types](https://fsharpforfunandprofit.com/posts/designing-with-types-more-semantic-types/). This pattern is pretty inefficient in .NET F# normally, but when transpiling to Rust there will be zero overhead.

Example [here](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=924724764419f846c788a8763da45992)
[source](https://github.com/rust-lang/unsafe-code-guidelines/issues/79)