### PR TITLE
[Rust] Updated module visibility

### DIFF
--- a/src/Fable.AST/Fable.fs
+++ b/src/Fable.AST/Fable.fs
@@ -127,6 +127,7 @@ type Entity =
     abstract DisplayName: string
     abstract CompiledName: string
     abstract FullName: string
+    abstract DeclaringEntity: EntityRef option
     abstract Attributes: Attribute seq
     abstract BaseType: DeclaredType option
     abstract AllInterfaces: DeclaredType seq

--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -319,6 +319,8 @@ type FsEnt(maybeAbbrevEnt: FSharpEntity) =
         member _.CompiledName = ent.CompiledName
         member _.FullName = FsEnt.FullName ent
 
+        member _.DeclaringEntity = ent.DeclaringEntity |> Option.map FsEnt.Ref
+
         member _.BaseType =
             match TypeHelpers.tryGetBaseEntity ent with
             | Some(baseEntity, baseGenArgs) -> Some(upcast FsDeclaredType(baseEntity, baseGenArgs))

--- a/src/Fable.Transforms/Rust/AST/Rust.AST.Helpers.fs
+++ b/src/Fable.Transforms/Rust/AST/Rust.AST.Helpers.fs
@@ -1282,7 +1282,7 @@ module Items =
 
     let mkItemWithVis isInternal isPrivate item: Item =
         if isPrivate then
-            item // default is INHERITED_VIS
+            item // INHERITED_VIS
         elif isInternal then
             item |> mkPublicCrateItem
         else

--- a/tests/Rust/Fable.Tests.Rust.fsproj
+++ b/tests/Rust/Fable.Tests.Rust.fsproj
@@ -31,7 +31,7 @@
     <!-- <Compile Include="tests/src/ComparisonTests.fs" /> -->
     <Compile Include="tests/src/ControlFlowTests.fs" />
     <Compile Include="tests/src/ConvertTests.fs" />
-    <!-- <Compile Include="tests/src/CustomOperatorTests.fs" /> -->
+    <Compile Include="tests/src/CustomOperatorTests.fs" />
     <!-- <Compile Include="tests/src/DateTimeOffsetTests.fs" /> -->
     <Compile Include="tests/src/DateTimeTests.fs" />
     <!-- <Compile Include="tests/src/DateOnlyTests.fs" /> -->

--- a/tests/Rust/tests/src/ApplicativeTests.fs
+++ b/tests/Rust/tests/src/ApplicativeTests.fs
@@ -1159,7 +1159,7 @@ let ``Curried function options work`` () =
 // See https://github.com/fable-compiler/Fable/issues/1199#issuecomment-347101093
 [<Fact>]
 let ``Applying function options works`` () =
-    Pointful.testFunctionOptions
+    Pointful.testFunctionOptions ()
 
 [<Fact>]
 let ``Point-free and partial application work`` () = // See #1199
@@ -1200,7 +1200,7 @@ let ``Uncurried functions in record fields can be partially applied`` () =
 // See https://github.com/fable-compiler/Fable/issues/1199#issuecomment-347190893
 [<Fact>]
 let ``Applicative operators work with three-argument functions``() =
-    Results.testOperatorsWith3Args
+    Results.testOperatorsWith3Args ()
 
 [<Fact>]
 let ``partialApply works with tuples`` () =

--- a/tests/Rust/tests/src/ComparisonTests.fs
+++ b/tests/Rust/tests/src/ComparisonTests.fs
@@ -1,10 +1,6 @@
 module Fable.Tests.ComparisonTests
 
-open System
 open Util.Testing
-open Fable.Tests.Util
-open Fable.Core.JsInterop
-open System.Collections.Generic
 open FSharp.Data.UnitSystems.SI.UnitSymbols
 
 type UTest = A of int | B of int
@@ -76,7 +72,6 @@ type FuzzyInt =
     override x.GetHashCode() =
         let (FuzzyInt x) = x
         x.GetHashCode()
-
     override x.Equals(y: obj) =
         match y with
         | :? FuzzyInt as y ->
@@ -85,675 +80,673 @@ type FuzzyInt =
             x - 2 <= y && y <= x + 2
         | _ -> false
 
-module tests =
-
-    [<Fact>]
-    let ``Typed array equality works`` () =
-        let xs1 = [| 1; 2; 3 |]
-        let xs2 = [| 1; 2; 3 |]
-        let xs3 = [| 1; 2; 4 |]
-        let xs4 = [| 1; 2 |]
-        equal true (xs1 = xs2)
-        equal false (xs1 = xs3)
-        equal true (xs1 <> xs3)
-        equal false (xs1 <> xs2)
-        equal true (xs1 <> xs4)
-
-    [<Fact>]
-    let ``Array equality works`` () =
-        let xs1 = [| "1"; "2"; "3" |]
-        let xs2 = [| "1"; "2"; "3" |]
-        let xs3 = [| "1"; "2"; "4" |]
-        let xs4 = [| "1"; "2" |]
-        equal true (xs1 = xs2)
-        equal false (xs1 = xs3)
-        equal true (xs1 <> xs3)
-        equal false (xs1 <> xs2)
-        equal true (xs1 <> xs4)
-
-    [<Fact>]
-    let ``Array custom equality works`` () =
-        let xs = [| FuzzyInt 3; FuzzyInt 5 |]
-        let ys = [| FuzzyInt 2; FuzzyInt 4 |]
-        let zs = [| FuzzyInt 2; FuzzyInt 8 |]
-        xs = ys |> equal true
-        xs = zs |> equal false
-
-    [<Fact>]
-    let ``Tuple equality works`` () =
-        let xs1 = ( 1, 2, 3 )
-        let xs2 = ( 1, 2, 3 )
-        let xs3 = ( 1, 2, 4 )
-        equal true (xs1 = xs2)
-        equal false (xs1 = xs3)
-        equal true (xs1 <> xs3)
-        equal false (xs1 <> xs2)
-
-    [<Fact>]
-    let ``List equality works`` () =
-        let xs1 = [ 1; 2; 3 ]
-        let xs2 = [ 1; 2; 3 ]
-        let xs3 = [ 1; 2; 4 ]
-        equal true (xs1 = xs2)
-        equal false (xs1 = xs3)
-        equal true (xs1 <> xs3)
-        equal false (xs1 <> xs2)
-
-    [<Fact>]
-    let ``Set equality works`` () =
-        let xs1 = Set [ 1; 2; 3 ]
-        let xs2 = Set [ 1; 2; 3 ]
-        let xs3 = Set [ 1; 2; 4 ]
-        let xs4 = Set [ 3; 2; 1 ]
-        let xs5 = Set [ 1; 2; 3; 1 ]
-        equal true (xs1 = xs2)
-        equal false (xs1 = xs3)
-        equal true (xs1 <> xs3)
-        equal false (xs1 <> xs2)
-        equal true (xs1 = xs4)
-        equal false (xs1 <> xs5)
-
-    [<Fact>]
-    let ``Map equality works`` () =
-        let xs1 = Map [ ("a", 1); ("b", 2); ("c", 3) ]
-        let xs2 = Map [ ("a", 1); ("b", 2); ("c", 3) ]
-        let xs3 = Map [ ("a", 1); ("b", 2); ("c", 4) ]
-        let xs4 = Map [ ("c", 3); ("b", 2); ("a", 1) ]
-        equal true (xs1 = xs2)
-        equal false (xs1 = xs3)
-        equal true (xs1 <> xs3)
-        equal false (xs1 <> xs2)
-        equal true (xs1 = xs4)
-
-    [<Fact>]
-    let ``Union equality works`` () =
-        let u1 = A 2
-        let u2 = A 2
-        let u3 = A 4
-        let u4 = B 2
-        equal true (u1 = u2)
-        equal false (u1 = u3)
-        equal true (u1 <> u3)
-        equal false (u1 <> u2)
-        equal false (u1 = u4)
-        Object.ReferenceEquals(u1, u1) |> equal true
-        Object.ReferenceEquals(u1, u2) |> equal false
-
-    [<Fact>]
-    let ``Union custom equality works`` () =
-        let u1 = String "A"
-        let u2 = String "A"
-        let u3 = String "AA"
-        equal false (u1 = u2)
-        equal true (u1 = u3)
-
-    [<Fact>]
-    let ``Record equality works`` () =
-        let r1 = { a = 1; b = 2 }
-        let r2 = { a = 1; b = 2 }
-        let r3 = { a = 1; b = 4 }
-        equal true (r1 = r2)
-        equal false (r1 = r3)
-        equal true (r1 <> r3)
-        equal false (r1 <> r2)
-        Object.ReferenceEquals(r1, r1) |> equal true
-        Object.ReferenceEquals(r1, r2) |> equal false
-
-    [<Fact>]
-    let ``Exception equality works`` () =
-        equal true ((Ex 1) = (Ex 1))
-        equal false ((Ex 1) = (Ex 2))
-
-    // TODO: If we want to make this work in Fable 2 we'll have
-    // to access reflection info for records
-
-    // #if FABLE_COMPILER
-    // [<Fact>]
-    // let ``Record equality ignores dynamic fields`` () =
-    //     let r1 = { a = 1; b = 2 }
-    //     r1?c <- 1
-    //     let r2 = { a = 1; b = 2 }
-    //     r2?c <- 2
-    //     equal true (r1 = r2)
-    //     equal false (r1 <> r2)
-
-    // [<Fact>]
-    // let ``Record comparison ignores dynamic fields`` () =
-    //     let r1 = { a = 1; b = 2 }
-    //     r1?c <- 1
-    //     let r2 = { a = 1; b = 2 }
-    //     r2?c <- 2
-    //     equal 0 (compare r1 r2)
-    // #endif
-
-    [<Fact>]
-    let ``Equality with objects implementing IEquatable works`` () =
-        let c1 = Test(5)
-        let c2 = Test(4)
-        let c3 = Test(5)
-        equal true (c1 = c2)
-        equal false (c1 = c3)
-        equal true (c1 <> c3)
-        equal false (c1 <> c2)
-        Object.ReferenceEquals(c1, c1) |> equal true
-        Object.ReferenceEquals(c1, c2) |> equal false
-
-    [<Fact>]
-    let ``Typed array comparison works`` () =
-        let xs1 = [| 1; 2; 3 |]
-        let xs2 = [| 1; 2; 3 |]
-        let xs3 = [| 1; 2; 4 |]
-        let xs4 = [| 1; 2; 2 |]
-        let xs5 = [| 1; 2 |]
-        let xs6 = [| 1; 2; 3; 1 |]
-        equal 0 (compare xs1 xs2)
-        equal -1 (compare xs1 xs3)
-        equal true (xs1 < xs3)
-        equal 1 (compare xs1 xs4)
-        equal false (xs1 < xs4)
-        equal 1 (compare xs1 xs5)
-        equal true (xs1 > xs5)
-        equal -1 (compare xs1 xs6)
-        equal false (xs1 > xs6)
-
-    [<Fact>]
-    let ``Array comparison works`` () =
-        let xs1 = [| "1"; "2"; "3" |]
-        let xs2 = [| "1"; "2"; "3" |]
-        let xs3 = [| "1"; "2"; "4" |]
-        let xs4 = [| "1"; "2"; "2" |]
-        let xs5 = [| "1"; "2" |]
-        let xs6 = [| "1"; "2"; "3"; "1" |]
-        equal 0 (compare xs1 xs2)
-        equal -1 (compare xs1 xs3)
-        equal true (xs1 < xs3)
-        equal 1 (compare xs1 xs4)
-        equal false (xs1 < xs4)
-        equal 1 (compare xs1 xs5)
-        equal true (xs1 > xs5)
-        equal -1 (compare xs1 xs6)
-        equal false (xs1 > xs6)
-
-    [<Fact>]
-    let ``Tuple comparison works`` () =
-        let xs1 = ( 1, 2, 3 )
-        let xs2 = ( 1, 2, 3 )
-        let xs3 = ( 1, 2, 4 )
-        let xs4 = ( 1, 2, 2 )
-        equal 0 (compare xs1 xs2)
-        equal -1 (compare xs1 xs3)
-        equal true (xs1 < xs3)
-        equal 1 (compare xs1 xs4)
-        equal false (xs1 < xs4)
-
-    [<Fact>]
-    let ``List comparison works`` () =
-        let xs1 = [ 1; 2; 3 ]
-        let xs2 = [ 1; 2; 3 ]
-        let xs3 = [ 1; 2; 4 ]
-        let xs4 = [ 1; 2; 2 ]
-        let xs5 = [ 1; 2 ]
-        let xs6 = [ 1; 2; 3; 1 ]
-        equal 0 (compare xs1 xs2)
-        equal -1 (compare xs1 xs3)
-        equal true (xs1 < xs3)
-        equal 1 (compare xs1 xs4)
-        equal false (xs1 < xs4)
-        equal 1 (compare xs1 xs5)
-        equal true (xs1 > xs5)
-        equal -1 (compare xs1 xs6)
-        equal false (xs1 > xs6)
-
-    [<Fact>]
-    let ``Set comparison works`` () =
-        let xs1 = Set [ 1; 2; 3 ]
-        let xs2 = Set [ 1; 2; 3 ]
-        let xs3 = Set [ 1; 2; 4 ]
-        let xs4 = Set [ 1; 2; 2 ]
-        let xs5 = Set [ 1; 2 ]
-        let xs6 = Set [ 1; 2; 3; 1 ]
-        equal 0 (compare xs1 xs2)
-        equal -1 (compare xs1 xs3)
-        equal true (xs1 < xs3)
-        equal 1 (compare xs1 xs4)
-        equal false (xs1 < xs4)
-        equal 1 (compare xs1 xs5)
-        equal true (xs1 > xs5)
-        equal 0 (compare xs1 xs6)
-
-    [<Fact>]
-    let ``Map comparison works`` () =
-        let xs1 = Map [ ("a", 1); ("b", 2); ("c", 3) ]
-        let xs2 = Map [ ("a", 1); ("b", 2); ("c", 3) ]
-        let xs3 = Map [ ("a", 1); ("b", 2); ("c", 4) ]
-        let xs4 = Map [ ("a", 1); ("b", 2); ("c", 2) ]
-        let xs5 = Map [ ("a", 1); ("b", 2) ]
-        let xs6 = Map [ ("a", 1); ("b", 2); ("c", 3); ("d", 1) ]
-        equal 0 (compare xs1 xs2)
-        equal -1 (compare xs1 xs3)
-        equal true (xs1 < xs3)
-        equal 1 (compare xs1 xs4)
-        equal false (xs1 < xs4)
-        equal 1 (compare xs1 xs5)
-        equal true (xs1 > xs5)
-        equal -1 (compare xs1 xs6)
-        equal false (xs1 > xs6)
-
-    [<Fact>]
-    let ``Union comparison works`` () =
-        let u1 = A 2
-        let u2 = A 2
-        let u3 = A 4
-        let u4 = A 1
-        let u5 = B 2
-        equal 0 (compare u1 u2)
-        equal -1 (compare u1 u3)
-        equal true (u1 < u3)
-        equal 1 (compare u1 u4)
-        equal false (u1 < u4)
-        (compare u1 u5) = 0 |> equal false
-
-    [<Fact>]
-    let ``Union custom comparison works`` () =
-        let u1 = String "A"
-        let u2 = String "A"
-        let u3 = String "AA"
-        equal 0 (compare u1 u3)
-        equal true (compare u1 u2 > 0)
-
-    [<Fact>]
-    let ``Record comparison works`` () =
-        let r1 = { a = 1; b = 2 }
-        let r2 = { a = 1; b = 2 }
-        let r3 = { a = 1; b = 4 }
-        equal 0 (compare r1 r2)
-        (compare r1 r3) = 0 |> equal false
-
-    [<Fact>]
-    let ``Comparison with objects implementing IComparable works`` () =
-        let c1 = Test(5)
-        let c2 = Test(4)
-        let c3 = Test(5)
-        equal 0 (compare c1 c2)
-        equal 1 (compare c1 c3)
-        equal true (c1 > c3)
-
-    [<Fact>]
-    let ``max works with primitives`` () =
-        max 1 2 |> equal 2
-        Math.Max(1, 2) |> equal 2
-        max "a" "b" |> equal "b"
-
-    [<Fact>]
-    let ``max works with records`` () =
-        let r1 = {a=1; b=1}
-        let r2 = {a=1; b=2}
-        max r1 r2 |> equal r2
-
-    [<Fact>]
-    let ``max with objects implementing IComparable works`` () =
-        let c1 = Test(5)
-        let c2 = Test(5)
-        Object.ReferenceEquals(max c1 c2, c1) |> equal true
-
-    [<Fact>]
-    let ``min works with primitives`` () =
-        min 1 2 |> equal 1
-        Math.Min(1, 2) |> equal 1
-        min "a" "b" |> equal "a"
-
-    [<Fact>]
-    let ``min works with records`` () =
-        let r1 = {a=1; b=1}
-        let r2 = {a=1; b=2}
-        min r1 r2 |> equal r1
-
-    [<Fact>]
-    let ``min with objects implementing IComparable works`` () =
-        let c1 = Test(5)
-        let c2 = Test(5)
-        Object.ReferenceEquals(min c1 c2, c2) |> equal true
-
-    // TODO: More tests, also with longs and decimals
-    [<Fact>]
-    let ``clamp works`` () =
-        Math.Clamp(14, 0, 12) |> equal 12
-
-    [<Fact>]
-    let ``nullArg works`` () =
-        try
-            nullArg null
-            true
-        with _ex ->
-            false
-        |> equal false
-
-    [<Fact>]
-    let ``using function disposes the resource when action finishes`` () =
-        let mutable disposed = false
-        let resource = { new IDisposable with member __.Dispose() = disposed <- true }
-        using resource (fun _resource -> ())
-        equal true disposed
-
-    [<Fact>]
-    let ``using function disposes the resource when action fails`` () =
-        let mutable disposed = false
-        let resource = { new IDisposable with member __.Dispose() = disposed <- true }
-        try
-            using resource (fun _resource -> failwith "action failed")
-        with
-        | _ -> () // ignore
-        equal true disposed
-
-    [<Fact>]
-    let ``isNull with primitives works`` () =
-        isNull null |> equal true
-        isNull "" |> equal false
-        isNull "0" |> equal false
-        isNull "hello" |> equal false
-
-    [<Fact>]
-    let ``isNull with objects works`` () =
-        let s1: String = null
-        isNull s1 |> equal true
-        let s2: String = "hello"
-        isNull s2 |> equal false
-
-    [<Fact>]
-    let ``Classes must use identity hashing by default`` () = // See #2291
-        let x = MyClass(5)
-        let y = MyClass(5)
-        let h1 = hash(box x)
-        let h2 = hash(box y)
-        x.Value <- 8
-        let h3 = hash(box x)
-        h1 = h2 |> equal false
-        h1 = h3 |> equal true
-
-    [<Fact>]
-    let ``GetHashCode with arrays works`` () =
-        ([|1; 2|].GetHashCode(), [|1; 2|].GetHashCode()) ||> notEqual
-        ([|2; 1|].GetHashCode(), [|1; 2|].GetHashCode()) ||> notEqual
-
-    [<Fact>]
-    let ``GetHashCode with lists works`` () =
-        ([1; 2].GetHashCode(), [1; 2].GetHashCode()) ||> equal
-        ([2; 1].GetHashCode(), [1; 2].GetHashCode()) ||> notEqual
-
-    [<Fact>]
-    let ``GetHashCode with tuples works`` () =
-        ((1, 2).GetHashCode(), (1, 2).GetHashCode()) ||> equal
-        ((2, 1).GetHashCode(), (1, 2).GetHashCode()) ||> notEqual
-
-    [<Fact>]
-    let ``GetHashCode with options works`` () =
-        ((Some 1).GetHashCode(), (Some 1).GetHashCode()) ||> equal
-        ((Some 2).GetHashCode(), (Some 1).GetHashCode()) ||> notEqual
-        ((Some None).GetHashCode(), (Some 1).GetHashCode()) ||> notEqual
-
-    [<Fact>]
-    let ``GetHashCode with unions works`` () =
-        ((UTest.A 1).GetHashCode(), (UTest.A 1).GetHashCode()) ||> equal
-        ((UTest.A 2).GetHashCode(), (UTest.A 1).GetHashCode()) ||> notEqual
-        ((UTest.B 1).GetHashCode(), (UTest.A 1).GetHashCode()) ||> notEqual
-
-    [<Fact>]
-    let ``GetHashCode with records works`` () =
-        ({a=1; b=2}.GetHashCode(), {a=1; b=2}.GetHashCode()) ||> equal
-        ({a=2; b=1}.GetHashCode(), {a=1; b=2}.GetHashCode()) ||> notEqual
-
-    [<Fact>]
-    let ``GetHashCode with structs works`` () =
-        (STest(1).GetHashCode(), STest(1).GetHashCode()) ||> equal
-        (STest(2).GetHashCode(), STest(1).GetHashCode()) ||> notEqual
-
-    [<Fact>]
-    let ``GetHashCode with objects works`` () =
-        (OTest(1).GetHashCode(), OTest(1).GetHashCode()) ||> notEqual
-        (OTest(2).GetHashCode(), OTest(1).GetHashCode()) ||> notEqual
-
-    [<Fact>]
-    let ``GetHashCode with objects that overwrite it works`` () =
-        (Test(1).GetHashCode(), Test(1).GetHashCode()) ||> equal
-        (Test(2).GetHashCode(), Test(1).GetHashCode()) ||> notEqual
-
-    [<Fact>]
-    let ``GetHashCode with same object works`` () =
-        let o = OTest(1)
-        let h1 = o.GetHashCode()
-        o.A <- 2
-        let h2 = o.GetHashCode()
-        (h1, h2) ||> equal
-
-    [<Fact>]
-    let ``GetHashCode with primitives works`` () =
-        ("1".GetHashCode(), "1".GetHashCode()) ||> equal
-        ("2".GetHashCode(), "1".GetHashCode()) ||> notEqual
-
-    // This is going to give different results in .NET and JS
-    // Just check no exception is thrown
-    [<Fact>]
-    let ``hash works with JS objects`` () = // See #2281
-        let _ = obj () |> hash
-        ()
-
-    [<Fact>]
-    let ``hash with arrays works`` () =
-        (hash [|1; 2|], hash [|1; 2|]) ||> equal
-        (hash [|2; 1|], hash [|1; 2|]) ||> notEqual
-
-    [<Fact>]
-    let ``hash with lists works`` () =
-        (hash [1; 2], hash [1; 2]) ||> equal
-        (hash [2; 1], hash [1; 2]) ||> notEqual
-
-    [<Fact>]
-    let ``hash with tuples works`` () =
-        (hash (1, 2), hash (1, 2)) ||> equal
-        (hash (2, 1), hash (1, 2)) ||> notEqual
-
-    [<Fact>]
-    let ``hash with options works`` () =
-        (hash (Some 1), hash (Some 1)) ||> equal
-        (hash (Some 2), hash (Some 1)) ||> notEqual
-        (hash (Some None), hash (Some 1)) ||> notEqual
-
-    [<Fact>]
-    let ``hash with unions works`` () =
-        (hash (UTest.A 1), hash (UTest.A 1)) ||> equal
-        (hash (UTest.A 2), hash (UTest.A 1)) ||> notEqual
-        (hash (UTest.B 1), hash (UTest.A 1)) ||> notEqual
-
-    [<Fact>]
-    let ``hash with records works`` () =
-        (hash {a=1; b=2}, hash {a=1; b=2}) ||> equal
-        (hash {a=2; b=1}, hash {a=1; b=2}) ||> notEqual
-
-    [<Fact>]
-    let ``hash with structs works`` () =
-        (hash (STest(1)), hash (STest(1))) ||> equal
-        (hash (STest(2)), hash (STest(1))) ||> notEqual
-
-    [<Fact>]
-    let ``hash with objects works`` () =
-        (hash (OTest(1)), hash (OTest(1))) ||> notEqual
-        (hash (OTest(2)), hash (OTest(1))) ||> notEqual
-
-    [<Fact>]
-    let ``hash with same object works`` () =
-        let o = OTest(1)
-        let h1 = hash o
-        o.A <- 2
-        let h2 = hash o
-        (h1, h2) ||> equal
-
-    [<Fact>]
-    let ``hash with longs works`` () =
-        (hash (1L<<<33), hash (1L<<<33)) ||> equal
-        (hash (1L<<<34), hash (1L<<<33)) ||> notEqual
-        (hash 3L, hash (3L + (1L<<<33))) ||> notEqual
-        (hash (-3L), hash (3L))          ||> notEqual
-
-    [<Fact>]
-    let ``hash with primitives works`` () =
-        (hash 111, hash 111) ||> equal
-        (hash 222, hash 111) ||> notEqual
-        (hash "1", hash "1") ||> equal
-        (hash "2", hash "1") ||> notEqual
-
-    [<Fact>]
-    let ``Unchecked.hash with primitives works`` () =
-        (Unchecked.hash 111, Unchecked.hash 111) ||> equal
-        (Unchecked.hash 222, Unchecked.hash 333) ||> notEqual
-        (Unchecked.hash "1", Unchecked.hash "1") ||> equal
-        (Unchecked.hash "2", Unchecked.hash "3") ||> notEqual
-
-    [<Fact>]
-    let ``Unchecked.hash with lists works`` () =
-        (Unchecked.hash [1;2], Unchecked.hash [1;2]) ||> equal
-        (Unchecked.hash [2;1], Unchecked.hash [1;2]) ||> notEqual
-
-    [<Fact>]
-    let ``Unchecked.hash with arrays works`` () =
-        (Unchecked.hash [|1;2|], Unchecked.hash [|1;2|]) ||> equal
-        (Unchecked.hash [|2;1|], Unchecked.hash [|1;2|]) ||> notEqual
-
-    [<Fact>]
-    let ``Unchecked.hash with tuples works`` () =
-        (Unchecked.hash (1,2), Unchecked.hash (1,2)) ||> equal
-        (Unchecked.hash (2,1), Unchecked.hash (1,2)) ||> notEqual
-
-    [<Fact>]
-    let ``Unchecked.equals works`` () =
-        Unchecked.equals 111 111 |> equal true
-        Unchecked.equals 222 333 |> equal false
-        Unchecked.equals "1" "1" |> equal true
-        Unchecked.equals "2" "3" |> equal false
-        Unchecked.equals [1] [1] |> equal true
-        Unchecked.equals [2] [3] |> equal false
-
-    [<Fact>]
-    let ``Unchecked.compare works`` () =
-        Unchecked.compare 111 111 |> equal 0
-        Unchecked.compare 222 333 |> equal -1
-        Unchecked.compare 333 222 |> equal 1
-        Unchecked.compare "1" "1" |> equal 0
-        Unchecked.compare "2" "3" |> equal -1
-        Unchecked.compare "3" "2" |> equal 1
-        Unchecked.compare [1] [1] |> equal 0
-        Unchecked.compare [2] [3] |> equal -1
-        Unchecked.compare [3] [2] |> equal 1
-
-    [<Fact>]
-    let ``DU comparison works`` () =
-        let hasStatusReached expectedStatus status =
-            status >= expectedStatus
-        Status.CreateNewMeterReadingPicture >= Status.SelectingNewDevice
-        |> equal true
-        hasStatusReached Status.SelectingNewDevice Status.CreateNewMeterReadingPicture
-        |> equal true
-
-    [<Fact>]
-    let ``LanguagePrimitives.GenericHash with primitives works`` () =
-        (LanguagePrimitives.GenericHash 111, LanguagePrimitives.GenericHash 111) ||> equal
-        (LanguagePrimitives.GenericHash 222, LanguagePrimitives.GenericHash 111) ||> notEqual
-        (LanguagePrimitives.GenericHash "1", LanguagePrimitives.GenericHash "1") ||> equal
-        (LanguagePrimitives.GenericHash "2", LanguagePrimitives.GenericHash "1") ||> notEqual
-
-    [<Fact>]
-    let ``LanguagePrimitives.GenericHash with lists works`` () =
-        (LanguagePrimitives.GenericHash [1;2], LanguagePrimitives.GenericHash [1;2]) ||> equal
-        (LanguagePrimitives.GenericHash [2;1], LanguagePrimitives.GenericHash [1;2]) ||> notEqual
-
-    [<Fact>]
-    let ``LanguagePrimitives.GenericHash with arrays works`` () =
-        (LanguagePrimitives.GenericHash [|1;2|], LanguagePrimitives.GenericHash [|1;2|]) ||> equal
-        (LanguagePrimitives.GenericHash [|2;1|], LanguagePrimitives.GenericHash [|1;2|]) ||> notEqual
-
-    [<Fact>]
-    let ``LanguagePrimitives.GenericHash with tuples works`` () =
-        (LanguagePrimitives.GenericHash (1,2), LanguagePrimitives.GenericHash (1,2)) ||> equal
-        (LanguagePrimitives.GenericHash (2,1), LanguagePrimitives.GenericHash (1,2)) ||> notEqual
-
-    [<Fact>]
-    let ``LanguagePrimitives.PhysicalHash with primitives works`` () =
-        (LanguagePrimitives.PhysicalHash "1", LanguagePrimitives.PhysicalHash "1") ||> equal
-        (LanguagePrimitives.PhysicalHash "2", LanguagePrimitives.PhysicalHash "1") ||> notEqual
-
-    [<Fact>]
-    let ``LanguagePrimitives.PhysicalHash with lists works`` () =
-        (LanguagePrimitives.PhysicalHash [1;2], LanguagePrimitives.PhysicalHash [1;2]) ||> notEqual
-        (LanguagePrimitives.PhysicalHash [2;1], LanguagePrimitives.PhysicalHash [1;2]) ||> notEqual
-
-    [<Fact>]
-    let ``LanguagePrimitives.PhysicalHash with arrays works`` () =
-        (LanguagePrimitives.PhysicalHash [|1;2|], LanguagePrimitives.PhysicalHash [|1;2|]) ||> notEqual
-        (LanguagePrimitives.PhysicalHash [|2;1|], LanguagePrimitives.PhysicalHash [|1;2|]) ||> notEqual
-
-    [<Fact>]
-    let ``LanguagePrimitives.PhysicalHash with tuples works`` () =
-        (LanguagePrimitives.PhysicalHash (1,2), LanguagePrimitives.PhysicalHash (1,2)) ||> notEqual
-        (LanguagePrimitives.PhysicalHash (2,1), LanguagePrimitives.PhysicalHash (1,2)) ||> notEqual
-
-    [<Fact>]
-    let ``LanguagePrimitives.GenericComparison works`` () =
-        LanguagePrimitives.GenericComparison 111 111 |> equal 0
-        LanguagePrimitives.GenericComparison 222 333 |> equal -1
-        LanguagePrimitives.GenericComparison 333 222 |> equal 1
-        LanguagePrimitives.GenericComparison "1" "1" |> equal 0
-        LanguagePrimitives.GenericComparison "2" "3" |> equal -1
-        LanguagePrimitives.GenericComparison "3" "2" |> equal 1
-        LanguagePrimitives.GenericComparison [1] [1] |> equal 0
-        LanguagePrimitives.GenericComparison [2] [3] |> equal -1
-        LanguagePrimitives.GenericComparison [3] [2] |> equal 1
-
-    [<Fact>]
-    let ``LanguagePrimitives.GenericEquality works`` () =
-        LanguagePrimitives.GenericEquality 111 111 |> equal true
-        LanguagePrimitives.GenericEquality 222 333 |> equal false
-        LanguagePrimitives.GenericEquality "1" "1" |> equal true
-        LanguagePrimitives.GenericEquality "2" "3" |> equal false
-        LanguagePrimitives.GenericEquality [1] [1] |> equal true
-        LanguagePrimitives.GenericEquality [2] [3] |> equal false
-
-    [<Fact>]
-    let ``LanguagePrimitives.PhysicalEquality works`` () =
-        LanguagePrimitives.PhysicalEquality "1" "1" |> equal true
-        LanguagePrimitives.PhysicalEquality "2" "3" |> equal false
-        LanguagePrimitives.PhysicalEquality [1] [1] |> equal false
-        LanguagePrimitives.PhysicalEquality [2] [3] |> equal false
-
-    [<Fact>]
-    let ``LanguagePrimitives.SByteWithMeasure works`` () =
-        let distance: sbyte<m> = LanguagePrimitives.SByteWithMeasure 1y
-        distance |> equal 1y<m>
-
-    [<Fact>]
-    let ``LanguagePrimitives.Int16WithMeasure works`` () =
-        let distance: int16<m> = LanguagePrimitives.Int16WithMeasure 1s
-        distance |> equal 1s<m>
-
-    [<Fact>]
-    let ``LanguagePrimitives.Int32WithMeasure works`` () =
-        let distance: int<m> = LanguagePrimitives.Int32WithMeasure 1
-        distance |> equal 1<m>
-
-    [<Fact>]
-    let ``LanguagePrimitives.Int64WithMeasure works`` () =
-        let distance: int64<m> = LanguagePrimitives.Int64WithMeasure 1L
-        distance |> equal 1L<m>
-
-    [<Fact>]
-    let ``LanguagePrimitives.Float32WithMeasure works`` () =
-        let distance: float32<m> = LanguagePrimitives.Float32WithMeasure 1.0f
-        distance |> equal 1.0f<m>
-
-    [<Fact>]
-    let ``LanguagePrimitives.FloatWithMeasure works`` () =
-        let distance: float<m> = LanguagePrimitives.FloatWithMeasure 1.0
-        distance |> equal 1.0<m>
-
-    [<Fact>]
-    let ``LanguagePrimitives.DecimalWithMeasure works`` () =
-        let distance: decimal<m> = LanguagePrimitives.DecimalWithMeasure 1.0m
-        distance |> equal 1.0m<m>
+[<Fact>]
+let ``Typed array equality works`` () =
+    let xs1 = [| 1; 2; 3 |]
+    let xs2 = [| 1; 2; 3 |]
+    let xs3 = [| 1; 2; 4 |]
+    let xs4 = [| 1; 2 |]
+    equal true (xs1 = xs2)
+    equal false (xs1 = xs3)
+    equal true (xs1 <> xs3)
+    equal false (xs1 <> xs2)
+    equal true (xs1 <> xs4)
+
+[<Fact>]
+let ``Array equality works`` () =
+    let xs1 = [| "1"; "2"; "3" |]
+    let xs2 = [| "1"; "2"; "3" |]
+    let xs3 = [| "1"; "2"; "4" |]
+    let xs4 = [| "1"; "2" |]
+    equal true (xs1 = xs2)
+    equal false (xs1 = xs3)
+    equal true (xs1 <> xs3)
+    equal false (xs1 <> xs2)
+    equal true (xs1 <> xs4)
+
+[<Fact>]
+let ``Array custom equality works`` () =
+    let xs = [| FuzzyInt 3; FuzzyInt 5 |]
+    let ys = [| FuzzyInt 2; FuzzyInt 4 |]
+    let zs = [| FuzzyInt 2; FuzzyInt 8 |]
+    xs = ys |> equal true
+    xs = zs |> equal false
+
+[<Fact>]
+let ``Tuple equality works`` () =
+    let xs1 = ( 1, 2, 3 )
+    let xs2 = ( 1, 2, 3 )
+    let xs3 = ( 1, 2, 4 )
+    equal true (xs1 = xs2)
+    equal false (xs1 = xs3)
+    equal true (xs1 <> xs3)
+    equal false (xs1 <> xs2)
+
+[<Fact>]
+let ``List equality works`` () =
+    let xs1 = [ 1; 2; 3 ]
+    let xs2 = [ 1; 2; 3 ]
+    let xs3 = [ 1; 2; 4 ]
+    equal true (xs1 = xs2)
+    equal false (xs1 = xs3)
+    equal true (xs1 <> xs3)
+    equal false (xs1 <> xs2)
+
+[<Fact>]
+let ``Set equality works`` () =
+    let xs1 = Set [ 1; 2; 3 ]
+    let xs2 = Set [ 1; 2; 3 ]
+    let xs3 = Set [ 1; 2; 4 ]
+    let xs4 = Set [ 3; 2; 1 ]
+    let xs5 = Set [ 1; 2; 3; 1 ]
+    equal true (xs1 = xs2)
+    equal false (xs1 = xs3)
+    equal true (xs1 <> xs3)
+    equal false (xs1 <> xs2)
+    equal true (xs1 = xs4)
+    equal false (xs1 <> xs5)
+
+[<Fact>]
+let ``Map equality works`` () =
+    let xs1 = Map [ ("a", 1); ("b", 2); ("c", 3) ]
+    let xs2 = Map [ ("a", 1); ("b", 2); ("c", 3) ]
+    let xs3 = Map [ ("a", 1); ("b", 2); ("c", 4) ]
+    let xs4 = Map [ ("c", 3); ("b", 2); ("a", 1) ]
+    equal true (xs1 = xs2)
+    equal false (xs1 = xs3)
+    equal true (xs1 <> xs3)
+    equal false (xs1 <> xs2)
+    equal true (xs1 = xs4)
+
+[<Fact>]
+let ``Union equality works`` () =
+    let u1 = A 2
+    let u2 = A 2
+    let u3 = A 4
+    let u4 = B 2
+    equal true (u1 = u2)
+    equal false (u1 = u3)
+    equal true (u1 <> u3)
+    equal false (u1 <> u2)
+    equal false (u1 = u4)
+    System.Object.ReferenceEquals(u1, u1) |> equal true
+    System.Object.ReferenceEquals(u1, u2) |> equal false
+
+[<Fact>]
+let ``Union custom equality works`` () =
+    let u1 = String "A"
+    let u2 = String "A"
+    let u3 = String "AA"
+    equal false (u1 = u2)
+    equal true (u1 = u3)
+
+[<Fact>]
+let ``Record equality works`` () =
+    let r1 = { a = 1; b = 2 }
+    let r2 = { a = 1; b = 2 }
+    let r3 = { a = 1; b = 4 }
+    equal true (r1 = r2)
+    equal false (r1 = r3)
+    equal true (r1 <> r3)
+    equal false (r1 <> r2)
+    System.Object.ReferenceEquals(r1, r1) |> equal true
+    System.Object.ReferenceEquals(r1, r2) |> equal false
+
+[<Fact>]
+let ``Exception equality works`` () =
+    equal true ((Ex 1) = (Ex 1))
+    equal false ((Ex 1) = (Ex 2))
+
+// TODO: If we want to make this work in Fable 2 we'll have
+// to access reflection info for records
+
+// #if FABLE_COMPILER
+// [<Fact>]
+// let ``Record equality ignores dynamic fields`` () =
+//     let r1 = { a = 1; b = 2 }
+//     r1?c <- 1
+//     let r2 = { a = 1; b = 2 }
+//     r2?c <- 2
+//     equal true (r1 = r2)
+//     equal false (r1 <> r2)
+
+// [<Fact>]
+// let ``Record comparison ignores dynamic fields`` () =
+//     let r1 = { a = 1; b = 2 }
+//     r1?c <- 1
+//     let r2 = { a = 1; b = 2 }
+//     r2?c <- 2
+//     equal 0 (compare r1 r2)
+// #endif
+
+[<Fact>]
+let ``Equality with objects implementing IEquatable works`` () =
+    let c1 = Test(5)
+    let c2 = Test(4)
+    let c3 = Test(5)
+    equal true (c1 = c2)
+    equal false (c1 = c3)
+    equal true (c1 <> c3)
+    equal false (c1 <> c2)
+    System.Object.ReferenceEquals(c1, c1) |> equal true
+    System.Object.ReferenceEquals(c1, c2) |> equal false
+
+[<Fact>]
+let ``Typed array comparison works`` () =
+    let xs1 = [| 1; 2; 3 |]
+    let xs2 = [| 1; 2; 3 |]
+    let xs3 = [| 1; 2; 4 |]
+    let xs4 = [| 1; 2; 2 |]
+    let xs5 = [| 1; 2 |]
+    let xs6 = [| 1; 2; 3; 1 |]
+    equal 0 (compare xs1 xs2)
+    equal -1 (compare xs1 xs3)
+    equal true (xs1 < xs3)
+    equal 1 (compare xs1 xs4)
+    equal false (xs1 < xs4)
+    equal 1 (compare xs1 xs5)
+    equal true (xs1 > xs5)
+    equal -1 (compare xs1 xs6)
+    equal false (xs1 > xs6)
+
+[<Fact>]
+let ``Array comparison works`` () =
+    let xs1 = [| "1"; "2"; "3" |]
+    let xs2 = [| "1"; "2"; "3" |]
+    let xs3 = [| "1"; "2"; "4" |]
+    let xs4 = [| "1"; "2"; "2" |]
+    let xs5 = [| "1"; "2" |]
+    let xs6 = [| "1"; "2"; "3"; "1" |]
+    equal 0 (compare xs1 xs2)
+    equal -1 (compare xs1 xs3)
+    equal true (xs1 < xs3)
+    equal 1 (compare xs1 xs4)
+    equal false (xs1 < xs4)
+    equal 1 (compare xs1 xs5)
+    equal true (xs1 > xs5)
+    equal -1 (compare xs1 xs6)
+    equal false (xs1 > xs6)
+
+[<Fact>]
+let ``Tuple comparison works`` () =
+    let xs1 = ( 1, 2, 3 )
+    let xs2 = ( 1, 2, 3 )
+    let xs3 = ( 1, 2, 4 )
+    let xs4 = ( 1, 2, 2 )
+    equal 0 (compare xs1 xs2)
+    equal -1 (compare xs1 xs3)
+    equal true (xs1 < xs3)
+    equal 1 (compare xs1 xs4)
+    equal false (xs1 < xs4)
+
+[<Fact>]
+let ``List comparison works`` () =
+    let xs1 = [ 1; 2; 3 ]
+    let xs2 = [ 1; 2; 3 ]
+    let xs3 = [ 1; 2; 4 ]
+    let xs4 = [ 1; 2; 2 ]
+    let xs5 = [ 1; 2 ]
+    let xs6 = [ 1; 2; 3; 1 ]
+    equal 0 (compare xs1 xs2)
+    equal -1 (compare xs1 xs3)
+    equal true (xs1 < xs3)
+    equal 1 (compare xs1 xs4)
+    equal false (xs1 < xs4)
+    equal 1 (compare xs1 xs5)
+    equal true (xs1 > xs5)
+    equal -1 (compare xs1 xs6)
+    equal false (xs1 > xs6)
+
+[<Fact>]
+let ``Set comparison works`` () =
+    let xs1 = Set [ 1; 2; 3 ]
+    let xs2 = Set [ 1; 2; 3 ]
+    let xs3 = Set [ 1; 2; 4 ]
+    let xs4 = Set [ 1; 2; 2 ]
+    let xs5 = Set [ 1; 2 ]
+    let xs6 = Set [ 1; 2; 3; 1 ]
+    equal 0 (compare xs1 xs2)
+    equal -1 (compare xs1 xs3)
+    equal true (xs1 < xs3)
+    equal 1 (compare xs1 xs4)
+    equal false (xs1 < xs4)
+    equal 1 (compare xs1 xs5)
+    equal true (xs1 > xs5)
+    equal 0 (compare xs1 xs6)
+
+[<Fact>]
+let ``Map comparison works`` () =
+    let xs1 = Map [ ("a", 1); ("b", 2); ("c", 3) ]
+    let xs2 = Map [ ("a", 1); ("b", 2); ("c", 3) ]
+    let xs3 = Map [ ("a", 1); ("b", 2); ("c", 4) ]
+    let xs4 = Map [ ("a", 1); ("b", 2); ("c", 2) ]
+    let xs5 = Map [ ("a", 1); ("b", 2) ]
+    let xs6 = Map [ ("a", 1); ("b", 2); ("c", 3); ("d", 1) ]
+    equal 0 (compare xs1 xs2)
+    equal -1 (compare xs1 xs3)
+    equal true (xs1 < xs3)
+    equal 1 (compare xs1 xs4)
+    equal false (xs1 < xs4)
+    equal 1 (compare xs1 xs5)
+    equal true (xs1 > xs5)
+    equal -1 (compare xs1 xs6)
+    equal false (xs1 > xs6)
+
+[<Fact>]
+let ``Union comparison works`` () =
+    let u1 = A 2
+    let u2 = A 2
+    let u3 = A 4
+    let u4 = A 1
+    let u5 = B 2
+    equal 0 (compare u1 u2)
+    equal -1 (compare u1 u3)
+    equal true (u1 < u3)
+    equal 1 (compare u1 u4)
+    equal false (u1 < u4)
+    (compare u1 u5) = 0 |> equal false
+
+[<Fact>]
+let ``Union custom comparison works`` () =
+    let u1 = String "A"
+    let u2 = String "A"
+    let u3 = String "AA"
+    equal 0 (compare u1 u3)
+    equal true (compare u1 u2 > 0)
+
+[<Fact>]
+let ``Record comparison works`` () =
+    let r1 = { a = 1; b = 2 }
+    let r2 = { a = 1; b = 2 }
+    let r3 = { a = 1; b = 4 }
+    equal 0 (compare r1 r2)
+    (compare r1 r3) = 0 |> equal false
+
+[<Fact>]
+let ``Comparison with objects implementing IComparable works`` () =
+    let c1 = Test(5)
+    let c2 = Test(4)
+    let c3 = Test(5)
+    equal 0 (compare c1 c2)
+    equal 1 (compare c1 c3)
+    equal true (c1 > c3)
+
+[<Fact>]
+let ``max works with primitives`` () =
+    max 1 2 |> equal 2
+    System.Math.Max(1, 2) |> equal 2
+    max "a" "b" |> equal "b"
+
+[<Fact>]
+let ``max works with records`` () =
+    let r1 = {a=1; b=1}
+    let r2 = {a=1; b=2}
+    max r1 r2 |> equal r2
+
+[<Fact>]
+let ``max with objects implementing IComparable works`` () =
+    let c1 = Test(5)
+    let c2 = Test(5)
+    System.Object.ReferenceEquals(max c1 c2, c1) |> equal true
+
+[<Fact>]
+let ``min works with primitives`` () =
+    min 1 2 |> equal 1
+    System.Math.Min(1, 2) |> equal 1
+    min "a" "b" |> equal "a"
+
+[<Fact>]
+let ``min works with records`` () =
+    let r1 = {a=1; b=1}
+    let r2 = {a=1; b=2}
+    min r1 r2 |> equal r1
+
+[<Fact>]
+let ``min with objects implementing IComparable works`` () =
+    let c1 = Test(5)
+    let c2 = Test(5)
+    System.Object.ReferenceEquals(min c1 c2, c2) |> equal true
+
+// TODO: More tests, also with longs and decimals
+[<Fact>]
+let ``clamp works`` () =
+    System.Math.Clamp(14, 0, 12) |> equal 12
+
+[<Fact>]
+let ``nullArg works`` () =
+    try
+        nullArg null
+        true
+    with _ex ->
+        false
+    |> equal false
+
+[<Fact>]
+let ``using function disposes the resource when action finishes`` () =
+    let mutable disposed = false
+    let resource = { new System.IDisposable with member __.Dispose() = disposed <- true }
+    using resource (fun _resource -> ())
+    equal true disposed
+
+[<Fact>]
+let ``using function disposes the resource when action fails`` () =
+    let mutable disposed = false
+    let resource = { new System.IDisposable with member __.Dispose() = disposed <- true }
+    try
+        using resource (fun _resource -> failwith "action failed")
+    with
+    | _ -> () // ignore
+    equal true disposed
+
+[<Fact>]
+let ``isNull with primitives works`` () =
+    isNull null |> equal true
+    isNull "" |> equal false
+    isNull "0" |> equal false
+    isNull "hello" |> equal false
+
+[<Fact>]
+let ``isNull with objects works`` () =
+    let s1: System.String = null
+    isNull s1 |> equal true
+    let s2: System.String = "hello"
+    isNull s2 |> equal false
+
+[<Fact>]
+let ``Classes must use identity hashing by default`` () = // See #2291
+    let x = MyClass(5)
+    let y = MyClass(5)
+    let h1 = hash(box x)
+    let h2 = hash(box y)
+    x.Value <- 8
+    let h3 = hash(box x)
+    h1 = h2 |> equal false
+    h1 = h3 |> equal true
+
+[<Fact>]
+let ``GetHashCode with arrays works`` () =
+    ([|1; 2|].GetHashCode(), [|1; 2|].GetHashCode()) ||> notEqual
+    ([|2; 1|].GetHashCode(), [|1; 2|].GetHashCode()) ||> notEqual
+
+[<Fact>]
+let ``GetHashCode with lists works`` () =
+    ([1; 2].GetHashCode(), [1; 2].GetHashCode()) ||> equal
+    ([2; 1].GetHashCode(), [1; 2].GetHashCode()) ||> notEqual
+
+[<Fact>]
+let ``GetHashCode with tuples works`` () =
+    ((1, 2).GetHashCode(), (1, 2).GetHashCode()) ||> equal
+    ((2, 1).GetHashCode(), (1, 2).GetHashCode()) ||> notEqual
+
+[<Fact>]
+let ``GetHashCode with options works`` () =
+    ((Some 1).GetHashCode(), (Some 1).GetHashCode()) ||> equal
+    ((Some 2).GetHashCode(), (Some 1).GetHashCode()) ||> notEqual
+    ((Some None).GetHashCode(), (Some 1).GetHashCode()) ||> notEqual
+
+[<Fact>]
+let ``GetHashCode with unions works`` () =
+    ((UTest.A 1).GetHashCode(), (UTest.A 1).GetHashCode()) ||> equal
+    ((UTest.A 2).GetHashCode(), (UTest.A 1).GetHashCode()) ||> notEqual
+    ((UTest.B 1).GetHashCode(), (UTest.A 1).GetHashCode()) ||> notEqual
+
+[<Fact>]
+let ``GetHashCode with records works`` () =
+    ({a=1; b=2}.GetHashCode(), {a=1; b=2}.GetHashCode()) ||> equal
+    ({a=2; b=1}.GetHashCode(), {a=1; b=2}.GetHashCode()) ||> notEqual
+
+[<Fact>]
+let ``GetHashCode with structs works`` () =
+    (STest(1).GetHashCode(), STest(1).GetHashCode()) ||> equal
+    (STest(2).GetHashCode(), STest(1).GetHashCode()) ||> notEqual
+
+[<Fact>]
+let ``GetHashCode with objects works`` () =
+    (OTest(1).GetHashCode(), OTest(1).GetHashCode()) ||> notEqual
+    (OTest(2).GetHashCode(), OTest(1).GetHashCode()) ||> notEqual
+
+[<Fact>]
+let ``GetHashCode with objects that overwrite it works`` () =
+    (Test(1).GetHashCode(), Test(1).GetHashCode()) ||> equal
+    (Test(2).GetHashCode(), Test(1).GetHashCode()) ||> notEqual
+
+[<Fact>]
+let ``GetHashCode with same object works`` () =
+    let o = OTest(1)
+    let h1 = o.GetHashCode()
+    o.A <- 2
+    let h2 = o.GetHashCode()
+    (h1, h2) ||> equal
+
+[<Fact>]
+let ``GetHashCode with primitives works`` () =
+    ("1".GetHashCode(), "1".GetHashCode()) ||> equal
+    ("2".GetHashCode(), "1".GetHashCode()) ||> notEqual
+
+// This is going to give different results in .NET and JS
+// Just check no exception is thrown
+[<Fact>]
+let ``hash works with JS objects`` () = // See #2281
+    let _ = obj () |> hash
+    ()
+
+[<Fact>]
+let ``hash with arrays works`` () =
+    (hash [|1; 2|], hash [|1; 2|]) ||> equal
+    (hash [|2; 1|], hash [|1; 2|]) ||> notEqual
+
+[<Fact>]
+let ``hash with lists works`` () =
+    (hash [1; 2], hash [1; 2]) ||> equal
+    (hash [2; 1], hash [1; 2]) ||> notEqual
+
+[<Fact>]
+let ``hash with tuples works`` () =
+    (hash (1, 2), hash (1, 2)) ||> equal
+    (hash (2, 1), hash (1, 2)) ||> notEqual
+
+[<Fact>]
+let ``hash with options works`` () =
+    (hash (Some 1), hash (Some 1)) ||> equal
+    (hash (Some 2), hash (Some 1)) ||> notEqual
+    (hash (Some None), hash (Some 1)) ||> notEqual
+
+[<Fact>]
+let ``hash with unions works`` () =
+    (hash (UTest.A 1), hash (UTest.A 1)) ||> equal
+    (hash (UTest.A 2), hash (UTest.A 1)) ||> notEqual
+    (hash (UTest.B 1), hash (UTest.A 1)) ||> notEqual
+
+[<Fact>]
+let ``hash with records works`` () =
+    (hash {a=1; b=2}, hash {a=1; b=2}) ||> equal
+    (hash {a=2; b=1}, hash {a=1; b=2}) ||> notEqual
+
+[<Fact>]
+let ``hash with structs works`` () =
+    (hash (STest(1)), hash (STest(1))) ||> equal
+    (hash (STest(2)), hash (STest(1))) ||> notEqual
+
+[<Fact>]
+let ``hash with objects works`` () =
+    (hash (OTest(1)), hash (OTest(1))) ||> notEqual
+    (hash (OTest(2)), hash (OTest(1))) ||> notEqual
+
+[<Fact>]
+let ``hash with same object works`` () =
+    let o = OTest(1)
+    let h1 = hash o
+    o.A <- 2
+    let h2 = hash o
+    (h1, h2) ||> equal
+
+[<Fact>]
+let ``hash with longs works`` () =
+    (hash (1L<<<33), hash (1L<<<33)) ||> equal
+    (hash (1L<<<34), hash (1L<<<33)) ||> notEqual
+    (hash 3L, hash (3L + (1L<<<33))) ||> notEqual
+    (hash (-3L), hash (3L))          ||> notEqual
+
+[<Fact>]
+let ``hash with primitives works`` () =
+    (hash 111, hash 111) ||> equal
+    (hash 222, hash 111) ||> notEqual
+    (hash "1", hash "1") ||> equal
+    (hash "2", hash "1") ||> notEqual
+
+[<Fact>]
+let ``Unchecked.hash with primitives works`` () =
+    (Unchecked.hash 111, Unchecked.hash 111) ||> equal
+    (Unchecked.hash 222, Unchecked.hash 333) ||> notEqual
+    (Unchecked.hash "1", Unchecked.hash "1") ||> equal
+    (Unchecked.hash "2", Unchecked.hash "3") ||> notEqual
+
+[<Fact>]
+let ``Unchecked.hash with lists works`` () =
+    (Unchecked.hash [1;2], Unchecked.hash [1;2]) ||> equal
+    (Unchecked.hash [2;1], Unchecked.hash [1;2]) ||> notEqual
+
+[<Fact>]
+let ``Unchecked.hash with arrays works`` () =
+    (Unchecked.hash [|1;2|], Unchecked.hash [|1;2|]) ||> equal
+    (Unchecked.hash [|2;1|], Unchecked.hash [|1;2|]) ||> notEqual
+
+[<Fact>]
+let ``Unchecked.hash with tuples works`` () =
+    (Unchecked.hash (1,2), Unchecked.hash (1,2)) ||> equal
+    (Unchecked.hash (2,1), Unchecked.hash (1,2)) ||> notEqual
+
+[<Fact>]
+let ``Unchecked.equals works`` () =
+    Unchecked.equals 111 111 |> equal true
+    Unchecked.equals 222 333 |> equal false
+    Unchecked.equals "1" "1" |> equal true
+    Unchecked.equals "2" "3" |> equal false
+    Unchecked.equals [1] [1] |> equal true
+    Unchecked.equals [2] [3] |> equal false
+
+[<Fact>]
+let ``Unchecked.compare works`` () =
+    Unchecked.compare 111 111 |> equal 0
+    Unchecked.compare 222 333 |> equal -1
+    Unchecked.compare 333 222 |> equal 1
+    Unchecked.compare "1" "1" |> equal 0
+    Unchecked.compare "2" "3" |> equal -1
+    Unchecked.compare "3" "2" |> equal 1
+    Unchecked.compare [1] [1] |> equal 0
+    Unchecked.compare [2] [3] |> equal -1
+    Unchecked.compare [3] [2] |> equal 1
+
+[<Fact>]
+let ``DU comparison works`` () =
+    let hasStatusReached expectedStatus status =
+        status >= expectedStatus
+    Status.CreateNewMeterReadingPicture >= Status.SelectingNewDevice
+    |> equal true
+    hasStatusReached Status.SelectingNewDevice Status.CreateNewMeterReadingPicture
+    |> equal true
+
+[<Fact>]
+let ``LanguagePrimitives.GenericHash with primitives works`` () =
+    (LanguagePrimitives.GenericHash 111, LanguagePrimitives.GenericHash 111) ||> equal
+    (LanguagePrimitives.GenericHash 222, LanguagePrimitives.GenericHash 111) ||> notEqual
+    (LanguagePrimitives.GenericHash "1", LanguagePrimitives.GenericHash "1") ||> equal
+    (LanguagePrimitives.GenericHash "2", LanguagePrimitives.GenericHash "1") ||> notEqual
+
+[<Fact>]
+let ``LanguagePrimitives.GenericHash with lists works`` () =
+    (LanguagePrimitives.GenericHash [1;2], LanguagePrimitives.GenericHash [1;2]) ||> equal
+    (LanguagePrimitives.GenericHash [2;1], LanguagePrimitives.GenericHash [1;2]) ||> notEqual
+
+[<Fact>]
+let ``LanguagePrimitives.GenericHash with arrays works`` () =
+    (LanguagePrimitives.GenericHash [|1;2|], LanguagePrimitives.GenericHash [|1;2|]) ||> equal
+    (LanguagePrimitives.GenericHash [|2;1|], LanguagePrimitives.GenericHash [|1;2|]) ||> notEqual
+
+[<Fact>]
+let ``LanguagePrimitives.GenericHash with tuples works`` () =
+    (LanguagePrimitives.GenericHash (1,2), LanguagePrimitives.GenericHash (1,2)) ||> equal
+    (LanguagePrimitives.GenericHash (2,1), LanguagePrimitives.GenericHash (1,2)) ||> notEqual
+
+[<Fact>]
+let ``LanguagePrimitives.PhysicalHash with primitives works`` () =
+    (LanguagePrimitives.PhysicalHash "1", LanguagePrimitives.PhysicalHash "1") ||> equal
+    (LanguagePrimitives.PhysicalHash "2", LanguagePrimitives.PhysicalHash "1") ||> notEqual
+
+[<Fact>]
+let ``LanguagePrimitives.PhysicalHash with lists works`` () =
+    (LanguagePrimitives.PhysicalHash [1;2], LanguagePrimitives.PhysicalHash [1;2]) ||> notEqual
+    (LanguagePrimitives.PhysicalHash [2;1], LanguagePrimitives.PhysicalHash [1;2]) ||> notEqual
+
+[<Fact>]
+let ``LanguagePrimitives.PhysicalHash with arrays works`` () =
+    (LanguagePrimitives.PhysicalHash [|1;2|], LanguagePrimitives.PhysicalHash [|1;2|]) ||> notEqual
+    (LanguagePrimitives.PhysicalHash [|2;1|], LanguagePrimitives.PhysicalHash [|1;2|]) ||> notEqual
+
+[<Fact>]
+let ``LanguagePrimitives.PhysicalHash with tuples works`` () =
+    (LanguagePrimitives.PhysicalHash (1,2), LanguagePrimitives.PhysicalHash (1,2)) ||> notEqual
+    (LanguagePrimitives.PhysicalHash (2,1), LanguagePrimitives.PhysicalHash (1,2)) ||> notEqual
+
+[<Fact>]
+let ``LanguagePrimitives.GenericComparison works`` () =
+    LanguagePrimitives.GenericComparison 111 111 |> equal 0
+    LanguagePrimitives.GenericComparison 222 333 |> equal -1
+    LanguagePrimitives.GenericComparison 333 222 |> equal 1
+    LanguagePrimitives.GenericComparison "1" "1" |> equal 0
+    LanguagePrimitives.GenericComparison "2" "3" |> equal -1
+    LanguagePrimitives.GenericComparison "3" "2" |> equal 1
+    LanguagePrimitives.GenericComparison [1] [1] |> equal 0
+    LanguagePrimitives.GenericComparison [2] [3] |> equal -1
+    LanguagePrimitives.GenericComparison [3] [2] |> equal 1
+
+[<Fact>]
+let ``LanguagePrimitives.GenericEquality works`` () =
+    LanguagePrimitives.GenericEquality 111 111 |> equal true
+    LanguagePrimitives.GenericEquality 222 333 |> equal false
+    LanguagePrimitives.GenericEquality "1" "1" |> equal true
+    LanguagePrimitives.GenericEquality "2" "3" |> equal false
+    LanguagePrimitives.GenericEquality [1] [1] |> equal true
+    LanguagePrimitives.GenericEquality [2] [3] |> equal false
+
+[<Fact>]
+let ``LanguagePrimitives.PhysicalEquality works`` () =
+    LanguagePrimitives.PhysicalEquality "1" "1" |> equal true
+    LanguagePrimitives.PhysicalEquality "2" "3" |> equal false
+    LanguagePrimitives.PhysicalEquality [1] [1] |> equal false
+    LanguagePrimitives.PhysicalEquality [2] [3] |> equal false
+
+[<Fact>]
+let ``LanguagePrimitives.SByteWithMeasure works`` () =
+    let distance: sbyte<m> = LanguagePrimitives.SByteWithMeasure 1y
+    distance |> equal 1y<m>
+
+[<Fact>]
+let ``LanguagePrimitives.Int16WithMeasure works`` () =
+    let distance: int16<m> = LanguagePrimitives.Int16WithMeasure 1s
+    distance |> equal 1s<m>
+
+[<Fact>]
+let ``LanguagePrimitives.Int32WithMeasure works`` () =
+    let distance: int<m> = LanguagePrimitives.Int32WithMeasure 1
+    distance |> equal 1<m>
+
+[<Fact>]
+let ``LanguagePrimitives.Int64WithMeasure works`` () =
+    let distance: int64<m> = LanguagePrimitives.Int64WithMeasure 1L
+    distance |> equal 1L<m>
+
+[<Fact>]
+let ``LanguagePrimitives.Float32WithMeasure works`` () =
+    let distance: float32<m> = LanguagePrimitives.Float32WithMeasure 1.0f
+    distance |> equal 1.0f<m>
+
+[<Fact>]
+let ``LanguagePrimitives.FloatWithMeasure works`` () =
+    let distance: float<m> = LanguagePrimitives.FloatWithMeasure 1.0
+    distance |> equal 1.0<m>
+
+[<Fact>]
+let ``LanguagePrimitives.DecimalWithMeasure works`` () =
+    let distance: decimal<m> = LanguagePrimitives.DecimalWithMeasure 1.0m
+    distance |> equal 1.0m<m>

--- a/tests/Rust/tests/src/CustomOperatorTests.fs
+++ b/tests/Rust/tests/src/CustomOperatorTests.fs
@@ -83,11 +83,14 @@ type D1 = D1
 type D2 = D2
 type D3 = D3
 
-type ToLength = ToLength with
-    static member (&.) (ToLength, x: int<px>) = fun D1 _ _ -> String.Join("", string x, "px")
-    static member (&.) (ToLength, x: int<em>) = fun D1 D2 _ -> String.Join("", string x, "em")
+// type ToLength = ToLength with
+type ToLength = ToLength of int
+with
+    static member (&.) (_a: ToLength, x: int<px>) = fun D1 _ _ -> String.Join("", string x, "px")
+    static member (&.) (_a: ToLength, x: int<em>) = fun D1 D2 _ -> String.Join("", string x, "em")
 
-let inline toLen x : string = (Unchecked.defaultof<ToLength> &. x) D1 D2 D3
+// let inline toLen x : string = (Unchecked.defaultof<ToLength> &. x) D1 D2 D3
+let inline toLen x : string = ((ToLength 0) &. x) D1 D2 D3
 
 [<Fact>]
 let ``first overload`` () =

--- a/tests/Rust/tests/src/UriTests.fs
+++ b/tests/Rust/tests/src/UriTests.fs
@@ -2,178 +2,175 @@ module Fable.Tests.UriTests
 
 open System
 open Util.Testing
-open Fable.Tests
 
-module tests =
+[<Fact>]
+let ``Uri from absolute uri string works`` () =
+    let uri = Uri("http://www.test0.com/hello?a=b#c")
+    equal true uri.IsAbsoluteUri
+    equal "http" uri.Scheme
+    equal "www.test0.com" uri.Host
+    equal "/hello" uri.AbsolutePath
+    equal "/hello?a=b" uri.PathAndQuery
+    equal "?a=b" uri.Query
+    equal "#c" uri.Fragment
+    equal "http://www.test0.com/hello?a=b#c" uri.AbsoluteUri
 
-    [<Fact>]
-    let ``Uri from absolute uri string works`` () =
-        let uri = Uri("http://www.test0.com/hello?a=b#c")
-        equal true uri.IsAbsoluteUri
-        equal "http" uri.Scheme
-        equal "www.test0.com" uri.Host
-        equal "/hello" uri.AbsolutePath
-        equal "/hello?a=b" uri.PathAndQuery
-        equal "?a=b" uri.Query
-        equal "#c" uri.Fragment
-        equal "http://www.test0.com/hello?a=b#c" uri.AbsoluteUri
+[<Fact>]
+let ``Uri from absolute uri string with RelativeOrAbsolute works`` () =
+    let uri = Uri("http://www.test1.com/hello?a=b#c", UriKind.RelativeOrAbsolute)
+    equal true uri.IsAbsoluteUri
+    equal "http" uri.Scheme
+    equal "www.test1.com" uri.Host
+    equal "/hello" uri.AbsolutePath
+    equal "/hello?a=b" uri.PathAndQuery
+    equal "?a=b" uri.Query
+    equal "#c" uri.Fragment
+    equal "http://www.test1.com/hello?a=b#c" uri.AbsoluteUri
 
-    [<Fact>]
-    let ``Uri from absolute uri string with RelativeOrAbsolute works`` () =
-        let uri = Uri("http://www.test1.com/hello?a=b#c", UriKind.RelativeOrAbsolute)
-        equal true uri.IsAbsoluteUri
-        equal "http" uri.Scheme
-        equal "www.test1.com" uri.Host
-        equal "/hello" uri.AbsolutePath
-        equal "/hello?a=b" uri.PathAndQuery
-        equal "?a=b" uri.Query
-        equal "#c" uri.Fragment
-        equal "http://www.test1.com/hello?a=b#c" uri.AbsoluteUri
+[<Fact>]
+let ``Uri from relative uri string works`` () =
+    let uri = Uri("/hello.html", UriKind.Relative)
+    equal false uri.IsAbsoluteUri
+    equal "/hello.html" (uri.ToString())
 
-    [<Fact>]
-    let ``Uri from relative uri string works`` () =
-        let uri = Uri("/hello.html", UriKind.Relative)
-        equal false uri.IsAbsoluteUri
-        equal "/hello.html" (uri.ToString())
+[<Fact>]
+let ``AbsoluteUri from relative uri should throw`` () =
+    let uri = Uri("/hello.html", UriKind.Relative)
+    Util.throwsError "This operation is not supported for a relative URI." (fun () -> uri.AbsoluteUri)
 
-    [<Fact>]
-    let ``AbsoluteUri from relative uri should throw`` () =
-        let uri = Uri("/hello.html", UriKind.Relative)
-        Util.throwsError "This operation is not supported for a relative URI." (fun () -> uri.AbsoluteUri)
+[<Fact>]
+let ``Uri from relative uri string without uri kind should throws`` () =
+    let createInvalidUri () =
+        Uri("hello.html")
 
-    [<Fact>]
-    let ``Uri from relative uri string without uri kind should throws`` () =
-        let createInvalidUri () =
-            Uri("hello.html")
+    Util.throwsError "Invalid URI: The format of the URI could not be determined." createInvalidUri
 
-        Util.throwsError "Invalid URI: The format of the URI could not be determined." createInvalidUri
+[<Fact>]
+let ``Uri from relative uri with kind Absolute fails`` () =
+    let createInvalidUri () =
+        Uri("hello.html")
 
-    [<Fact>]
-    let ``Uri from relative uri with kind Absolute fails`` () =
-        let createInvalidUri () =
-            Uri("hello.html")
+    Util.throwsError "Invalid URI: The format of the URI could not be determined." createInvalidUri
 
-        Util.throwsError "Invalid URI: The format of the URI could not be determined." createInvalidUri
+[<Fact>]
+let ``Uri from baseUri with relative string works`` () =
+    let uri = Uri(Uri("http://www.test2.com/"), "/hello?a=b#c")
+    equal true uri.IsAbsoluteUri
+    equal "http" uri.Scheme
+    equal "www.test2.com" uri.Host
+    equal "/hello" uri.AbsolutePath
+    equal "/hello?a=b" uri.PathAndQuery
+    equal "?a=b" uri.Query
+    equal "#c" uri.Fragment
+    equal "http://www.test2.com/hello?a=b#c" uri.AbsoluteUri
 
-    [<Fact>]
-    let ``Uri from baseUri with relative string works`` () =
-        let uri = Uri(Uri("http://www.test2.com/"), "/hello?a=b#c")
-        equal true uri.IsAbsoluteUri
-        equal "http" uri.Scheme
-        equal "www.test2.com" uri.Host
-        equal "/hello" uri.AbsolutePath
-        equal "/hello?a=b" uri.PathAndQuery
-        equal "?a=b" uri.Query
-        equal "#c" uri.Fragment
-        equal "http://www.test2.com/hello?a=b#c" uri.AbsoluteUri
+[<Fact>]
+let ``Uri from baseUri with relativeUri works`` () =
+    let uri = Uri(Uri("http://www.test3.com/"), Uri("/hello?a=b#c", UriKind.Relative))
+    equal true uri.IsAbsoluteUri
+    equal "http" uri.Scheme
+    equal "www.test3.com" uri.Host
+    equal "/hello" uri.AbsolutePath
+    equal "/hello?a=b" uri.PathAndQuery
+    equal "?a=b" uri.Query
+    equal "#c" uri.Fragment
+    equal "http://www.test3.com/hello?a=b#c" uri.AbsoluteUri
 
-    [<Fact>]
-    let ``Uri from baseUri with relativeUri works`` () =
-        let uri = Uri(Uri("http://www.test3.com/"), Uri("/hello?a=b#c", UriKind.Relative))
-        equal true uri.IsAbsoluteUri
-        equal "http" uri.Scheme
-        equal "www.test3.com" uri.Host
-        equal "/hello" uri.AbsolutePath
-        equal "/hello?a=b" uri.PathAndQuery
-        equal "?a=b" uri.Query
-        equal "#c" uri.Fragment
-        equal "http://www.test3.com/hello?a=b#c" uri.AbsoluteUri
+[<Fact>]
+let ``Uri from baseUri with absolute Uri works`` () =
+    let absUri = Uri("http://www.example.com/", UriKind.Absolute)
+    let uri = Uri(absUri, absUri)
+    equal true uri.IsAbsoluteUri
+    equal "http" uri.Scheme
+    equal "www.example.com" uri.Host
+    equal "http://www.example.com/" uri.AbsoluteUri
 
-    [<Fact>]
-    let ``Uri from baseUri with absolute Uri works`` () =
-        let absUri = Uri("http://www.example.com/", UriKind.Absolute)
-        let uri = Uri(absUri, absUri)
-        equal true uri.IsAbsoluteUri
-        equal "http" uri.Scheme
-        equal "www.example.com" uri.Host
-        equal "http://www.example.com/" uri.AbsoluteUri
+[<Fact>]
+let ``TryCreate from absolute string with kind Absolute works`` () =
+    let (valid, uri) = Uri.TryCreate("http://www.test0.com/hello?a=b#c", UriKind.Absolute)
+    equal true valid
+    equal true uri.IsAbsoluteUri
+    equal "http" uri.Scheme
+    equal "www.test0.com" uri.Host
+    equal "/hello" uri.AbsolutePath
+    equal "/hello?a=b" uri.PathAndQuery
+    equal "?a=b" uri.Query
+    equal "#c" uri.Fragment
+    equal "http://www.test0.com/hello?a=b#c" uri.AbsoluteUri
 
-    [<Fact>]
-    let ``TryCreate from absolute string with kind Absolute works`` () =
-        let (valid, uri) = Uri.TryCreate("http://www.test0.com/hello?a=b#c", UriKind.Absolute)
-        equal true valid
-        equal true uri.IsAbsoluteUri
-        equal "http" uri.Scheme
-        equal "www.test0.com" uri.Host
-        equal "/hello" uri.AbsolutePath
-        equal "/hello?a=b" uri.PathAndQuery
-        equal "?a=b" uri.Query
-        equal "#c" uri.Fragment
-        equal "http://www.test0.com/hello?a=b#c" uri.AbsoluteUri
+[<Fact>]
+let ``TryCreate from absolute string with kind RelativeOrAbsolute works`` () =
+    let (valid, uri) = Uri.TryCreate("http://www.test1.com/hello?a=b#c", UriKind.RelativeOrAbsolute)
+    equal true valid
+    equal true uri.IsAbsoluteUri
+    equal "http" uri.Scheme
+    equal "www.test1.com" uri.Host
+    equal "/hello" uri.AbsolutePath
+    equal "/hello?a=b" uri.PathAndQuery
+    equal "?a=b" uri.Query
+    equal "#c" uri.Fragment
+    equal "http://www.test1.com/hello?a=b#c" uri.AbsoluteUri
 
-    [<Fact>]
-    let ``TryCreate from absolute string with kind RelativeOrAbsolute works`` () =
-        let (valid, uri) = Uri.TryCreate("http://www.test1.com/hello?a=b#c", UriKind.RelativeOrAbsolute)
-        equal true valid
-        equal true uri.IsAbsoluteUri
-        equal "http" uri.Scheme
-        equal "www.test1.com" uri.Host
-        equal "/hello" uri.AbsolutePath
-        equal "/hello?a=b" uri.PathAndQuery
-        equal "?a=b" uri.Query
-        equal "#c" uri.Fragment
-        equal "http://www.test1.com/hello?a=b#c" uri.AbsoluteUri
+[<Fact>]
+let ``TryCreate from absolute string with kind Relative fails`` () =
+    let (valid, _) = Uri.TryCreate("http://www.test1.com/hello?a=b#c", UriKind.Relative)
+    equal false valid
 
-    [<Fact>]
-    let ``TryCreate from absolute string with kind Relative fails`` () =
-        let (valid, _) = Uri.TryCreate("http://www.test1.com/hello?a=b#c", UriKind.Relative)
-        equal false valid
+[<Fact>]
+let ``TryCreate from relative string with kind Absolute fails`` () =
+    let (valid, uri) = Uri.TryCreate("hello?a=b#c", UriKind.Absolute)
+    equal false valid
 
-    [<Fact>]
-    let ``TryCreate from relative string with kind Absolute fails`` () =
-        let (valid, uri) = Uri.TryCreate("hello?a=b#c", UriKind.Absolute)
-        equal false valid
+[<Fact>]
+let ``TryCreate from relative string with kind RelativeOrAbsolute works`` () =
+    let (valid, uri) = Uri.TryCreate("hello?a=b#c", UriKind.RelativeOrAbsolute)
+    equal true valid
+    equal "hello?a=b#c" (uri.ToString())
 
-    [<Fact>]
-    let ``TryCreate from relative string with kind RelativeOrAbsolute works`` () =
-        let (valid, uri) = Uri.TryCreate("hello?a=b#c", UriKind.RelativeOrAbsolute)
-        equal true valid
-        equal "hello?a=b#c" (uri.ToString())
+[<Fact>]
+let ``TryCreate from relative string with kind Relative works`` () =
+    let (valid, uri) = Uri.TryCreate("hello?a=b#c", UriKind.Relative)
+    equal true valid
+    equal "hello?a=b#c" (uri.ToString())
 
-    [<Fact>]
-    let ``TryCreate from relative string with kind Relative works`` () =
-        let (valid, uri) = Uri.TryCreate("hello?a=b#c", UriKind.Relative)
-        equal true valid
-        equal "hello?a=b#c" (uri.ToString())
+[<Fact>]
+let ``TryCreate from absolute uri and absolute uri should work`` () =
+    let absUri = Uri("https://example.com", UriKind.Absolute)
+    let (valid, uri) = Uri.TryCreate(absUri, absUri)
+    equal true valid
+    equal absUri uri
 
-    [<Fact>]
-    let ``TryCreate from absolute uri and absolute uri should work`` () =
-        let absUri = Uri("https://example.com", UriKind.Absolute)
-        let (valid, uri) = Uri.TryCreate(absUri, absUri)
-        equal true valid
-        equal absUri uri
+[<Fact>]
+let ``TryCreate from absolute uri and relative uri should work`` () =
+    let (valid, uri) = Uri.TryCreate(Uri("https://example.com", UriKind.Absolute), Uri("test", UriKind.Relative))
+    equal true valid
+    equal "https://example.com/test" (uri.ToString())
 
-    [<Fact>]
-    let ``TryCreate from absolute uri and relative uri should work`` () =
-        let (valid, uri) = Uri.TryCreate(Uri("https://example.com", UriKind.Absolute), Uri("test", UriKind.Relative))
-        equal true valid
-        equal "https://example.com/test" (uri.ToString())
+[<Fact>]
+let ``TryCreate from relative uri and relative uri should fail`` () =
+    let relativeUri = Uri("test", UriKind.Relative)
+    let (valid, _) = Uri.TryCreate(relativeUri, relativeUri)
+    equal false valid
 
-    [<Fact>]
-    let ``TryCreate from relative uri and relative uri should fail`` () =
-        let relativeUri = Uri("test", UriKind.Relative)
-        let (valid, _) = Uri.TryCreate(relativeUri, relativeUri)
-        equal false valid
+[<Fact>]
+let ``TryCreate from relative uri and absolute uri should fail`` () =
+    let (valid, _) = Uri.TryCreate(Uri("test", UriKind.Relative), Uri("https://example.com", UriKind.Absolute))
+    equal false valid
 
-    [<Fact>]
-    let ``TryCreate from relative uri and absolute uri should fail`` () =
-        let (valid, _) = Uri.TryCreate(Uri("test", UriKind.Relative), Uri("https://example.com", UriKind.Absolute))
-        equal false valid
+[<Fact>]
+let ``Uri.ToString works`` () =
+    let uri = Uri("HTTP://www.test4.com:80/a%20b%20c.html")
+    uri.ToString() |> equal "http://www.test4.com/a b c.html"
+    sprintf "%A" uri |> equal "http://www.test4.com/a b c.html"
 
-    [<Fact>]
-    let ``Uri.ToString works`` () =
-        let uri = Uri("HTTP://www.test4.com:80/a%20b%20c.html")
-        uri.ToString() |> equal "http://www.test4.com/a b c.html"
-        sprintf "%A" uri |> equal "http://www.test4.com/a b c.html"
-
-    [<Fact>]
-    let ``Uri.OriginalString works`` () =
-        let cases = [
-            "http://example.org"
-            "http://example.org/"
-            "HTTP://www.ConToso.com:80//thick%20and%20thin.htm"
-            "http://www.test0.com/hello?a=b#c"
-        ]
-        for case in cases do
-            let uri = Uri(case)
-            uri.OriginalString |> equal case
+[<Fact>]
+let ``Uri.OriginalString works`` () =
+    let cases = [
+        "http://example.org"
+        "http://example.org/"
+        "HTTP://www.ConToso.com:80//thick%20and%20thin.htm"
+        "http://www.test0.com/hello?a=b#c"
+    ]
+    for case in cases do
+        let uri = Uri(case)
+        uri.OriginalString |> equal case


### PR DESCRIPTION
- Updated module and member visibility.
- Enabled some operator tests.

For some reason F# member visibility properties are not independently set, they seem to be affected by their parent's visibility.

@alfonsogarciacaro I had to add another missing property to the AST to handle visibility, sorry about that.
But it's a new addition so it shouldn't affect existing plugins. The new property is `Entity.DeclaringEntity`.