### PR TITLE
Python interface fixes

### DIFF
--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -139,10 +139,10 @@ module private Util =
                         .ToLowerInvariant()
                         .Split([|'/'|])
 
-                // When building packages we generate Python snake_case module within the kebab-case package
                 let modules =
                     match Array.toList modules, cliArgs.FableLibraryPath with
                     | Naming.fableModules :: package :: modules, Some PY.Naming.sitePackages ->
+                        // When building packages we generate Python snake_case module within the kebab-case package
                         let packageModule = package.Replace("-", "_")
                         Naming.fableModules :: package :: packageModule :: modules
                     | modules, _ -> modules

--- a/src/Fable.Cli/Pipeline.fs
+++ b/src/Fable.Cli/Pipeline.fs
@@ -193,7 +193,8 @@ module Python =
                         elif part = ".." then None
                         elif part = PY.Naming.sitePackages then Some("fable_library")
                         elif part = Naming.fableModules && (not isLibrary) then None
-                        else Some(normalizeFileName part)
+                        elif i = parts.Length - 1 then Some(normalizeFileName part)
+                        else Some part // Do not normalize dir names. See #3079
                     )
                     |> String.concat "."
 

--- a/src/Fable.Transforms/Dart/Replacements.fs
+++ b/src/Fable.Transforms/Dart/Replacements.fs
@@ -556,7 +556,7 @@ let injectArg (com: ICompiler) (ctx: Context) r moduleName methName (genArgs: Ty
             match injectType with
             | Types.comparer ->
                 args @ [makeComparer com ctx genArg] |> Some
-            | Types.equalityComparer ->
+            | Types.equalityComparerGeneric ->
                 args @ [makeEqualityComparer com ctx genArg] |> Some
             | Types.adder ->
                 args @ [makeGenericAdder com ctx genArg] |> Some
@@ -604,7 +604,7 @@ let tryReplacedEntityRef (com: Compiler) entFullName =
     | Naming.EndsWith "Enumerator" _
         -> makeIdentExpr "Iterator" |> Some
     | Types.icomparable | Types.icomparableGeneric -> makeIdentExpr "Comparable" |> Some
-    | Types.idisposable | Types.adder | Types.averager | Types.comparer | Types.equalityComparer ->
+    | Types.idisposable | Types.adder | Types.averager | Types.comparer | Types.equalityComparerGeneric ->
         let entFullName = entFullName[entFullName.LastIndexOf(".") + 1..]
         let entFullName =
             match entFullName.IndexOf("`") with

--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -1979,7 +1979,7 @@ module Util =
             | Types.ienumerableGeneric
             // These are used for injections
             | Types.comparer
-            | Types.equalityComparer -> false
+            | Types.equalityComparerGeneric -> false
             | Types.icomparable -> false
             | Types.icomparableGeneric -> com.Options.Language <> Dart
             | _ -> true

--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -770,7 +770,7 @@ let injectArg (com: ICompiler) (ctx: Context) r moduleName methName (genArgs: Ty
         | Some genArg ->
             match injectType with
             | Types.comparer -> args @ [ makeComparer com ctx genArg ]
-            | Types.equalityComparer -> args @ [ makeEqualityComparer com ctx genArg ]
+            | Types.equalityComparerGeneric -> args @ [ makeEqualityComparer com ctx genArg ]
             | Types.arrayCons ->
                 match genArg with
                 // We don't have a module for ResizeArray so let's assume the kind is MutableArray

--- a/src/Fable.Transforms/Replacements.Util.fs
+++ b/src/Fable.Transforms/Replacements.Util.fs
@@ -410,7 +410,7 @@ let (|IDictionary|IEqualityComparer|Other|) = function
     | DeclaredType(ent,_) ->
         match ent.FullName with
         | Types.idictionary -> IDictionary
-        | Types.equalityComparer -> IEqualityComparer
+        | Types.equalityComparerGeneric -> IEqualityComparer
         | _ -> Other
     | _ -> Other
 
@@ -418,7 +418,7 @@ let (|IEnumerable|IEqualityComparer|Other|) = function
     | DeclaredType(ent,_) ->
         match ent.FullName with
         | Types.ienumerableGeneric -> IEnumerable
-        | Types.equalityComparer -> IEqualityComparer
+        | Types.equalityComparerGeneric -> IEqualityComparer
         | _ -> Other
     | _ -> Other
 

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -691,7 +691,7 @@ let injectArg (com: ICompiler) (ctx: Context) r moduleName methName (genArgs: Ty
             match injectType with
             | Types.comparer ->
                 args @ [makeComparer com ctx genArg]
-            | Types.equalityComparer ->
+            | Types.equalityComparerGeneric ->
                 args @ [makeEqualityComparer com ctx genArg]
             | Types.arrayCons ->
                 match genArg with

--- a/src/Fable.Transforms/ReplacementsInject.fs
+++ b/src/Fable.Transforms/ReplacementsInject.fs
@@ -14,13 +14,13 @@ let fableReplacementsModules =
       "mapFold", (Types.arrayCons, 2)
       "mapFoldBack", (Types.arrayCons, 2)
       "concat", (Types.arrayCons, 0)
-      "contains", (Types.equalityComparer, 0)
+      "contains", (Types.equalityComparerGeneric, 0)
       "collect", (Types.arrayCons, 1)
-      "contains", (Types.equalityComparer, 0)
+      "contains", (Types.equalityComparerGeneric, 0)
       "singleton", (Types.arrayCons, 0)
-      "indexOf", (Types.equalityComparer, 0)
+      "indexOf", (Types.equalityComparerGeneric, 0)
       "initialize", (Types.arrayCons, 0)
-      "removeInPlace", (Types.equalityComparer, 0)
+      "removeInPlace", (Types.equalityComparerGeneric, 0)
       "replicate", (Types.arrayCons, 0)
       "scan", (Types.arrayCons, 1)
       "scanBack", (Types.arrayCons, 1)
@@ -47,7 +47,7 @@ let fableReplacementsModules =
       "transpose", (Types.arrayCons, 0)
     ]
     "List", Map [
-      "contains", (Types.equalityComparer, 0)
+      "contains", (Types.equalityComparerGeneric, 0)
       "sort", (Types.comparer, 0)
       "sortBy", (Types.comparer, 1)
       "sortDescending", (Types.comparer, 0)
@@ -62,7 +62,7 @@ let fableReplacementsModules =
       "averageBy", ("Fable.Core.IGenericAverager`1", 1)
     ]
     "Seq", Map [
-      "contains", (Types.equalityComparer, 0)
+      "contains", (Types.equalityComparerGeneric, 0)
       "sort", (Types.comparer, 0)
       "sortBy", (Types.comparer, 1)
       "sortDescending", (Types.comparer, 0)
@@ -77,11 +77,11 @@ let fableReplacementsModules =
       "averageBy", ("Fable.Core.IGenericAverager`1", 1)
     ]
     "Seq2", Map [
-      "distinct", (Types.equalityComparer, 0)
-      "distinctBy", (Types.equalityComparer, 1)
-      "except", (Types.equalityComparer, 0)
-      "countBy", (Types.equalityComparer, 1)
-      "groupBy", (Types.equalityComparer, 1)
+      "distinct", (Types.equalityComparerGeneric, 0)
+      "distinctBy", (Types.equalityComparerGeneric, 1)
+      "except", (Types.equalityComparerGeneric, 0)
+      "countBy", (Types.equalityComparerGeneric, 1)
+      "groupBy", (Types.equalityComparerGeneric, 1)
     ]
     "Set", Map [
       "FSharpSet__Map", (Types.comparer, 1)

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -133,8 +133,8 @@ module Types =
     let [<Literal>] equalityComparer = "System.Collections.IEqualityComparer"
 
     // Types compatible with Inject attribute (fable library)
-    let [<Literal>] comparer = "System.Collections.Generic.IComparer`1"    
-    let [<Literal>] equalityComparerGeneric = "System.Collections.Generic.IEqualityComparer`1"                                       
+    let [<Literal>] comparer = "System.Collections.Generic.IComparer`1"
+    let [<Literal>] equalityComparerGeneric = "System.Collections.Generic.IEqualityComparer`1"
     let [<Literal>] arrayCons = "Array.Cons`1"
     let [<Literal>] adder = "Fable.Core.IGenericAdder`1"
     let [<Literal>] averager = "Fable.Core.IGenericAverager`1"

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -129,10 +129,11 @@ module Types =
     let [<Literal>] printfModule = "Microsoft.FSharp.Core.PrintfModule"
     let [<Literal>] printfFormat = "Microsoft.FSharp.Core.PrintfFormat"
     let [<Literal>] createEvent = "Microsoft.FSharp.Core.CompilerServices.RuntimeHelpers.CreateEvent"
+    let [<Literal>] equalityComparer = "System.Collections.IEqualityComparer"
 
     // Types compatible with Inject attribute (fable library)
-    let [<Literal>] comparer = "System.Collections.Generic.IComparer`1"
-    let [<Literal>] equalityComparer = "System.Collections.Generic.IEqualityComparer`1"
+    let [<Literal>] comparer = "System.Collections.Generic.IComparer`1"    
+    let [<Literal>] equalityComparerGeneric = "System.Collections.Generic.IEqualityComparer`1"                                       
     let [<Literal>] arrayCons = "Array.Cons`1"
     let [<Literal>] adder = "Fable.Core.IGenericAdder`1"
     let [<Literal>] averager = "Fable.Core.IGenericAverager`1"

--- a/src/fable-library-py/fable_library/util.py
+++ b/src/fable-library-py/fable_library/util.py
@@ -40,6 +40,7 @@ class SupportsLessThan(Protocol):
 
 _T = TypeVar("_T")
 _T_in = TypeVar("_T_in", contravariant=True)
+_T_out = TypeVar("_T_out", covariant=True)
 _Key = TypeVar("_Key")
 _Value = TypeVar("_Value")
 _TSupportsLessThan = TypeVar("_TSupportsLessThan", bound=SupportsLessThan)
@@ -51,6 +52,12 @@ class ObjectDisposedException(Exception):
 
 
 class IDisposable(ABC):
+    """IDisposable interface.
+
+    Note currently not a protocol since it also impmelents resource
+    management and needs to be inherited from.
+    """
+
     __slots__ = ()
 
     @abstractmethod
@@ -108,10 +115,10 @@ class AnonymousDisposable(IDisposable):
         return self
 
 
-class IEquatable(Protocol):
+class IEquatable(Generic[_T_in], Protocol):
     @abstractmethod
-    def __eq__(self, other: Any) -> bool:
-        return NotImplemented
+    def __eq__(self, other: _T_in) -> bool:
+        raise NotImplementedError
 
     @abstractmethod
     def __hash__(self) -> int:
@@ -128,7 +135,17 @@ class IComparable(IEquatable, Protocol):
         raise NotImplementedError
 
 
-class IComparer(Generic[_T_in], Protocol):
+class IComparable_1(Generic[_T_in], IEquatable, Protocol):
+    @abstractmethod
+    def __cmp__(self, __other: _T_in) -> int:
+        raise NotImplementedError
+
+    @abstractmethod
+    def __lt__(self, other: Any) -> bool:
+        raise NotImplementedError
+
+
+class IComparer(Protocol):
     """Defines a method that a type implements to compare two objects.
 
     https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.icomparer-1
@@ -140,14 +157,60 @@ class IComparer(Generic[_T_in], Protocol):
         ...
 
 
-class IEqualityComparer(Generic[_T]):
-    __slots__ = ()
+class IComparer_1(Generic[_T_in], Protocol):
+    """Defines a method that a type implements to compare two objects.
 
-    def Equals(self, __y: _T) -> bool:
-        return self == __y
+    https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.icomparer-1
+    """
+
+    @property
+    @abstractmethod
+    def Compare(self) -> Callable[[_T_in, _T_in], int]:
+        ...
+
+
+class IEqualityComparer(Protocol):
+    def Equals(self, __x: _T_in, __y: _T_in) -> bool:
+        return self.System_Collections_IEqualityComparer_Equals541DA560(__x, __y)
 
     def GetHashCode(self) -> int:
-        return hash(self)
+        return self.System_Collections_IEqualityComparer_GetHashCode4E60E31B()
+
+    @abstractmethod
+    def System_Collections_IEqualityComparer_Equals541DA560(
+        self, x: Any = None, y: Any = None
+    ) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
+    def System_Collections_IEqualityComparer_GetHashCode4E60E31B(
+        self, x_1: Any = None
+    ) -> int:
+        raise NotImplementedError
+
+
+class IEqualityComparer_1(Generic[_T_in], Protocol):
+    def Equals(self, __x: _T_in, __y: _T_in) -> bool:
+        raise NotImplementedError
+
+    def GetHashCode(self) -> int:
+        raise NotImplementedError
+
+
+class IStructuralEquatable(Protocol):
+    @abstractmethod
+    def Equals(self, other: Any, comparer: IEqualityComparer) -> bool:
+        return NotImplemented
+
+    @abstractmethod
+    def __hash__(self) -> int:
+        raise NotImplementedError
+
+
+class IStructuralComparable(Protocol):
+    @abstractmethod
+    def __cmp__(self, other: Any, comparer: IComparer) -> int:
+        raise NotImplementedError
 
 
 class DateKind(IntEnum):

--- a/tests/Python/TestArithmetic.fs
+++ b/tests/Python/TestArithmetic.fs
@@ -397,13 +397,13 @@ let ``test Math.log10 works`` () =
 let ``test incr works`` () =
     let i = ref 5
     incr i
-    !i |> equal 6
+    i.Value |> equal 6
 
 [<Fact>]
 let ``test decr works`` () =
     let i = ref 5
     decr i
-    !i |> equal 4
+    i.Value |> equal 4
 
 [<Fact>]
 let ``test System.Random works`` () =


### PR DESCRIPTION
This PR fixes a number of interface related issues in Python. Adds many missing inferfaces and makes the inferfaces into Python protocols.

FYI: @alfonsogarciacaro @ncave It also renames `Types.equalityComparer` to `Types.equalityComparerGeneric` and adds `Types.equalityComparer` from `System.Collections`.

Renames:
```fs
-    let [<Literal>] equalityComparer = "System.Collections.Generic.IEqualityComparer`1"
+    let [<Literal>] equalityComparerGeneric = "System.Collections.Generic.IEqualityComparer`1"
```

Adds:
```fs
+    let [<Literal>] equalityComparer = "System.Collections.IEqualityComparer"
```

