### PR TITLE
Rust - another problematic ref counting scenario + fix

### DIFF
--- a/tests/Rust/tests/src/RecordTests.fs
+++ b/tests/Rust/tests/src/RecordTests.fs
@@ -391,3 +391,33 @@ module ComplexEdgeCases =
                 next::t
             | _ -> cmpPropLstR
         notEqual res cmpPropLstR
+
+    type ItemWithSpatialDta2 = {
+        Name: string
+        Spatial: SpatialDta option
+    }
+    type GameState = {
+        Items: ItemWithSpatialDta2 list
+    }
+    type TestInput = | T_A | T_B | T_C
+
+    let applyFn1 r p : ItemWithSpatialDta2 = { p with Name = "next" }
+    let applyFn2 p = p
+
+    let someStateTransform inputs current =
+        match current.Items with
+        | ({ Spatial = Some sp } as boundItemState)::t ->
+            let playerNext =
+                match inputs with
+                | T_A -> boundItemState |> applyFn1 boundItemState.Spatial
+                | T_B -> boundItemState |> applyFn2
+                | T_C -> boundItemState
+            { current with Items = playerNext::t }
+        | _ -> { current with Items = [] }
+
+    // This is mainly about ensuring the idents are correctly counted leading to too little/much cloning and potentially a build error
+    [<Fact>]
+    let ``Ref tracking should correctly count arm ident usages 2 + clone accordingly`` () =
+        let current = { Items = [{Name = "ab"; Spatial = Some { Rotation = 1.1f<Rad>; Position = { x = 1f<m>; y = 2f<m> } }}]}
+        let next = someStateTransform T_A current
+        next |> notEqual current


### PR DESCRIPTION
@ncave  wouldn't mind your thoughts on this if you are happy to take a peek...

So I found a particularly gnarly bug when experimenting with v24, where counts were yet again not right - yes, a problem of my own creation, I know :)

I added in some extra hooks etc to track what is going on, but it seems that this might be due to the compiler generated ident ```matchValue```. Unfortunately my knowledge here is super limited of how this is generated, but it appears that some of the idents in the subtree are using the original name, and some are using the rewritten ```matchValue```, so it makes sense that they do not line up if you are just counting ```matchValue``` usages in isolation. Somehow these named idents are rewritten to also become matchValue calls in the output Rust AST, but I cannot work out where this is happening.

Perhaps the real problem here is actually that in F# it is not defined that two different idents are actually pointing to the same thing, and thus should perhaps be tracked together rather than as 2 independent idents?


Anyway, I went for a copout option of "we can't reason about matchValue, so 9999". It fixes the problematic scenario (which I have replicated in test in it's smallest form), but it kind of sweeps the real problem under the rug i think.

Any input is appreciated as always, although I do completely accept this is quite hard to follow, and the devil is in the detail.