### PR TITLE
Enable emitExpr/Statement with interpolation

### DIFF
--- a/src/Fable.Core/Fable.Core.Py.fs
+++ b/src/Fable.Core/Fable.Core.Py.fs
@@ -39,7 +39,8 @@ module Py =
     [<Emit("lambda *args: $0(args)")>]
     let argsFunc (fn: obj[] -> obj): Callable = nativeOnly
 
-    /// Embeds literal Python code into F#
+    /// Embeds literal Python code into F#. Code will be printed as statements,
+    /// if you want to return a value use Python `return` keyword within a function.
     let python (template: string): 'T = nativeOnly
 
     /// Defines a Jupyter-like code cell. Translates to `# %%`

--- a/src/Fable.Core/Fable.Core.PyInterop.fs
+++ b/src/Fable.Core/Fable.Core.PyInterop.fs
@@ -30,12 +30,12 @@ let ($) (callee: obj) (args: obj): 'a = nativeOnly
 let (==>) (key: string) (v: obj): string*obj = nativeOnly
 
 /// Destructure a tuple of arguments and applies to literal Python code as with EmitAttribute.
-/// E.g. `emitPyExpr (arg1, arg2) "$0 + $1"` in Python becomes `arg1 + arg2`
-let emitPyExpr<'T> (args: obj) (pyCode: string): 'T = nativeOnly
+/// E.g. `emitExpr (arg1, arg2) "$0 + $1"` in Python becomes `arg1 + arg2`
+let emitExpr<'T> (args: obj) (pyCode: string): 'T = nativeOnly
 
-/// Same as emitPyExpr but intended for Python code that must appear in a statement position
-/// E.g. `emitPyExpr aValue "while($0 < 5) doSomething()"`
-let emitPyStatement<'T> (args: obj) (pyCode: string): 'T = nativeOnly
+/// Same as emitExpr but intended for Python code that must appear in a statement position
+/// E.g. `emitStatement aValue "while($0 < 5) doSomething()"`
+let emitStatement<'T> (args: obj) (pyCode: string): 'T = nativeOnly
 
 /// Create a literal Python object from a collection of key-value tuples.
 /// E.g. `createObj [ "a" ==> 5 ]` in Python becomes `{ a: 5 }`

--- a/src/Fable.Transforms/BabelPrinter.fs
+++ b/src/Fable.Transforms/BabelPrinter.fs
@@ -533,18 +533,7 @@ module PrinterExtensions =
                 let segmentLength = segmentEnd - segmentStart
                 if segmentLength > 0 then
                     let segment = value.Substring(segmentStart, segmentLength)
-
-                    let subSegments = Regex.Split(segment, @"\r?\n")
-                    for i = 1 to subSegments.Length do
-                        let subSegment =
-                            // Remove whitespace in front of new lines,
-                            // indent will be automatically applied
-                            if printer.Column = 0 then subSegments.[i - 1].TrimStart()
-                            else subSegments.[i - 1]
-                        if subSegment.Length > 0 then
-                            printer.Print(subSegment)
-                            if i < subSegments.Length then
-                                printer.PrintNewLine()
+                    printer.Print(segment)
 
             // Macro transformations
             // https://fable.io/docs/communicate/js-from-fable.html#Emit-when-F-is-not-enough

--- a/src/Fable.Transforms/Dart/DartPrinter.fs
+++ b/src/Fable.Transforms/Dart/DartPrinter.fs
@@ -68,18 +68,7 @@ module PrinterExtensions =
                 let segmentLength = segmentEnd - segmentStart
                 if segmentLength > 0 then
                     let segment = value.Substring(segmentStart, segmentLength)
-
-                    let subSegments = Regex.Split(segment, @"\r?\n")
-                    for i = 1 to subSegments.Length do
-                        let subSegment =
-                            // Remove whitespace in front of new lines,
-                            // indent will be automatically applied
-                            if printer.Column = 0 then subSegments[i - 1].TrimStart()
-                            else subSegments[i - 1]
-                        if subSegment.Length > 0 then
-                            printer.Print(subSegment)
-                            if i < subSegments.Length then
-                                printer.PrintNewLine()
+                    printer.Print(segment)
 
             // Macro transformations
             // https://fable.io/docs/communicate/js-from-fable.html#Emit-when-F-is-not-enough

--- a/src/Fable.Transforms/Dart/Replacements.fs
+++ b/src/Fable.Transforms/Dart/Replacements.fs
@@ -769,10 +769,10 @@ let fableCoreLib (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Exp
                 | _ -> None
             | Naming.StartsWith "emit" rest, [args; macro] ->
                 match macro with
-                | RequireStringConst com ctx r macro ->
+                | RequireStringConstOrTemplate com ctx r template ->
                     let args = destructureTupleArgs [args]
                     let isStatement = rest = "Statement"
-                    emit r t args isStatement macro |> Some
+                    emitTemplate r t args isStatement template |> Some
             | ("toNullable" | "ofNullable"), [arg] -> Some arg
             | "toOption" | "ofOption"|"defaultValue"|"defaultWith" as meth, args ->
                 Helper.LibCall(com, "Types", meth, t, args, ?loc=r) |> Some

--- a/src/Fable.Transforms/Replacements.Util.fs
+++ b/src/Fable.Transforms/Replacements.Util.fs
@@ -477,7 +477,7 @@ let (|MaybeInScope|) (ctx: Context) e =
 
 let rec (|MaybeInScopeStringConst|_|) ctx = function
     | MaybeInScope ctx (StringConst s) -> Some s
-    | Operation(Binary(AST.BinaryPlus, (MaybeInScopeStringConst ctx s1), (MaybeInScopeStringConst ctx s2)), _, _) -> Some(s1 + s2)
+    | Operation(Binary(BinaryPlus, (MaybeInScopeStringConst ctx s1), (MaybeInScopeStringConst ctx s2)), _, _) -> Some(s1 + s2)
     | _ -> None
 
 let rec (|RequireStringConst|) com (ctx: Context) r e =
@@ -486,6 +486,14 @@ let rec (|RequireStringConst|) com (ctx: Context) r e =
     | _ ->
         addError com ctx.InlinePath r "Expecting string literal"
         ""
+
+let rec (|RequireStringConstOrTemplate|) com (ctx: Context) r e =
+    match e with
+    | MaybeInScopeStringConst ctx s -> [s], []
+    | MaybeInScope ctx (Value(StringTemplate(None, parts, values),_)) -> parts, values
+    | _ ->
+        addError com ctx.InlinePath r "Expecting string literal"
+        [""], []
 
 let (|CustomOp|_|) (com: ICompiler) (ctx: Context) r t opName (argExprs: Expr list) sourceTypes =
    let argTypes = argExprs |> List.map (fun a -> a.Type)

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -949,10 +949,10 @@ let fableCoreLib (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Exp
             |> emitExpr r t (callee::args) |> Some
         | Naming.StartsWith "emitJs" rest, [args; macro] ->
             match macro with
-            | RequireStringConst com ctx r macro ->
+            | RequireStringConstOrTemplate com ctx r template ->
                 let args = destructureTupleArgs [args]
                 let isStatement = rest = "Statement"
-                emit r t args isStatement macro |> Some
+                emitTemplate r t args isStatement template |> Some
         | "op_EqualsEqualsGreater", [name; MaybeLambdaUncurriedAtCompileTime value] ->
             makeTuple r true [name; value] |> Some
         | "createObj", _ ->

--- a/src/Fable.Transforms/Rust/Replacements.fs
+++ b/src/Fable.Transforms/Rust/Replacements.fs
@@ -903,9 +903,9 @@ let fableCoreLib (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Exp
             makeImportUserGenerated r t selector path |> Some
         | "importAll", [RequireStringConst com ctx r path] ->
             makeImportUserGenerated r t "*" path |> Some
-        | "emitExpr", [args; RequireStringConst com ctx r macro] ->
+        | "emitExpr", [args; RequireStringConstOrTemplate com ctx r template] ->
             let args = destructureTupleArgs [args]
-            emitExpr r t args macro |> Some
+            emitTemplate r t args false template |> Some
         | _ -> None
     | _ -> None
 

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -638,6 +638,16 @@ module AST =
               CallInfo = CallInfo.Create(args=args) }
         Emit(emitInfo, t, r)
 
+    let emitTemplate r t args isStatement (templateParts, templateValues)  =
+        let macro =
+            match templateParts with
+            | [] -> ""
+            | head::tail ->
+                ((head, List.length args), tail)
+                ||> List.fold (fun (macro, pos) part -> $"{macro}$%i{pos}{part}", pos + 1)
+                |> fst
+        emit r t (args @ templateValues) isStatement macro
+
     let emitExpr r t args macro =
         emit r t args false macro
 

--- a/tests/Js/Main/JsInteropTests.fs
+++ b/tests/Js/Main/JsInteropTests.fs
@@ -92,6 +92,21 @@ type MyCustomHTMLElement() =
 let inline sqrtJsExpr (jsExpr: string): float =
     emitJsExpr () ("Math.sqrt(" + jsExpr + ")")
 
+let doSomethingInJs (x: int) (y: float) (z: float): string =
+    emitJsStatement () $"""
+    let acc = 0;
+    for (let i = 0; i < {min x 10}; i++) {{
+        acc += {y ** 2} + {x + 3} * 2;
+    }}
+    return acc + {sprintf "%.2f" z};
+    """
+
+let doSomethingInFSharp (x: int) (y: float) (z: float): string =
+    let mutable acc = 0.
+    for _ = 0 to (min x 10) - 1 do
+        acc <- acc + (y ** 2) + (float x + 3.) * 2.
+    string acc + sprintf "%.2f" z
+
 let myMeth (x: int) (y: int) = x - y
 
 let curry2 (f: 'a -> 'b -> 'c) = f
@@ -621,6 +636,11 @@ let tests =
         let f x y: int =
             emitJsStatement (x, y) "return $0 << $1"
         f 4 8 |> equal 1024
+
+    testCase "emitJsStatement can be used with interpolation" <| fun () ->
+        let res1 = doSomethingInJs 8 3 4.5678
+        let res2 = doSomethingInFSharp 8 3 4.5678
+        equal res1 res2
 
     testCase "Assigning null with emit works" <| fun () ->
         let x = createEmpty<obj>


### PR DESCRIPTION
This allows you to use interpolation when emitting native code. This PR enables the four for all four languages. Example in JS:

```fsharp
let doSomethingInJs (x: int) (y: float) (z: float): string =
    emitJsStatement () $"""
    let acc = 0;
    for (let i = 0; i < {min x 10}; i++) {{
        acc += {y ** 2} + {x + 3} * 2;
    }}
    return acc + {sprintf "%.2f" z};
    """
```

@dbrattli I've also renamed `emitPyExpr`/`emitPyStatement` to `emitExpr`/`emitStatement` to be in line with Dart and Rust (JS cannot change to avoid breaking changes, although maybe we can add the alias helpers). Please let me know if you prefer to undo the change.