### PR TITLE
[TypeScript] Fixed QuickTest

### DIFF
--- a/src/Fable.Transforms/Replacements.Util.fs
+++ b/src/Fable.Transforms/Replacements.Util.fs
@@ -82,7 +82,13 @@ let makeUniqueIdent ctx t name =
 
 let withTag tag = function
     | Call(e, i, t, r) -> Call(e, { i with Tags = tag::i.Tags }, t, r)
+    | Get(e, FieldGet i, t, r) -> Get(e, FieldGet { i with Tags = tag::i.Tags }, t, r)
     | e -> e
+
+let getTags = function
+    | Call(e, i, t, r) -> i.Tags
+    | Get(e, FieldGet i, t, r) -> i.Tags
+    | _e -> []
 
 let objValue (k, v): ObjectExprMember =
     {

--- a/src/fable-library/Option.ts
+++ b/src/fable-library/Option.ts
@@ -12,6 +12,8 @@ import { compare, equals, structuralHash } from "./Util.js";
 // Note: We use non-strict null check for backwards compatibility with
 // code that use F# options to represent values that could be null in JS
 
+export type Nullable<T> = T | undefined;
+
 export type Option<T> = T | Some<T> | undefined;
 
 // Using a class here for better compatibility with TS files importing Some

--- a/src/quicktest/QuickTest.fs
+++ b/src/quicktest/QuickTest.fs
@@ -21,7 +21,9 @@ let equal expected actual =
    if not areEqual then
        failwithf "[ASSERT ERROR] Expected %A but got %A" expected actual
 
-#if !FABLE_COMPILER_TYPESCRIPT
+[<Emit("$0 ?? $1")>]
+let (??=) (x: 'T) (y: 'T): 'T = nativeOnly
+
 let throwsError (expected: string) (f: unit -> 'a): unit =
    let success =
        try
@@ -41,7 +43,7 @@ let testCase (msg: string) f: unit =
    with ex ->
        printfn "%s" ex.Message
        if ex.Message <> null && ex.Message.StartsWith("[ASSERT ERROR]") |> not then
-           printfn "%s" ex.StackTrace
+           printfn "%s" (ex.StackTrace ??= "")
    printfn ""
 
 let testCaseAsync msg f =
@@ -52,7 +54,7 @@ let testCaseAsync msg f =
            with ex ->
                printfn "%s" ex.Message
                if ex.Message <> null && ex.Message.StartsWith("[ASSERT ERROR]") |> not then
-                   printfn "%s" ex.StackTrace
+                   printfn "%s" (ex.StackTrace ??= "")
        } |> Async.StartImmediate)
 
 let throwsAnyError (f: unit -> 'a): unit =
@@ -65,7 +67,6 @@ let throwsAnyError (f: unit -> 'a): unit =
             false
     if success then
         printfn "[ERROR EXPECTED]"
-#endif
 
 let measureTime (f: unit -> unit): unit = emitJsStatement () """
    //js


### PR DESCRIPTION
- Fixed catch type to `any`.
- Fixed nullable string property.
- Added `Nullable<T>`.

The real problem IMO is the (lack of) support for nullable reference types in F#.
I'm not sure we can do much about it until [RFC FS-1060](https://github.com/dotnet/fsharp/pull/6804) gets more traction.