### PR TITLE
Allow alias for default/namespace imports

### DIFF
--- a/src/Fable.Transforms/Global/Prelude.fs
+++ b/src/Fable.Transforms/Global/Prelude.fs
@@ -178,6 +178,16 @@ module Naming =
         then txt.Substring(0, txt.Length - pattern.Length) |> Some
         else None
 
+    let (|Regex|_|) (reg: Regex) (str: string) =
+        let m = reg.Match(str)
+        if m.Success then
+            m.Groups
+            |> Seq.cast<Group>
+            |> Seq.map (fun g -> g.Value)
+            |> Seq.toList
+            |> Some
+        else None
+
     let [<Literal>] fableCompilerConstant = "FABLE_COMPILER"
     let [<Literal>] placeholder = "__PLACE-HOLDER__"
     let [<Literal>] dummyFile = "__DUMMY-FILE__.txt"


### PR DESCRIPTION
This enables setting the preferred alias for default namespaces/imports. See discussion: https://github.com/Zaid-Ajaj/Feliz/issues/510

For example `import "default as React" "react"` will be compiled to `import React from "react"`.