### PR TITLE
Rust - some progress on timespans

### DIFF
--- a/src/Fable.Transforms/Rust/Replacements.fs
+++ b/src/Fable.Transforms/Rust/Replacements.fs
@@ -2424,13 +2424,6 @@ let dates (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr optio
         Helper.LibCall(com, "DateTime", "get_ticks", t, [thisArg.Value], [thisArg.Value.Type], ?loc=r) |> Some
     | "get_UtcTicks" ->
         Helper.LibCall(com, "DateTimeOffset", "get_utc_ticks", t, [thisArg.Value], [thisArg.Value.Type], ?loc=r) |> Some
-    | "AddTicks" ->
-        match thisArg, args with
-        | Some c, [ticks] ->
-            let ms = Helper.LibCall(com, "Long", "op_division", i.SignatureArgTypes.Head, [ticks; makeIntConst 10000], [ticks.Type; Number(Int32, NumberInfo.Empty)])
-            let ms = Helper.LibCall(com, "Long", "to_number", Number(Float64, NumberInfo.Empty), [ms], [ms.Type])
-            Helper.LibCall(com, moduleName, "add_milliseconds", Number(Float64, NumberInfo.Empty), [c; ms], [c.Type; ms.Type], ?loc=r) |> Some
-        | _ -> None
     | meth ->
         let meth = Naming.removeGetSetPrefix meth |> Naming.applyCaseRule Fable.Core.CaseRules.SnakeCase
         match thisArg with

--- a/src/fable-library-rust/src/DateTime.rs
+++ b/src/fable-library-rust/src/DateTime.rs
@@ -54,7 +54,7 @@ pub mod DateTime_ {
     }
 
     pub fn op_Subtraction(a: DateTime, b: DateTime) -> TimeSpan {
-        crate::TimeSpan_::new_from_ticks(get_ticks(a) - get_ticks(b))
+        crate::TimeSpan_::new_ticks(get_ticks(a) - get_ticks(b))
     }
 
     pub fn new_ymd(y: i32, m: i32, d: i32) -> DateTime {
@@ -426,63 +426,4 @@ pub mod DateTime_ {
     }
 
     pub fn year() {}
-}
-
-#[cfg(feature = "date")]
-pub mod DateTimeOffset_ {
-    use crate::{DateTime_::DateTime, String_::string};
-    use chrono::{DateTime as CDT, FixedOffset, NaiveDateTime, TimeZone, Utc};
-
-    #[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
-    pub struct DateTimeOffset(CDT<FixedOffset>);
-
-    pub fn from_date(d: DateTime) -> DateTimeOffset {
-        let cdto = d.to_cdt_with_offset();
-        DateTimeOffset(cdto)
-    }
-
-    impl DateTimeOffset {
-        pub(crate) fn get_cdt_with_offset(&self) -> CDT<FixedOffset> {
-            self.0
-        }
-    }
-
-    // impl core::fmt::Display for DateTimeOffset {
-    //     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-    //         write!(f, "{}", self.0.to_string())
-    //     }
-    // }
-}
-
-#[cfg(feature = "date")]
-pub mod TimeSpan_ {
-    use crate::String_::string;
-    use chrono::{DateTime as CDT, TimeZone, Utc};
-
-    #[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
-    pub struct TimeSpan{
-        ticks: i64
-    }
-    pub(crate) const num_ticks_per_second: i64 = 10_000_000;
-
-    pub fn new_from_ticks(ticks:i64) -> TimeSpan {
-        TimeSpan {ticks: ticks}
-    }
-
-    impl TimeSpan {
-        pub fn total_seconds(&self) -> f64 {
-            (self.ticks / num_ticks_per_second) as f64
-        }
-
-        pub fn total_milliseconds(&self) -> f64 {
-            let num_ticks_per_millisecond = num_ticks_per_second / 1000;
-            (self.ticks / num_ticks_per_millisecond) as f64
-        }
-    }
-
-    // impl core::fmt::Display for TimeSpan {
-    //     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-    //         write!(f, "{}", self.0.to_string())
-    //     }
-    // }
 }

--- a/src/fable-library-rust/src/DateTime.rs
+++ b/src/fable-library-rust/src/DateTime.rs
@@ -4,7 +4,7 @@ pub mod DateTime_ {
 
     use crate::{
         DateTimeOffset_::DateTimeOffset,
-        String_::{string, stringFrom}, TimeSpan_::TimeSpan,
+        String_::{string, stringFrom}, TimeSpan_::{TimeSpan, num_ticks_per_second},
     };
     use chrono::{
         DateTime as CDT, Datelike, FixedOffset, Local, NaiveDate, NaiveDateTime, Offset, TimeZone,
@@ -154,7 +154,6 @@ pub mod DateTime_ {
     // as per docs here:
     // https://docs.microsoft.com/en-us/dotnet/api/system.datetime.ticks?view=net-6.0
     fn get_ticks_from_ndt(ndt: NaiveDateTime) -> i64 {
-        const num_ticks_per_second: i64 = 10_000_000;
         let dayTicks = ((ndt.num_days_from_ce() - 1) as i64) * 24 * 60 * 60 * num_ticks_per_second;
         let secondsTicks = (ndt.num_seconds_from_midnight() as i64) * num_ticks_per_second;
         let subsecondTicks = (ndt.timestamp_subsec_millis() as i64) * num_ticks_per_second / 1000;
@@ -411,6 +410,12 @@ pub mod DateTime_ {
             DateTime(next)
         }
 
+        pub fn add_ticks(&self, ticks: i64) -> DateTime {
+            let ticks_per_ms = num_ticks_per_second / 1000;
+            let ms = ticks / ticks_per_ms;
+            self.add_milliseconds(ms as f64)
+        }
+
         pub(crate) fn to_cdt_with_offset(&self) -> CDT<FixedOffset> {
             match &self.0 {
                 LocalUtcWrap::CUnspecified(dt) => Utc.from_utc_datetime(&dt).into(),
@@ -458,7 +463,7 @@ pub mod TimeSpan_ {
     pub struct TimeSpan{
         ticks: i64
     }
-    const num_ticks_per_second: i64 = 10_000_000;
+    pub(crate) const num_ticks_per_second: i64 = 10_000_000;
 
     pub fn new_from_ticks(ticks:i64) -> TimeSpan {
         TimeSpan {ticks: ticks}

--- a/src/fable-library-rust/src/DateTimeOffset.rs
+++ b/src/fable-library-rust/src/DateTimeOffset.rs
@@ -1,0 +1,25 @@
+#[cfg(feature = "date")]
+pub mod DateTimeOffset_ {
+    use crate::{DateTime_::DateTime, String_::string};
+    use chrono::{DateTime as CDT, FixedOffset, NaiveDateTime, TimeZone, Utc};
+
+    #[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
+    pub struct DateTimeOffset(CDT<FixedOffset>);
+
+    pub fn from_date(d: DateTime) -> DateTimeOffset {
+        let cdto = d.to_cdt_with_offset();
+        DateTimeOffset(cdto)
+    }
+
+    impl DateTimeOffset {
+        pub(crate) fn get_cdt_with_offset(&self) -> CDT<FixedOffset> {
+            self.0
+        }
+    }
+
+    // impl core::fmt::Display for DateTimeOffset {
+    //     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+    //         write!(f, "{}", self.0.to_string())
+    //     }
+    // }
+}

--- a/src/fable-library-rust/src/TimeSpan.rs
+++ b/src/fable-library-rust/src/TimeSpan.rs
@@ -5,15 +5,20 @@ pub mod TimeSpan_ {
     pub struct TimeSpan{
         ticks: i64
     }
+    pub(crate) const num_ticks_per_microsecond: i64 = 10;
+    pub(crate) const num_ticks_per_millisecond: i64 = 10_000;
     pub(crate) const num_ticks_per_second: i64 = 10_000_000;
+    pub(crate) const num_ticks_per_minute: i64 = num_ticks_per_second * 60;
+    pub(crate) const num_ticks_per_hour: i64 = num_ticks_per_minute * 60;
+    pub(crate) const num_ticks_per_day: i64 = num_ticks_per_hour * 24;
 
     pub fn new_ticks(ticks:i64) -> TimeSpan {
         TimeSpan {ticks: ticks}
     }
 
     pub fn new_hms(h: i32, m: i32, s: i32) -> TimeSpan {
-        let hoursTicks = (h as i64) * num_ticks_per_second * 60 * 60;
-        let minsTicks = (m as i64) * num_ticks_per_second * 60;
+        let hoursTicks = (h as i64) * num_ticks_per_hour;
+        let minsTicks = (m as i64) * num_ticks_per_minute;
         let secTicks = (s as i64) * num_ticks_per_second;
         new_ticks(hoursTicks + minsTicks + secTicks)
     }
@@ -25,10 +30,10 @@ pub mod TimeSpan_ {
 
     pub fn new_dhmsms(d: i32, h: i32, m: i32, s: i32, ms: i32) -> TimeSpan {
         let hours = (d * 24 + h) as i64;
-        let hoursTicks = hours * num_ticks_per_second * 60 * 60;
-        let minsTicks = (m as i64) * num_ticks_per_second * 60;
+        let hoursTicks = hours * num_ticks_per_hour;
+        let minsTicks = (m as i64) * num_ticks_per_minute;
         let secTicks = (s as i64) * num_ticks_per_second;
-        let msTicks = (ms as i64) * num_ticks_per_second / 1000;
+        let msTicks = (ms as i64) * num_ticks_per_millisecond;
         new_ticks(hoursTicks + minsTicks + secTicks + msTicks)
     }
 
@@ -53,12 +58,8 @@ pub mod TimeSpan_ {
     }
 
     pub fn from_milliseconds(ms: f64) -> TimeSpan {
-        let ticks_per_ms = num_ticks_per_second / 1000;
-        TimeSpan { ticks: (ms * (ticks_per_ms as f64)) as i64 }
+        TimeSpan { ticks: (ms * (num_ticks_per_millisecond as f64)) as i64 }
     }
-
-
-
 
     impl TimeSpan {
         pub fn total_seconds(&self) -> f64 {
@@ -66,8 +67,26 @@ pub mod TimeSpan_ {
         }
 
         pub fn total_milliseconds(&self) -> f64 {
-            let num_ticks_per_millisecond = num_ticks_per_second / 1000;
             (self.ticks / num_ticks_per_millisecond) as f64
+        }
+
+        pub fn total_days(&self) -> f64 {
+            let days = self.ticks as f64 / num_ticks_per_day as f64;
+            days
+        }
+
+        pub fn total_hours(&self) -> f64 {
+            let hours = self.ticks as f64 / num_ticks_per_hour as f64;
+            hours
+        }
+
+        pub fn total_minutes(&self) -> f64 {
+            let minutes = self.ticks as f64 / num_ticks_per_minute as f64;
+            minutes
+        }
+
+        pub fn ticks(&self) -> i64 {
+            self.ticks
         }
     }
 

--- a/src/fable-library-rust/src/TimeSpan.rs
+++ b/src/fable-library-rust/src/TimeSpan.rs
@@ -1,0 +1,79 @@
+pub mod TimeSpan_ {
+    use crate::String_::string;
+
+    #[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
+    pub struct TimeSpan{
+        ticks: i64
+    }
+    pub(crate) const num_ticks_per_second: i64 = 10_000_000;
+
+    pub fn new_ticks(ticks:i64) -> TimeSpan {
+        TimeSpan {ticks: ticks}
+    }
+
+    pub fn new_hms(h: i32, m: i32, s: i32) -> TimeSpan {
+        let hoursTicks = (h as i64) * num_ticks_per_second * 60 * 60;
+        let minsTicks = (m as i64) * num_ticks_per_second * 60;
+        let secTicks = (s as i64) * num_ticks_per_second;
+        new_ticks(hoursTicks + minsTicks + secTicks)
+    }
+
+    pub fn new_dhms(d: i32, h: i32, m: i32, s: i32) -> TimeSpan {
+        let hours = d * 24 + h;
+        new_hms(hours, m, s)
+    }
+
+    pub fn new_dhmsms(d: i32, h: i32, m: i32, s: i32, ms: i32) -> TimeSpan {
+        let hours = (d * 24 + h) as i64;
+        let hoursTicks = hours * num_ticks_per_second * 60 * 60;
+        let minsTicks = (m as i64) * num_ticks_per_second * 60;
+        let secTicks = (s as i64) * num_ticks_per_second;
+        let msTicks = (ms as i64) * num_ticks_per_second / 1000;
+        new_ticks(hoursTicks + minsTicks + secTicks + msTicks)
+    }
+
+    pub fn from_ticks(ticks: i64) -> TimeSpan {
+        new_ticks(ticks)
+    }
+
+    pub fn from_days(days: f64) -> TimeSpan {
+        from_hours(days * 24.)
+    }
+
+    pub fn from_hours(h: f64) -> TimeSpan {
+        from_minutes(h * 60.)
+    }
+
+    pub fn from_minutes(m: f64) -> TimeSpan {
+        from_seconds(m * 60.)
+    }
+
+    pub fn from_seconds(s: f64) -> TimeSpan {
+        TimeSpan { ticks: (s * (num_ticks_per_second as f64)) as i64 }
+    }
+
+    pub fn from_milliseconds(ms: f64) -> TimeSpan {
+        let ticks_per_ms = num_ticks_per_second / 1000;
+        TimeSpan { ticks: (ms * (ticks_per_ms as f64)) as i64 }
+    }
+
+
+
+
+    impl TimeSpan {
+        pub fn total_seconds(&self) -> f64 {
+            (self.ticks / num_ticks_per_second) as f64
+        }
+
+        pub fn total_milliseconds(&self) -> f64 {
+            let num_ticks_per_millisecond = num_ticks_per_second / 1000;
+            (self.ticks / num_ticks_per_millisecond) as f64
+        }
+    }
+
+    // impl core::fmt::Display for TimeSpan {
+    //     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+    //         write!(f, "{}", self.0.to_string())
+    //     }
+    // }
+}

--- a/src/fable-library-rust/src/lib.fs
+++ b/src/fable-library-rust/src/lib.fs
@@ -5,6 +5,8 @@ open Fable.Core.Rust
 let _imports() =
     importAll "./Async.rs"
     importAll "./DateTime.rs"
+    importAll "./DateTimeOffset.rs"
+    importAll "./TimeSpan.rs"
     importAll "./Decimal.rs"
     importAll "./Func.rs"
     importAll "./Guid.rs"

--- a/tests/Rust/Fable.Tests.Rust.fsproj
+++ b/tests/Rust/Fable.Tests.Rust.fsproj
@@ -66,7 +66,7 @@
     <Compile Include="tests/src/SudokuTest.fs" />
     <Compile Include="tests/src/TailCallTests.fs" />
     <!-- <Compile Include="tests/src/TimeOnlyTests.fs" /> -->
-    <!-- <Compile Include="tests/src/TimeSpanTests.fs" /> -->
+    <Compile Include="tests/src/TimeSpanTests.fs" />
     <Compile Include="tests/src/TupleTests.fs" />
     <Compile Include="tests/src/TypeTests.fs" />
     <Compile Include="tests/src/UnionTests.fs" />

--- a/tests/Rust/tests/src/DateTimeTests.fs
+++ b/tests/Rust/tests/src/DateTimeTests.fs
@@ -453,17 +453,16 @@ module tests =
         test -100. 2.19455999e+10
         test 0. 2.19456e+10
 
-//     // NOTE: Doesn't work for values between 10000L (TimeSpan.TicksPerMillisecond) and -10000L, except 0L
-//     [<Fact>]
-//     let ``DateTime.AddTicks works`` () =
-//         let test v expected =
-//             let dt = DateTime(2014,9,12,0,0,0,DateTimeKind.Utc).AddTicks(v)
-//             dt.Ticks
-//             |> equal expected
-//         let ticks = 635460768000000000L
-//         test 100000L (ticks + 100000L)
-//         test -100000L (ticks - 100000L)
-//         test 0L ticks
+    [<Fact>]
+    let ``DateTime.AddTicks works`` () =
+        let test v (expected: int64) =
+            let dt = DateTime(2014,9,12,0,0,0,DateTimeKind.Utc).AddTicks(v)
+            dt.Ticks
+            |> equal expected
+        let ticks = 635460768000000000L
+        test 100000L (ticks + 100000L)
+        test -100000L (ticks - 100000L)
+        test 0L ticks
 
 //     [<Fact>]
 //     let ``DateTime Addition works`` () =

--- a/tests/Rust/tests/src/TimeSpanTests.fs
+++ b/tests/Rust/tests/src/TimeSpanTests.fs
@@ -8,690 +8,699 @@ open System.Globalization
 module tests =
 
         [<Fact>]
-        let ``TimeSpan.ToString() works`` () =
-            TimeSpan(0L).ToString() |> equal "00:00:00"
-            TimeSpan.FromSeconds(12345.).ToString() |> equal "03:25:45"
-            TimeSpan.FromDays(18.).ToString() |> equal "18.00:00:00"
-            TimeSpan.FromMilliseconds(25.).ToString() |> equal "00:00:00.0250000"
-
-        [<Fact>]
-        let ``TimeSpan.ToString() works for negative TimeSpan`` () =
-            TimeSpan.FromSeconds(-5.).ToString() |> equal "-00:00:05"
-            TimeSpan.FromDays(-5.23).ToString() |> equal "-5.05:31:12"
-
-        [<Fact>]
-        let ``TimeSpan.ToString(\"c\", CultureInfo.InvariantCulture) works`` () =
-            TimeSpan(0L).ToString("c", CultureInfo.InvariantCulture) |> equal "00:00:00"
-            TimeSpan.FromSeconds(12345.).ToString("c", CultureInfo.InvariantCulture) |> equal "03:25:45"
-            TimeSpan.FromDays(18.).ToString("c", CultureInfo.InvariantCulture) |> equal "18.00:00:00"
-            TimeSpan.FromMilliseconds(25.).ToString("c", CultureInfo.InvariantCulture) |> equal "00:00:00.0250000"
-
-        [<Fact>]
-        let ``TimeSpan.ToString(\"g\", CultureInfo.InvariantCulture) works`` () =
-            TimeSpan(0L).ToString("g", CultureInfo.InvariantCulture) |> equal "0:00:00"
-            TimeSpan.FromSeconds(12345.).ToString("g", CultureInfo.InvariantCulture) |> equal "3:25:45"
-            TimeSpan.FromDays(18.).ToString("g", CultureInfo.InvariantCulture) |> equal "18:0:00:00"
-            TimeSpan.FromMilliseconds(25.).ToString("g", CultureInfo.InvariantCulture) |> equal "0:00:00.025"
-
-        [<Fact>]
-        let ``TimeSpan.ToString(\"G\", CultureInfo.InvariantCulture) works`` () =
-            TimeSpan(0L).ToString("G", CultureInfo.InvariantCulture) |> equal "0:00:00:00.0000000"
-            TimeSpan.FromSeconds(12345.).ToString("G", CultureInfo.InvariantCulture) |> equal "0:03:25:45.0000000"
-            TimeSpan.FromDays(18.).ToString("G", CultureInfo.InvariantCulture) |> equal "18:00:00:00.0000000"
-            TimeSpan.FromMilliseconds(25.).ToString("G", CultureInfo.InvariantCulture) |> equal "0:00:00:00.0250000"
-
-        // TODO
-        // [<Fact>]
-        // let ``TimeSpan.ToString with format works`` () =
-        //     TimeSpan.FromMinutes(234.).ToString("hh\:mm\:ss")
-        //     |> equal "03:54:00"
-
-        [<Fact>]
-        let ``TimeSpan constructors work`` () =
-            let t1 = TimeSpan(20000L)
-            let t2 = TimeSpan(3, 3, 3)
-            let t3 = TimeSpan(5, 5, 5, 5)
-            let t4 = TimeSpan(7, 7, 7, 7, 7)
-            let t5 = TimeSpan(-2,0,0,0)
-
-            t1.TotalMilliseconds |> equal 2.0
-            t2.TotalMilliseconds |> equal 10983000.0
-            t3.TotalMilliseconds |> equal 450305000.0
-            t4.TotalMilliseconds |> equal 630427007.0
-            t5.TotalMilliseconds |> equal -172800000.0
-
-            t1.TotalMilliseconds + t2.TotalMilliseconds + t3.TotalMilliseconds + t4.TotalMilliseconds
-            |> equal 1091715009.0
-
-        [<Fact>]
-        let ``TimeSpan static creation works`` () =
-            let t1 = TimeSpan.FromTicks(20000L)
-            let t2 = TimeSpan.FromMilliseconds(2.)
-            let t3 = TimeSpan.FromDays   (2.)
-            let t4 = TimeSpan.FromHours  (2.)
-            let t5 = TimeSpan.FromMinutes(2.)
-            let t6 = TimeSpan.FromSeconds(2.)
-            let t7 = TimeSpan.Zero
-            t1.TotalMilliseconds + t2.TotalMilliseconds + t3.TotalMilliseconds + t4.TotalMilliseconds +
-               t5.TotalMilliseconds + t6.TotalMilliseconds + t7.TotalMilliseconds
-            |> equal 180122004.0
-
-        [<Fact>]
-        let ``TimeSpan components work`` () =
-            let t = TimeSpan.FromMilliseconds(96441615.)
-            t.Days + t.Hours + t.Minutes + t.Seconds + t.Milliseconds |> float
-            |> equal 686.
-
-        [<Fact>]
-        let ``TimeSpan.Ticks works`` () =
-            let t = TimeSpan.FromTicks(20000L)
-            t.Ticks
-            |> equal 20000L
-
-        // NOTE: This test fails because of very small fractions, so I cut the fractional part
-        [<Fact>]
-        let ``TimeSpan totals work`` () =
-            let t = TimeSpan.FromMilliseconds(96441615.)
-            t.TotalDays + t.TotalHours + t.TotalMinutes + t.TotalSeconds |> floor
-            |> equal 98076.0
-
-        [<Fact>]
-        let ``TimeSpan.Duration works`` () =
-            let test ms expected =
-                let t = TimeSpan.FromMilliseconds(ms)
-                t.Duration().TotalMilliseconds
-                |> equal expected
-            test 1. 1.
-            test -1. 1.
-            test 0. 0.
-
-        [<Fact>]
-        let ``TimeSpan.Negate works`` () =
-            let test ms expected =
-                let t = TimeSpan.FromMilliseconds(ms)
-                t.Negate().TotalMilliseconds
-                |> equal expected
-            test 1. -1.
-            test -1. 1.
-            test 0. 0.
-
-        [<Fact>]
-        let ``TimeSpan Addition works`` () =
-            let test ms1 ms2 expected =
-                let t1 = TimeSpan.FromMilliseconds(ms1)
-                let t2 = TimeSpan.FromMilliseconds(ms2)
-                let res1 = t1.Add(t2).TotalMilliseconds
-                let res2 = (t1 + t2).TotalMilliseconds
-                equal true (res1 = res2)
-                equal expected res1
-            test 1000. 2000. 3000.
-            test 200. -1000. -800.
-            test -2000. 1000. -1000.
-            test -200. -300. -500.
-            test 0. 1000. 1000.
-            test -2000. 0. -2000.
-            test 0. 0. 0.
-
-        [<Fact>]
-        let ``TimeSpan Subtraction works`` () =
-            let test ms1 ms2 expected =
-                let t1 = TimeSpan.FromMilliseconds(ms1)
-                let t2 = TimeSpan.FromMilliseconds(ms2)
-                let res1 = t1.Subtract(t2).TotalMilliseconds
-                let res2 = (t1 - t2).TotalMilliseconds
-                equal true (res1 = res2)
-                equal expected res1
-            test 1000. 2000. -1000.
-            test 200. -2000. 2200.
-            test -2000. 1000. -3000.
-            test 200. -300. 500.
-            test 0. 1000. -1000.
-            test 1000. 1000. 0.
-            test 0. 0. 0.
-
-        [<Fact>]
-        let ``TimeSpan Multiplication works`` () =
-            let test ms factor expected =
-                    // sprintf "(%f, %f) = %f" ms factor expected
-                    let t = TimeSpan.FromMilliseconds(ms)
-                    let res1 = t.Multiply(factor).TotalMilliseconds
-                    let res2 = (t * factor).TotalMilliseconds
-                    equal res1 res2
-                    equal true (res1 = res2)
-                    equal expected res1
-            test 1000. -1. -1000.
-            test 200. 11. 2200.
-            test -2000. 1.5 -3000.
-            test 0. 1000. 0.
-            test 1000. 0. 0.
-            test 0. 0. 0.
-
-        [<Fact>]
-        let ``TimeSpan Division works`` () =
-            // Note: there are two overloads, one with TimeSpan, one with float
-            let test_ts ms1 ms2 expected =
-                    // sprintf "ts(%f, %f) = %f" ms1 ms2 expected
-                    let t1 = TimeSpan.FromMilliseconds(ms1)
-                    let t2 = TimeSpan.FromMilliseconds(ms2)
-                    let res1 = t1.Divide(t2)
-                    let res2 = (t1 / t2)
-                    equal res1 res2
-                    equal true (res1 = res2)
-                    equal expected res1
-            let test_float ms (factor: float) expected =
-                    // sprintf "float(%f, %f) = %f" ms factor expected
-                    let t = TimeSpan.FromMilliseconds(ms)
-                    let res1 = t.Divide(factor).TotalMilliseconds
-                    let res2 = (t / factor).TotalMilliseconds
-                    equal res1 res2
-                    equal true (res1 = res2)
-                    equal expected res1
-
-            test_ts 1000. -1. -1000.
-            test_ts 2200. 11. 200.
-            test_ts -3000. 1.5 -2000.
-            test_ts 0. 1000. 0.
-
-            test_float 1000. -1. -1000.
-            test_float 2200. 11. 200.
-            test_float -3000. 1.5 -2000.
-            test_float 0. 1000. 0.
-
-        [<Fact>]
-        let ``TimeSpan Comparison works`` () =
-            let test ms1 ms2 expected =
-                let t1 = TimeSpan.FromMilliseconds(ms1)
-                let t2 = TimeSpan.FromMilliseconds(ms2)
-                let res1 = compare t1 t2
-                let res2 = t1.CompareTo(t2)
-                let res3 = TimeSpan.Compare(t1, t2)
-                equal true (res1 = res2 && res2 = res3)
-                equal expected res1
-            test 1000. 2000. -1
-            test 2000. 1000. 1
-            test -2000. -2000. 0
-            test 200. -200. 1
-            test 0. 1000. -1
-            test 1000. 1000. 0
-            test 0. 0. 0
-
-        [<Fact>]
-        let ``TimeSpan GreaterThan works`` () =
-            let test ms1 ms2 expected =
-                let t1 = TimeSpan.FromMilliseconds(ms1)
-                let t2 = TimeSpan.FromMilliseconds(ms2)
-                t1 > t2
-                |> equal expected
-            test 1000. 2000. false
-            test 2000. 1000. true
-            test -2000. -2000. false
-
-        [<Fact>]
-        let ``TimeSpan LessThan works`` () =
-            let test ms1 ms2 expected =
-                let t1 = TimeSpan.FromMilliseconds(ms1)
-                let t2 = TimeSpan.FromMilliseconds(ms2)
-                t1 < t2
-                |> equal expected
-            test 1000. 2000. true
-            test 2000. 1000. false
-            test -2000. -2000. false
-
-        [<Fact>]
-        let ``TimeSpan Equality works`` () =
-            let test ms1 ms2 expected =
-                let t1 = TimeSpan.FromMilliseconds(ms1)
-                let t2 = TimeSpan.FromMilliseconds(ms2)
-                t1 = t2
-                |> equal expected
-            test 1000. 2000. false
-            test 2000. 1000. false
-            test -2000. -2000. true
-
-        [<Fact>]
-        let ``TimeSpan Inequality works`` () =
-            let test ms1 ms2 expected =
-                let t1 = TimeSpan.FromMilliseconds(ms1)
-                let t2 = TimeSpan.FromMilliseconds(ms2)
-                t1 <> t2
-                |> equal expected
-            test 1000. 2000. true
-            test 2000. 1000. true
-            test -2000. -2000. false
-
-    // **************************************************
-    // Test Cases From :
-    // https://docs.microsoft.com/en-us/dotnet/api/system.timespan.tryparse
-    //
-    // **************************************************
-    //
-    //            String to Parse                TimeSpan
-    //            ---------------   ---------------------
-    //                          0        00:00:00
-    //                         14     14.00:00:00
-    //                      1:2:3        01:02:03
-    //                  0:0:0.250        00:00:00.2500000
-    //            10.20:30:40.050     10.20:30:40.0050000
-    //        99.23:59:59.9990000     99.23:59:59.9999000
-    //        0023:0059:0059.0009        23:59:59.0009000
-    //                     23:0:0        23:00:00
-    //                     24:0:0   Parse operation failed. (actually not true, it's parsed to 24 days...)
-    //                     0:59:0        00:59:00
-    //                     0:60:0   Parse operation failed.
-    //                     0:0:59        00:00:59
-    //                     0:0:60   Parse operation failed.
-    //                        10:   Parse operation failed.
-    //                       10:0        10:00:00
-    //                        :10   Parse operation failed.
-    //                       0:10        00:10:00
-    //                     10:20:   Parse operation failed.
-    //                    10:20:0        10:20:00
-    //                       .123   Parse operation failed.
-    //                    0.12:00        12:00:00
-    //                        10.   Parse operation failed.
-    //                      10.12   Parse operation failed.
-    //                   10.12:00     10.12:00:00
-
-        [<Fact>]
-        let ``TimeSpan 0 parse works`` () =
-            let actual = TimeSpan.Parse("0")
-            let expected = TimeSpan(0, 0, 0, 0, 0)
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan 14 parse works`` () =
-            let actual = TimeSpan.Parse("14")
-            let expected = TimeSpan(14, 0, 0, 0, 0)
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan 1:2:3 parse works`` () =
-            let actual = TimeSpan.Parse("1:2:3")
-            let expected = TimeSpan(0, 1, 2, 3, 0)
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan 0:0:0.250 parse works`` () =
-            let actual = TimeSpan.Parse("0:0:0.250")
-            let expected = TimeSpan(0, 0, 0, 0, 250)
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan 10.20:30:40.050 parse works`` () =
-            let actual = TimeSpan.Parse("10.20:30:40.050")
-            let expected = TimeSpan(10, 20, 30, 40, 50)
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan 99.23:59:59.999 parse works`` () =
-            let actual = TimeSpan.Parse("99.23:59:59.999")
-            let expected = TimeSpan(99, 23, 59, 59, 999)
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan 0023:0059:0059.0099 parse works`` () =
-            let actual = TimeSpan.Parse("0023:0059:0059.009")
-            let expected = TimeSpan(00, 23, 59, 59, 9)
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan 23:0:0 parse works`` () =
-            let actual = TimeSpan.Parse("23:0:0")
-            let expected = TimeSpan(0, 23, 0, 0, 0)
-            equal actual expected
-#if FABLE_COMPILER
-        // msft assumes it's 24 days...
-        // https://docs.microsoft.com/en-us/dotnet/api/system.timespan.parse
-        // or
-        // https://github.com/dotnet/dotnet-api-docs/blob/7f6a3882631bc008b858adfadb43cd17bbd55d49/xml/System/TimeSpan.xml#L2772
-        [<Fact>]
-        let ``TimeSpan 24:0:0 parse fails`` () =
-            (fun _ -> TimeSpan.Parse("24:0:0"))
-            |> Util.throwsError "String '24:0:0' was not recognized as a valid TimeSpan."
-
-        [<Fact>]
-        let ``TimeSpan 24:0:0 TryParse fails`` () =
-            let status, _ = TimeSpan.TryParse("24:0:0")
-            equal status false
-#endif
-
-        [<Fact>]
-        let ``TimeSpan 0:0:59 parse works`` () =
-            let actual = TimeSpan.Parse("0:0:59")
-            let expected = TimeSpan(0, 0, 0, 59, 0)
-            equal actual expected
-
-#if FABLE_COMPILER // temporary, TODO: fix test to be backwards compatible
-        [<Fact>]
-        let ``TimeSpan 0:60:0 parse fails`` () =
-            (fun _ -> TimeSpan.Parse("0:60:0"))
-#if FABLE_COMPILER
-            |> Util.throwsError "String '0:60:0' was not recognized as a valid TimeSpan."
-#else
-            |> Util.throwsError "The TimeSpan string '0:60:0' could not be parsed because at least one of the numeric components is out of range or contains too many digits."
-#endif
-#endif
-
-#if FABLE_COMPILER // temporary, TODO: fix test to be backwards compatible
-        [<Fact>]
-        let ``TimeSpan 10: parse fails`` () =
-            (fun _ -> TimeSpan.Parse("10:"))
-            |> Util.throwsError "String '10:' was not recognized as a valid TimeSpan."
-#endif
-
-        [<Fact>]
-        let ``TimeSpan 10:0 parse works`` () =
-            let actual = TimeSpan.Parse("10:0")
-            let expected = TimeSpan(0, 10, 0, 0, 0)
-            equal actual expected
-
-#if FABLE_COMPILER // temporary, TODO: fix test to be backwards compatible
-        [<Fact>]
-        let ``TimeSpan 10:20: parse fails`` () =
-            (fun _ -> TimeSpan.Parse("10:20:"))
-            |> Util.throwsError "String '10:20:' was not recognized as a valid TimeSpan."
-#endif
-
-        [<Fact>]
-        let ``TimeSpan 10:20:0 parse works`` () =
-            let actual = TimeSpan.Parse("10:20:0")
-            let expected = TimeSpan(0, 10, 20, 0, 0)
-            equal actual expected
-
-#if FABLE_COMPILER // temporary, TODO: fix test to be backwards compatible
-        [<Fact>]
-        let ``TimeSpan .123 parse fails`` () =
-            (fun _ -> TimeSpan.Parse(".123"))
-            |> Util.throwsError "String '.123' was not recognized as a valid TimeSpan."
-#endif
-
-        [<Fact>]
-        let ``TimeSpan 0.12:00 parse works`` () =
-            let actual = TimeSpan.Parse("0.12:00")
-            let expected = TimeSpan(0, 12, 00, 0, 0)
-            equal actual expected
-
-#if FABLE_COMPILER // temporary, TODO: fix test to be backwards compatible
-        [<Fact>]
-        let ``TimeSpan 10. parse fails`` () =
-            (fun _ -> TimeSpan.Parse("10."))
-            |> Util.throwsError "String '10.' was not recognized as a valid TimeSpan."
-#endif
-
-#if FABLE_COMPILER // temporary, TODO: fix test to be backwards compatible
-        [<Fact>]
-        let ``TimeSpan 10.12 parse fails`` () =
-            (fun _ -> TimeSpan.Parse("10.12"))
-            |> Util.throwsError "String '10.12' was not recognized as a valid TimeSpan."
-#endif
-
-        [<Fact>]
-        let ``TimeSpan 10.12:00 parse works`` () =
-            let actual = TimeSpan.Parse("10.12:00")
-            let expected = TimeSpan(10, 12, 00, 0, 0)
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan 0 TryParse works`` () =
-            let status, actual = TimeSpan.TryParse("0")
-            let expected = TimeSpan(0, 0, 0, 0, 0)
-            equal status true
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan 14 TryParse works`` () =
-            let status, actual = TimeSpan.TryParse("14")
-            let expected = TimeSpan(14, 0, 0, 0, 0)
-            equal status true
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan 1:2:3 TryParse works`` () =
-            let status, actual = TimeSpan.TryParse("1:2:3")
-            let expected = TimeSpan(0, 1, 2, 3, 0)
-            equal status true
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan 0:0:0.250 TryParse works`` () =
-            let status, actual = TimeSpan.TryParse("0:0:0.250")
-            let expected = TimeSpan(0, 0, 0, 0, 250)
-            equal status true
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan 10.20:30:40.050 TryParse works`` () =
-            let status, actual = TimeSpan.TryParse("10.20:30:40.050")
-            let expected = TimeSpan(10, 20, 30, 40, 50)
-            equal status true
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan 99.23:59:59.999 TryParse works`` () =
-            let status, actual = TimeSpan.TryParse("99.23:59:59.999")
-            let expected = TimeSpan(99, 23, 59, 59, 999)
-            equal status true
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan 0023:0059:0059.009 TryParse works`` () =
-            let status, actual = TimeSpan.TryParse("0023:0059:0059.009")
-            let expected = TimeSpan(00, 23, 59, 59, 9)
-            equal status true
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan 23:0:0 TryParse works`` () =
-            let status, actual = TimeSpan.TryParse("23:0:0")
-            let expected = TimeSpan(0, 23, 0, 0, 0)
-            equal status true
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan 0:0:59 TryParse works`` () =
-            let status, actual = TimeSpan.TryParse("0:0:59")
-            let expected = TimeSpan(0, 0, 0, 59, 0)
-            equal status true
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan 0:60:0 TryParse fails`` () =
-            let status, _ = TimeSpan.TryParse("0:60:0")
-            equal status false
-
-        [<Fact>]
-        let ``TimeSpan 10: TryParse fails`` () =
-            let status, _ = TimeSpan.TryParse("10:")
-            equal status false
-        [<Fact>]
-        let ``TimeSpan 10:0 TryParse works`` () =
-            let status, actual = TimeSpan.TryParse("10:0")
-            let expected = TimeSpan(0, 10, 0, 0, 0)
-            equal status true
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan 10:20: TryParse fails`` () =
-            let status, _ = TimeSpan.TryParse("10:20:")
-            equal status false
-
-        [<Fact>]
-        let ``TimeSpan 10:20:0 TryParse works`` () =
-            let status, actual = TimeSpan.TryParse("10:20:0")
-            let expected = TimeSpan(0, 10, 20, 0, 0)
-            equal status true
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan .123 TryParse fails`` () =
-            let status, _ = TimeSpan.TryParse(".123")
-            equal status false
-
-        [<Fact>]
-        let ``TimeSpan 0.12:00 TryParse works`` () =
-            let status, actual = TimeSpan.TryParse("0.12:00")
-            let expected = TimeSpan(0, 12, 00, 0, 0)
-            equal status true
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan 10. TryParse fails`` () =
-            let status, _ = TimeSpan.TryParse("10.")
-            equal status false
-
-        [<Fact>]
-        let ``TimeSpan 10.12 TryParse fails`` () =
-            let status, _ = TimeSpan.TryParse("10.12")
-            equal status false
-
-        [<Fact>]
-        let ``TimeSpan 10.12:00 TryParse works`` () =
-            let status, actual = TimeSpan.TryParse("10.12:00")
-            let expected = TimeSpan(10, 12, 00, 0, 0)
-            equal status true
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan 00:00:00.1 Parse handle correctly the milliseconds`` () =
-            let actual = TimeSpan.Parse("00:00:00.1").TotalMilliseconds
-            let expected = 100.
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan 00:00:00.12 Parse handle correctly the milliseconds`` () =
-            let actual = TimeSpan.Parse("00:00:00.12").TotalMilliseconds
-            let expected = 120.
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan 00:00:00.123 Parse handle correctly the milliseconds`` () =
-            let actual = TimeSpan.Parse("00:00:00.123").TotalMilliseconds
-            let expected = 123.
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan 00:00:00.1234 Parse handle correctly the milliseconds`` () =
-            let actual = TimeSpan.Parse("00:00:00.1234").TotalMilliseconds
-            let expected = 123.4
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan 00:00:00.12345 Parse handle correctly the milliseconds`` () =
-            let actual = TimeSpan.Parse("00:00:00.12345").TotalMilliseconds
-            let expected = 123.45
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan 00:00:00.123456 Parse handle correctly the milliseconds`` () =
-            let actual = TimeSpan.Parse("00:00:00.123456").TotalMilliseconds
-            let expected = 123.456
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan 00:00:00.0034567 Parse handle correctly the milliseconds`` () =
-            let actual = TimeSpan.Parse("00:00:00.0034567").TotalMilliseconds
-            let expected = 3.4567
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan Parse work with negative TimeSpan`` () =
-            let actual = TimeSpan.Parse("-2:00:00")
-            equal actual.TotalMilliseconds -7200000.0
-
-        [<Fact>]
-        let ``TimeSpan 1.23:45:06.789 TotalMilliseconds works`` () =
-            let actual = TimeSpan.Parse("1.23:45:06.789").TotalMilliseconds
-            let expected = 171906789.0
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan 1.23:45:06.789 TotalSeconds works`` () =
-            let actual = TimeSpan.Parse("1.23:45:06.789").TotalSeconds
-            let expected = 171906.789
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan 1.23:45:06.789 TotalMinutes works`` () =
-            let actual = TimeSpan.Parse("1.23:45:06.789").TotalMinutes
-            let expected = 2865.11315
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan 1.23:45:06.789 TotalHours works`` () =
-            let actual = TimeSpan.Parse("1.23:45:06.789").TotalHours
-            let expected = 47.75188583333333
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan 1.23:45:06.789 TotalDays works`` () =
-            let actual = TimeSpan.Parse("1.23:45:06.789").TotalDays
-            let expected = 1.9896619097222221
-            equal actual expected
-
-        // TODO: This tests fails because of the decimal part of the milliseconds, see #1867
-        // [<Fact>]
-        // let ``TimeSpan TotalSeconds & friends work`` () =
-        //     let ts = TimeSpan.FromDays(0.005277777778)
-        //     ts.TotalMilliseconds |> equal 456000.0
-        //     ts.TotalSeconds |> equal 456.
-        //     ts.TotalMinutes |> equal 7.6
-
-        [<Fact>]
-        let ``TimeSpan.Milliseconds works with positive TimeSpan`` () =
-            let actual = TimeSpan.Parse("1.23:45:06.789").Milliseconds
-            let expected = 789
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan.Milliseconds works with negative TimeSpan`` () =
-            let actual = TimeSpan.Parse("-1.23:45:06.78999").Milliseconds
-            let expected = -789
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan.Seconds works with positive TimeSpan`` () =
-            let actual = TimeSpan.Parse("1.23:45:06.789").Seconds
-            let expected = 6
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan.Seconds works with negative TimeSpan`` () =
-            let actual = TimeSpan.Parse("-1.23:45:06.78999").Seconds
-            let expected = -6
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan.Minutes works with positive TimeSpan`` () =
-            let actual = TimeSpan.Parse("1.23:45:06.789").Minutes
-            let expected = 45
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan.Minutes works with negative TimeSpan`` () =
-            let actual = TimeSpan.Parse("-1.23:45:06.78999").Minutes
-            let expected = -45
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan.Hours works with positive TimeSpan`` () =
-            let actual = TimeSpan.Parse("1.23:45:06.789").Hours
-            let expected = 23
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan.Hours works with negative TimeSpan`` () =
-            let actual = TimeSpan.Parse("-1.23:45:06.78999").Hours
-            let expected = -23
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan.Days works with positive TimeSpan`` () =
-            let actual = TimeSpan.Parse("1.23:45:06.789").Days
-            let expected = 1
-            equal actual expected
-
-        [<Fact>]
-        let ``TimeSpan.Days works with negative TimeSpan`` () =
-            let actual = TimeSpan.Parse("-1.23:45:06.78999").Days
-            let expected = -1
-            equal actual expected
+        let ``Timespan ticks statics should work`` () =
+            TimeSpan.TicksPerMillisecond |> equal 10000L
+            TimeSpan.TicksPerSecond |> equal (10000L * 1000L)
+            TimeSpan.TicksPerMinute |> equal (10000L * 1000L * 60L)
+            TimeSpan.TicksPerHour |> equal (10000L * 1000L * 60L * 60L)
+            TimeSpan.TicksPerDay |> equal (10000L * 1000L * 60L * 60L* 24L)
+
+
+//         [<Fact>]
+//         let ``TimeSpan.ToString() works`` () =
+//             TimeSpan(0L).ToString() |> equal "00:00:00"
+//             TimeSpan.FromSeconds(12345.).ToString() |> equal "03:25:45"
+//             TimeSpan.FromDays(18.).ToString() |> equal "18.00:00:00"
+//             TimeSpan.FromMilliseconds(25.).ToString() |> equal "00:00:00.0250000"
+
+//         [<Fact>]
+//         let ``TimeSpan.ToString() works for negative TimeSpan`` () =
+//             TimeSpan.FromSeconds(-5.).ToString() |> equal "-00:00:05"
+//             TimeSpan.FromDays(-5.23).ToString() |> equal "-5.05:31:12"
+
+//         [<Fact>]
+//         let ``TimeSpan.ToString(\"c\", CultureInfo.InvariantCulture) works`` () =
+//             TimeSpan(0L).ToString("c", CultureInfo.InvariantCulture) |> equal "00:00:00"
+//             TimeSpan.FromSeconds(12345.).ToString("c", CultureInfo.InvariantCulture) |> equal "03:25:45"
+//             TimeSpan.FromDays(18.).ToString("c", CultureInfo.InvariantCulture) |> equal "18.00:00:00"
+//             TimeSpan.FromMilliseconds(25.).ToString("c", CultureInfo.InvariantCulture) |> equal "00:00:00.0250000"
+
+//         [<Fact>]
+//         let ``TimeSpan.ToString(\"g\", CultureInfo.InvariantCulture) works`` () =
+//             TimeSpan(0L).ToString("g", CultureInfo.InvariantCulture) |> equal "0:00:00"
+//             TimeSpan.FromSeconds(12345.).ToString("g", CultureInfo.InvariantCulture) |> equal "3:25:45"
+//             TimeSpan.FromDays(18.).ToString("g", CultureInfo.InvariantCulture) |> equal "18:0:00:00"
+//             TimeSpan.FromMilliseconds(25.).ToString("g", CultureInfo.InvariantCulture) |> equal "0:00:00.025"
+
+//         [<Fact>]
+//         let ``TimeSpan.ToString(\"G\", CultureInfo.InvariantCulture) works`` () =
+//             TimeSpan(0L).ToString("G", CultureInfo.InvariantCulture) |> equal "0:00:00:00.0000000"
+//             TimeSpan.FromSeconds(12345.).ToString("G", CultureInfo.InvariantCulture) |> equal "0:03:25:45.0000000"
+//             TimeSpan.FromDays(18.).ToString("G", CultureInfo.InvariantCulture) |> equal "18:00:00:00.0000000"
+//             TimeSpan.FromMilliseconds(25.).ToString("G", CultureInfo.InvariantCulture) |> equal "0:00:00:00.0250000"
+
+//         // TODO
+//         // [<Fact>]
+//         // let ``TimeSpan.ToString with format works`` () =
+//         //     TimeSpan.FromMinutes(234.).ToString("hh\:mm\:ss")
+//         //     |> equal "03:54:00"
+
+//         [<Fact>]
+//         let ``TimeSpan constructors work`` () =
+//             let t1 = TimeSpan(20000L)
+//             let t2 = TimeSpan(3, 3, 3)
+//             let t3 = TimeSpan(5, 5, 5, 5)
+//             let t4 = TimeSpan(7, 7, 7, 7, 7)
+//             let t5 = TimeSpan(-2,0,0,0)
+
+//             t1.TotalMilliseconds |> equal 2.0
+//             t2.TotalMilliseconds |> equal 10983000.0
+//             t3.TotalMilliseconds |> equal 450305000.0
+//             t4.TotalMilliseconds |> equal 630427007.0
+//             t5.TotalMilliseconds |> equal -172800000.0
+
+//             t1.TotalMilliseconds + t2.TotalMilliseconds + t3.TotalMilliseconds + t4.TotalMilliseconds
+//             |> equal 1091715009.0
+
+//         [<Fact>]
+//         let ``TimeSpan static creation works`` () =
+//             let t1 = TimeSpan.FromTicks(20000L)
+//             let t2 = TimeSpan.FromMilliseconds(2.)
+//             let t3 = TimeSpan.FromDays   (2.)
+//             let t4 = TimeSpan.FromHours  (2.)
+//             let t5 = TimeSpan.FromMinutes(2.)
+//             let t6 = TimeSpan.FromSeconds(2.)
+//             let t7 = TimeSpan.Zero
+//             t1.TotalMilliseconds + t2.TotalMilliseconds + t3.TotalMilliseconds + t4.TotalMilliseconds +
+//                t5.TotalMilliseconds + t6.TotalMilliseconds + t7.TotalMilliseconds
+//             |> equal 180122004.0
+
+//         [<Fact>]
+//         let ``TimeSpan components work`` () =
+//             let t = TimeSpan.FromMilliseconds(96441615.)
+//             t.Days + t.Hours + t.Minutes + t.Seconds + t.Milliseconds |> float
+//             |> equal 686.
+
+//         [<Fact>]
+//         let ``TimeSpan.Ticks works`` () =
+//             let t = TimeSpan.FromTicks(20000L)
+//             t.Ticks
+//             |> equal 20000L
+
+//         // NOTE: This test fails because of very small fractions, so I cut the fractional part
+//         [<Fact>]
+//         let ``TimeSpan totals work`` () =
+//             let t = TimeSpan.FromMilliseconds(96441615.)
+//             t.TotalDays + t.TotalHours + t.TotalMinutes + t.TotalSeconds |> floor
+//             |> equal 98076.0
+
+//         [<Fact>]
+//         let ``TimeSpan.Duration works`` () =
+//             let test ms expected =
+//                 let t = TimeSpan.FromMilliseconds(ms)
+//                 t.Duration().TotalMilliseconds
+//                 |> equal expected
+//             test 1. 1.
+//             test -1. 1.
+//             test 0. 0.
+
+//         [<Fact>]
+//         let ``TimeSpan.Negate works`` () =
+//             let test ms expected =
+//                 let t = TimeSpan.FromMilliseconds(ms)
+//                 t.Negate().TotalMilliseconds
+//                 |> equal expected
+//             test 1. -1.
+//             test -1. 1.
+//             test 0. 0.
+
+//         [<Fact>]
+//         let ``TimeSpan Addition works`` () =
+//             let test ms1 ms2 expected =
+//                 let t1 = TimeSpan.FromMilliseconds(ms1)
+//                 let t2 = TimeSpan.FromMilliseconds(ms2)
+//                 let res1 = t1.Add(t2).TotalMilliseconds
+//                 let res2 = (t1 + t2).TotalMilliseconds
+//                 equal true (res1 = res2)
+//                 equal expected res1
+//             test 1000. 2000. 3000.
+//             test 200. -1000. -800.
+//             test -2000. 1000. -1000.
+//             test -200. -300. -500.
+//             test 0. 1000. 1000.
+//             test -2000. 0. -2000.
+//             test 0. 0. 0.
+
+//         [<Fact>]
+//         let ``TimeSpan Subtraction works`` () =
+//             let test ms1 ms2 expected =
+//                 let t1 = TimeSpan.FromMilliseconds(ms1)
+//                 let t2 = TimeSpan.FromMilliseconds(ms2)
+//                 let res1 = t1.Subtract(t2).TotalMilliseconds
+//                 let res2 = (t1 - t2).TotalMilliseconds
+//                 equal true (res1 = res2)
+//                 equal expected res1
+//             test 1000. 2000. -1000.
+//             test 200. -2000. 2200.
+//             test -2000. 1000. -3000.
+//             test 200. -300. 500.
+//             test 0. 1000. -1000.
+//             test 1000. 1000. 0.
+//             test 0. 0. 0.
+
+//         [<Fact>]
+//         let ``TimeSpan Multiplication works`` () =
+//             let test ms factor expected =
+//                     // sprintf "(%f, %f) = %f" ms factor expected
+//                     let t = TimeSpan.FromMilliseconds(ms)
+//                     let res1 = t.Multiply(factor).TotalMilliseconds
+//                     let res2 = (t * factor).TotalMilliseconds
+//                     equal res1 res2
+//                     equal true (res1 = res2)
+//                     equal expected res1
+//             test 1000. -1. -1000.
+//             test 200. 11. 2200.
+//             test -2000. 1.5 -3000.
+//             test 0. 1000. 0.
+//             test 1000. 0. 0.
+//             test 0. 0. 0.
+
+//         [<Fact>]
+//         let ``TimeSpan Division works`` () =
+//             // Note: there are two overloads, one with TimeSpan, one with float
+//             let test_ts ms1 ms2 expected =
+//                     // sprintf "ts(%f, %f) = %f" ms1 ms2 expected
+//                     let t1 = TimeSpan.FromMilliseconds(ms1)
+//                     let t2 = TimeSpan.FromMilliseconds(ms2)
+//                     let res1 = t1.Divide(t2)
+//                     let res2 = (t1 / t2)
+//                     equal res1 res2
+//                     equal true (res1 = res2)
+//                     equal expected res1
+//             let test_float ms (factor: float) expected =
+//                     // sprintf "float(%f, %f) = %f" ms factor expected
+//                     let t = TimeSpan.FromMilliseconds(ms)
+//                     let res1 = t.Divide(factor).TotalMilliseconds
+//                     let res2 = (t / factor).TotalMilliseconds
+//                     equal res1 res2
+//                     equal true (res1 = res2)
+//                     equal expected res1
+
+//             test_ts 1000. -1. -1000.
+//             test_ts 2200. 11. 200.
+//             test_ts -3000. 1.5 -2000.
+//             test_ts 0. 1000. 0.
+
+//             test_float 1000. -1. -1000.
+//             test_float 2200. 11. 200.
+//             test_float -3000. 1.5 -2000.
+//             test_float 0. 1000. 0.
+
+//         [<Fact>]
+//         let ``TimeSpan Comparison works`` () =
+//             let test ms1 ms2 expected =
+//                 let t1 = TimeSpan.FromMilliseconds(ms1)
+//                 let t2 = TimeSpan.FromMilliseconds(ms2)
+//                 let res1 = compare t1 t2
+//                 let res2 = t1.CompareTo(t2)
+//                 let res3 = TimeSpan.Compare(t1, t2)
+//                 equal true (res1 = res2 && res2 = res3)
+//                 equal expected res1
+//             test 1000. 2000. -1
+//             test 2000. 1000. 1
+//             test -2000. -2000. 0
+//             test 200. -200. 1
+//             test 0. 1000. -1
+//             test 1000. 1000. 0
+//             test 0. 0. 0
+
+//         [<Fact>]
+//         let ``TimeSpan GreaterThan works`` () =
+//             let test ms1 ms2 expected =
+//                 let t1 = TimeSpan.FromMilliseconds(ms1)
+//                 let t2 = TimeSpan.FromMilliseconds(ms2)
+//                 t1 > t2
+//                 |> equal expected
+//             test 1000. 2000. false
+//             test 2000. 1000. true
+//             test -2000. -2000. false
+
+//         [<Fact>]
+//         let ``TimeSpan LessThan works`` () =
+//             let test ms1 ms2 expected =
+//                 let t1 = TimeSpan.FromMilliseconds(ms1)
+//                 let t2 = TimeSpan.FromMilliseconds(ms2)
+//                 t1 < t2
+//                 |> equal expected
+//             test 1000. 2000. true
+//             test 2000. 1000. false
+//             test -2000. -2000. false
+
+//         [<Fact>]
+//         let ``TimeSpan Equality works`` () =
+//             let test ms1 ms2 expected =
+//                 let t1 = TimeSpan.FromMilliseconds(ms1)
+//                 let t2 = TimeSpan.FromMilliseconds(ms2)
+//                 t1 = t2
+//                 |> equal expected
+//             test 1000. 2000. false
+//             test 2000. 1000. false
+//             test -2000. -2000. true
+
+//         [<Fact>]
+//         let ``TimeSpan Inequality works`` () =
+//             let test ms1 ms2 expected =
+//                 let t1 = TimeSpan.FromMilliseconds(ms1)
+//                 let t2 = TimeSpan.FromMilliseconds(ms2)
+//                 t1 <> t2
+//                 |> equal expected
+//             test 1000. 2000. true
+//             test 2000. 1000. true
+//             test -2000. -2000. false
+
+//     // **************************************************
+//     // Test Cases From :
+//     // https://docs.microsoft.com/en-us/dotnet/api/system.timespan.tryparse
+//     //
+//     // **************************************************
+//     //
+//     //            String to Parse                TimeSpan
+//     //            ---------------   ---------------------
+//     //                          0        00:00:00
+//     //                         14     14.00:00:00
+//     //                      1:2:3        01:02:03
+//     //                  0:0:0.250        00:00:00.2500000
+//     //            10.20:30:40.050     10.20:30:40.0050000
+//     //        99.23:59:59.9990000     99.23:59:59.9999000
+//     //        0023:0059:0059.0009        23:59:59.0009000
+//     //                     23:0:0        23:00:00
+//     //                     24:0:0   Parse operation failed. (actually not true, it's parsed to 24 days...)
+//     //                     0:59:0        00:59:00
+//     //                     0:60:0   Parse operation failed.
+//     //                     0:0:59        00:00:59
+//     //                     0:0:60   Parse operation failed.
+//     //                        10:   Parse operation failed.
+//     //                       10:0        10:00:00
+//     //                        :10   Parse operation failed.
+//     //                       0:10        00:10:00
+//     //                     10:20:   Parse operation failed.
+//     //                    10:20:0        10:20:00
+//     //                       .123   Parse operation failed.
+//     //                    0.12:00        12:00:00
+//     //                        10.   Parse operation failed.
+//     //                      10.12   Parse operation failed.
+//     //                   10.12:00     10.12:00:00
+
+//         [<Fact>]
+//         let ``TimeSpan 0 parse works`` () =
+//             let actual = TimeSpan.Parse("0")
+//             let expected = TimeSpan(0, 0, 0, 0, 0)
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan 14 parse works`` () =
+//             let actual = TimeSpan.Parse("14")
+//             let expected = TimeSpan(14, 0, 0, 0, 0)
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan 1:2:3 parse works`` () =
+//             let actual = TimeSpan.Parse("1:2:3")
+//             let expected = TimeSpan(0, 1, 2, 3, 0)
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan 0:0:0.250 parse works`` () =
+//             let actual = TimeSpan.Parse("0:0:0.250")
+//             let expected = TimeSpan(0, 0, 0, 0, 250)
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan 10.20:30:40.050 parse works`` () =
+//             let actual = TimeSpan.Parse("10.20:30:40.050")
+//             let expected = TimeSpan(10, 20, 30, 40, 50)
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan 99.23:59:59.999 parse works`` () =
+//             let actual = TimeSpan.Parse("99.23:59:59.999")
+//             let expected = TimeSpan(99, 23, 59, 59, 999)
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan 0023:0059:0059.0099 parse works`` () =
+//             let actual = TimeSpan.Parse("0023:0059:0059.009")
+//             let expected = TimeSpan(00, 23, 59, 59, 9)
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan 23:0:0 parse works`` () =
+//             let actual = TimeSpan.Parse("23:0:0")
+//             let expected = TimeSpan(0, 23, 0, 0, 0)
+//             equal actual expected
+// #if FABLE_COMPILER
+//         // msft assumes it's 24 days...
+//         // https://docs.microsoft.com/en-us/dotnet/api/system.timespan.parse
+//         // or
+//         // https://github.com/dotnet/dotnet-api-docs/blob/7f6a3882631bc008b858adfadb43cd17bbd55d49/xml/System/TimeSpan.xml#L2772
+//         [<Fact>]
+//         let ``TimeSpan 24:0:0 parse fails`` () =
+//             (fun _ -> TimeSpan.Parse("24:0:0"))
+//             |> Util.throwsError "String '24:0:0' was not recognized as a valid TimeSpan."
+
+//         [<Fact>]
+//         let ``TimeSpan 24:0:0 TryParse fails`` () =
+//             let status, _ = TimeSpan.TryParse("24:0:0")
+//             equal status false
+// #endif
+
+//         [<Fact>]
+//         let ``TimeSpan 0:0:59 parse works`` () =
+//             let actual = TimeSpan.Parse("0:0:59")
+//             let expected = TimeSpan(0, 0, 0, 59, 0)
+//             equal actual expected
+
+// #if FABLE_COMPILER // temporary, TODO: fix test to be backwards compatible
+//         [<Fact>]
+//         let ``TimeSpan 0:60:0 parse fails`` () =
+//             (fun _ -> TimeSpan.Parse("0:60:0"))
+// #if FABLE_COMPILER
+//             |> Util.throwsError "String '0:60:0' was not recognized as a valid TimeSpan."
+// #else
+//             |> Util.throwsError "The TimeSpan string '0:60:0' could not be parsed because at least one of the numeric components is out of range or contains too many digits."
+// #endif
+// #endif
+
+// #if FABLE_COMPILER // temporary, TODO: fix test to be backwards compatible
+//         [<Fact>]
+//         let ``TimeSpan 10: parse fails`` () =
+//             (fun _ -> TimeSpan.Parse("10:"))
+//             |> Util.throwsError "String '10:' was not recognized as a valid TimeSpan."
+// #endif
+
+//         [<Fact>]
+//         let ``TimeSpan 10:0 parse works`` () =
+//             let actual = TimeSpan.Parse("10:0")
+//             let expected = TimeSpan(0, 10, 0, 0, 0)
+//             equal actual expected
+
+// #if FABLE_COMPILER // temporary, TODO: fix test to be backwards compatible
+//         [<Fact>]
+//         let ``TimeSpan 10:20: parse fails`` () =
+//             (fun _ -> TimeSpan.Parse("10:20:"))
+//             |> Util.throwsError "String '10:20:' was not recognized as a valid TimeSpan."
+// #endif
+
+//         [<Fact>]
+//         let ``TimeSpan 10:20:0 parse works`` () =
+//             let actual = TimeSpan.Parse("10:20:0")
+//             let expected = TimeSpan(0, 10, 20, 0, 0)
+//             equal actual expected
+
+// #if FABLE_COMPILER // temporary, TODO: fix test to be backwards compatible
+//         [<Fact>]
+//         let ``TimeSpan .123 parse fails`` () =
+//             (fun _ -> TimeSpan.Parse(".123"))
+//             |> Util.throwsError "String '.123' was not recognized as a valid TimeSpan."
+// #endif
+
+//         [<Fact>]
+//         let ``TimeSpan 0.12:00 parse works`` () =
+//             let actual = TimeSpan.Parse("0.12:00")
+//             let expected = TimeSpan(0, 12, 00, 0, 0)
+//             equal actual expected
+
+// #if FABLE_COMPILER // temporary, TODO: fix test to be backwards compatible
+//         [<Fact>]
+//         let ``TimeSpan 10. parse fails`` () =
+//             (fun _ -> TimeSpan.Parse("10."))
+//             |> Util.throwsError "String '10.' was not recognized as a valid TimeSpan."
+// #endif
+
+// #if FABLE_COMPILER // temporary, TODO: fix test to be backwards compatible
+//         [<Fact>]
+//         let ``TimeSpan 10.12 parse fails`` () =
+//             (fun _ -> TimeSpan.Parse("10.12"))
+//             |> Util.throwsError "String '10.12' was not recognized as a valid TimeSpan."
+// #endif
+
+//         [<Fact>]
+//         let ``TimeSpan 10.12:00 parse works`` () =
+//             let actual = TimeSpan.Parse("10.12:00")
+//             let expected = TimeSpan(10, 12, 00, 0, 0)
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan 0 TryParse works`` () =
+//             let status, actual = TimeSpan.TryParse("0")
+//             let expected = TimeSpan(0, 0, 0, 0, 0)
+//             equal status true
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan 14 TryParse works`` () =
+//             let status, actual = TimeSpan.TryParse("14")
+//             let expected = TimeSpan(14, 0, 0, 0, 0)
+//             equal status true
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan 1:2:3 TryParse works`` () =
+//             let status, actual = TimeSpan.TryParse("1:2:3")
+//             let expected = TimeSpan(0, 1, 2, 3, 0)
+//             equal status true
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan 0:0:0.250 TryParse works`` () =
+//             let status, actual = TimeSpan.TryParse("0:0:0.250")
+//             let expected = TimeSpan(0, 0, 0, 0, 250)
+//             equal status true
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan 10.20:30:40.050 TryParse works`` () =
+//             let status, actual = TimeSpan.TryParse("10.20:30:40.050")
+//             let expected = TimeSpan(10, 20, 30, 40, 50)
+//             equal status true
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan 99.23:59:59.999 TryParse works`` () =
+//             let status, actual = TimeSpan.TryParse("99.23:59:59.999")
+//             let expected = TimeSpan(99, 23, 59, 59, 999)
+//             equal status true
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan 0023:0059:0059.009 TryParse works`` () =
+//             let status, actual = TimeSpan.TryParse("0023:0059:0059.009")
+//             let expected = TimeSpan(00, 23, 59, 59, 9)
+//             equal status true
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan 23:0:0 TryParse works`` () =
+//             let status, actual = TimeSpan.TryParse("23:0:0")
+//             let expected = TimeSpan(0, 23, 0, 0, 0)
+//             equal status true
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan 0:0:59 TryParse works`` () =
+//             let status, actual = TimeSpan.TryParse("0:0:59")
+//             let expected = TimeSpan(0, 0, 0, 59, 0)
+//             equal status true
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan 0:60:0 TryParse fails`` () =
+//             let status, _ = TimeSpan.TryParse("0:60:0")
+//             equal status false
+
+//         [<Fact>]
+//         let ``TimeSpan 10: TryParse fails`` () =
+//             let status, _ = TimeSpan.TryParse("10:")
+//             equal status false
+//         [<Fact>]
+//         let ``TimeSpan 10:0 TryParse works`` () =
+//             let status, actual = TimeSpan.TryParse("10:0")
+//             let expected = TimeSpan(0, 10, 0, 0, 0)
+//             equal status true
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan 10:20: TryParse fails`` () =
+//             let status, _ = TimeSpan.TryParse("10:20:")
+//             equal status false
+
+//         [<Fact>]
+//         let ``TimeSpan 10:20:0 TryParse works`` () =
+//             let status, actual = TimeSpan.TryParse("10:20:0")
+//             let expected = TimeSpan(0, 10, 20, 0, 0)
+//             equal status true
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan .123 TryParse fails`` () =
+//             let status, _ = TimeSpan.TryParse(".123")
+//             equal status false
+
+//         [<Fact>]
+//         let ``TimeSpan 0.12:00 TryParse works`` () =
+//             let status, actual = TimeSpan.TryParse("0.12:00")
+//             let expected = TimeSpan(0, 12, 00, 0, 0)
+//             equal status true
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan 10. TryParse fails`` () =
+//             let status, _ = TimeSpan.TryParse("10.")
+//             equal status false
+
+//         [<Fact>]
+//         let ``TimeSpan 10.12 TryParse fails`` () =
+//             let status, _ = TimeSpan.TryParse("10.12")
+//             equal status false
+
+//         [<Fact>]
+//         let ``TimeSpan 10.12:00 TryParse works`` () =
+//             let status, actual = TimeSpan.TryParse("10.12:00")
+//             let expected = TimeSpan(10, 12, 00, 0, 0)
+//             equal status true
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan 00:00:00.1 Parse handle correctly the milliseconds`` () =
+//             let actual = TimeSpan.Parse("00:00:00.1").TotalMilliseconds
+//             let expected = 100.
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan 00:00:00.12 Parse handle correctly the milliseconds`` () =
+//             let actual = TimeSpan.Parse("00:00:00.12").TotalMilliseconds
+//             let expected = 120.
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan 00:00:00.123 Parse handle correctly the milliseconds`` () =
+//             let actual = TimeSpan.Parse("00:00:00.123").TotalMilliseconds
+//             let expected = 123.
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan 00:00:00.1234 Parse handle correctly the milliseconds`` () =
+//             let actual = TimeSpan.Parse("00:00:00.1234").TotalMilliseconds
+//             let expected = 123.4
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan 00:00:00.12345 Parse handle correctly the milliseconds`` () =
+//             let actual = TimeSpan.Parse("00:00:00.12345").TotalMilliseconds
+//             let expected = 123.45
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan 00:00:00.123456 Parse handle correctly the milliseconds`` () =
+//             let actual = TimeSpan.Parse("00:00:00.123456").TotalMilliseconds
+//             let expected = 123.456
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan 00:00:00.0034567 Parse handle correctly the milliseconds`` () =
+//             let actual = TimeSpan.Parse("00:00:00.0034567").TotalMilliseconds
+//             let expected = 3.4567
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan Parse work with negative TimeSpan`` () =
+//             let actual = TimeSpan.Parse("-2:00:00")
+//             equal actual.TotalMilliseconds -7200000.0
+
+//         [<Fact>]
+//         let ``TimeSpan 1.23:45:06.789 TotalMilliseconds works`` () =
+//             let actual = TimeSpan.Parse("1.23:45:06.789").TotalMilliseconds
+//             let expected = 171906789.0
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan 1.23:45:06.789 TotalSeconds works`` () =
+//             let actual = TimeSpan.Parse("1.23:45:06.789").TotalSeconds
+//             let expected = 171906.789
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan 1.23:45:06.789 TotalMinutes works`` () =
+//             let actual = TimeSpan.Parse("1.23:45:06.789").TotalMinutes
+//             let expected = 2865.11315
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan 1.23:45:06.789 TotalHours works`` () =
+//             let actual = TimeSpan.Parse("1.23:45:06.789").TotalHours
+//             let expected = 47.75188583333333
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan 1.23:45:06.789 TotalDays works`` () =
+//             let actual = TimeSpan.Parse("1.23:45:06.789").TotalDays
+//             let expected = 1.9896619097222221
+//             equal actual expected
+
+//         // TODO: This tests fails because of the decimal part of the milliseconds, see #1867
+//         // [<Fact>]
+//         // let ``TimeSpan TotalSeconds & friends work`` () =
+//         //     let ts = TimeSpan.FromDays(0.005277777778)
+//         //     ts.TotalMilliseconds |> equal 456000.0
+//         //     ts.TotalSeconds |> equal 456.
+//         //     ts.TotalMinutes |> equal 7.6
+
+//         [<Fact>]
+//         let ``TimeSpan.Milliseconds works with positive TimeSpan`` () =
+//             let actual = TimeSpan.Parse("1.23:45:06.789").Milliseconds
+//             let expected = 789
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan.Milliseconds works with negative TimeSpan`` () =
+//             let actual = TimeSpan.Parse("-1.23:45:06.78999").Milliseconds
+//             let expected = -789
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan.Seconds works with positive TimeSpan`` () =
+//             let actual = TimeSpan.Parse("1.23:45:06.789").Seconds
+//             let expected = 6
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan.Seconds works with negative TimeSpan`` () =
+//             let actual = TimeSpan.Parse("-1.23:45:06.78999").Seconds
+//             let expected = -6
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan.Minutes works with positive TimeSpan`` () =
+//             let actual = TimeSpan.Parse("1.23:45:06.789").Minutes
+//             let expected = 45
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan.Minutes works with negative TimeSpan`` () =
+//             let actual = TimeSpan.Parse("-1.23:45:06.78999").Minutes
+//             let expected = -45
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan.Hours works with positive TimeSpan`` () =
+//             let actual = TimeSpan.Parse("1.23:45:06.789").Hours
+//             let expected = 23
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan.Hours works with negative TimeSpan`` () =
+//             let actual = TimeSpan.Parse("-1.23:45:06.78999").Hours
+//             let expected = -23
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan.Days works with positive TimeSpan`` () =
+//             let actual = TimeSpan.Parse("1.23:45:06.789").Days
+//             let expected = 1
+//             equal actual expected
+
+//         [<Fact>]
+//         let ``TimeSpan.Days works with negative TimeSpan`` () =
+//             let actual = TimeSpan.Parse("-1.23:45:06.78999").Days
+//             let expected = -1
+//             equal actual expected

--- a/tests/Rust/tests/src/TimeSpanTests.fs
+++ b/tests/Rust/tests/src/TimeSpanTests.fs
@@ -85,24 +85,23 @@ module tests =
                t5.TotalMilliseconds + t6.TotalMilliseconds + t7.TotalMilliseconds
             |> equal 180122004.0
 
-//         [<Fact>]
-//         let ``TimeSpan components work`` () =
-//             let t = TimeSpan.FromMilliseconds(96441615.)
-//             t.Days + t.Hours + t.Minutes + t.Seconds + t.Milliseconds |> float
-//             |> equal 686.
+        // [<Fact>]
+        // let ``TimeSpan components work`` () =
+        //     let t = TimeSpan.FromMilliseconds(96441615.)
+        //     t.Days + t.Hours + t.Minutes + t.Seconds + t.Milliseconds |> float
+        //     |> equal 686.
 
-//         [<Fact>]
-//         let ``TimeSpan.Ticks works`` () =
-//             let t = TimeSpan.FromTicks(20000L)
-//             t.Ticks
-//             |> equal 20000L
+        [<Fact>]
+        let ``TimeSpan.Ticks works`` () =
+            let t = TimeSpan.FromTicks(20000L)
+            t.Ticks
+            |> equal 20000L
 
-//         // NOTE: This test fails because of very small fractions, so I cut the fractional part
-//         [<Fact>]
-//         let ``TimeSpan totals work`` () =
-//             let t = TimeSpan.FromMilliseconds(96441615.)
-//             t.TotalDays + t.TotalHours + t.TotalMinutes + t.TotalSeconds |> floor
-//             |> equal 98076.0
+        [<Fact>]
+        let ``TimeSpan totals work`` () =
+            let t = TimeSpan.FromMilliseconds(96441615.)
+            t.TotalDays + t.TotalHours + t.TotalMinutes + t.TotalSeconds |> floor
+            |> equal 98076.0
 
 //         [<Fact>]
 //         let ``TimeSpan.Duration works`` () =

--- a/tests/Rust/tests/src/TimeSpanTests.fs
+++ b/tests/Rust/tests/src/TimeSpanTests.fs
@@ -55,35 +55,35 @@ module tests =
 //         //     TimeSpan.FromMinutes(234.).ToString("hh\:mm\:ss")
 //         //     |> equal "03:54:00"
 
-//         [<Fact>]
-//         let ``TimeSpan constructors work`` () =
-//             let t1 = TimeSpan(20000L)
-//             let t2 = TimeSpan(3, 3, 3)
-//             let t3 = TimeSpan(5, 5, 5, 5)
-//             let t4 = TimeSpan(7, 7, 7, 7, 7)
-//             let t5 = TimeSpan(-2,0,0,0)
+        [<Fact>]
+        let ``TimeSpan constructors work`` () =
+            let t1 = TimeSpan(20000L)
+            let t2 = TimeSpan(3, 3, 3)
+            let t3 = TimeSpan(5, 5, 5, 5)
+            let t4 = TimeSpan(7, 7, 7, 7, 7)
+            let t5 = TimeSpan(-2,0,0,0)
 
-//             t1.TotalMilliseconds |> equal 2.0
-//             t2.TotalMilliseconds |> equal 10983000.0
-//             t3.TotalMilliseconds |> equal 450305000.0
-//             t4.TotalMilliseconds |> equal 630427007.0
-//             t5.TotalMilliseconds |> equal -172800000.0
+            t1.TotalMilliseconds |> equal 2.0
+            t2.TotalMilliseconds |> equal 10983000.0
+            t3.TotalMilliseconds |> equal 450305000.0
+            t4.TotalMilliseconds |> equal 630427007.0
+            t5.TotalMilliseconds |> equal -172800000.0
 
-//             t1.TotalMilliseconds + t2.TotalMilliseconds + t3.TotalMilliseconds + t4.TotalMilliseconds
-//             |> equal 1091715009.0
+            t1.TotalMilliseconds + t2.TotalMilliseconds + t3.TotalMilliseconds + t4.TotalMilliseconds
+            |> equal 1091715009.0
 
-//         [<Fact>]
-//         let ``TimeSpan static creation works`` () =
-//             let t1 = TimeSpan.FromTicks(20000L)
-//             let t2 = TimeSpan.FromMilliseconds(2.)
-//             let t3 = TimeSpan.FromDays   (2.)
-//             let t4 = TimeSpan.FromHours  (2.)
-//             let t5 = TimeSpan.FromMinutes(2.)
-//             let t6 = TimeSpan.FromSeconds(2.)
-//             let t7 = TimeSpan.Zero
-//             t1.TotalMilliseconds + t2.TotalMilliseconds + t3.TotalMilliseconds + t4.TotalMilliseconds +
-//                t5.TotalMilliseconds + t6.TotalMilliseconds + t7.TotalMilliseconds
-//             |> equal 180122004.0
+        [<Fact>]
+        let ``TimeSpan static creation works`` () =
+            let t1 = TimeSpan.FromTicks(20000L)
+            let t2 = TimeSpan.FromMilliseconds(2.)
+            let t3 = TimeSpan.FromDays   (2.)
+            let t4 = TimeSpan.FromHours  (2.)
+            let t5 = TimeSpan.FromMinutes(2.)
+            let t6 = TimeSpan.FromSeconds(2.)
+            let t7 = TimeSpan.FromSeconds 0. //TimeSpan.Zero - todo zero not working
+            t1.TotalMilliseconds + t2.TotalMilliseconds + t3.TotalMilliseconds + t4.TotalMilliseconds +
+               t5.TotalMilliseconds + t6.TotalMilliseconds + t7.TotalMilliseconds
+            |> equal 180122004.0
 
 //         [<Fact>]
 //         let ``TimeSpan components work`` () =


### PR DESCRIPTION
* Timespan constructors
* Timespan static create
* DateTime add_ticks
* Refactor - move timespan + datetimeoffset to new .rs files
* Timespan does not depend on Chrono so I have removed it from the feature switch - It can always be available perhaps?


_Timespan.Zero is still rendering wrong even though I have redirected it to supposedly call TimeSpan.zero(). Not sure why this would be ?_