### PR TITLE
[Rust] Reduced some allocations

### DIFF
--- a/src/fable-library-rust/src/Decimal.rs
+++ b/src/fable-library-rust/src/Decimal.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "decimal")]
 pub mod Decimal_ {
-    use crate::Native_::{array, Array, Lrc, RefCell, Vec};
+    use crate::Native_::{array, Array, Lrc, MutCell, Vec};
     use crate::String_::{string, toString as toString_1};
 
     use rust_decimal::prelude::*;
@@ -61,7 +61,7 @@ pub mod Decimal_ {
         toString_1(&x)
     }
 
-    pub fn tryParse(s: string, res: &RefCell<Decimal>) -> bool {
+    pub fn tryParse(s: string, res: &MutCell<Decimal>) -> bool {
         match Decimal::from_str(s.as_ref()) {
             Ok(d) => { res.set(d); true },
             Err(e) => false,

--- a/src/fable-library-rust/src/HashMap.rs
+++ b/src/fable-library-rust/src/HashMap.rs
@@ -83,7 +83,7 @@ pub mod HashMap_ {
     pub fn tryGetValue<K: Eq + Hash + Clone, V: Clone>(
         dict: HashMap<K, V>,
         k: K,
-        res: &Lrc<MutCell<V>>,
+        res: &MutCell<V>,
     ) -> bool {
         match dict.get_mut().get(&k) {
             Some(v) => {


### PR DESCRIPTION
- Removed allocation for local non-captured mutable let bindings.
- Removed allocation for byref/outref parameters.
- Removed allocation when calling local non-capturing function.