### PR TITLE
[Python] allow python code embedder to return generic type T

### DIFF
--- a/src/Fable.Core/Fable.Core.Py.fs
+++ b/src/Fable.Core/Fable.Core.Py.fs
@@ -40,7 +40,7 @@ module Py =
     let argsFunc (fn: obj[] -> obj): Callable = nativeOnly
 
     /// Embeds literal Python code into F#
-    let python (template: string): unit = nativeOnly
+    let python (template: string): 'T = nativeOnly
 
     /// Defines a Jupyter-like code cell. Translates to `# %%`
     /// https://code.visualstudio.com/docs/python/jupyter-support-py


### PR DESCRIPTION
This enables embedded code to return back values e.g:

```fs
let foo (x: int) : int = Py.python """
    print("Hello", x)
    return 42
    """
```