### PR TITLE
[Python] type var cleanup. Use Any for types starting with $$

### DIFF
--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -700,6 +700,8 @@ module Annotation =
         match t with
         | Fable.Measure _
         | Fable.Any -> stdlibModuleTypeHint com ctx "typing" "Any" []
+        | Fable.GenericParam (name = name) when name.StartsWith("$$") ->
+            stdlibModuleTypeHint com ctx "typing" "Any" []
         | Fable.GenericParam (name = name) ->
             match repeatedGenerics with
             | Some names when names.Contains name ->


### PR DESCRIPTION
Btw: What are these inferred types starting with `$$` and then a number @alfonsogarciacaro ?