### PR TITLE
[Python] fix module names

### DIFF
--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -145,7 +145,11 @@ module private Util =
                         // Make sure all modules (subdirs) we create within outDir are lower case (PEP8)
                         let modules = modules |> List.map (fun m -> m.ToLowerInvariant())
                         Naming.fableModules :: package :: packageModule :: modules
-                    | modules, _ -> modules
+                    | modules, _ ->
+                        modules |> List.map (fun m ->
+                            match m with
+                            | "." -> m
+                            | m -> m.Replace(".", "_"))
                     |> List.toArray
                     |> IO.Path.Join
 

--- a/src/Fable.Cli/Pipeline.fs
+++ b/src/Fable.Cli/Pipeline.fs
@@ -182,7 +182,7 @@ module Python =
                             if part = "." then None
                             elif part = ".." then Some ""
                             elif i = parts.Length - 1 then Some(normalizeFileName part)
-                            else Some part // Do not normalize dir names. See #3079
+                            else part.Replace(".", "_") |> Some // Do not lowercase dir names. See #3079
                         )
                         |> String.concat "."
                     if isLibrary then "." + path else path


### PR DESCRIPTION
- Make sure we don't have dots in the module names e.g Fable.SimpleJson.Python