### PR TITLE
Rust - a little more progress on dates

### DIFF
--- a/src/Fable.Transforms/Rust/Replacements.fs
+++ b/src/Fable.Transforms/Rust/Replacements.fs
@@ -2325,6 +2325,9 @@ let dates (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr optio
             Helper.LibCall(com, "DateTime", "new_ymd", t, args, i.SignatureArgTypes, ?loc=r) |> Some
         | ExprType(Number(Int32,_))::ExprType(Number(Int32,_))::ExprType(Number(Int32,_))::ExprType(Number(Int32,_))::ExprType(Number(Int32,_))::ExprType(Number(Int32,_))::[] ->
             Helper.LibCall(com, "DateTime", "new_ymdhms", t, args, i.SignatureArgTypes, ?loc=r) |> Some
+        | ExprType(Number(Int32,_))::ExprType(Number(Int32,_))::ExprType(Number(Int32,_))::ExprType(Number(Int32,_))::ExprType(Number(Int32,_))::ExprType(Number(Int32,_))
+            ::ExprType(Number(_, NumberInfo.IsEnum ent))::[]  when ent.FullName = "System.DateTimeKind"->
+            Helper.LibCall(com, "DateTime", "new_ymdhms_withkind", t, args, i.SignatureArgTypes, ?loc=r) |> Some
         | ExprType(Number(Int32,_))::ExprType(Number(Int32,_))::ExprType(Number(Int32,_))::ExprType(Number(Int32,_))::ExprType(Number(Int32,_))::ExprType(Number(Int32,_))::ExprType(Number(Int32,_))::[] ->
             Helper.LibCall(com, "DateTime", "new_ymdhmsms", t, args, i.SignatureArgTypes, ?loc=r) |> Some
         | _ ->

--- a/tests/Rust/tests/src/DateTimeTests.fs
+++ b/tests/Rust/tests/src/DateTimeTests.fs
@@ -35,11 +35,11 @@ module tests =
         DateTime(2014, 9, 11, 16, 37, 11, 345).ToString("ss.fff")
         |> equal "11.345"
 
-//     [<Fact>]
-//     let ``DateTime.ToString with Round-trip format works for Utc`` () =
-//         let str = DateTime(2014, 9, 11, 16, 37, 2, DateTimeKind.Utc).ToString("O")
-//         System.Text.RegularExpressions.Regex.Replace(str, "0{3,}", "000")
-//         |> equal "2014-09-11T16:37:02.000Z"
+    // [<Fact>]
+    // let ``DateTime.ToString with Round-trip format works for Utc`` () =
+    //     let str = DateTime(2014, 9, 11, 16, 37, 2, DateTimeKind.Utc).ToString("O")
+    //     System.Text.RegularExpressions.Regex.Replace(str, "0{3,}", "000")
+    //     |> equal "2014-09-11T16:37:02.000Z"
 
 //     // TODO
 //     // Next test is disabled because it's depends on the time zone of the machine
@@ -50,34 +50,33 @@ module tests =
 //     //     DateTime(2014, 9, 11, 16, 37, 2, DateTimeKind.Local).ToString("O")
 //     //     |> equal "2014-09-11T16:37:02.000+02:00" // Here the time zone is Europte/Paris (GMT+2)
 
-// api plugged in but exploding on windows api with https://github.com/chronotope/chrono/issues/651 - perhaps windows 11 problem?
-    // [<Fact>]
-    // let ``DateTime from Year 1 to 99 works`` () =
-    //     let date = DateTime(1, 1, 2)
-    //     date.Year |> equal 1
-    //     let date = DateTime(99, 1, 2)
-    //     date.Year |> equal 99
+    [<Fact>]
+    let ``DateTime from Year 1 to 99 works`` () =
+        let date = DateTime(1, 1, 2)
+        date.Year |> equal 1
+        let date = DateTime(99, 1, 2)
+        date.Year |> equal 99
 
-//     [<Fact>]
-//     let ``DateTime UTC from Year 1 to 99 works`` () =
-//         let date = DateTime(1, 1, 2, 0, 0, 0, DateTimeKind.Utc)
-//         date.Year |> equal 1
-//         let date = DateTime(99, 1, 2, 0, 0, 0, DateTimeKind.Utc)
-//         date.Year |> equal 99
+    [<Fact>]
+    let ``DateTime UTC from Year 1 to 99 works`` () =
+        let date = DateTime(1, 1, 2, 0, 0, 0, DateTimeKind.Utc)
+        date.Year |> equal 1
+        let date = DateTime(99, 1, 2, 0, 0, 0, DateTimeKind.Utc)
+        date.Year |> equal 99
 
 //     // TODO: These two tests give different values for .NET and JS because DateTime
 //     // becomes as a plain JS Date object, so I'm just checking the fields get translated
-//     [<Fact>]
-//     let ``DateTime.MaxValue works`` () =
-//         let d1 = DateTime.Now
-//         let d2 = DateTime.MaxValue
-//         d1 < d2 |> equal true
+    [<Fact>]
+    let ``DateTime.MaxValue works`` () =
+        let d1 = DateTime.Now
+        let d2 = DateTime.MaxValue
+        d1 < d2 |> equal true
 
-//     [<Fact>]
-//     let ``DateTime.MinValue works`` () =
-//         let d1 = DateTime.Now
-//         let d2 = DateTime.MinValue
-//         d1 < d2 |> equal false
+    [<Fact>]
+    let ``DateTime.MinValue works`` () =
+        let d1 = DateTime.Now
+        let d2 = DateTime.MinValue
+        d1 < d2 |> equal false
 
 //     [<Fact>]
 //     let ``DateTime.MinValue works in pattern match`` () =


### PR DESCRIPTION
* Unspecified type
* Enum now works for defining Utc/Local (in F#) - we might want to rewrite these call sites so they produce an actual rust enum though
* First pass at comparison - highly likely to not be sufficient but better than nothing
* Min value
* Max value
* Unspecified fixed problem for test: https://github.com/chronotope/chrono/issues/651. This looks like it might be due to using small local dates https://github.com/microsoft/windows-rs/issues/1549#issuecomment-1044861209

The whole area is obviously a massive WIP still, but starting to slowly consolidate some foundations. I think there may still be a good argument for totally throwing out the higher level datetime concepts, and replacing entirely with NaiveDateTime as @ncave  suggested [here](https://github.com/fable-compiler/Fable/pull/3080#discussion_r946883436).