### PR TITLE
[Python] fixes for .ToArray

### DIFF
--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -1987,7 +1987,7 @@ let resizeArrays (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (this
         Helper.LibCall(com, "array", "sortInPlace", t, [ ar; arg ], i.SignatureArgTypes, ?loc = r)
         |> Some
     | "ToArray", Some ar, [] ->
-        Helper.InstanceCall(ar, "slice", t, args, ?loc = r)
+        Helper.InstanceCall(ar, "to_array", t, args, ?loc = r)
         |> Some
     | _ -> None
 

--- a/src/fable-library-py/fable_library/async_.py
+++ b/src/fable-library-py/fable_library/async_.py
@@ -37,6 +37,13 @@ from .task import TaskCompletionSource
 _T = TypeVar("_T")
 
 
+def cancellation_token() -> Async[CancellationToken]:
+    def cont(ctx: IAsyncContext[Any]):
+        ctx.on_success(ctx.cancel_token)
+
+    return protected_cont(cont)
+
+
 default_cancellation_token = CancellationToken()
 
 # see AsyncBuilder.Delay
@@ -294,6 +301,7 @@ __all__ = [
     "await_task",
     "cancel",
     "cancel_after",
+    "cancellation_token",
     "catch_async",
     "create_cancellation_token",
     "from_continuations",

--- a/tests/Python/TestResizeArray.fs
+++ b/tests/Python/TestResizeArray.fs
@@ -1,6 +1,7 @@
 module Fable.Tests.ResizeArrays
 
 open Util.Testing
+open System.Text
 
 type Animal = Duck of int | Dog of int
 
@@ -292,6 +293,14 @@ let ``test ResizeArray.ToArray works`` () =
     ar[0] <- 2.
     equal 3. li[0]
     equal 2. ar[0]
+
+[<Fact>]
+let ``test ResizeArray<byte>.ToArray works`` () =
+    let li = ResizeArray<byte>()
+    li.Add(0x66uy); li.Add(0x61uy); li.Add(0x62uy); li.Add(0x6cuy); li.Add(0x65uy)
+    let ar = li.ToArray()
+    let text = ar |> Encoding.UTF8.GetString
+    equal text "fable"
 
 [<Fact>]
 let ``test ResizeArray.Item is undefined when index is out of range`` () =


### PR DESCRIPTION
- Convert to the right array type
- Add async cancellation_token()