### PR TITLE
[Rust] Retain inlined funcs with CompiledName attr

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,7 +22,7 @@
             "skipFiles": [
                 "<node_internals>/**"
             ],
-            "type": "pwa-node"
+            "type": "node"
         },
         {
             "args": [
@@ -39,7 +39,7 @@
             "skipFiles": [
                 "<node_internals>/**"
             ],
-            "type": "pwa-node"
+            "type": "node"
         },
         {
             "name": "Run Fable.Cli",

--- a/src/Fable.Transforms/Rust/Fable2Rust.fs
+++ b/src/Fable.Transforms/Rust/Fable2Rust.fs
@@ -3412,10 +3412,12 @@ module Util =
                 // replace 'this.field' with just 'field' in body
                 let body =
                     body |> visitFromInsideOut (function
-                        | Fable.Set(Fable.Value(Fable.ThisValue _, _), Fable.SetKind.FieldSet(fieldName), t, value, r) ->
+                        | Fable.Set(Fable.Value(Fable.ThisValue _, _), Fable.SetKind.FieldSet(fieldName), t, value, r)
+                                when not (fieldName.Contains("@")) ->
                             let identExpr = identMap |> Map.find fieldName |> Fable.IdentExpr
                             Fable.Set(identExpr, Fable.ValueSet, t, value, r)
-                        | Fable.Get(Fable.Value(Fable.ThisValue _, _), Fable.GetKind.FieldGet info, t, r) ->
+                        | Fable.Get(Fable.Value(Fable.ThisValue _, _), Fable.GetKind.FieldGet info, t, r)
+                                when not (info.Name.Contains("@")) ->
                             let identExpr = identMap |> Map.find info.Name |> Fable.IdentExpr
                             identExpr
                         | e -> e)

--- a/src/Fable.Transforms/Rust/Replacements.fs
+++ b/src/Fable.Transforms/Rust/Replacements.fs
@@ -3029,7 +3029,8 @@ let tryCall (com: ICompiler) (ctx: Context) r t (info: CallInfo) (thisArg: Expr 
         | _ -> None
     | _ -> None
 
-let tryType = function
+let tryType typ =
+    match typ with
     | Boolean -> Some(Types.bool, parseBool, [])
     | Number(kind, info) ->
         let f =
@@ -3061,6 +3062,6 @@ let tryType = function
         | FSharpResult(genArg1, genArg2) -> Some(Types.result, results, [genArg1; genArg2])
         | FSharpChoice genArgs -> Some($"{Types.choiceNonGeneric}`{List.length genArgs}", results, genArgs)
         | FSharpReference genArg -> Some(Types.refCell, refCells, [genArg])
-        | BclDateOnly
+        | BclDateOnly -> None
         | BclTimeOnly -> None
     | _ -> None

--- a/src/fable-library-rust/src/Array.fs
+++ b/src/fable-library-rust/src/Array.fs
@@ -658,12 +658,14 @@ let splitAt (index: int) (source: 'T[]): 'T[] * 'T[] =
         invalidArg "index" SR.indexOutOfBounds
     getSubArray source 0 index, getSubArray source index (source.Length - index)
 
+[<CompiledName("sum")>]
 let inline sum (source: 'T[]): 'T =
     let mutable acc = LanguagePrimitives.GenericZero
     for i = 0 to source.Length - 1 do
         acc <- acc + source.[i]
     acc
 
+[<CompiledName("sumBy")>]
 let inline sumBy (projection: 'T -> 'U) (source: 'T[]): 'U =
     let mutable acc = LanguagePrimitives.GenericZero
     for i = 0 to source.Length - 1 do
@@ -682,6 +684,7 @@ let minBy (projection: 'T -> 'U) (xs: 'T[]): 'T =
 let min (xs: 'T[]): 'T =
     reduce (fun x y -> if x < y then x else y) xs
 
+[<CompiledName("average")>]
 let inline average (source: 'T[]): 'T =
     if isEmpty source then
         invalidArg "array" SR.arrayWasEmpty
@@ -690,6 +693,7 @@ let inline average (source: 'T[]): 'T =
         total <- total + source.[i]
     LanguagePrimitives.DivideByInt total source.Length
 
+[<CompiledName("averageBy")>]
 let inline averageBy (projection: 'T -> 'U) (source: 'T[]): 'U =
     if isEmpty source then
         invalidArg "array" SR.arrayWasEmpty

--- a/src/fable-library-rust/src/List.fs
+++ b/src/fable-library-rust/src/List.fs
@@ -470,10 +470,12 @@ let sortDescending (xs: 'T list) =
 let sortByDescending (projection: 'T -> 'U) (xs: 'T list) =
     sortWith (fun x y -> (compare (projection x) (projection y)) * -1) xs
 
+[<CompiledName("sum")>]
 let inline sum (xs: 'T list): 'T =
     let zero = LanguagePrimitives.GenericZero
     fold (fun acc x -> acc + x) zero xs
 
+[<CompiledName("sumBy")>]
 let inline sumBy (projection: 'T -> 'U) (xs: 'T list): 'U =
     let zero = LanguagePrimitives.GenericZero
     fold (fun acc x -> acc + (projection x)) zero xs
@@ -490,6 +492,7 @@ let minBy (projection: 'T -> 'U) (xs: 'T list): 'T =
 let min (xs: 'T list): 'T =
     reduce (fun x y -> if x < y then x else y) xs
 
+[<CompiledName("average")>]
 let inline average (xs: 'T list): 'T =
     if isEmpty xs then invalidOp SR.inputListWasEmpty
     let mutable count = 0
@@ -498,7 +501,8 @@ let inline average (xs: 'T list): 'T =
     let total = fold folder zero xs
     LanguagePrimitives.DivideByInt total count
 
-let inline averageBy (projection: 'T -> 'U) (xs: 'T list) : 'U =
+[<CompiledName("averageBy")>]
+let inline averageBy (projection: 'T -> 'U) (xs: 'T list): 'U =
     if isEmpty xs then invalidOp SR.inputListWasEmpty
     let mutable count = 0
     let zero = LanguagePrimitives.GenericZero

--- a/src/fable-library-rust/src/Range.fs
+++ b/src/fable-library-rust/src/Range.fs
@@ -1,5 +1,6 @@
 module Range_
 
+[<CompiledName("rangeNumeric")>]
 let inline rangeNumeric (start: 'T) (step: 'T) (stop: 'T) =
     let zero = LanguagePrimitives.GenericZero
     let stepComparedWithZero = compare step zero

--- a/src/fable-library-rust/src/Seq.fs
+++ b/src/fable-library-rust/src/Seq.fs
@@ -1010,10 +1010,12 @@ let sortDescending (xs: 'T seq) =
 let sortByDescending (projection: 'T -> 'U) (xs: 'T seq) =
     sortWith (fun x y -> (compare (projection x) (projection y)) * -1) xs
 
+[<CompiledName("sum")>]
 let inline sum (xs: 'T seq): 'T =
     let zero = LanguagePrimitives.GenericZero
     fold (fun acc x -> acc + x) zero xs
 
+[<CompiledName("sumBy")>]
 let inline sumBy (projection: 'T -> 'U) (xs: 'T seq): 'U =
     let zero = LanguagePrimitives.GenericZero
     fold (fun acc x -> acc + (projection x)) zero xs
@@ -1030,6 +1032,7 @@ let minBy (projection: 'T -> 'U) (xs: 'T seq): 'T =
 let min (xs: 'T seq): 'T =
     reduce (fun x y -> if x < y then x else y) xs
 
+[<CompiledName("average")>]
 let inline average (xs: 'T seq): 'T =
     let mutable count = 0
     let zero = LanguagePrimitives.GenericZero
@@ -1038,6 +1041,7 @@ let inline average (xs: 'T seq): 'T =
     if count = 0 then invalidOp SR.inputSequenceEmpty
     LanguagePrimitives.DivideByInt total count
 
+[<CompiledName("averageBy")>]
 let inline averageBy (projection: 'T -> 'U) (xs: 'T seq): 'U =
     let mutable count = 0
     let zero = LanguagePrimitives.GenericZero

--- a/tests/Rust/Fable.Tests.Rust.fsproj
+++ b/tests/Rust/Fable.Tests.Rust.fsproj
@@ -16,6 +16,7 @@
     <ProjectReference Include="../../src/Fable.Core/Fable.Core.fsproj" />
   </ItemGroup>
   <ItemGroup>
+    <!-- <Compile Include="tests/common/Aether.fs" /> -->
     <Compile Include="tests/common/Util.fs" />
     <Compile Include="tests/common/Interfaces.fs" />
     <Compile Include="tests/common/Records.fs" />

--- a/tests/Rust/tests/common/Aether.fs
+++ b/tests/Rust/tests/common/Aether.fs
@@ -1,0 +1,321 @@
+module Aether
+
+open System
+
+//  Optics
+
+/// Lens from 'a -> 'b.
+type Lens<'a,'b> =
+    ('a -> 'b) * ('b -> 'a -> 'a)
+
+/// Prism from 'a -> 'b.
+type Prism<'a,'b> =
+    ('a -> 'b option) * ('b -> 'a -> 'a)
+
+//  Morphisms
+
+/// Isomorphism between 'a <> 'b.
+type Isomorphism<'a,'b> =
+    ('a -> 'b) * ('b -> 'a)
+
+/// Epimorphism between 'a <> 'b.
+type Epimorphism<'a,'b> =
+    ('a -> 'b option) * ('b -> 'a)
+
+/// Functions for composing lenses and prisms with other optics, which
+/// returns a new lens or prism based on the optic composed. Open `Aether.Operators`
+/// to use the infix operator forms of these compositions, which is significantly
+/// less verbose.
+[<RequireQualifiedAccess>]
+module Compose =
+
+    /// Static overloads of the composition function for lenses (>->).
+    /// These functions do not generally need to be called directly, but will
+    /// be used when calling Compose.optic.
+    type Lens =
+        | Lens with
+
+        static member (>->) (Lens, (g2, s2): Lens<'b,'c>) =
+            fun ((g1, s1): Lens<'a,'b>) ->
+                (fun a -> g2 (g1 a)),
+                (fun c a -> s1 (s2 c (g1 a)) a) : Lens<'a,'c>
+
+        static member (>->) (Lens, (g2, s2): Prism<'b,'c>) =
+            fun ((g1, s1): Lens<'a,'b>) ->
+                (fun a -> g2 (g1 a)),
+                (fun c a -> s1 (s2 c (g1 a)) a) : Prism<'a,'c>
+
+        static member (>->) (Lens, (f, t): Isomorphism<'b,'c>) =
+            fun ((g, s): Lens<'a,'b>) ->
+                (fun a -> f (g a)),
+                (fun c a -> s (t c) a) : Lens<'a,'c>
+
+        static member (>->) (Lens, (f, t): Epimorphism<'b,'c>) =
+            fun ((g, s): Lens<'a,'b>) ->
+                (fun a -> f (g a)),
+                (fun c a -> s (t c) a) : Prism<'a,'c>
+
+    /// Compose a lens with an optic or morphism.
+    let inline lens l o =
+        (Lens >-> o) l
+
+    /// Static overloads of the composition function for prisms (>?>).
+    /// These functions do not generally need to be called directly, but will
+    /// be used when calling Compose.optic.
+    type Prism =
+        | Prism with
+
+        static member (>?>) (Prism, (g2, s2): Lens<'b,'c>) =
+            fun ((g1, s1): Prism<'a,'b>) ->
+                (fun a -> Option.map g2 (g1 a)),
+                (fun c a -> Option.map (s2 c) (g1 a) |> function | Some b -> s1 b a
+                                                                 | _ -> a) : Prism<'a,'c>
+
+        static member (>?>) (Prism, (g2, s2): Prism<'b,'c>) =
+            fun ((g1, s1): Prism<'a,'b>) ->
+                (fun a -> Option.bind g2 (g1 a)),
+                (fun c a -> Option.map (s2 c) (g1 a) |> function | Some b -> s1 b a
+                                                                 | _ -> a) : Prism<'a,'c>
+
+        static member (>?>) (Prism, (f, t): Isomorphism<'b,'c>) =
+            fun ((g, s): Prism<'a,'b>) ->
+                (fun a -> Option.map f (g a)),
+                (fun c a -> s (t c) a) : Prism<'a,'c>
+
+        static member (>?>) (Prism, (f, t): Epimorphism<'b,'c>) =
+            fun ((g, s): Prism<'a,'b>) ->
+                (fun a -> Option.bind f (g a)),
+                (fun c a -> s (t c) a) : Prism<'a,'c>
+
+    /// Compose a prism with an optic or morphism.
+    let inline prism p o =
+        (Prism >?> o) p
+
+/// Functions for using optics to operate on data structures, using the basic optic
+/// operations of get, set and map. The functions are overloaded to take either lenses or
+/// prisms, with the return type being inferred.
+[<RequireQualifiedAccess>]
+module Optic =
+
+    /// Static overloads of the optic get function (^.). These functions do not generally
+    /// need to be called directly, but will be used when calling Optic.get.
+    type Get =
+        | Get with
+
+        static member (^.) (Get, (g, _): Lens<'a,'b>) =
+            fun (a: 'a) ->
+                g a : 'b
+
+        static member (^.) (Get, (g, _): Prism<'a,'b>) =
+            fun (a: 'a) ->
+                g a : 'b option
+
+    /// Get a value using an optic.
+    let inline get optic target =
+        (Get ^. optic) target
+
+    /// Static overloads of the optic set function (^=). These functions do
+    /// not generally need to be called directly, but will be used when calling
+    /// Optic.set.
+    type Set =
+        | Set with
+
+        static member (^=) (Set, (_, s): Lens<'a,'b>) =
+            fun (b: 'b) ->
+                s b : 'a -> 'a
+
+        static member (^=) (Set, (_, s): Prism<'a,'b>) =
+            fun (b: 'b) ->
+                s b : 'a -> 'a
+
+    /// Set a value using an optic.
+    let inline set optic value =
+        (Set ^= optic) value
+
+    /// Static overloads of the optic map function (%=). These functions do not generally
+    /// need to be called directly, but will be used when calling Optic.map.
+    type Map =
+        | Map with
+
+        static member (^%) (Map, (g, s): Lens<'a,'b>) =
+            fun (f: 'b -> 'b) ->
+                (fun a -> s (f (g a)) a) : 'a -> 'a
+
+        static member (^%) (Map, (g, s): Prism<'a,'b>) =
+            fun (f: 'b -> 'b) ->
+                (fun a -> Option.map f (g a) |> function | Some b -> s b a
+                                                         | _ -> a) : 'a -> 'a
+
+    /// Modify a value using an optic.
+    let inline map optic f =
+        (Map ^% optic) f
+
+/// Functions for creating or using lenses.
+[<RequireQualifiedAccess>]
+module Lens =
+
+    /// Converts an isomorphism into a lens.
+    let ofIsomorphism ((f, t): Isomorphism<'a,'b>) : Lens<'a,'b> =
+        f, (fun b _ -> t b)
+
+/// Functions for creating or using prisms.
+[<RequireQualifiedAccess>]
+module Prism =
+
+    /// Converts an epimorphism into a prism.
+    let ofEpimorphism ((f, t): Epimorphism<'a,'b>) : Prism<'a,'b> =
+        f, (fun b _ -> t b)
+
+/// Various optics implemented for common types such as tuples,
+/// lists and maps, along with an identity lens.
+[<AutoOpen>]
+module Optics =
+
+    // Lens for the identity function (does not change the focus of operation).
+    let id_ : Lens<'a,'a> =
+        (fun x -> x),
+        (fun x _ -> x)
+
+    /// Isomorphism between a boxed and unboxed type.
+    let box_<'a> : Isomorphism<obj,'a> =
+        unbox<'a>, box
+
+    /// Lens to the first item of a tuple.
+    let fst_ : Lens<('a * 'b),'a> =
+        fst,
+        (fun a t -> a, snd t)
+
+    /// Lens to the second item of a tuple.
+    let snd_ : Lens<('a * 'b),'b> =
+        snd,
+        (fun b t -> fst t, b)
+
+    [<RequireQualifiedAccess>]
+    module Array =
+
+        /// Isomorphism to an list.
+        let list_ : Isomorphism<'v[], 'v list> =
+            Array.toList,
+            Array.ofList
+
+    [<RequireQualifiedAccess>]
+    module Choice =
+
+        /// Prism to Choice1Of2.
+        let choice1Of2_ : Prism<Choice<_,_>, _> =
+            (fun x ->
+                match x with
+                | Choice1Of2 v -> Some v
+                | _ -> None),
+            (fun v x ->
+                match x with
+                | Choice1Of2 _ -> Choice1Of2 v
+                | _ -> x)
+
+        /// Prism to Choice2Of2.
+        let choice2Of2_ : Prism<Choice<_,_>, _> =
+            (fun x ->
+                match x with
+                | Choice2Of2 v -> Some v
+                | _ -> None),
+            (fun v x ->
+                match x with
+                | Choice2Of2 _ -> Choice2Of2 v
+                | _ -> x)
+
+    [<RequireQualifiedAccess>]
+    module List =
+
+        /// Prism to the head of a list.
+        let head_ : Prism<'v list, 'v> =
+            (function | h :: _ -> Some h
+                      | _ -> None),
+            (fun v ->
+                function | _ :: t -> v :: t
+                         | l -> l)
+
+        /// Prism to an indexed position in a list.
+        let pos_ (i: int) : Prism<'v list, 'v> =
+#if NET35
+            (function | l when List.length l > i -> Some (List.nth l i)
+#else
+            (function | l when List.length l > i -> Some (List.item i l)
+#endif
+                      | _ -> None),
+            (fun v l ->
+                List.mapi (fun i' x -> if i = i' then v else x) l)
+
+        /// Prism to the tail of a list.
+        let tail_ : Prism<'v list, 'v list> =
+            (function | _ :: t -> Some t
+                      | _ -> None),
+            (fun t ->
+                function | h :: _ -> h :: t
+                         | [] -> [])
+
+        /// Isomorphism to an array.
+        let array_ : Isomorphism<'v list, 'v[]> =
+            List.toArray,
+            List.ofArray
+
+    [<RequireQualifiedAccess>]
+    module Map =
+
+        /// Prism to a value associated with a key in a map.
+        let key_ (k: 'k) : Prism<Map<'k,'v>,'v> =
+            Map.tryFind k,
+            (fun v x ->
+                if Map.containsKey k x then Map.add k v x else x)
+
+        /// Lens to a value option associated with a key in a map.
+        let value_ (k: 'k) : Lens<Map<'k,'v>, 'v option> =
+            Map.tryFind k,
+            (fun v x ->
+                match v with
+                | Some v -> Map.add k v x
+                | _ -> Map.remove k x)
+
+        /// Weak Isomorphism to an array of key-value pairs.
+        let array_ : Isomorphism<Map<'k,'v>, ('k * 'v)[]> =
+            Map.toArray,
+            Map.ofArray
+
+        /// Weak Isomorphism to a list of key-value pairs.
+        let list_ : Isomorphism<Map<'k,'v>, ('k * 'v) list> =
+            Map.toList,
+            Map.ofList
+
+    [<RequireQualifiedAccess>]
+    module Option =
+
+        /// Prism to the value in an Option.
+        let value_ : Prism<'v option, 'v> =
+            id,
+            (fun v ->
+                function | Some _ -> Some v
+                         | None -> None)
+
+/// Optional custom operators for working with optics. Provides more concise
+/// syntactic options for working with the functions in the `Compose` and
+/// `Optic` modules.
+module Operators =
+
+    /// Compose a lens with an optic or morphism.
+    let inline (>->) l o =
+        Compose.lens l o
+
+    /// Compose a prism with an optic or morphism.
+    let inline (>?>) p o =
+        Compose.prism p o
+
+    /// Get a value using an optic.
+    let inline (^.) target optic =
+        Optic.get optic target
+
+    /// Set a value using an optic.
+    let inline (^=) value optic =
+        Optic.set optic value
+
+    /// Modify a value using an optic.
+    let inline (^%) f optic =
+        Optic.map optic f

--- a/tests/Rust/tests/src/ApplicativeTests.fs
+++ b/tests/Rust/tests/src/ApplicativeTests.fs
@@ -131,56 +131,54 @@ let inline addSomething2 (x: ^T) = (^T : (member Add : string -> string) (x, "ab
 //     let z = add2 x
 //     y + z
 
-module tests1 =
-    [<Fact>]
-    let ``Picks the right witness`` () =
-        getFullName {| FirstName = "Alfonso"; LastName = "Horigome" |}
-        |> equal "Horigome Alfonso"
+[<Fact>]
+let ``Picks the right witness`` () =
+    getFullName {| FirstName = "Alfonso"; LastName = "Horigome" |}
+    |> equal "Horigome Alfonso"
 
-    [<Fact>]
-    let ``Picks the right witness II`` () =
-        getFirsAndLastName {| FirstName = "Alfonso"; LastName = "Horigome" |}
-        |> equal "Alfonso Horigome"
+[<Fact>]
+let ``Picks the right witness II`` () =
+    getFirsAndLastName {| FirstName = "Alfonso"; LastName = "Horigome" |}
+    |> equal "Alfonso Horigome"
 
-    [<Fact>]
-    let ``Infix applicative can be generated`` () =
-        let r = Ok 1
-        let a = Ok string
-        match a <*> r with
-        | Ok x -> equal "1" x
-        | _ -> failwith "expected Ok('1')"
+[<Fact>]
+let ``Infix applicative can be generated`` () =
+    let r = Ok 1
+    let a = Ok string
+    match a <*> r with
+    | Ok x -> equal "1" x
+    | _ -> failwith "expected Ok('1')"
 
-    [<Fact>]
-    let ``Infix applicative with inline functions can be generated`` () =
-        let r = Ok 1
-        let a = Ok string
-        match applyInline a r with
-        | Ok x -> equal "1" x
-        | _ -> failwith "expected Ok('1')"
+[<Fact>]
+let ``Infix applicative with inline functions can be generated`` () =
+    let r = Ok 1
+    let a = Ok string
+    match applyInline a r with
+    | Ok x -> equal "1" x
+    | _ -> failwith "expected Ok('1')"
 
-    [<Fact>]
-    let ``Infix applicative with inline composed functions can be generated`` () =
-        let r = Ok 1
-        let a = Ok (string >> int)
-        match applyInline a r with
-        | Ok x -> equal 1 x
-        | _ -> failwith "expected Ok(1)"
+[<Fact>]
+let ``Infix applicative with inline composed functions can be generated`` () =
+    let r = Ok 1
+    let a = Ok (string >> int)
+    match applyInline a r with
+    | Ok x -> equal 1 x
+    | _ -> failwith "expected Ok(1)"
 
-    [<Fact>]
-    let ``Infix applicative with even more inline functions can be generated`` () =
-        let r = Ok (fun x -> x + 1)
-        let a = Ok (fun f x -> f x)
-        match applyInline a r with
-        | Ok addOne -> equal 2 (addOne 1)
-        | _ -> failwith "expected Ok(addOne) where addOne(1) = 2"
+[<Fact>]
+let ``Infix applicative with even more inline functions can be generated`` () =
+    let r = Ok (fun x -> x + 1)
+    let a = Ok (fun f x -> f x)
+    match applyInline a r with
+    | Ok addOne -> equal 2 (addOne 1)
+    | _ -> failwith "expected Ok(addOne) where addOne(1) = 2"
 
-    [<Fact>]
-    let ``Inline code doesn't call many times function with side effects`` () = // See #1321
-        SideEffects.New(5).MethodN(false).MethodN(true).MethodN().count |> equal 1
-        SideEffects.New(5).MethodN(false).MethodN(true).MethodN().count |> equal 2
-        SideEffects.New(5).MethodI(false).MethodI(true).MethodI().count |> equal 3
-        SideEffects.New(5).MethodI(false).MethodI(true).MethodI().count |> equal 4
-
+[<Fact>]
+let ``Inline code doesn't call many times function with side effects`` () = // See #1321
+    SideEffects.New(5).MethodN(false).MethodN(true).MethodN().count |> equal 1
+    SideEffects.New(5).MethodN(false).MethodN(true).MethodN().count |> equal 2
+    SideEffects.New(5).MethodI(false).MethodI(true).MethodI().count |> equal 3
+    SideEffects.New(5).MethodI(false).MethodI(true).MethodI().count |> equal 4
 
 type Foo1(i) =
     member x.Foo() = i
@@ -192,32 +190,31 @@ type Foo2(i) =
 let inline foo< ^t when ^t : (member Foo : int -> int)> x i =
     (^t : (member Foo : int -> int) (x, i))
 
-module tests2 =
-    [<Fact>]
-    let ``Local inline typed lambdas work`` () =
-        let inline localFoo (x:^t) = foo x 5
-        let x1 = Foo1(2)
-        let x2 = Foo2(2)
-        equal 7 <| localFoo x1
-        equal 14 <| localFoo x2
+[<Fact>]
+let ``Local inline typed lambdas work`` () =
+    let inline localFoo (x:^t) = foo x 5
+    let x1 = Foo1(2)
+    let x2 = Foo2(2)
+    equal 7 <| localFoo x1
+    equal 14 <| localFoo x2
 
-    [<Fact>]
-    let ``Local inline values work`` () =
-        let res = zipAny [|("a",1);("b",2)|] [|("c",5.);("a",4.)|]
-        res.Length |> equal 3
-        res.[0] |> fst |> equal "a"
-        res.[0] |> snd |> equal (Some 1, Some 4.)
-        res.[1] |> fst |> equal "b"
-        res.[1] |> snd |> equal (Some 2, None)
-        res.[2] |> fst |> equal "c"
-        res.[2] |> snd |> equal (None, Some 5.)
+[<Fact>]
+let ``Local inline values work`` () =
+    let res = zipAny [|("a",1);("b",2)|] [|("c",5.);("a",4.)|]
+    res.Length |> equal 3
+    res.[0] |> fst |> equal "a"
+    res.[0] |> snd |> equal (Some 1, Some 4.)
+    res.[1] |> fst |> equal "b"
+    res.[1] |> snd |> equal (Some 2, None)
+    res.[2] |> fst |> equal "c"
+    res.[2] |> snd |> equal (None, Some 5.)
 
-    [<Fact>]
-    let ``Local inline lambdas work standalone`` () = // See #1234
-        let mutable setInternalState = Some(fun (_:obj) -> ())
-        let withReact () =
-          let mutable lastModel = Some 2
-          let setState () =
+[<Fact>]
+let ``Local inline lambdas work standalone`` () = // See #1234
+    let mutable setInternalState = Some(fun (_:obj) -> ())
+    let withReact () =
+        let mutable lastModel = Some 2
+        let setState () =
             let inline notEqual a = not <| obj.ReferenceEquals (1, a)
             match setInternalState with
             | Some _ ->
@@ -225,9 +222,8 @@ module tests2 =
                 hasUpdate
             | None ->
                 false
-          setState()
-        withReact() |> equal true
-
+        setState()
+    withReact() |> equal true
 
 open Aether
 open Aether.Operators
@@ -244,35 +240,33 @@ let rev : Isomorphism<char[], char[]> =
 
 let inline (=!) x y = equal y x
 
-module tests3 =
-    [<Fact>]
-    let ``Lens.get returns correct values`` () =
-        Lens_get fst_ ("Good","Bad") =! "Good"
+[<Fact>]
+let ``Lens.get returns correct values`` () =
+    Lens_get fst_ ("Good","Bad") =! "Good"
 
-    [<Fact>]
-    let ``Lens.set sets value correctly`` () =
-        Lens_set fst_ "Good" ("Bad",()) =! ("Good",())
+[<Fact>]
+let ``Lens.set sets value correctly`` () =
+    Lens_set fst_ "Good" ("Bad",()) =! ("Good",())
 
-    [<Fact>]
-    let ``Lens.map modifies values correctly`` () =
-        Lens_map fst_ (fun x -> x + x) ("Good",()) =! ("GoodGood",())
+[<Fact>]
+let ``Lens.map modifies values correctly`` () =
+    Lens_map fst_ (fun x -> x + x) ("Good",()) =! ("GoodGood",())
 
-    [<Fact>]
-    let ``Ismorphism composition over a lens gets value`` () =
-        Lens_get (fst_ >-> chars) ("Good",()) =! [| 'G'; 'o'; 'o'; 'd' |]
+[<Fact>]
+let ``Ismorphism composition over a lens gets value`` () =
+    Lens_get (fst_ >-> chars) ("Good",()) =! [| 'G'; 'o'; 'o'; 'd' |]
 
-    [<Fact>]
-    let ``Ismorphism composition over a lens sets value`` () =
-        Lens_set (fst_ >-> chars) [| 'G'; 'o'; 'o'; 'd' |] ("Bad",()) =! ("Good",())
+[<Fact>]
+let ``Ismorphism composition over a lens sets value`` () =
+    Lens_set (fst_ >-> chars) [| 'G'; 'o'; 'o'; 'd' |] ("Bad",()) =! ("Good",())
 
-    [<Fact>]
-    let ``Ismorphism composition over a lens gets value over multiple isomorphisms`` () =
-        Lens_get (fst_ >-> chars >-> rev) ("dooG",()) =! [| 'G'; 'o'; 'o'; 'd' |]
+[<Fact>]
+let ``Ismorphism composition over a lens gets value over multiple isomorphisms`` () =
+    Lens_get (fst_ >-> chars >-> rev) ("dooG",()) =! [| 'G'; 'o'; 'o'; 'd' |]
 
-    [<Fact>]
-    let ``Ismorphism composition over a lens sets value over multiple isomorphisms`` () =
-        Lens_set (fst_ >-> chars >-> rev) [| 'd'; 'o'; 'o'; 'G' |] ("Bad",()) =! ("Good",())
-
+[<Fact>]
+let ``Ismorphism composition over a lens sets value over multiple isomorphisms`` () =
+    Lens_set (fst_ >-> chars >-> rev) [| 'd'; 'o'; 'o'; 'G' |] ("Bad",()) =! ("Good",())
 
 let mutable mutableValue = 0
 
@@ -305,67 +299,65 @@ let partialApplication(f: int->int->int) =
     let f4' = f3' 3
     f2 7 + f4 8 + f4' 9
 
-module tests4 =
-    [<Fact>]
-    let ``Module values/methods returning lambdas work`` () =
-        moduleValueReturnsLambda() |> equal 10
-        moduleMethodReturnsLambda 7 9 |> equal 63
-        // mutableValue has changed so this produces a different result
-        moduleValueReturnsLambda() |> equal 14
+[<Fact>]
+let ``Module values/methods returning lambdas work`` () =
+    moduleValueReturnsLambda() |> equal 10
+    moduleMethodReturnsLambda 7 9 |> equal 63
+    // mutableValue has changed so this produces a different result
+    moduleValueReturnsLambda() |> equal 14
 
-    [<Fact>]
-    let ``Class properties/methods returning lambdas work`` () =
-        let x = LambdaFactory()
-        x.ClassPropertyReturnsLambda 5 |> equal 25
-        x.ClassMethodReturnsLambda 2 8 |> equal 16
-        // Class properties are actually methods,
-        // so this should still give the same result
-        x.ClassPropertyReturnsLambda 5 |> equal 25
+[<Fact>]
+let ``Class properties/methods returning lambdas work`` () =
+    let x = LambdaFactory()
+    x.ClassPropertyReturnsLambda 5 |> equal 25
+    x.ClassMethodReturnsLambda 2 8 |> equal 16
+    // Class properties are actually methods,
+    // so this should still give the same result
+    x.ClassPropertyReturnsLambda 5 |> equal 25
 
-    [<Fact>]
-    let ``Local values returning lambdas work`` () =
-        let mutable mutableValue = 0
-        let localValueReturnsLambda =
-            mutableValue <- 5
-            fun () -> mutableValue * 2
-        let localFunctionReturnsLambda i =
-            mutableValue <- i
-            fun j -> mutableValue * j
-        localValueReturnsLambda() |> equal 10
-        localFunctionReturnsLambda 7 9 |> equal 63
-        // mutableValue has changed so this produces a different result
-        localValueReturnsLambda() |> equal 14
+[<Fact>]
+let ``Local values returning lambdas work`` () =
+    let mutable mutableValue = 0
+    let localValueReturnsLambda =
+        mutableValue <- 5
+        fun () -> mutableValue * 2
+    let localFunctionReturnsLambda i =
+        mutableValue <- i
+        fun j -> mutableValue * j
+    localValueReturnsLambda() |> equal 10
+    localFunctionReturnsLambda 7 9 |> equal 63
+    // mutableValue has changed so this produces a different result
+    localValueReturnsLambda() |> equal 14
 
-    [<Fact>]
-    let ``Generic lambda arguments work`` () =
-        genericLambdaArgument (fun x y -> x + y) 3 |> equal 45
-        genericLambdaArgument ((+) 1) |> equal 43
-        genericLambdaArgument2 (fun f -> f 1) 3 |> equal 3
+[<Fact>]
+let ``Generic lambda arguments work`` () =
+    genericLambdaArgument (fun x y -> x + y) 3 |> equal 45
+    genericLambdaArgument ((+) 1) |> equal 43
+    genericLambdaArgument2 (fun f -> f 1) 3 |> equal 3
 
-    [<Fact>]
-    let ``Generic lambda arguments work with multi-arity subargument`` () =
-        // TODO: Add test also with expected arity for f > 1
-        genericLambdaArgument2 (fun f -> f 1 2) id |> equal 2
+[<Fact>]
+let ``Generic lambda arguments work with multi-arity subargument`` () =
+    // TODO: Add test also with expected arity for f > 1
+    genericLambdaArgument2 (fun f -> f 1 2) id |> equal 2
 
-    [<Fact>]
-    let ``Generic lambda arguments work locally`` () =
-        let genericLambdaArgument f = f 42
-        genericLambdaArgument (+) 3 |> equal 45
-        genericLambdaArgument (fun x -> x + 1) |> equal 43
+[<Fact>]
+let ``Generic lambda arguments work locally`` () =
+    let genericLambdaArgument f = f 42
+    genericLambdaArgument (+) 3 |> equal 45
+    genericLambdaArgument (fun x -> x + 1) |> equal 43
 
-        let genericLambdaArgument2 f g = f (fun x -> g)
-        genericLambdaArgument2 (fun f -> f 1) 3 |> equal 3
+    let genericLambdaArgument2 f g = f (fun x -> g)
+    genericLambdaArgument2 (fun f -> f 1) 3 |> equal 3
 
-    [<Fact>]
-    let ``Lambdas can be partially applied`` () =
-        partialApplication (+) |> equal 29
+[<Fact>]
+let ``Lambdas can be partially applied`` () =
+    partialApplication (+) |> equal 29
 
-    [<Fact>]
-    let ``Flattened lambdas can be composed`` () = // See #704
-        let f = (+) >> id
-        List.foldBack f [1;2;3;4] 0
-        |> equal 10
-
+[<Fact>]
+let ``Flattened lambdas can be composed`` () = // See #704
+    let f = (+) >> id
+    List.foldBack f [1;2;3;4] 0
+    |> equal 10
 
 type ImplicitType<'a,'b> =
     | Case1 of 'a
@@ -417,8 +409,8 @@ type Action<'model> =
 // with
 //     override x.ToString () =
 //         match x with
-//         | InputChanged (id, value, _) -> sprintf "InputChanged (%s, %s)" id value
-//         | CheckboxChanged (id, value, _) -> sprintf "CheckboxChanged (%s, %b)" id value
+//         | InputChanged (id, value, _) -> $"InputChanged ({id}, {value})"
+//         | CheckboxChanged (id, value, _) -> $"CheckboxChanged ({id}, {value})"
 
 let makeInput<'model> id (model: 'model) (lens: Lens<'model, string>) =
 // let makeInput id (model: RecordB) (lens: Lens<RecordB, string>) =
@@ -536,164 +528,162 @@ type Parent =
             | p when p.c.IsSome -> { p with c = Some x }
             | p -> p)
 
-module tests5 =
-    [<Fact>]
-    let ``TraitCall can resolve overloads with a single generic argument`` () =
-        implicitMethod !+"hello" 5 |> equal 1
-        implicitMethod !+6       5 |> equal 2
+[<Fact>]
+let ``TraitCall can resolve overloads with a single generic argument`` () =
+    implicitMethod !+"hello" 5 |> equal 1
+    implicitMethod !+6       5 |> equal 2
 
-    [<Fact>]
-    let ``NestedLambdas`` () =
-        let mutable m = 0
-        let f i =
-            m <- i
-            fun j ->
-                m <- m + j
-                fun k ->
-                    m <- m + k
-                    fun u ->
-                        m + u
-        let f2 = f 1
-        let f3 = f2 2
-        let f4 = f3 3
-        f4 4 |> equal 10
-        let f5 = f 6 7 8
-        f5 9 |> equal 30
+[<Fact>]
+let ``NestedLambdas`` () =
+    let mutable m = 0
+    let f i =
+        m <- i
+        fun j ->
+            m <- m + j
+            fun k ->
+                m <- m + k
+                fun u ->
+                    m + u
+    let f2 = f 1
+    let f3 = f2 2
+    let f4 = f3 3
+    f4 4 |> equal 10
+    let f5 = f 6 7 8
+    f5 9 |> equal 30
 
-    [<Fact>]
-    let ``More than two lambdas can be nested`` () =
-        let mutable mut = 0
-        let f x =
+[<Fact>]
+let ``More than two lambdas can be nested`` () =
+    let mutable mut = 0
+    let f x =
+        mut <- mut + 1
+        fun y z ->
             mut <- mut + 1
-            fun y z ->
-                mut <- mut + 1
-                fun u w ->
-                    x + y + z + u + w
-        f 1 2 3 4 5 |> equal 15
-        let f2 = f 3 4 5 6
-        f2 7 |> equal 25
+            fun u w ->
+                x + y + z + u + w
+    f 1 2 3 4 5 |> equal 15
+    let f2 = f 3 4 5 6
+    f2 7 |> equal 25
 
-    [<Fact>]
-    let ``Multiple nested lambdas can be partially applied`` () =
-        let mutable mut = 0
-        let f x y z =
+[<Fact>]
+let ``Multiple nested lambdas can be partially applied`` () =
+    let mutable mut = 0
+    let f x y z =
+        mut <- mut + 1
+        fun u ->
             mut <- mut + 1
-            fun u ->
-                mut <- mut + 1
-                fun w ->
-                    x + y + z + u + w
-        let f2 = f 1 2
-        f2 3 4 5 |> equal 15
+            fun w ->
+                x + y + z + u + w
+    let f2 = f 1 2
+    f2 3 4 5 |> equal 15
 
-    // TODO
-    // open Microsoft.FSharp.Core.OptimizedClosures
+// TODO
+// open Microsoft.FSharp.Core.OptimizedClosures
 
-    // [<Fact>]
-    // let ``Partial application of optimized closures works`` () =
-    //   let mutable m = 1
-    //   let f x = m <- m + 1; (fun y z -> x + y + z)
-    //   let f = FSharpFunc<_,_,_,_>.Adapt(f)
-    //   let r = f.Invoke(1, 2, 3)
-    //   equal 2 m
-    //   equal 6 r
+// [<Fact>]
+// let ``Partial application of optimized closures works`` () =
+//   let mutable m = 1
+//   let f x = m <- m + 1; (fun y z -> x + y + z)
+//   let f = FSharpFunc<_,_,_,_>.Adapt(f)
+//   let r = f.Invoke(1, 2, 3)
+//   equal 2 m
+//   equal 6 r
 
-    [<Fact>]
-    let ``No errors because references to missing unit args`` () =
-        let foofy str =
-            fun () -> "foo" + str
-        let f1 = foofy "bar"
-        f1 () |> equal "foobar"
+[<Fact>]
+let ``No errors because references to missing unit args`` () =
+    let foofy str =
+        fun () -> "foo" + str
+    let f1 = foofy "bar"
+    f1 () |> equal "foobar"
 
-    [<Fact>]
-    let ``Arity is checked also when constructing records`` () =
-        let f i j = (i * 2) + (j * 3)
-        let r = { arity2 = fun x -> f x >> fun y -> sprintf "foo%i" y }
-        r.arity2 4 5 |> equal "foo23"
+[<Fact>]
+let ``Arity is checked also when constructing records`` () =
+    let f i j = (i * 2) + (j * 3)
+    let r = { arity2 = fun x -> f x >> fun y -> $"foo{y}" }
+    r.arity2 4 5 |> equal "foo23"
 
-    [<Fact>]
-    let ``Aether with generics works`` () = // See #750
-        let a = { RecordB = {A= "foo"; B=true} }
-        let input, checkbox = view a
-        input |> equal "foo"
-        checkbox |> equal true
-        let a2 = InputChanged("abc", "bar", RecordB.A_) |> update a
-        let input2, checkbox2 = view a2
-        input2 |> equal "bar"
-        checkbox2 |> equal true
+[<Fact>]
+let ``Aether with generics works`` () = // See #750
+    let a = { RecordB = {A= "foo"; B=true} }
+    let input, checkbox = view a
+    input |> equal "foo"
+    checkbox |> equal true
+    let a2 = InputChanged("abc", "bar", RecordB.A_) |> update a
+    let input2, checkbox2 = view a2
+    input2 |> equal "bar"
+    checkbox2 |> equal true
 
-    [<Fact>]
-    let ``Aether works II`` () = // See #2101
-        let x : Parent = { c = Some { g = { x = Some 5 } } }
-        let y : Parent = { c = None }
-        let z : Parent = { c = Some { g = { x = None } } }
-        let grandchild = Parent.c_ >?> Child.g_ >?> Grandchild.x_
-        x ^. grandchild |> equal (Some 5)
-        y ^. grandchild |> equal None
-        z ^. grandchild |> equal None
+[<Fact>]
+let ``Aether works II`` () = // See #2101
+    let x : Parent = { c = Some { g = { x = Some 5 } } }
+    let y : Parent = { c = None }
+    let z : Parent = { c = Some { g = { x = None } } }
+    let grandchild = Parent.c_ >?> Child.g_ >?> Grandchild.x_
+    x ^. grandchild |> equal (Some 5)
+    y ^. grandchild |> equal None
+    z ^. grandchild |> equal None
 
-    [<Fact>]
-    let ``Trait calls work with tuples`` () =
-        Item2.Invoke (1,2,3) |> equal 2
+[<Fact>]
+let ``Trait calls work with tuples`` () =
+    Item2.Invoke (1,2,3) |> equal 2
 
-    [<Fact>]
-    let ``Trait calls work with record fields`` () =
-        let ar = [| {Id=Id"foo"; Name="Sarah"}; {Id=Id"bar"; Name="James"} |]
-        replaceById {Id=Id"ja"; Name="Voll"} ar |> Seq.head |> fun x -> equal "Sarah" x.Name
-        replaceById {Id=Id"foo"; Name="Anna"} ar |> Seq.head |> fun x -> equal "Anna" x.Name
+[<Fact>]
+let ``Trait calls work with record fields`` () =
+    let ar = [| {Id=Id"foo"; Name="Sarah"}; {Id=Id"bar"; Name="James"} |]
+    replaceById {Id=Id"ja"; Name="Voll"} ar |> Seq.head |> fun x -> equal "Sarah" x.Name
+    replaceById {Id=Id"foo"; Name="Anna"} ar |> Seq.head |> fun x -> equal "Anna" x.Name
 
-    [<Fact>]
-    let ``Nested trait calls work`` () = // See #2468
-        let i: int  = parse "123"
-        let b: bool = parse "true"
-        let p: Parseable = parse ""
-        let h : DateTimeOffset = parse "2011-03-04T15:42:19+03:00"
-        equal 123 i
-        equal true b
-        equal Parseable p
-        equal (DateTimeOffset(2011, 3, 4, 15, 42, 19, TimeSpan.FromHours(3.))) h
+// [<Fact>]
+// let ``Nested trait calls work`` () = // See #2468
+//     let i: int  = parse "123"
+//     let b: bool = parse "true"
+//     let p: Parseable = parse ""
+//     let h : DateTimeOffset = parse "2011-03-04T15:42:19+03:00"
+//     equal 123 i
+//     equal true b
+//     equal Parseable p
+//     equal (DateTimeOffset(2011, 3, 4, 15, 42, 19, TimeSpan.FromHours(3.))) h
 
-    [<Fact>]
-    let ``Inline local function can call another inline function with trait call" <| fun _ ->
-        let inline wrapIdLocal x =
-            let id = getId x
-            "<<<" + id + ">>>"
-        let a = wrapId { Ideable2.Id="ABC"; Name="OOOO"}
-        let b = wrapId {| Id = "xyz" |}
-        let c = wrapIdLocal { Ideable2.Id="ABC"; Name="EEEE"}
-        let d = wrapIdLocal {| Id = "xyz" |}
-        equal "<<<ABC>>>" a
-        equal "<<<xyz>>>" b
-        equal "<<<ABC>>>" c
-        equal "<<<xyz>>>" d
+[<Fact>]
+let ``Inline local function can call another inline function with trait call`` () =
+    let inline wrapIdLocal x =
+        let id = getId x
+        "<<<" + id + ">>>"
+    let a = wrapId { Ideable2.Id="ABC"; Name="OOOO"}
+    let b = wrapId {| Id = "xyz" |}
+    let c = wrapIdLocal { Ideable2.Id="ABC"; Name="EEEE"}
+    let d = wrapIdLocal {| Id = "xyz" |}
+    equal "<<<ABC>>>" a
+    equal "<<<xyz>>>" b
+    equal "<<<ABC>>>" c
+    equal "<<<xyz>>>" d
 
-    [<Fact>]
-    let ``Unit expression arguments are not removed`` () =
-        let mutable x = 0
-        let foo i =
-            x <- i
-        doNothing <| foo 5
-        equal 5 x
+[<Fact>]
+let ``Unit expression arguments are not removed`` () =
+    let mutable x = 0
+    let foo i =
+        x <- i
+    doNothing <| foo 5
+    equal 5 x
 
-    [<Fact>]
-    let ``Basic currying works`` () =
-        let plus = curry (+)
-        let result = plus 2 3
-        equal 5 result
-        equal 5 (plus 2 3)
-        equal 5 ((curry (+)) 2 3)
+[<Fact>]
+let ``Basic currying works`` () =
+    let plus = curry (+)
+    let result = plus 2 3
+    equal 5 result
+    equal 5 (plus 2 3)
+    equal 5 ((curry (+)) 2 3)
 
-    [<Fact>]
-    let ``CurriedLambda don't delay side effects unnecessarily`` () = // See #996
-          let a, b = applyTup2 id mutateAndLambdify 2685397
-          sprintf "%A" mutableValue3 |> equal "2685397"
-          let a2, b2 = applyTup2Inline id mutateAndLambdify 843252
-          sprintf "%A" mutableValue3 |> equal "843252"
-          let a3, b3 =
-              let a = id 349787
-              let b = mutateAndLambdify 349787
-              (a,b)
-          sprintf "%A" mutableValue3 |> equal "349787"
-]
+[<Fact>]
+let ``CurriedLambda don't delay side effects unnecessarily`` () = // See #996
+    let a, b = applyTup2 id mutateAndLambdify 2685397
+    string mutableValue3 |> equal "2685397"
+    let a2, b2 = applyTup2Inline id mutateAndLambdify 843252
+    string mutableValue3 |> equal "843252"
+    let a3, b3 =
+        let a = id 349787
+        let b = mutateAndLambdify 349787
+        (a,b)
+    string mutableValue3 |> equal "349787"
 
 module Types =
     let inline flip f a b = f b a
@@ -726,73 +716,71 @@ module State =
 
 type StringEnvironment<'a> = string -> 'a
 
-module tests6 =
-    [<Fact>]
-    let ``Point-free style with multiple arguments works`` () = // See #1041
-        let initialValue = { Types.Email = Types.StringField.Empty }
-        let m = State.update "m" initialValue
-        m.Email.Value |> equal "m"
+[<Fact>]
+let ``Point-free style with multiple arguments works`` () = // See #1041
+    let initialValue = { Types.Email = Types.StringField.Empty }
+    let m = State.update "m" initialValue
+    m.Email.Value |> equal "m"
 
-    [<Fact>]
-    let ``Function generic type alias works`` () = // See #1121
-        let five = fun _ -> 5
+[<Fact>]
+let ``Function generic type alias works`` () = // See #1121
+    let five = fun _ -> 5
 
-        let bind (x : StringEnvironment<'a>) (f : 'a -> StringEnvironment<'b>) : StringEnvironment<'b> =
-            fun environment ->
-                f (x environment) environment
+    let bind (x : StringEnvironment<'a>) (f : 'a -> StringEnvironment<'b>) : StringEnvironment<'b> =
+        fun environment ->
+            f (x environment) environment
 
-        bind five (fun i -> five) "environment"
-        |> equal 5
+    bind five (fun i -> five) "environment"
+    |> equal 5
 
-    [<Fact>]
-    let ``Function generic type alias works II`` () =
-        let three = fun _ -> 3
+[<Fact>]
+let ``Function generic type alias works II`` () =
+    let three = fun _ -> 3
 
-        let bind (x : string -> 'a) (f : 'a -> string -> 'b) : string -> 'b =
-            fun environment ->
-                f (x environment) environment
+    let bind (x : string -> 'a) (f : 'a -> string -> 'b) : string -> 'b =
+        fun environment ->
+            f (x environment) environment
 
-        bind three (fun i -> three) "environment"
-        |> equal 3
+    bind three (fun i -> three) "environment"
+    |> equal 3
 
-    [<Fact>]
-    let ``Piping to an alias of a function which returns a function works`` () = // See #2657
-        let f a b = sprintf $"{a} {b}"
+[<Fact>]
+let ``Piping to an alias of a function which returns a function works`` () = // See #2657
+    let f a b = $"{a} {b}"
 
-        let f_option = Some f
-        let defaultValue x = Option.defaultValue x
+    let f_option = Some f
+    let defaultValue x = Option.defaultValue x
 
-        let functionA = f_option |> Option.defaultValue f
-        functionA "functionA" "works" |> equal "functionA works"
+    let functionA = f_option |> Option.defaultValue f
+    functionA "functionA" "works" |> equal "functionA works"
 
-        let functionB = defaultValue f f_option
-        functionB "functionB" "works" |> equal "functionB works"
+    let functionB = defaultValue f f_option
+    functionB "functionB" "works" |> equal "functionB works"
 
-        let functionC = f_option |> defaultValue f
-        functionC "functionC" "works" |> equal "functionC works"
+    let functionC = f_option |> defaultValue f
+    functionC "functionC" "works" |> equal "functionC works"
 
-        let functionC x = (f_option |> defaultValue f) x
-        functionC "functionC" "works" |> equal "functionC works"
+    let functionC x = (f_option |> defaultValue f) x
+    functionC "functionC" "works" |> equal "functionC works"
 
-        let functionC x y = (f_option |> defaultValue f) x y
-        functionC "functionC" "works" |> equal "functionC works"
+    let functionC x y = (f_option |> defaultValue f) x y
+    functionC "functionC" "works" |> equal "functionC works"
 
-    [<Fact>]
-    let ``Piping to an alias of a function which returns a function works II`` () = // See #2657
-        let f a b = sprintf $"{a} {b}"
+[<Fact>]
+let ``Piping to an alias of a function which returns a function works II`` () = // See #2657
+    let f a b = $"{a} {b}"
 
-        let getFunction x y = y
-        let getFunctionAlias = getFunction
+    let getFunction x y = y
+    let getFunctionAlias = getFunction
 
-        let functionA = f |> getFunction 1
-        functionA "functionA" "works" |> equal "functionA works"
+    let functionA = f |> getFunction 1
+    functionA "functionA" "works" |> equal "functionA works"
 
-        let functionB = getFunctionAlias 1 f
-        functionB "functionB" "works" |> equal "functionB works"
+    let functionB = getFunctionAlias 1 f
+    functionB "functionB" "works" |> equal "functionB works"
 
-        let functionC = f |> getFunctionAlias 2
-        functionC "functionC" "works?" |> equal "functionC works?"
-]
+    let functionC = f |> getFunctionAlias 2
+    functionC "functionC" "works?" |> equal "functionC works?"
 
 module CurriedApplicative =
     type Option2<'T> =
@@ -814,8 +802,6 @@ module CurriedApplicative =
             let inline (<*>) m x = apply x m
             let inline (<**>) m x = apply2 x m
 
-    open Option.Operators
-
     let apply3 (f: 'a->'a->'b->'c) (a: 'a) =
         f a a
 
@@ -827,46 +813,47 @@ module CurriedApplicative =
 
     let addModule5 h i j k l = h + i + j + k + l
 
-    module tests =
-        [<Fact>]
-        let ``Option.apply (<*>) non-curried`` () =
-            let f x = x + 1
-            let r = Some f <*> Some 2
-            r |> equal (Some 3)
+open CurriedApplicative
+open Option.Operators
 
-        [<Fact>]
-        let ``Option.apply (<*>) auto curried`` () =
-            let f x y = x + y
-            let r = Some f <*> Some 2 <*> Some 3
-            r |> equal (Some 5)
+[<Fact>]
+let ``Option.apply (<*>) non-curried`` () =
+    let f x = x + 1
+    let r = Some f <*> Some 2
+    r |> equal (Some 3)
 
-        [<Fact>]
-        let ``Option.apply (<**>) auto curried`` () =
-            let f x y = x + y
-            let r = Some2 f <**> Some2 2 <**> Some2 3
-            r |> equal (Some2 5)
+[<Fact>]
+let ``Option.apply (<*>) auto curried`` () =
+    let f x y = x + y
+    let r = Some f <*> Some 2 <*> Some 3
+    r |> equal (Some 5)
 
-        [<Fact>]
-        let ``Option.apply (<*>) manually curried workaround`` () =
-            let f x =
-                let f' = fun y -> x + y
-                f'
-            let r = Some f <*> Some 2 <*> Some 3
-            r |> equal (Some 5)
+[<Fact>]
+let ``Option.apply (<**>) auto curried`` () =
+    let f x y = x + y
+    let r = Some2 f <**> Some2 2 <**> Some2 3
+    r |> equal (Some2 5)
 
-        // TODO: Add tests with side-effects
-        [<Fact>]
-        let ``Currying/uncurrying works`` () =
-            let addLocal x y z u v = x + y + z + u + v
-            let f1 = changeArity addModule5 2
-            let f2 = changeArity addLocal 2
-            let f3 = changeArityInlined addModule5 2
-            let f4 = changeArityInlined addLocal 2
-            f1 1 2 3 |> equal 10
-            f2 1 2 3 |> equal 10
-            f3 1 2 3 |> equal 10
-            f4 1 2 3 |> equal 10
+[<Fact>]
+let ``Option.apply (<*>) manually curried workaround`` () =
+    let f x =
+        let f' = fun y -> x + y
+        f'
+    let r = Some f <*> Some 2 <*> Some 3
+    r |> equal (Some 5)
 
+// TODO: Add tests with side-effects
+[<Fact>]
+let ``Currying/uncurrying works`` () =
+    let addLocal x y z u v = x + y + z + u + v
+    let f1 = changeArity addModule5 2
+    let f2 = changeArity addLocal 2
+    let f3 = changeArityInlined addModule5 2
+    let f4 = changeArityInlined addLocal 2
+    f1 1 2 3 |> equal 10
+    f2 1 2 3 |> equal 10
+    f3 1 2 3 |> equal 10
+    f4 1 2 3 |> equal 10
 
 type Node(parent: HTMLElement option) =
   member __.parentElement: HTMLElement = parent.Value
@@ -966,9 +953,9 @@ module Results =
         let sum = add3 <!> Ok 1 <*> Ok 2 <*> Ok 3
         equal (Ok 6) sum
 
-#if FABLE_COMPILER
-open Thoth.Json.Decode
-#endif
+// #if FABLE_COMPILER
+// open Thoth.Json.Decode
+// #endif
 
 type User =
     { Id : int
@@ -1092,400 +1079,396 @@ type Const<'t,'u> = Const of 't with
     static member inline Return (_: 'Y) = Const LanguagePrimitives.GenericZero : Const<'X,'Y>
     static member run (Const a) = a
 
-module tests7 =
-    [<Fact>]
-    let ``SRTP with ActivePattern works`` () =
-        (lengthWrapper []) |> equal 0
-        (lengthWrapper [1;2;3;4]) |> equal 4
-        lengthFixed |> equal 3
+[<Fact>]
+let ``SRTP with ActivePattern works`` () =
+    (lengthWrapper []) |> equal 0
+    (lengthWrapper [1;2;3;4]) |> equal 4
+    lengthFixed |> equal 3
 
-    [<Fact>]
-    let ``SRTP with inlined functions relying on generic info works`` () = // See #2135
-        let t2: int option =
-            Error 1
-            |> fun x ->  (^``Applicative<'T>`` : (static member Return : ^T -> ^``Applicative<'T>``) x)
-            // |> Const.Return
-            |> Const.run
-            |> First.run
+[<Fact>]
+let ``SRTP with inlined functions relying on generic info works`` () = // See #2135
+    let t2: int option =
+        Error 1
+        |> fun x ->  (^``Applicative<'T>`` : (static member Return : ^T -> ^``Applicative<'T>``) x)
+        // |> Const.Return
+        |> Const.run
+        |> First.run
 
-        equal None t2
+    equal None t2
 
-    [<Fact>]
-    let ``Closures generated by casts work`` () = // See #1150
-      let rec loop (current : Element) width height =
+[<Fact>]
+let ``Closures generated by casts work`` () = // See #1150
+    let rec loop (current : Element) width height =
         let w = current.clientWidth
         let h = current.clientHeight
         if w > 0 && h > 0 then
-          w, h
+            w, h
         else
-          loop current.parentElement w h
-      let element = getElement()
-      let result = loop element 0 0
-      equal (2,2) result
+            loop current.parentElement w h
+    let element = getElement()
+    let result = loop element 0 0
+    equal (2,2) result
 
-    [<Fact>]
-    let ``Applying to a function returned by a member works`` () =
-        equal (1,5) baz
-        equal (1,5) baz2
+[<Fact>]
+let ``Applying to a function returned by a member works`` () =
+    equal (1,5) baz
+    equal (1,5) baz2
 
-    [<Fact>]
-    let ``Applying to a function returned by a local function works`` () =
-        let foo a b c d = a , b + c d
-        let bar a = foo 1 a
-        let baz = bar 2 (fun _ -> 3) ()
-        equal (1,5) baz
+[<Fact>]
+let ``Applying to a function returned by a local function works`` () =
+    let foo a b c d = a , b + c d
+    let bar a = foo 1 a
+    let baz = bar 2 (fun _ -> 3) ()
+    equal (1,5) baz
 
-    [<Fact>]
-    let ``Partially applied functions don't duplicate side effects`` () = // See #1156
-        ADD 1 + ADD 2 + ADD 3 |> equal 6
+[<Fact>]
+let ``Partially applied functions don't duplicate side effects`` () = // See #1156
+    ADD 1 + ADD 2 + ADD 3 |> equal 6
 
-    [<Fact>]
-    let ``Partially applied functions don't duplicate side effects locally`` () =
-        let mutable counter = 0
-        let next () =
-          let result = counter
-          counter <- counter + 1
-          result
-        let adder () =
-          let add a b = a + b
-          add (next())
-        let add = adder ()
-        add 1 + add 2 + add 3 |> equal 6
+[<Fact>]
+let ``Partially applied functions don't duplicate side effects locally`` () =
+    let mutable counter = 0
+    let next () =
+        let result = counter
+        counter <- counter + 1
+        result
+    let adder () =
+        let add a b = a + b
+        add (next())
+    let add = adder ()
+    add 1 + add 2 + add 3 |> equal 6
 
-    [<Fact>]
-    let ``Partially applied lambdas capture this`` () =
-        let foo = Foo3()
-        let f = foo.GetLambda()
-        let f2 = f 2
-        f2 3 |> equal 10
+[<Fact>]
+let ``Partially applied lambdas capture this`` () =
+    let foo = Foo3()
+    let f = foo.GetLambda()
+    let f2 = f 2
+    f2 3 |> equal 10
 
-    [<Fact>]
-    let ``Partially applied curried lambdas capture this`` () =
-        let foo = Foo3()
-        let f = foo.GetCurriedLambda()
-        let f2 = f 2
-        f2 4 |> equal 14
+[<Fact>]
+let ``Partially applied curried lambdas capture this`` () =
+    let foo = Foo3()
+    let f = foo.GetCurriedLambda()
+    let f2 = f 2
+    f2 4 |> equal 14
 
-    [<Fact>]
-    let ``Curried function options work`` () =
-        maybeApply (Some ( * )) 5 6 |> equal 30
-        maybeApply None 5 6 |> equal 6
+[<Fact>]
+let ``Curried function options work`` () =
+    maybeApply (Some (*)) 5 6 |> equal 30
+    maybeApply None 5 6 |> equal 6
 
-    // See https://github.com/fable-compiler/Fable/issues/1199#issuecomment-347101093
-    [<Fact>]
-    let ``Applying function options works"
-        Pointful.testFunctionOptions
+// See https://github.com/fable-compiler/Fable/issues/1199#issuecomment-347101093
+[<Fact>]
+let ``Applying function options works`` () =
+    Pointful.testFunctionOptions
 
-    [<Fact>]
-    let ``Point-free and partial application work`` () = // See #1199
-        equal Pointfree.x Pointful.x
+[<Fact>]
+let ``Point-free and partial application work`` () = // See #1199
+    equal Pointfree.x Pointful.x
 
-    // See https://github.com/fable-compiler/Fable/issues/1199#issuecomment-345958891
-    [<Fact>]
-    let ``Point-free works when passing a 2-arg function`` () =
-        Pointfree.y |> equal (Some 3)
+// See https://github.com/fable-compiler/Fable/issues/1199#issuecomment-345958891
+[<Fact>]
+let ``Point-free works when passing a 2-arg function`` () =
+    Pointfree.y |> equal (Some 3)
 
-    [<Fact>]
-    let ``Functions in record fields are uncurried`` () =
-        let r = { myFunction = fun x y z -> x + y - z }
-        r.myFunction 4 4 2 |> equal 6
-        // If the function record field is assigned
-        // to a variable, just curry it
-        let mutable f = r.myFunction
-        f 4 4 2 |> equal 6
-        apply3 r.myFunction 5 7 4 |> equal 8
-        apply (r.myFunction 1 1 |> Some) (Some 5) |> equal (Some -3)
+[<Fact>]
+let ``Functions in record fields are uncurried`` () =
+    let r = { myFunction = fun x y z -> x + y - z }
+    r.myFunction 4 4 2 |> equal 6
+    // If the function record field is assigned
+    // to a variable, just curry it
+    let mutable f = r.myFunction
+    f 4 4 2 |> equal 6
+    apply3 r.myFunction 5 7 4 |> equal 8
+    apply (r.myFunction 1 1 |> Some) (Some 5) |> equal (Some -3)
 
-    [<Fact>]
-    let ``Uncurried functions in record fields can be partially applied`` () =
-        // Test also non-record functions just in case
-        let result = getStrLen () "hello"
-        let partiallyApplied = getStrLen ()
-        let secondResult = partiallyApplied "hello"
-        equal 5 result
-        equal 5 secondResult
+[<Fact>]
+let ``Uncurried functions in record fields can be partially applied`` () =
+    // Test also non-record functions just in case
+    let result = getStrLen () "hello"
+    let partiallyApplied = getStrLen ()
+    let secondResult = partiallyApplied "hello"
+    equal 5 result
+    equal 5 secondResult
 
-        let record = { fn = getStrLen }
-        let recordResult = record.fn () "hello"
-        let recordPartiallyApplied = record.fn ()
-        let recordSecondResult = recordPartiallyApplied "hello"
-        equal 5 recordResult
-        equal 5 recordSecondResult
+    let record = { fn = getStrLen }
+    let recordResult = record.fn () "hello"
+    let recordPartiallyApplied = record.fn ()
+    let recordSecondResult = recordPartiallyApplied "hello"
+    equal 5 recordResult
+    equal 5 recordSecondResult
 
-    // See https://github.com/fable-compiler/Fable/issues/1199#issuecomment-347190893
-    [<Fact>]
-    let ``Applicative operators work with three-argument functions"
-        Results.testOperatorsWith3Args
+// See https://github.com/fable-compiler/Fable/issues/1199#issuecomment-347190893
+[<Fact>]
+let ``Applicative operators work with three-argument functions``() =
+    Results.testOperatorsWith3Args
 
-    [<Fact>]
-    let ``partialApply works with tuples`` () =
-        let sum x (y,z) =
-            x + y + z
-        let li =
-            [1,2; 3,4; 5,6]
-            |> List.map (sum 10)
-        List.sum li |> equal 51
+[<Fact>]
+let ``partialApply works with tuples`` () =
+    let sum x (y,z) =
+        x + y + z
+    let li =
+        [1,2; 3,4; 5,6]
+        |> List.map (sum 10)
+    List.sum li |> equal 51
 
-    [<Fact>]
-    let ``Arguments of implicit constructors are uncurried too`` () = // See #1441
-        let f1 x y = if x = y then 0 else 1
-        let f2 x y = if x = y then 1 else 0
-        PrimaryConstructorUncurrying(f1).Value |> equal 1
-        PrimaryConstructorUncurrying(f2).Value |> equal 0
+[<Fact>]
+let ``Arguments of implicit constructors are uncurried too`` () = // See #1441
+    let f1 x y = if x = y then 0 else 1
+    let f2 x y = if x = y then 1 else 0
+    PrimaryConstructorUncurrying(f1).Value |> equal 1
+    PrimaryConstructorUncurrying(f2).Value |> equal 0
 
-    [<Fact>]
-    let ``Union case function fields are properly uncurried/curried`` () = // See #1445
-        let (Fun f) = Fun (fun x y -> [x; y])
-        let xs = f 3 4
-        List.sum xs |> equal 7
+[<Fact>]
+let ``Union case function fields are properly uncurried/curried`` () = // See #1445
+    let (Fun f) = Fun (fun x y -> [x; y])
+    let xs = f 3 4
+    List.sum xs |> equal 7
 
-    [<Fact>]
-    let ``Lambdas with tuple arguments don't conflict with uncurrying`` () = // See #1448
-        let revert xs =
-            let rec rev ls (a,b) acc =
-                match ls with
-                | [] -> acc
-                | h::t -> rev t (a,b) (h::acc)
-            rev xs (0, 0) []
-        let res = revert [2;3;4]
-        equal 3 res.Length
-        equal 4 res.Head
+[<Fact>]
+let ``Lambdas with tuple arguments don't conflict with uncurrying`` () = // See #1448
+    let revert xs =
+        let rec rev ls (a,b) acc =
+            match ls with
+            | [] -> acc
+            | h::t -> rev t (a,b) (h::acc)
+        rev xs (0, 0) []
+    let res = revert [2;3;4]
+    equal 3 res.Length
+    equal 4 res.Head
 
-    [<Fact>]
-    let ``Uncurrying works for base constructors`` () = // See #1458
-        let str = AddString()
-        str.MakeString "foo" "bar" |> equal "foobar"
+[<Fact>]
+let ``Uncurrying works for base constructors`` () = // See #1458
+    let str = AddString()
+    str.MakeString "foo" "bar" |> equal "foobar"
 
-    [<Fact>]
-    let ``Uncurrying works for base constructors II`` () = // See #1459
-        let str = AddString2 (fun a b -> "Prefix: " + a + b)
-        str.MakeString "a" "b" |> equal "Prefix: ab - Prefix: ba"
+[<Fact>]
+let ``Uncurrying works for base constructors II`` () = // See #1459
+    let str = AddString2 (fun a b -> "Prefix: " + a + b)
+    str.MakeString "a" "b" |> equal "Prefix: ab - Prefix: ba"
 
-    [<Fact>]
-    let ``Sequence of functions is uncurried in folding`` () =
-        let vals = [(4,5); (6,7)]
-        let ops  = [(+); (-)]
-        (-5, vals, ops) |||> List.fold2 (fun acc (v1,v2) op -> acc * op v1 v2)
-        |> equal 45
+[<Fact>]
+let ``Sequence of functions is uncurried in folding`` () =
+    let vals = [(4,5); (6,7)]
+    let ops  = [(+); (-)]
+    (-5, vals, ops) |||> List.fold2 (fun acc (v1,v2) op -> acc * op v1 v2)
+    |> equal 45
 
-    #if FABLE_COMPILER
-    [<Fact>]
-    let ``Composing methods returning 2-arity lambdas works" <| fun _ ->
-        let infoHelp version =
-            match version with
-            | 4 -> succeed 1
-            | 3 -> succeed 1
-            | _ -> fail <| "Trying to decode info, but version " + (version.ToString()) + "is not supported"
+// #if FABLE_COMPILER
+// [<Fact>]
+// let ``Composing methods returning 2-arity lambdas works`` () =
+//     let infoHelp version =
+//         match version with
+//         | 4 -> succeed 1
+//         | 3 -> succeed 1
+//         | _ -> fail <| "Trying to decode info, but version " + (version.ToString()) + "is not supported"
 
-        let info : Decoder<int> =
-            field "version" int
-            |> andThen infoHelp
+//     let info : Decoder<int> =
+//         field "version" int
+//         |> andThen infoHelp
 
-        decodeString info """{ "version": 3, "data": 2 }"""
-        |> equal (FSharp.Core.Ok 1)
+//     decodeString info """{ "version": 3, "data": 2 }"""
+//     |> equal (FSharp.Core.Ok 1)
 
-    [<Fact>]
-    let ``Applying curried lambdas to a module value works" <| fun _ ->
-        let expected =
-            FSharp.Core.Ok(User.Create 67 "user@mail.com" "" 0)
+// [<Fact>]
+// let ``Applying curried lambdas to a module value works`` () =
+//     let expected =
+//         FSharp.Core.Ok(User.Create 67 "user@mail.com" "" 0)
 
-        let userDecoder =
-            decode User.Create
-                |> required "id" int
-                |> required "email" string
-                |> optional "name" string ""
-                |> hardcoded 0 // `hardcoded` is compiled as module value
+//     let userDecoder =
+//         decode User.Create
+//             |> required "id" int
+//             |> required "email" string
+//             |> optional "name" string ""
+//             |> hardcoded 0 // `hardcoded` is compiled as module value
 
-        let actual =
-            decodeString
-                userDecoder
-                """{ "id": 67, "email": "user@mail.com" }"""
+//     let actual =
+//         decodeString
+//             userDecoder
+//             """{ "id": 67, "email": "user@mail.com" }"""
 
-        equal expected actual
-    #endif
+//     equal expected actual
+// #endif
 
-    [<Fact>]
-    let ``failwithf is not compiled as function`` () =
-        let makeFn value =
-            if value then
-                // When one of the branches is a function
-                // failwithf can be compiled to a function
-                // because of optimizations
-                fun x -> x + x
-            else
-                failwithf "Boom!"
+// [<Fact>]
+// let ``failwithf is not compiled as function`` () =
+//     let makeFn value =
+//         if value then
+//             // When one of the branches is a function
+//             // failwithf can be compiled to a function
+//             // because of optimizations
+//             fun x -> x + x
+//         else
+//             failwithf "Boom!"
 
-        let mutable x = ""
-        try
-            // It should fail even if `f` is not called
-            let f = makeFn false
-            ()
-        with ex -> x <- ex.Message
-        equal "Boom!" x
+//     let mutable x = ""
+//     try
+//         // It should fail even if `f` is not called
+//         let f = makeFn false
+//         ()
+//     with ex -> x <- ex.Message
+//     equal "Boom!" x
 
+[<Fact>]
+let ``Partial Applying caches side-effects`` () = // See #1836
+    PseudoElmish.reset()
+    let changedProgram = PseudoElmish.withChanges PseudoElmish.testProgram
+    changedProgram.setState "Foo" (fun _ -> ())
+    changedProgram.setState "Bar" (fun _ -> ())
+    PseudoElmish.doMapRunTimes |> equal 1
+    PseudoElmish.setStateAccumulated |> equal "FooBar"
 
-    [<Fact>]
-    let ``Partial Applying caches side-effects`` () = // See #1836
-        PseudoElmish.reset()
-        let changedProgram = PseudoElmish.withChanges PseudoElmish.testProgram
-        changedProgram.setState "Foo" (fun _ -> ())
-        changedProgram.setState "Bar" (fun _ -> ())
-        PseudoElmish.doMapRunTimes |> equal 1
-        PseudoElmish.setStateAccumulated |> equal "FooBar"
+    PseudoElmish.reset()
+    let changedProgram = PseudoElmish.withChangesAndCurrying3 PseudoElmish.testProgram
+    changedProgram.setState "Foo" (fun _ -> ())
+    changedProgram.setState "Bar" (fun _ -> ())
+    PseudoElmish.doMapRunTimes |> equal 1
+    PseudoElmish.setStateAccumulated |> equal "FooBar"
 
-        PseudoElmish.reset()
-        let changedProgram = PseudoElmish.withChangesAndCurrying3 PseudoElmish.testProgram
-        changedProgram.setState "Foo" (fun _ -> ())
-        changedProgram.setState "Bar" (fun _ -> ())
-        PseudoElmish.doMapRunTimes |> equal 1
-        PseudoElmish.setStateAccumulated |> equal "FooBar"
+    PseudoElmish.reset()
+    let changedProgram = PseudoElmish.withChangesAndCurrying2 PseudoElmish.testProgram
+    changedProgram.setState "Foo" (fun _ -> ())
+    changedProgram.setState "Bar" (fun _ -> ())
+    PseudoElmish.doMapRunTimes |> equal 1
+    PseudoElmish.setStateAccumulated |> equal "FooBar"
 
-        PseudoElmish.reset()
-        let changedProgram = PseudoElmish.withChangesAndCurrying2 PseudoElmish.testProgram
-        changedProgram.setState "Foo" (fun _ -> ())
-        changedProgram.setState "Bar" (fun _ -> ())
-        PseudoElmish.doMapRunTimes |> equal 1
-        PseudoElmish.setStateAccumulated |> equal "FooBar"
+[<Fact>]
+let ``Partial Applying locally caches side-effects`` () = // See #1836
+    let mutable doMapRunTimes = 0
+    let mutable setStateAccumulated = ""
 
-    [<Fact>]
-    let ``Partial Applying locally caches side-effects`` () = // See #1836
-        let mutable doMapRunTimes = 0
-        let mutable setStateAccumulated = ""
+    let inline map mapSetState (program: PseudoElmish.Program<'model, 'msg>) =
+        { PseudoElmish.setState = mapSetState (program.setState) }
 
-        let inline map mapSetState (program: PseudoElmish.Program<'model, 'msg>) =
-            { PseudoElmish.setState = mapSetState (program.setState) }
+    let changedProgram =
+        { PseudoElmish.setState = (fun m d -> setStateAccumulated <- setStateAccumulated + m) }
+        |> map (fun setState ->
+            doMapRunTimes <- doMapRunTimes + 1
+            setState)
 
-        let changedProgram =
-            { PseudoElmish.setState = (fun m d -> setStateAccumulated <- setStateAccumulated + m) }
-            |> map (fun setState ->
-                doMapRunTimes <- doMapRunTimes + 1
-                setState)
+    changedProgram.setState "Foo" (fun _ -> ())
+    changedProgram.setState "Bar" (fun _ -> ())
+    changedProgram.setState "Baz" (fun _ -> ())
 
-        changedProgram.setState "Foo" (fun _ -> ())
-        changedProgram.setState "Bar" (fun _ -> ())
-        changedProgram.setState "Baz" (fun _ -> ())
+    doMapRunTimes |> equal 1
+    setStateAccumulated |> equal "FooBarBaz"
 
-        doMapRunTimes |> equal 1
-        setStateAccumulated |> equal "FooBarBaz"
+[<Fact>]
+let ``Fix lambda uncurry/curry semantic #1836`` () =
+    let map (mapSetState: int -> (int -> unit))  =
+        mapSetState 1
 
-    [<Fact>]
-    let ``Fix lambda uncurry/curry semantic #1836`` () =
-        let map (mapSetState: int -> (int -> unit))  =
-            mapSetState 1
+    let mutable doMapCalled = 0
+    let mutable doMapResultCalled = 0
+    let doMap (i:int) : (int -> unit) =
+        doMapCalled <- doMapCalled + 1
+        (fun j -> doMapResultCalled <- doMapResultCalled + 1)
 
-        let mutable doMapCalled = 0
-        let mutable doMapResultCalled = 0
-        let doMap (i:int) : (int -> unit) =
-            doMapCalled <- doMapCalled + 1
-            (fun j -> doMapResultCalled <- doMapResultCalled + 1)
+    let setState = map (doMap)
+    setState 1
+    setState 2
+    doMapCalled |> equal 1
+    doMapResultCalled |> equal 2
 
-        let setState = map (doMap)
-        setState 1
-        setState 2
-        doMapCalled |> equal 1
-        doMapResultCalled |> equal 2
+[<Fact>]
+let ``OptimizedClosures.FSharpFunc<_,_,_>.Adapt works`` () = // See #1904
+    let f = OptimizedClosures.FSharpFunc<_,_,_>.Adapt (fun x y -> x + y)
+    f.Invoke(3, 4) |> equal 7
+    let f2 = OptimizedClosures.FSharpFunc<_,_,_>.Adapt mul
+    f2.Invoke(3, 4) |> equal 12
 
-    [<Fact>]
-    let ``OptimizedClosures.FSharpFunc<_,_,_>.Adapt works`` () = // See #1904
-        let f = OptimizedClosures.FSharpFunc<_,_,_>.Adapt (fun x y -> x + y)
-        f.Invoke(3, 4) |> equal 7
-        let f2 = OptimizedClosures.FSharpFunc<_,_,_>.Adapt mul
-        f2.Invoke(3, 4) |> equal 12
+[<Fact>]
+let ``Arguments passed to point-free function are uncurried`` () = // See #1959
+    let x = pointFree_addOne (+) 2
+    let y = addOne (+) 2
+    equal 3 x
+    equal 3 y
 
-    [<Fact>]
-    let ``Arguments passed to point-free function are uncurried`` () = // See #1959
-        let x = pointFree_addOne (+) 2
-        let y = addOne (+) 2
-        equal 3 x
-        equal 3 y
+[<Fact>]
+let ``fold produces incorrect output when state is a function with arity > 1`` () = // See #2035
+    let folder state value x y = value :: state x y
+    let state x y = [x; y]
+    let d = List.fold folder state [0..3]
+    d 42 42 |> equal [3; 2; 1; 0; 42; 42]
+    let s = Seq.fold folder state [0..3]
+    s 15 20 |> equal [3; 2; 1; 0; 15; 20]
 
-    [<Fact>]
-    let ``fold produces incorrect output when state is a function with arity > 1`` () = // See #2035
-        let folder state value x y = value :: state x y
-        let state x y = [x; y]
-        let d = List.fold folder state [0..3]
-        d 42 42 |> equal [3; 2; 1; 0; 42; 42]
-        let s = Seq.fold folder state [0..3]
-        s 15 20 |> equal [3; 2; 1; 0; 15; 20]
+[<Fact>]
+let ``Assigning a function with arity > 1 to a scoped mutable variable #2046`` () =
+    let mutable state = fortyTwo
+    state "a" "b" |> equal "a42b"
+    state <- fun x y -> x + "32" + y
+    state "a" "b" |> equal "a32b"
 
-    [<Fact>]
-    let ``Assigning a function with arity > 1 to a scoped mutable variable #2046" <| fun _ ->
-        let mutable state = fortyTwo
-        state "a" "b" |> equal "a42b"
-        state <- fun x y -> x + "32" + y
-        state "a" "b" |> equal "a32b"
+[<Fact>]
+let ``Uncurrying works with generic records returning lambdas`` () =
+    applyFooInRecord { foo = fun x y -> x ** y } 5. 2. |> equal 25.
+    let f = applyFooInRecord { foo = fun x y z -> x ** y + z } 5.
+    f 3. 2. |> equal 127.
+    applyFooInRecord2 { foo = fun x y -> x ** y } 5. 2. |> equal 25.
+    let f = applyFooInRecord2 { foo = fun x y z -> x ** y + z } 5.
+    f 3. 2. |> equal 127.
+    applyFooInRecord3 { foo = fun x y z -> x ** y - z } 5. 2. 1. |> equal 24.
+    let f = applyFooInRecord3 { foo = fun x y z -> x ** y - z } 5.
+    f 3. 3. |> equal 122.
 
-    [<Fact>]
-    let ``Uncurrying works with generic records returning lambdas`` () =
-        applyFooInRecord { foo = fun x y -> x ** y } 5. 2. |> equal 25.
-        let f = applyFooInRecord { foo = fun x y z -> x ** y + z } 5.
-        f 3. 2. |> equal 127.
-        applyFooInRecord2 { foo = fun x y -> x ** y } 5. 2. |> equal 25.
-        let f = applyFooInRecord2 { foo = fun x y z -> x ** y + z } 5.
-        f 3. 2. |> equal 127.
-        applyFooInRecord3 { foo = fun x y z -> x ** y - z } 5. 2. 1. |> equal 24.
-        let f = applyFooInRecord3 { foo = fun x y z -> x ** y - z } 5.
-        f 3. 3. |> equal 122.
+[<Fact>]
+let ``Uncurrying works with generic anonymous records returning lambdas`` () =
+    applyFooInAnonRecord {| foo = fun x y -> x ** y |} 5. 2. |> equal 25.
+    let f = applyFooInAnonRecord {| foo = fun x y -> x ** y |} 5.
+    f 3. |> equal 125.
 
-    [<Fact>]
-    let ``Uncurrying works with generic anonymous records returning lambdas`` () =
-        applyFooInAnonRecord {| foo = fun x y -> x ** y |} 5. 2. |> equal 25.
-        let f = applyFooInAnonRecord {| foo = fun x y -> x ** y |} 5.
-        f 3. |> equal 125.
+[<Fact>]
+let ``Curried functions being mangled via DU, List.fold and match combination #2356`` () =
+    let testData = [ In (fun b i -> "fly"); Out (fun b i -> "fade")]
 
-    [<Fact>]
-    let ``Curried functions being mangled via DU, List.fold and match combination #2356" <| fun _ ->
-        let testData = [ In (fun b i -> "fly"); Out (fun b i -> "fade")]
+    let test = match findThing testData with
+                        | Some f -> f true 1
+                        | None -> "nothing"
+    test |> equal "fly"
 
-        let test = match findThing testData with
-                            | Some f -> f true 1
-                            | None -> "nothing"
-        test |> equal "fly"
+[<Fact>]
+let ``Option uncurrying #2116`` () =
+    let optionFn = Some (fun x y -> x + y)
 
-    [<Fact>]
-    let ``Option uncurrying #2116" <| fun _ ->
-        let optionFn = Some (fun x y -> x + y)
+    let list = List.choose id [optionFn]
+    List.length list |> equal 1
+    let x =
+        match list with
+        | [f] -> f 3 4
+        | _ -> -1
+    equal 7 x
 
-        let list = List.choose id [optionFn]
-        List.length list |> equal 1
-        let x =
-            match list with
-            | [f] -> f 3 4
-            | _ -> -1
-        equal 7 x
+// See https://github.com/fable-compiler/Fable/issues/2436#issuecomment-919165092
+[<Fact>]
+let ``Functions passed to an object expression are uncurried`` () =
+    let mutable d = 0
+    let getAdder x =
+        d <- d + 1
+        fun y z -> x + y + z
+    let _ = getAdder 4
+    let f = getAdder 4
+    let adder = { new IAdder with member _.Add = f }
+    d |> equal 2
+    adder.Add 3 4 |> equal 11
 
-    // See https://github.com/fable-compiler/Fable/issues/2436#issuecomment-919165092
-    [<Fact>]
-    let ``Functions passed to an object expression are uncurried`` () =
-        let mutable d = 0
-        let getAdder x =
-            d <- d + 1
-            fun y z -> x + y + z
-        let _ = getAdder 4
-        let f = getAdder 4
-        let adder = { new IAdder with member _.Add = f }
-        d |> equal 2
-        adder.Add 3 4 |> equal 11
+[<Fact>]
+let ``Iterating list of functions #2047`` () =
+    let mutable s = "X"
+    for someFun in [fortyTwo] do
+        s <- s + someFun "y" "z" + s
+    equal "Xy42zX" s
 
-    [<Fact>]
-    let ``Iterating list of functions #2047" <| fun _ ->
-        let mutable s = "X"
-        for someFun in [fortyTwo] do
-            s <- s + someFun "y" "z" + s
-        equal "Xy42zX" s
-
-    [<Fact>]
-    let ``Aliasing a function wrapping a multi-arity function in point-free style #2045" <| fun _ ->
-        equal "4426" <| doesWork fortyTwo () ()
-        equal "4426" <| doesNotWork fortyTwo () ()
-        equal "4426" <| Wrapper().doesNotWorki fortyTwo () ()
-        equal "4426" <| Wrapper.doesNotWork fortyTwo () ()
-        equal 56 <| doesWork fortyTwo2 () () () 4
-        equal 56 <| doesNotWork fortyTwo2 () () () 4
-        equal 56 <| Wrapper().doesNotWorki2 fortyTwo2 () () () 4
-        equal 56 <| Wrapper.doesNotWork2 fortyTwo2 () () () 4
-
-
+[<Fact>]
+let ``Aliasing a function wrapping a multi-arity function in point-free style #2045`` () =
+    equal "4426" <| doesWork fortyTwo () ()
+    equal "4426" <| doesNotWork fortyTwo () ()
+    equal "4426" <| Wrapper().doesNotWorki fortyTwo () ()
+    equal "4426" <| Wrapper.doesNotWork fortyTwo () ()
+    equal 56 <| doesWork fortyTwo2 () () () 4
+    equal 56 <| doesNotWork fortyTwo2 () () () 4
+    equal 56 <| Wrapper().doesNotWorki2 fortyTwo2 () () () 4
+    equal 56 <| Wrapper.doesNotWork2 fortyTwo2 () () () 4
 
 module FSharpPlus =
     module Option =
@@ -1537,12 +1520,12 @@ module FSharpPlus =
     let sequence (t: seq<option<'t>>) =
         forInfiniteSeqs (t, Option.isNone, List.toSeq) : option<seq<'t>>
 
-    module tests =
-        [<Fact>]
-        let ``FSharpPlus regression`` () = // See #2471
-            let expected = Some(seq [1; 2])
-            sequence (seq [Some 1; Some 2]) |> equal expected
+open FSharpPlus
 
+[<Fact>]
+let ``FSharpPlus regression`` () = // See #2471
+    let expected = Some(seq [1; 2])
+    sequence (seq [Some 1; Some 2]) |> equal expected
 
 module Curry =
     let addString (value : string) (f : string -> 'T) =
@@ -1551,161 +1534,157 @@ module Curry =
     let addBool (value : bool) (f : bool -> 'T) =
         f value
 
-    module tests =
+open Curry
 
-            // Test the smallest arity I managed to create
-            [<Fact>]
-            let ``curried function of arity 2 works" <| fun _ ->
-                let res =
+// Test the smallest arity I managed to create
+[<Fact>]
+let ``curried function of arity 2 works`` () =
+    let res =
 
-                    let onSubmit =
-                        fun (arg1 : string)
-                            (arg2 : bool) ->
+        let onSubmit =
+            fun (arg1 : string)
+                (arg2 : bool) ->
 
-                            (arg1, arg2)
+                (arg1, arg2)
 
-                    onSubmit
-                        |> addString "name"
-                        |> addBool true
+        onSubmit
+            |> addString "name"
+            |> addBool true
 
-                equal ("name", true) res
+    equal ("name", true) res
 
-            // Test old maximum limit for curried functions
-            [<Fact>]
-            let ``curried function of arity 8 works" <| fun _ ->
-                let actual =
-                    let onSubmit =
-                        fun (arg1 : string)
-                            (arg2 : bool)
-                            (arg3 : string)
-                            (arg4 : string)
-                            (arg5 : string)
-                            (arg6 : string)
-                            (arg7 : string)
-                            (arg8 : string) ->
+// Test old maximum limit for curried functions
+[<Fact>]
+let ``curried function of arity 8 works`` () =
+    let actual =
+        let onSubmit =
+            fun (arg1 : string)
+                (arg2 : bool)
+                (arg3 : string)
+                (arg4 : string)
+                (arg5 : string)
+                (arg6 : string)
+                (arg7 : string)
+                (arg8 : string) ->
 
-                            (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+                (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 
-                    onSubmit
-                        |> addString "arg1"
-                        |> addBool true
-                        |> addString "arg3"
-                        |> addString "arg4"
-                        |> addString "arg5"
-                        |> addString "arg6"
-                        |> addString "arg7"
-                        |> addString "arg8"
+        onSubmit
+            |> addString "arg1"
+            |> addBool true
+            |> addString "arg3"
+            |> addString "arg4"
+            |> addString "arg5"
+            |> addString "arg6"
+            |> addString "arg7"
+            |> addString "arg8"
 
-                let expected =
-                    ("arg1", true, "arg3", "arg4", "arg5", "arg6", "arg7", "arg8")
+    let expected =
+        ("arg1", true, "arg3", "arg4", "arg5", "arg6", "arg7", "arg8")
 
-                equal expected actual
-
-
-            // Test an arity which exceeds the old limit of 8
-            [<Fact>]
-            let ``curried function of arity 10 works" <| fun _ ->
-                let actual =
-                    let onSubmit =
-                        fun (arg1 : string)
-                            (arg2 : bool)
-                            (arg3 : string)
-                            (arg4 : string)
-                            (arg5 : string)
-                            (arg6 : string)
-                            (arg7 : string)
-                            (arg8 : string)
-                            (arg9 : string)
-                            (arg10 : string) ->
-
-                            (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)
-
-                    onSubmit
-                        |> addString "arg1"
-                        |> addBool true
-                        |> addString "arg3"
-                        |> addString "arg4"
-                        |> addString "arg5"
-                        |> addString "arg6"
-                        |> addString "arg7"
-                        |> addString "arg8"
-                        |> addString "arg9"
-                        |> addString "arg10"
-
-                let expected =
-                    ("arg1", true, "arg3", "arg4", "arg5", "arg6", "arg7", "arg8", "arg9", "arg10")
-
-                equal expected actual
+    equal expected actual
 
 
-module Uncurry =
-    // Wrap everything into a compiler directives because we are using JS interop
-    // to provoke the behavior we want
-    #if FABLE_COMPILER
-    open Fable.Core
+// Test an arity which exceeds the old limit of 8
+[<Fact>]
+let ``curried function of arity 10 works`` () =
+    let actual =
+        let onSubmit =
+            fun (arg1 : string)
+                (arg2 : bool)
+                (arg3 : string)
+                (arg4 : string)
+                (arg5 : string)
+                (arg6 : string)
+                (arg7 : string)
+                (arg8 : string)
+                (arg9 : string)
+                (arg10 : string) ->
 
-    let private add2WithLambda (adder: int->int->int) (arg1: int) (arg2: int): int =
-        adder arg1 arg2
+                (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)
 
-    let add_2 =
-        add2WithLambda (JsInterop.import "add2Arguments" "./js/1foo.js")
+        onSubmit
+            |> addString "arg1"
+            |> addBool true
+            |> addString "arg3"
+            |> addString "arg4"
+            |> addString "arg5"
+            |> addString "arg6"
+            |> addString "arg7"
+            |> addString "arg8"
+            |> addString "arg9"
+            |> addString "arg10"
 
-    let private add10WithLambda
-        (adder: int->int->int->int->int->int->int->int->int->int->int)
-        (arg1: int)
-        (arg2: int)
-        (arg3: int)
-        (arg4: int)
-        (arg5: int)
-        (arg6: int)
-        (arg7: int)
-        (arg8: int)
-        (arg9: int)
-        (arg10: int)
-            : int =
+    let expected =
+        ("arg1", true, "arg3", "arg4", "arg5", "arg6", "arg7", "arg8", "arg9", "arg10")
 
-        adder arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10
+    equal expected actual
 
-    let add_10 =
-        add10WithLambda (JsInterop.import "add10Arguments" "./js/1foo.js")
+// module Uncurry =
+//     // Wrap everything into a compiler directives because we are using JS interop
+//     // to provoke the behavior we want
+//     #if FABLE_COMPILER
+//     open Fable.Core
 
-    module tests =
+//     let private add2WithLambda (adder: int->int->int) (arg1: int) (arg2: int): int =
+//         adder arg1 arg2
 
-            [<Fact>]
-            let ``uncurry function of arity 2 works" <| fun _ ->
-                let actual =
-                    add_2 10 5
+//     let add_2 =
+//         add2WithLambda (JsInterop.import "add2Arguments" "./js/1foo.js")
 
-                equal 15 actual
+//     let private add10WithLambda
+//         (adder: int->int->int->int->int->int->int->int->int->int->int)
+//         (arg1: int)
+//         (arg2: int)
+//         (arg3: int)
+//         (arg4: int)
+//         (arg5: int)
+//         (arg6: int)
+//         (arg7: int)
+//         (arg8: int)
+//         (arg9: int)
+//         (arg10: int)
+//             : int =
 
-            [<Fact>]
-            let ``uncurry function of arity 10 works" <| fun _ ->
-                let actual =
-                    add_10 1 2 3 4 5 6 7 8 9 10
+//         adder arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10
 
-                equal 55 actual
+//     let add_10 =
+//         add10WithLambda (JsInterop.import "add10Arguments" "./js/1foo.js")
 
-    #endif
+//     module tests =
+
+//             [<Fact>]
+//             let ``uncurry function of arity 2 works`` () =
+//                 let actual =
+//                     add_2 10 5
+
+//                 equal 15 actual
+
+//             [<Fact>]
+//             let ``uncurry function of arity 10 works`` () =
+//                 let actual =
+//                     add_10 1 2 3 4 5 6 7 8 9 10
+
+//                 equal 55 actual
+
+//     #endif
 
 module MultipleInlines =
-    open Aether
-    open Aether.Operators
-
     //
     // Types with required nesting and optics to reproduce error
     //
-    type private Result<'T> =
+    type Result<'T> =
         | Ok of 'T
         | Error of string
 
-    type private PaymentFrequencyDto =
+    type PaymentFrequencyDto =
         | Weekly = 1
         | Fortnightly = 2
         | Monthly = 3
         | Quarterly = 4
         | Annual = 5
 
-    type private InsurancePolicyDetailsDto = {
+    type InsurancePolicyDetailsDto = {
         PaymentFrequency : PaymentFrequencyDto
         Discount : decimal option
     } with
@@ -1718,7 +1697,7 @@ module MultipleInlines =
         static member paymentFrequency_ : Lens<InsurancePolicyDetailsDto, PaymentFrequencyDto> =
             (fun p -> p.PaymentFrequency), (fun x p -> { p with PaymentFrequency = x })
 
-    type private AccountDetailsDto = {
+    type AccountDetailsDto = {
         Tag : string
         InsurancePolicyData : InsurancePolicyDetailsDto option
     } with
@@ -1730,7 +1709,7 @@ module MultipleInlines =
                 | p -> p)
 
 
-    type private AccountDto = {
+    type AccountDto = {
         Details : AccountDetailsDto
     } with
         static member details_ : Lens<AccountDto, AccountDetailsDto> =
@@ -1747,30 +1726,31 @@ module MultipleInlines =
       static member inline map (Functor, f: 'a -> 'b, NonEmptyList(h, t): NonEmptyList<'a>) =
         NonEmptyList (f h, map f t)
 
-    let private mapMyList (xs: NonEmptyList<string>) : NonEmptyList<string> =
+    let mapMyList (xs: NonEmptyList<string>) : NonEmptyList<string> =
       map (fun s -> s + "_") xs
 
-    module tests =
-        [<Fact>]
-        let ``Trait call works with multiple inlined functions I`` () = // See #2809
-            let account = Some { Details = { Tag = "Test"; InsurancePolicyData = None }}
-            let details_ = Option.value_ >?> AccountDto.details_ >?> AccountDetailsDto.insurancePolicyData_
+open MultipleInlines
 
-            let inline getP (optic : Prism<InsurancePolicyDetailsDto,'a>) = Optic.get (details_ >?> optic) account
+[<Fact>]
+let ``Trait call works with multiple inlined functions I`` () = // See #2809
+    let account = Some { Details = { Tag = "Test"; InsurancePolicyData = None }}
+    let details_ = Option.value_ >?> AccountDto.details_ >?> AccountDetailsDto.insurancePolicyData_
 
-            getP InsurancePolicyDetailsDto.discount_
-            |> equal None
+    let inline getP (optic : Prism<InsurancePolicyDetailsDto,'a>) = Optic.get (details_ >?> optic) account
 
-        [<Fact>]
-        let ``Trait call works with multiple inlined functions II`` () = // See #2809
-            let account = Some { Details = { Tag = "Test"; InsurancePolicyData = None }}
-            let details_ = Option.value_ >?> AccountDto.details_ >?> AccountDetailsDto.insurancePolicyData_
+    getP InsurancePolicyDetailsDto.discount_
+    |> equal None
 
-            let inline getP (optic : Prism<InsurancePolicyDetailsDto,'a>) = account^.(details_ >?> optic)
+[<Fact>]
+let ``Trait call works with multiple inlined functions II`` () = // See #2809
+    let account = Some { Details = { Tag = "Test"; InsurancePolicyData = None }}
+    let details_ = Option.value_ >?> AccountDto.details_ >?> AccountDetailsDto.insurancePolicyData_
 
-            getP InsurancePolicyDetailsDto.discount_
-            |> equal None
+    let inline getP (optic : Prism<InsurancePolicyDetailsDto,'a>) = account^.(details_ >?> optic)
 
-        [<Fact>]
-        let ``Identifiers from witnesses don't get duplicated when resolving inline expressions`` () = // See #2855
-            NonEmptyList("a", ["b"; "c"]) |> mapMyList |> equal (NonEmptyList("a_", ["b_"; "c_"]))
+    getP InsurancePolicyDetailsDto.discount_
+    |> equal None
+
+[<Fact>]
+let ``Identifiers from witnesses don't get duplicated when resolving inline expressions`` () = // See #2855
+    NonEmptyList("a", ["b"; "c"]) |> mapMyList |> equal (NonEmptyList("a_", ["b_"; "c_"]))

--- a/tests/Rust/tests/src/DateTimeOffsetTests.fs
+++ b/tests/Rust/tests/src/DateTimeOffsetTests.fs
@@ -675,22 +675,22 @@ module tests =
 
         module ``(DateTime)`` =
             [<Fact>]
-            let ``Default (= unspecified)" <| fun _ ->
+            let ``Default (= unspecified)`` () =
                 let dt = DateTime(usedDate.Year, usedDate.Month, usedDate.Day, usedDate.Hour, usedDate.Minute, usedDate.Second)
                 let dto = DateTimeOffset(dt)
                 equal dto.Offset localOffset
             [<Fact>]
-            let ``Unspecified" <| fun _ ->
+            let ``Unspecified`` () =
                 let dt = DateTime(usedDate.Year, usedDate.Month, usedDate.Day, usedDate.Hour, usedDate.Minute, usedDate.Second, DateTimeKind.Unspecified)
                 let dto = DateTimeOffset(dt)    // no custom offset -> local offset
                 equal dto.Offset localOffset
             [<Fact>]
-            let ``UTC" <| fun _ ->
+            let ``UTC`` () =
                 let dt = DateTime(usedDate.Year, usedDate.Month, usedDate.Day, usedDate.Hour, usedDate.Minute, usedDate.Second, DateTimeKind.Utc)
                 let dto = DateTimeOffset(dt)
                 equal dto.Offset TimeSpan.Zero
             [<Fact>]
-            let ``Local" <| fun _ ->
+            let ``Local`` () =
                 let dt = DateTime(usedDate.Year, usedDate.Month, usedDate.Day, usedDate.Hour, usedDate.Minute, usedDate.Second, DateTimeKind.Local)
                 let dto = DateTimeOffset(dt)
                 equal dto.Offset localOffset
@@ -729,7 +729,7 @@ module tests =
 
 
         [<Fact>]
-        let ``offset = localOffset succeeds" <| fun _ ->
+        let ``offset = localOffset succeeds`` () =
             localOffset
             |> testSucceeds fromLocalDateTime
 

--- a/tests/Rust/tests/src/DictionaryTests.fs
+++ b/tests/Rust/tests/src/DictionaryTests.fs
@@ -321,7 +321,7 @@ let ``conversion from array works with duplicates`` () =
     |> equal 2
 
 // [<Fact>]
-// let ``Dictionary with type as key works" <| fun _ -> // See #2202
+// let ``Dictionary with type as key works`` () = // See #2202
 //     let cache = Dictionary<Type, int>()
 //     cache.Add(typeof<int>, 1)
 //     cache.Add(typeof<string>, 2)

--- a/tests/Rust/tests/src/ImportTests.fs
+++ b/tests/Rust/tests/src/ImportTests.fs
@@ -260,7 +260,7 @@ module tests =
         add 3 2 |> equal 8
 
     [<Fact>]
-    let ``Inline import expressions can absorb arguments" <| fun _ -> // See #2284
+    let ``Inline import expressions can absorb arguments`` () = // See #2284
         let stylesheet = Stylesheet.load "./js/1foo.js"
         stylesheet.["myKey"] |> equal "a secret"
     #endif

--- a/tests/Rust/tests/src/MiscTests2.fs
+++ b/tests/Rust/tests/src/MiscTests2.fs
@@ -510,7 +510,7 @@ module tests =
 #if FABLE_COMPILER
 #if !FABLE_COMPILER_JAVASCRIPT
     [<Fact>]
-    let ``Fable.JsonProvider works" <| fun _ ->
+    let ``Fable.JsonProvider works`` () =
         let parsed = LiteralJson(ANOTHER_JSON)
         parsed.widget.debug |> equal false
         parsed.widget.text.data |> equal "lots of"
@@ -524,7 +524,7 @@ module tests =
         x() |> equal 1
 
     [<Fact>]
-    let ``Can check compiler version with constant" <| fun _ ->
+    let ``Can check compiler version with constant`` () =
         let mutable x = 0
         #if FABLE_COMPILER
         x <- x + 1
@@ -544,12 +544,12 @@ module tests =
         equal 13 x
 
     [<Fact>]
-    let ``Can check compiler version at runtime" <| fun _ ->
+    let ``Can check compiler version at runtime`` () =
         Compiler.majorMinorVersion >=  4.0 |> equal true
         Text.RegularExpressions.Regex.IsMatch(Compiler.version, @"^\d+\.\d+") |> equal true
 
     [<Fact>]
-    let ``Can access compiler options" <| fun _ ->
+    let ``Can access compiler options`` () =
         let canAccessOpts =
             match box Compiler.debugMode, box Compiler.typedArrays with
             | :? bool, :? bool -> true
@@ -557,7 +557,7 @@ module tests =
         equal true canAccessOpts
 
     [<Fact>]
-    let ``Can access extension for generated files" <| fun _ ->
+    let ``Can access extension for generated files`` () =
         Compiler.extension.EndsWith(".js") |> equal true
 #endif
 

--- a/tests/Rust/tests/src/RegexTests.fs
+++ b/tests/Rust/tests/src/RegexTests.fs
@@ -6,14 +6,14 @@ open System.Text.RegularExpressions
 module tests =
 
     [<Fact>]
-    let ``Regex literals work with forward slashes" <| fun _ ->
+    let ``Regex literals work with forward slashes`` () =
         let str = "<a>foo</a><b>bar</b>"
         let reg = Regex(@"(<a>)\w+(</a>)")
         reg.Replace(str, "$1bar$2")
         |> equal "<a>bar</a><b>bar</b>"
 
     [<Fact>]
-    let ``Regex literals work with new lines" <| fun _ ->
+    let ``Regex literals work with new lines`` () =
         let str = """<a>`   foo `</a>
 <b>bar</b>"""
         let reg = Regex("""(<a>)`   \w+ `(</a>)
@@ -22,7 +22,7 @@ module tests =
         |> equal "<a>bar</a><b>ham</b>"
 
     [<Fact>]
-    let ``Literal regex works with whitespace characters" <| fun _ -> // See #2635
+    let ``Literal regex works with whitespace characters`` () = // See #2635
         Regex("\r\n|\n").IsMatch("foo\r\nbar") |> equal true
         Regex(@"\r\n|\n").IsMatch("foo\r\nbar") |> equal true
         Regex("\\r\\n|\\n").IsMatch("foo\r\nbar") |> equal true
@@ -34,7 +34,7 @@ module tests =
         Regex(@"\\t").IsMatch("foo\tbar") |> equal false
 
     [<Fact>]
-    let ``Regex.Options works" <| fun _ ->
+    let ``Regex.Options works`` () =
         let option1 = RegexOptions.IgnoreCase
         let option2 = RegexOptions.ECMAScript
         let options = option1 ||| option2
@@ -42,7 +42,7 @@ module tests =
         int r.Options |> equal 257
 
     [<Fact>]
-    let ``Regex.IsMatch with IgnoreCase and Multiline works" <| fun _ ->
+    let ``Regex.IsMatch with IgnoreCase and Multiline works`` () =
         let str = "ab\ncd"
         let option1 = RegexOptions.IgnoreCase
         let option2 = RegexOptions.Multiline
@@ -56,31 +56,31 @@ module tests =
         test "^bc" false
 
     [<Fact>]
-    let ``Regex.Escape works" <| fun _ ->
+    let ``Regex.Escape works`` () =
         // TODO: a few chars are not escaped (e.g. # and white space)
         Regex.Escape(@"\*+?|{[()^$") |> equal @"\\\*\+\?\|\{\[\(\)\^\$"
         Regex.Escape(@"C:\Temp") |> equal @"C:\\Temp"
 
     [<Fact>]
-    let ``Regex.Unescape works" <| fun _ ->
+    let ``Regex.Unescape works`` () =
         Regex.Unescape(@"\\\*\+\?\|\{\[\(\)\^\$") |> equal @"\*+?|{[()^$"
         Regex.Unescape(@"C:\\Temp") |> equal @"C:\Temp"
 
     [<Fact>]
-    let ``Regex instance IsMatch works" <| fun _ ->
+    let ``Regex instance IsMatch works`` () =
         let str = "For more information, see Chapter 3.4.5.1"
         Regex("Chapter \d+(\.\d)*").IsMatch(str) |> equal true
         Regex("chapter \d+(\.\d)*").IsMatch(str) |> equal false
 
     [<Fact>]
-    let ``Regex instance IsMatch with offset works" <| fun _ ->
+    let ``Regex instance IsMatch with offset works`` () =
         let str = "For more information, see Chapter 3.4.5.1"
         let re = Regex("Chapter \d+(\.\d)*")
         re.IsMatch(str, 10) |> equal true
         re.IsMatch(str, 40) |> equal false
 
     [<Fact>]
-    let ``Regex instance Match and Matches work" <| fun _ ->
+    let ``Regex instance Match and Matches work`` () =
         let str = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
         let test pattern expected =
             let re = Regex(pattern, RegexOptions.IgnoreCase)
@@ -91,7 +91,7 @@ module tests =
         test "(ZZ)+" -1
 
     [<Fact>]
-    let ``Regex instance Match and Matches with offset work" <| fun _ ->
+    let ``Regex instance Match and Matches with offset work`` () =
         let str = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
         let test offset expected =
             let re = Regex("[A-E]", RegexOptions.IgnoreCase)
@@ -102,26 +102,26 @@ module tests =
         test 40 -1
 
     [<Fact>]
-    let ``Regex.IsMatch works" <| fun _ ->
+    let ``Regex.IsMatch works`` () =
         let str = "For more information, see Chapter 3.4.5.1"
         Regex.IsMatch(str, "Chapter \d+(\.\d)*") |> equal true
         Regex.IsMatch(str, "chapter \d+(\.\d)*") |> equal false
 
     [<Fact>]
-    let ``Regex.IsMatch with IgnoreCase works" <| fun _ ->
+    let ``Regex.IsMatch with IgnoreCase works`` () =
         let str = "For more information, see Chapter 3.4.5.1"
         Regex.IsMatch(str, "Chapter \d+(\.\d)*", RegexOptions.IgnoreCase) |> equal true
         Regex.IsMatch(str, "chapter \d+(\.\d)*", RegexOptions.IgnoreCase) |> equal true
 
     [<Fact>]
-    let ``Regex.IsMatch with Multiline works" <| fun _ ->
+    let ``Regex.IsMatch with Multiline works`` () =
         let str = "ab\ncd"
         Regex.IsMatch(str, "^ab", RegexOptions.Multiline) |> equal true
         Regex.IsMatch(str, "^cd", RegexOptions.Multiline) |> equal true
         Regex.IsMatch(str, "^AB", RegexOptions.Multiline) |> equal false
 
     [<Fact>]
-    let ``RegexOptions.Singleline works" <| fun _ ->
+    let ``RegexOptions.Singleline works`` () =
         let str = "ab\ncd"
         let m1 = Regex.Match(str, ".+")
         let m2 = Regex.Match(str, ".+", RegexOptions.Singleline)
@@ -129,20 +129,20 @@ module tests =
         m2.Length |> equal 5
 
     [<Fact>]
-    let ``Regex.Match works" <| fun _ ->
+    let ``Regex.Match works`` () =
         let str = "For more information, see Chapter 3.4.5.1"
         Regex.Match(str, "Chapter \d+(\.\d)*").Success |> equal true
         Regex.Match(str, "chapter \d+(\.\d)*").Success |> equal false
 
     [<Fact>]
-    let ``Match.Groups indexer getter works" <| fun _ ->
+    let ``Match.Groups indexer getter works`` () =
         let str = "For more information, see Chapter 3.4.5.1"
         let m = Regex.Match(str, "Chapter \d+(\.\d)*")
         let g = m.Groups.[1]
         g.Value |> equal ".1"
 
     [<Fact>]
-    let ``Match.Groups iteration works" <| fun _ ->
+    let ``Match.Groups iteration works`` () =
         let str = "For more information, see Chapter 3.4.5.1"
         let m = Regex.Match(str, "Chapter \d+(\.\d)*")
         let count = ref 0
@@ -157,37 +157,37 @@ module tests =
         equal "foobaz" x
 
     [<Fact>]
-    let ``Match.Groups.Count works" <| fun _ ->
+    let ``Match.Groups.Count works`` () =
         let str = "For more information, see Chapter 3.4.5.1"
         let m = Regex.Match(str, "Chapter \d+(\.\d)*")
         m.Groups.Count |> equal 2
 
     [<Fact>]
-    let ``Match.Index works" <| fun _ ->
+    let ``Match.Index works`` () =
         let str = "For more information, see Chapter 3.4.5.1"
         let m = Regex.Match(str, "Chapter \d+(\.\d)*")
         m.Index |> equal 26
 
     [<Fact>]
-    let ``Match.Length works" <| fun _ ->
+    let ``Match.Length works`` () =
         let str = "For more information, see Chapter 3.4.5.1"
         let m = Regex.Match(str, "Chapter \d+(\.\d)*")
         m.Length |> equal 15
 
     [<Fact>]
-    let ``Match.Value works" <| fun _ ->
+    let ``Match.Value works`` () =
         let str = "For more information, see Chapter 3.4.5.1"
         let m = Regex.Match(str, "Chapter \d+(\.\d)*")
         m.Value |> equal "Chapter 3.4.5.1"
 
     [<Fact>]
-    let ``Regex.Matches indexer getter works" <| fun _ ->
+    let ``Regex.Matches indexer getter works`` () =
         let str = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
         let ms = Regex.Matches(str, "[A-E]", RegexOptions.IgnoreCase)
         ms.[8].Index |> equal 29
 
     [<Fact>]
-    let ``Regex.Matches iteration works" <| fun _ ->
+    let ``Regex.Matches iteration works`` () =
         let str = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
         let ms = Regex.Matches(str, "[A-E]", RegexOptions.IgnoreCase)
         let count = ref 0
@@ -195,7 +195,7 @@ module tests =
         equal 10 !count
 
     [<Fact>]
-    let ``Regex.Matches iteration with casting works" <| fun _ ->
+    let ``Regex.Matches iteration with casting works`` () =
         let str = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
         let ms = Regex.Matches(str, "[A-E]", RegexOptions.IgnoreCase)
         let count =
@@ -203,7 +203,7 @@ module tests =
         equal 10 count
 
     [<Fact>]
-    let ``MatchCollection.Count works" <| fun _ ->
+    let ``MatchCollection.Count works`` () =
         let str = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
         let test pattern expected =
             let ms = Regex.Matches(str, pattern, RegexOptions.IgnoreCase)
@@ -233,7 +233,7 @@ module tests =
         test "a\" \\\\\" \\\"\"\"a\\sdf\\  '\"' \\' A\"Sd \\af\\aef '\\ a ' ''\\\\\\\\\"\"\" \"\"\" \" \" |\"\" |\" \"\"\"\" \"\" \\\\ \\ \\\\\"\" \\\"\"\"b \\\"c\" de\"f\"" pattern ["a"; " \\\\\" \\\"\"\"a\\sdf\\  '\"' \\' A\"Sd \\af\\aef '\\ a ' ''\\\\\\\\\"\"\" \"\"\" \" \" |\"\" |\" \"\"\"\" \"\" \\\\ \\ \\\\\"\" \\\"\"\"b \\\"c\" de\"f"]
 
     [<Fact>]
-    let ``Regex.Split works" <| fun _ ->
+    let ``Regex.Split works`` () =
         let test str expected =
             let splits = Regex.Split(str, "[;,]")
             splits.Length |> equal expected
@@ -241,21 +241,21 @@ module tests =
         test "" 1
 
     [<Fact>]
-    let ``Regex.Split with limit works" <| fun _ ->
+    let ``Regex.Split with limit works`` () =
         let s = "blah blah blah, blah blah blah"
         let r = Regex(" ")
         r.Split(s, 1).Length |> equal 1
         r.Split(s, 3).Length |> equal 3
 
     [<Fact>]
-    let ``Regex.Split with limit and offset works" <| fun _ ->
+    let ``Regex.Split with limit and offset works`` () =
         let s = "blah blah blah, blah blah blah"
         let r = Regex(" ")
         r.Split(s, 10, 0).Length |> equal 6
         r.Split(s, 10, 20).Length |> equal 3
 
     [<Fact>]
-    let ``Regex.Replace works" <| fun _ ->
+    let ``Regex.Replace works`` () =
         let str = "Too   much   space"
         Regex.Replace(str, "\\s+", " ")
         |> equal "Too much space"
@@ -263,13 +263,13 @@ module tests =
         |> equal " T o o       m u c h       s p a c e "
 
     [<Fact>]
-    let ``Regex.Replace with macros works" <| fun _ ->
+    let ``Regex.Replace with macros works`` () =
         let str = "Alfonso Garcia-Caro"
         Regex.Replace(str, "([A-Za-z]+) ([A-Za-z\-]+)", "$2 $1") |> equal "Garcia-Caro Alfonso"
         Regex.Replace(str, "(fon)(so)", "$2 $1") |> equal "Also fon Garcia-Caro"
 
     [<Fact>]
-    let ``Regex.Replace with limit works" <| fun _ ->
+    let ``Regex.Replace with limit works`` () =
         let str = "Too   much   space"
         let r = Regex("\\s+")
         r.Replace(str, " ", count=1)
@@ -278,7 +278,7 @@ module tests =
         |> equal "Too much space"
 
     [<Fact>]
-    let ``Regex.Replace with limit and offset works" <| fun _ ->
+    let ``Regex.Replace with limit and offset works`` () =
         let str = "Too   much   space"
         let r = Regex("\\s+")
         r.Replace(str, " ", count=20, startat=0)
@@ -287,14 +287,14 @@ module tests =
         |> equal "Too   much space"
 
     [<Fact>]
-    let ``Regex.Replace with limit, offset and macros works" <| fun _ ->
+    let ``Regex.Replace with limit, offset and macros works`` () =
         let str = "Alfonso Garcia-Caro"
         let re = Regex("([A-Za-z]+) ([A-Za-z\-]+)")
         re.Replace(str, "$2 $1", 1) |> equal "Garcia-Caro Alfonso"
         re.Replace(str, "$2 $1", 10, 5) |> equal "AlfonGarcia-Caro so"
 
     [<Fact>]
-    let ``Regex.Replace with evaluator works" <| fun _ ->
+    let ``Regex.Replace with evaluator works`` () =
         let str = "Alfonso García-Caro"
         let test pattern expected =
             Regex.Replace(str, pattern, fun (m: Match) ->
@@ -304,7 +304,7 @@ module tests =
         test "(fon)(so)" "Also fon García-Caro"
 
     [<Fact>]
-    let ``Regex.Replace with evaluator and limit works" <| fun _ ->
+    let ``Regex.Replace with evaluator and limit works`` () =
         let str = "abcabcabcabcabcabcabcabc"
         let r = Regex("c")
         let test count expected =
@@ -314,7 +314,7 @@ module tests =
         test 3 "ab2ab5ab8abcabcabcabcabc"
 
     [<Fact>]
-    let ``Regex.Replace with evaluator, limit and offset works" <| fun _ ->
+    let ``Regex.Replace with evaluator, limit and offset works`` () =
         let str = "abcCcabCCabcccabcabcabCCCcabcabc"
         let r = Regex("c+", RegexOptions.IgnoreCase)
         let test startat expected =
@@ -324,13 +324,13 @@ module tests =
         test 10 "abcCcabCCab3ab1ab1abCCCcabcabc"
 
     [<Fact>]
-    let ``Replacing with $0 works" <| fun _ -> // See #1155
+    let ``Replacing with $0 works`` () = // See #1155
         let s = Regex.Replace("1234567890", ".{2}", "$0-")
         equal "12-34-56-78-90-" s
 
     // See #838
     [<Fact>]
-    let ``Group values are correct and empty when not being matched" <| fun _ ->
+    let ``Group values are correct and empty when not being matched`` () =
         Regex.Matches("\n\n\n", @"(?:([^\n\r]+)|\r\n|\n\r|\n|\r)")
         |> Seq.cast<Match>
         |> Seq.map (fun m -> m.Groups.[1].Value)
@@ -338,14 +338,14 @@ module tests =
         |> equal true
 
     [<Fact>]
-    let ``Group values can be converted to int" <| fun _ -> // See #1753
+    let ``Group values can be converted to int`` () = // See #1753
         let m = Regex.Match("ABC123", @"([A-Z]+)(\d+)")
         let group = m.Groups.[2]
         int (group.Value) |> equal 123
 
     // see #2359
     [<Fact>]
-    let ``Regex.Replace with elevator works when regex has named capture group" <| fun _ ->
+    let ``Regex.Replace with elevator works when regex has named capture group`` () =
         let r = Regex "0(?<number>\\d+)"
         let text = "Number 012345!"
 
@@ -370,26 +370,26 @@ module tests =
     module tests =
         module Match =
             [<Fact>]
-            let ``succeeds when match" <| fun _ ->
+            let ``succeeds when match`` () =
                 let r = Regex "(?<number>\\d+)"
                 let m = r.Match "Number 12345 is positive"
                 m.Success |> equal true
 
             [<Fact>]
-            let ``doesn't succeed when unmatched" <| fun _ ->
+            let ``doesn't succeed when unmatched`` () =
                 let r = Regex "(?<number>\\d+)"
                 let m = r.Match "Hello World"
                 m.Success |> equal false
 
             [<Fact>]
-            let ``can get value of existing group" <| fun _ ->
+            let ``can get value of existing group`` () =
                 let r = Regex "(?<number>\\d+)"
                 let m = r.Match "Number 12345 is positive"
 
                 m.Groups.["number"].Value |> equal "12345"
 
             [<Fact>]
-            let ``can get values of multiple existing groups" <| fun _ ->
+            let ``can get values of multiple existing groups`` () =
                 let r = Regex "\\+(?<country>\\d{1,3}) (?<num>\\d+)"
                 let m = r.Match "Number: +49 1234!"
 
@@ -397,35 +397,35 @@ module tests =
                 m.Groups.["num"].Value |> equal "1234"
 
             [<Fact>]
-            let ``doesn't succeed for not existing named group" <| fun _ ->
+            let ``doesn't succeed for not existing named group`` () =
                 let r = Regex "(?<number>\\d+)"
                 let m = r.Match "Number 12345 is positive"
 
                 m.Groups.["nothing"].Success |> equal false
 
             [<Fact>]
-            let ``doesn't succeed for not existing named group in regex without named group" <| fun _ ->
+            let ``doesn't succeed for not existing named group in regex without named group`` () =
                 let r = Regex "\\d+"
                 let m = r.Match "Number 12345 is positive"
 
                 m.Groups.["nothing"].Success |> equal false
 
             [<Fact>]
-            let ``doesn't succeed for existing unmatched group" <| fun _ ->
+            let ``doesn't succeed for existing unmatched group`` () =
                 let r = Regex "(?<exact>42)|(?<number>\\d+)"
                 let m = r.Match "Number 12345 is positive"
 
                 m.Groups.["exact"].Success |> equal false
 
             [<Fact>]
-            let ``group name from string" <| fun _ ->
+            let ``group name from string`` () =
                 let r = Regex "(?<number>\\d+)"
                 let m = r.Match "Number 12345 is positive"
 
                 m.Groups.["number"].Value |> equal "12345"
 
             [<Fact>]
-            let ``group name from variable" <| fun _ ->
+            let ``group name from variable`` () =
                 let r = Regex "(?<number>\\d+)"
                 let m = r.Match "Number 12345 is positive"
 
@@ -433,14 +433,14 @@ module tests =
                 m.Groups.[g].Value |> equal "12345"
 
             [<Fact>]
-            let ``group name from addition" <| fun _ ->
+            let ``group name from addition`` () =
                 let r = Regex "(?<number>\\d+)"
                 let m = r.Match "Number 12345 is positive"
 
                 m.Groups.["num" + "ber"].Value |> equal "12345"
 
             [<Fact>]
-            let ``group name from string in function" <| fun _ ->
+            let ``group name from string in function`` () =
                 let r = Regex "(?<number>\\d+)"
                 let m = r.Match "Number 12345 is positive"
 
@@ -450,7 +450,7 @@ module tests =
                 m |> namedGroup "number" |> equal "12345"
 
             [<Fact>]
-            let ``group name from variable in function" <| fun _ ->
+            let ``group name from variable in function`` () =
                 let r = Regex "(?<number>\\d+)"
                 let m = r.Match "Number 12345 is positive"
 
@@ -461,7 +461,7 @@ module tests =
                 m |> namedGroup g |> equal "12345"
 
             [<Fact>]
-            let ``group name from function call" <| fun _ ->
+            let ``group name from function call`` () =
                 let r = Regex "(?<number>\\d+)"
                 let m = r.Match "Number 12345 is positive"
 
@@ -469,7 +469,7 @@ module tests =
                 m.Groups.[getName ()].Value |> equal "12345"
 
             [<Fact>]
-            let ``group name from if expression" <| fun _ ->
+            let ``group name from if expression`` () =
                 let r = Regex "(?<number>\\d+)"
                 let m = r.Match "Number 12345 is positive"
 
@@ -483,7 +483,7 @@ module tests =
                 let equalUndefined (x: obj) = isUndefined x |> equal true
 
                 [<Fact>]
-                let ``not existing indexed group" <| fun _ ->
+                let ``not existing indexed group`` () =
                     let r = Regex "\\d+"
                     let m = r.Match "Number 12345 is positive"
 
@@ -491,7 +491,7 @@ module tests =
                     g |> equalUndefined
 
                 [<Fact>]
-                let ``not existing named grouped with other named groups" <| fun _ ->
+                let ``not existing named grouped with other named groups`` () =
                     let r = Regex "(?<number>\\d+)"
                     let m = r.Match "Number 12345 is positive"
                     // in JS: `m.groups` exists
@@ -500,7 +500,7 @@ module tests =
                     g |> equalUndefined
 
                 [<Fact>]
-                let ``not existing named grouped without named groups" <| fun _ ->
+                let ``not existing named grouped without named groups`` () =
                     let r = Regex "\\d+"
                     let m = r.Match "Number 12345 is positive"
                     // in JS: no `m.groups`
@@ -509,7 +509,7 @@ module tests =
                     g |> equalUndefined
 
                 [<Fact>]
-                let ``unmatched existing named group" <| fun _ ->
+                let ``unmatched existing named group`` () =
                     let r = Regex "(?<exact>42)|(?<number>\\d+)"
                     let m = r.Match "Number 12345 is positive"
                     // in JS: `m.groups` exists, `m.groups.["exact"]` is `undefined`
@@ -521,7 +521,7 @@ module tests =
 
         module Matches =
             [<Fact>]
-            let ``gets all matches with all named groups" <| fun _ ->
+            let ``gets all matches with all named groups`` () =
                 let r = Regex "\\+(?<country>\\d{1,3}) (?<num>\\d+)"
                 let text = "Numbers: +1 12; +49 456; +44 7890;"
 
@@ -539,7 +539,7 @@ module tests =
                 actual |> equal expected
 
             [<Fact>]
-            let ``group name from string" <| fun _ ->
+            let ``group name from string`` () =
                 let r = Regex "\\+(?<country>\\d{1,3}) (?<num>\\d+)"
                 let text = "Numbers: +1 12; +49 456; +44 7890;"
 
@@ -557,7 +557,7 @@ module tests =
                 actual |> equal expected
 
             [<Fact>]
-            let ``group name from variable" <| fun _ ->
+            let ``group name from variable`` () =
                 let r = Regex "\\+(?<country>\\d{1,3}) (?<num>\\d+)"
                 let text = "Numbers: +1 12; +49 456; +44 7890;"
 
@@ -587,7 +587,7 @@ module tests =
 
                 // "replacement: string"
                 [<Fact>]
-                let ``.Net named group gets replaced" <| fun _ ->
+                let ``.Net named group gets replaced`` () =
                     let r = Regex "\\+(?<country>\\d{1,3}) (?<num>\\d+)"
                     let text = "Numbers: +1 12; +49 456; +44 7890;"
 
@@ -602,7 +602,7 @@ module tests =
 
                 //"evaluator: Match -> string"
                 [<Fact>]
-                let ``can access named groups" <| fun _ ->
+                let ``can access named groups`` () =
                     let r = Regex "\\+(?<country>\\d{1,3}) (?<num>\\d+)"
                     let text = "Numbers: +1 12; +49 456; +44 7890;"
 
@@ -615,7 +615,7 @@ module tests =
                     actual |> equal expected
 
                 [<Fact>]
-                let ``doesn't succeed when not existing group" <| fun _ ->
+                let ``doesn't succeed when not existing group`` () =
                     let r = Regex "\\+(?<country>\\d{1,3}) (?<num>\\d+)"
                     let text = "Numbers: +1 12; +49 456; +44 7890;"
 
@@ -631,7 +631,7 @@ module tests =
                     actual |> equal expected
 
                 [<Fact>]
-                let ``doesn't succeed when not existing group without any named groups" <| fun _ ->
+                let ``doesn't succeed when not existing group without any named groups`` () =
                     let r = Regex "\\+(\\d{1,3}) (\\d+)"
                     let text = "Numbers: +1 12; +49 456; +44 7890;"
 

--- a/tests/Rust/tests/src/TypeTests.fs
+++ b/tests/Rust/tests/src/TypeTests.fs
@@ -929,7 +929,7 @@ let ``Type testing with primitive types works`` () =
 
 // // // Test ported from https://github.com/fable-compiler/Fable/pull/1336/files
 // // [<Fact>]
-// // let ``default value attributes works" <| fun _ ->
+// // let ``default value attributes works`` () =
 // //     let withDefaultValue = TestTypeWithDefaultValue()
 
 // //     withDefaultValue.IntValue |> equal Unchecked.defaultof<int>
@@ -942,7 +942,7 @@ let ``Type testing with primitive types works`` () =
 // //     withDefaultValue.ObjValue |> equal null
 
 // [<Fact>]
-// let ``Private fields don't conflict with parent classes" <| fun _ -> // See #2070
+// let ``Private fields don't conflict with parent classes`` () = // See #2070
 //     let a1 = InfoBClass({ InfoA = { Foo = "foo" }; Bar = "bar" }) :> InfoAClass
 //     let a2 = a1.WithFoo("foo2")
 //     a1.Foo |> equal "foo"
@@ -950,7 +950,7 @@ let ``Type testing with primitive types works`` () =
 
 // // See #2084
 // [<Fact>]
-// let ``Non-mangled interfaces work with object expressions" <| fun _ ->
+// let ``Non-mangled interfaces work with object expressions`` () =
 //     let mutable foo = "Foo"
 //     let foo = { new FooInterface with
 //                     member _.Foo with get() = foo and set x = foo <- x
@@ -969,7 +969,7 @@ let ``Type testing with primitive types works`` () =
 
 // // See #2084
 // [<Fact>]
-// let ``Mangled interfaces work with object expressions" <| fun _ ->
+// let ``Mangled interfaces work with object expressions`` () =
 //     let mutable bar = "Bar"
 //     let bar = { new BarInterface with
 //                     member _.Bar with get() = bar and set x = bar <- x
@@ -989,7 +989,7 @@ let ``Type testing with primitive types works`` () =
 
 // // See #2084
 // [<Fact>]
-// let ``Non-mangled interfaces work with classes" <| fun _ ->
+// let ``Non-mangled interfaces work with classes`` () =
 //     let addPlus2 x y = x + y + 2.
 //     let multiplyTwice x y = x * y * y
 //     let foo2 = FooClass("Foo") :> FooInterface
@@ -1000,7 +1000,7 @@ let ``Type testing with primitive types works`` () =
 
 // // See #2084
 // [<Fact>]
-// let ``Mangled interfaces work with classes" <| fun _ ->
+// let ``Mangled interfaces work with classes`` () =
 //     let addPlus2 x y = x + y + 2.
 //     let multiplyTwice x y = x * y * y
 //     let bar2 = BarClass("Bar") :> BarInterface
@@ -1010,7 +1010,7 @@ let ``Type testing with primitive types works`` () =
 //     bar2.Bar |> equal "BZr9536.74rtruefalseaabcbcaabcbcdd"
 
 // [<Fact>]
-// let ``Multiple `this` references work in nested attached members" <| fun _ ->
+// let ``Multiple `this` references work in nested attached members`` () =
 //     (MixedThese(2) :> Interface1).Create(3).Add() |> equal 5
 
 // [<Fact>]

--- a/tests/Rust/tests/src/UriTests.fs
+++ b/tests/Rust/tests/src/UriTests.fs
@@ -7,7 +7,7 @@ open Fable.Tests
 module tests =
 
     [<Fact>]
-    let ``Uri from absolute uri string works" <| fun _ ->
+    let ``Uri from absolute uri string works`` () =
         let uri = Uri("http://www.test0.com/hello?a=b#c")
         equal true uri.IsAbsoluteUri
         equal "http" uri.Scheme
@@ -19,7 +19,7 @@ module tests =
         equal "http://www.test0.com/hello?a=b#c" uri.AbsoluteUri
 
     [<Fact>]
-    let ``Uri from absolute uri string with RelativeOrAbsolute works" <| fun _ ->
+    let ``Uri from absolute uri string with RelativeOrAbsolute works`` () =
         let uri = Uri("http://www.test1.com/hello?a=b#c", UriKind.RelativeOrAbsolute)
         equal true uri.IsAbsoluteUri
         equal "http" uri.Scheme
@@ -31,32 +31,32 @@ module tests =
         equal "http://www.test1.com/hello?a=b#c" uri.AbsoluteUri
 
     [<Fact>]
-    let ``Uri from relative uri string works" <| fun _ ->
+    let ``Uri from relative uri string works`` () =
         let uri = Uri("/hello.html", UriKind.Relative)
         equal false uri.IsAbsoluteUri
         equal "/hello.html" (uri.ToString())
 
     [<Fact>]
-    let ``AbsoluteUri from relative uri should throw" <| fun _ ->
+    let ``AbsoluteUri from relative uri should throw`` () =
         let uri = Uri("/hello.html", UriKind.Relative)
         Util.throwsError "This operation is not supported for a relative URI." (fun () -> uri.AbsoluteUri)
 
     [<Fact>]
-    let ``Uri from relative uri string without uri kind should throws" <| fun _ ->
+    let ``Uri from relative uri string without uri kind should throws`` () =
         let createInvalidUri () =
             Uri("hello.html")
 
         Util.throwsError "Invalid URI: The format of the URI could not be determined." createInvalidUri
 
     [<Fact>]
-    let ``Uri from relative uri with kind Absolute fails" <| fun _ ->
+    let ``Uri from relative uri with kind Absolute fails`` () =
         let createInvalidUri () =
             Uri("hello.html")
 
         Util.throwsError "Invalid URI: The format of the URI could not be determined." createInvalidUri
 
     [<Fact>]
-    let ``Uri from baseUri with relative string works" <| fun _ ->
+    let ``Uri from baseUri with relative string works`` () =
         let uri = Uri(Uri("http://www.test2.com/"), "/hello?a=b#c")
         equal true uri.IsAbsoluteUri
         equal "http" uri.Scheme
@@ -68,7 +68,7 @@ module tests =
         equal "http://www.test2.com/hello?a=b#c" uri.AbsoluteUri
 
     [<Fact>]
-    let ``Uri from baseUri with relativeUri works" <| fun _ ->
+    let ``Uri from baseUri with relativeUri works`` () =
         let uri = Uri(Uri("http://www.test3.com/"), Uri("/hello?a=b#c", UriKind.Relative))
         equal true uri.IsAbsoluteUri
         equal "http" uri.Scheme
@@ -80,7 +80,7 @@ module tests =
         equal "http://www.test3.com/hello?a=b#c" uri.AbsoluteUri
 
     [<Fact>]
-    let ``Uri from baseUri with absolute Uri works" <| fun _ ->
+    let ``Uri from baseUri with absolute Uri works`` () =
         let absUri = Uri("http://www.example.com/", UriKind.Absolute)
         let uri = Uri(absUri, absUri)
         equal true uri.IsAbsoluteUri
@@ -89,7 +89,7 @@ module tests =
         equal "http://www.example.com/" uri.AbsoluteUri
 
     [<Fact>]
-    let ``TryCreate from absolute string with kind Absolute works" <| fun _ ->
+    let ``TryCreate from absolute string with kind Absolute works`` () =
         let (valid, uri) = Uri.TryCreate("http://www.test0.com/hello?a=b#c", UriKind.Absolute)
         equal true valid
         equal true uri.IsAbsoluteUri
@@ -102,7 +102,7 @@ module tests =
         equal "http://www.test0.com/hello?a=b#c" uri.AbsoluteUri
 
     [<Fact>]
-    let ``TryCreate from absolute string with kind RelativeOrAbsolute works" <| fun _ ->
+    let ``TryCreate from absolute string with kind RelativeOrAbsolute works`` () =
         let (valid, uri) = Uri.TryCreate("http://www.test1.com/hello?a=b#c", UriKind.RelativeOrAbsolute)
         equal true valid
         equal true uri.IsAbsoluteUri
@@ -115,59 +115,59 @@ module tests =
         equal "http://www.test1.com/hello?a=b#c" uri.AbsoluteUri
 
     [<Fact>]
-    let ``TryCreate from absolute string with kind Relative fails" <| fun _ ->
+    let ``TryCreate from absolute string with kind Relative fails`` () =
         let (valid, _) = Uri.TryCreate("http://www.test1.com/hello?a=b#c", UriKind.Relative)
         equal false valid
 
     [<Fact>]
-    let ``TryCreate from relative string with kind Absolute fails" <| fun _ ->
+    let ``TryCreate from relative string with kind Absolute fails`` () =
         let (valid, uri) = Uri.TryCreate("hello?a=b#c", UriKind.Absolute)
         equal false valid
 
     [<Fact>]
-    let ``TryCreate from relative string with kind RelativeOrAbsolute works" <| fun _ ->
+    let ``TryCreate from relative string with kind RelativeOrAbsolute works`` () =
         let (valid, uri) = Uri.TryCreate("hello?a=b#c", UriKind.RelativeOrAbsolute)
         equal true valid
         equal "hello?a=b#c" (uri.ToString())
 
     [<Fact>]
-    let ``TryCreate from relative string with kind Relative works" <| fun _ ->
+    let ``TryCreate from relative string with kind Relative works`` () =
         let (valid, uri) = Uri.TryCreate("hello?a=b#c", UriKind.Relative)
         equal true valid
         equal "hello?a=b#c" (uri.ToString())
 
     [<Fact>]
-    let ``TryCreate from absolute uri and absolute uri should work" <| fun _ ->
+    let ``TryCreate from absolute uri and absolute uri should work`` () =
         let absUri = Uri("https://example.com", UriKind.Absolute)
         let (valid, uri) = Uri.TryCreate(absUri, absUri)
         equal true valid
         equal absUri uri
 
     [<Fact>]
-    let ``TryCreate from absolute uri and relative uri should work" <| fun _ ->
+    let ``TryCreate from absolute uri and relative uri should work`` () =
         let (valid, uri) = Uri.TryCreate(Uri("https://example.com", UriKind.Absolute), Uri("test", UriKind.Relative))
         equal true valid
         equal "https://example.com/test" (uri.ToString())
 
     [<Fact>]
-    let ``TryCreate from relative uri and relative uri should fail" <| fun _ ->
+    let ``TryCreate from relative uri and relative uri should fail`` () =
         let relativeUri = Uri("test", UriKind.Relative)
         let (valid, _) = Uri.TryCreate(relativeUri, relativeUri)
         equal false valid
 
     [<Fact>]
-    let ``TryCreate from relative uri and absolute uri should fail" <| fun _ ->
+    let ``TryCreate from relative uri and absolute uri should fail`` () =
         let (valid, _) = Uri.TryCreate(Uri("test", UriKind.Relative), Uri("https://example.com", UriKind.Absolute))
         equal false valid
 
     [<Fact>]
-    let ``Uri.ToString works" <| fun _ ->
+    let ``Uri.ToString works`` () =
         let uri = Uri("HTTP://www.test4.com:80/a%20b%20c.html")
         uri.ToString() |> equal "http://www.test4.com/a b c.html"
         sprintf "%A" uri |> equal "http://www.test4.com/a b c.html"
 
     [<Fact>]
-    let ``Uri.OriginalString works" <| fun _ ->
+    let ``Uri.OriginalString works`` () =
         let cases = [
             "http://example.org"
             "http://example.org/"


### PR DESCRIPTION
- Retain inlined funcs with `CompiledName` attribute (for Rust only).
- Made explicit that `IsPublic` is actually `IsNotPrivate` member.
- Fixed primary constructors with compiler-generated fields (with `@`).
- Minor test cleanup.