### PR TITLE
Fix local package version generation to satisfy test.

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -569,7 +569,7 @@ let testDart isWatch =
     runInDir runDir "dart test main.dart"
 
 let buildLocalPackageWith pkgDir pkgCommand fsproj action =
-    let version = "3.0.0-local-build-" + DateTime.Now.ToString("yyyyMMdd-HHmm")
+    let version = Publish.loadReleaseVersion "src/Fable.Cli" + "-local-build-" + DateTime.Now.ToString("yyyyMMdd-HHmm")
     action version
     updatePkgVersionInFsproj fsproj version
     run $"dotnet pack {fsproj} -p:Pack=true -c Release -o {pkgDir}"

--- a/tests/Js/Main/MiscTests.fs
+++ b/tests/Js/Main/MiscTests.fs
@@ -508,7 +508,7 @@ let tests =
         equal 13 x
 
     testCase "Can check compiler version at runtime" <| fun _ ->
-        Compiler.majorMinorVersion >=  4.0 |> equal true
+        Compiler.majorMinorVersion >= 4.0 |> equal true
         Text.RegularExpressions.Regex.IsMatch(Compiler.version, @"^\d+\.\d+") |> equal true
 
     testCase "Can access compiler options" <| fun _ ->


### PR DESCRIPTION
Makes sure the local package build version number will always match the version expected by tests.