### PR TITLE
[Python] fix is_array_like

### DIFF
--- a/src/fable-library-py/fable_library/util.py
+++ b/src/fable-library-py/fable_library/util.py
@@ -684,7 +684,7 @@ def partial_apply(
 
 
 def is_array_like(x: Any) -> bool:
-    return isinstance(x, (list, tuple, set, array))
+    return isinstance(x, (list, tuple, set, array, bytes, bytearray))
 
 
 def is_disposable(x: Any) -> bool:


### PR DESCRIPTION
- bytes and bytearrays are also arrays