### PR TITLE
Rust - improvements to ref counting

### DIFF
--- a/tests/Rust/tests/src/RecordTests.fs
+++ b/tests/Rust/tests/src/RecordTests.fs
@@ -379,3 +379,15 @@ module ComplexEdgeCases =
             { Name = "A"; Spatial = { Rotation = 1.1f<Rad>; Position = { x = 1f<m>; y = 2f<m> } } }
             |> rotate (1.2f<Rad>)
         res.Spatial.Rotation |> equal (1.1f<Rad> + 1.2f<Rad>)
+
+    [<Fact>]
+    let ``Ref tracking should correctly count arm ident usages + clone accordingly`` () =
+        let cmpPropLstR = [{ a = 1}]
+        let add1 x = {x with a = x.a + 1}
+        let res =
+            match cmpPropLstR with
+            | ({ a = 1 } as h)::t ->
+                let next = add1 h
+                next::t
+            | _ -> cmpPropLstR
+        notEqual res cmpPropLstR


### PR DESCRIPTION
This was driven by a new bug I found in v22. Match arms were not correctly being counted leading to use after move build error.

A while ago I was experimenting with changing the way we did calcIdentUsages so it was recursive. This has benefits, because the built in function for FableTransforms.deepExists unfortunately does not thread through any context. It is becoming more apparent that we are going to need ancestry context. Currently there are four cases that require this:
* Is it a match arm context, if so we need to pull the correct target & count accordingly - fixes above bug. (walking over all the targets indiscriminately with getSubExpressions seems to lead to inaccurate counts)
* Is it a ref or a value being consumed - WIP, not used yet but could lead to being able to ignore reference usages. Still not sure if this is necessary, so we could strip out to simplify if easier.
* Is the ident shadowed in the ancestry - again, WIP - prevent unnecessary cloning where shadowed ident usages are interfering with count, and leading to too many clones. _Side note - Does Fable even allow shadowing? It seems to create its own names in some contexts._
* For captured variables, they should only be counted once upon capturing for the outer scope, and inner usages should be excluded. This is hard to control unless you have control over recursion - WIP

Appreciate this does add some complexity, but I think this is necessary to get accurate counts. It is pretty contained at least.

