### PR TITLE
Update community section from Gitter > Discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,6 @@ Then run `dotnet fsi build.fsx` at the root folder to see the build options.
 
 Just by using Fable you're already contributing! You can help the community a lot by sharing examples and experiences in your personal (or Fable's) blog and/or by editing the [Fable Resources](https://fable.io/resources.html) page.
 
-Send bug reports (ideally with minimal code to reproduce the problem) and feature requests to this [GitHub repository](https://github.com/fable-compiler/Fable/issues). To interact with the community you can use the [Gitter chat](https://gitter.im/fable-compiler/Fable) but please note maintainers are not checking the chat regularly.
+Send bug reports (ideally with minimal code to reproduce the problem) and feature requests to this [GitHub repository](https://github.com/fable-compiler/Fable/issues). To interact with the community you can use the [Discussions](https://github.com/fable-compiler/Fable/discussions) but please note maintainers are not checking the chat regularly.
 
 If you are up to contribute a fix or a feature yourself, you're more than welcome! Please send first an issue or a minimal Work In Progess PR so we can discuss the implementation details in advance.


### PR DESCRIPTION
I remove Gitter from the Readme, since it is not used anymore. 

I replaced it with Github Discussions.

Note: I did not choose Slack since it is quite complicated to register for it and everyone who reads that README already has a Github account.