### PR TITLE
Re-enable React tests

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -420,8 +420,8 @@ let testStandalone(minify) =
     runInDir fableDir "npm unlink ../fable-standalone && cd ../fable-standalone && npm unlink"
 
 let testReact() =
-    runFableWithArgs "tests/Js/React" ["--noCache"]
-    runInDir "tests/Js/React" "npm i && npm test"
+    runFableWithArgs "tests/React" ["--noCache"]
+    runInDir "tests/React" "npm i && npm test"
 
 let compileAndRunTestsWithMocha clean projectName =
     let projectDir = "tests/Js/" + projectName
@@ -474,8 +474,7 @@ let testJs() =
     // Adaptive tests must go in a different project to avoid conflicts with Queue shim, see #2559
     compileAndRunTestsWithMocha true "Adaptive"
 
-    // TODO: Re-enable React tests after updating Feliz ReactComponent plugin
-    // testReact()
+    testReact()
 
     if envVarOrNone "CI" |> Option.isSome then
         testStandaloneFast()

--- a/lib/fcs/FSharp.Compiler.Service.xml
+++ b/lib/fcs/FSharp.Compiler.Service.xml
@@ -4965,7 +4965,7 @@
 </member>
 <member name="M:FSComp.SR.optsUnknownSignatureData(System.String)">
 <summary>
- Invalid value &apos;%s&apos; for --interfacedata, valid value are: none, file, compress.&quot;
+ Invalid value &apos;%s&apos; for --interfacedata, valid value are: none, file, compress.
  (Originally from FSComp.txt:933)
 </summary>
 </member>

--- a/src/Fable.Transforms/OverloadSuffix.fs
+++ b/src/Fable.Transforms/OverloadSuffix.fs
@@ -49,8 +49,13 @@ let rec private getTypeFastFullName (genParams: IDictionary<_,_>) (t: Fable.Type
         let genArgs = genArgs |> Seq.map (getTypeFastFullName genParams) |> String.concat " * "
         if isStruct then "struct " + genArgs
         else genArgs
-    | Fable.Array(genArg, _) -> // TODO: check kind
-        getTypeFastFullName genParams genArg + "[]"
+    | Fable.Array(genArg, kind) ->
+        let name =
+            match kind with
+            | Fable.ResizeArray -> "array"
+            | Fable.MutableArray -> "resizearray"
+            | Fable.ImmutableArray -> "immutablearray"
+        getTypeFastFullName genParams genArg + " " + name
     | Fable.List genArg ->
         getTypeFastFullName genParams genArg + " list"
     | Fable.Option(genArg, isStruct) ->

--- a/tests/React/Fable.Tests.React.fsproj
+++ b/tests/React/Fable.Tests.React.fsproj
@@ -8,9 +8,11 @@
     <Compile Include="__tests__/Tests.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Fable.FluentUI" Version="0.6.0" />
-    <PackageReference Include="Fable.Jester" Version="0.29.1" />
-    <PackageReference Include="Fable.ReactTestingLibrary" Version="0.29.1" />
-    <PackageReference Include="Feliz" Version="1.22.0" />
+    <PackageReference Include="Fable.FluentUI" Version="0.7.0" />
+    <PackageReference Include="Fable.Jester" Version="0.33.0" />
+    <PackageReference Include="Fable.React" Version="8.0.1" />
+    <PackageReference Include="Fable.ReactTestingLibrary" Version="0.33.0" />
+    <PackageReference Include="Feliz" Version="1.68.0" />
+    <PackageReference Include="Feliz.CompilerPlugins" Version="2.0.0-prerelease-001" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This re-enables React tests for Fable 4! 🎉 Thanks to @Zaid-Ajaj for publishing [the updated plugins](https://github.com/Zaid-Ajaj/Feliz/pull/506). I will push a new release after merging and hopefully this should allow users to update their apps to Fable 4.

This includes an updated version of our custom FCS build with [this fix](https://github.com/ncave/fsharp/pull/12).