### PR TITLE
[Rust] Updated on_startup macro

### DIFF
--- a/src/Fable.Transforms/Rust/Fable2Rust.fs
+++ b/src/Fable.Transforms/Rust/Fable2Rust.fs
@@ -3372,8 +3372,8 @@ module Util =
         |> addWarning com [] body.Range
 
         let expr = transformExpr com ctx body
-        let attrs = [mkAttr "cfg" ["feature = \"static_do_bindings\""]]
-        let macroName = "startup::startup"
+        let attrs = [] //[mkAttr "cfg" ["feature = \"static_do_bindings\""]]
+        let macroName = getLibraryImportName com ctx "Native" "on_startup"
         let macroItem = mkMacroItem attrs macroName [expr]
         [macroItem]
 

--- a/src/fable-library-rust/src/Native.rs
+++ b/src/fable-library-rust/src/Native.rs
@@ -19,6 +19,18 @@ pub mod Native_ {
     pub use super::Lazy::*;
     pub use crate::Choice_::*;
 
+    mod macros {
+        #[macro_export]
+        macro_rules! on_startup {
+            ($($tokens:tt)*) => {}; // does nothing
+        }
+    }
+
+    #[cfg(not(feature = "static_do_bindings"))]
+    pub use crate::on_startup;
+    #[cfg(feature = "static_do_bindings")]
+    pub use startup::on_startup;
+
     #[cfg(not(feature = "atomic"))]
     pub type Lrc<T> = Rc<T>;
     #[cfg(feature = "atomic")]


### PR DESCRIPTION
- Added dummy `on_startup` macro so `static do bindings` can be turned on with a feature on `fable-library-rust`.