### PR TITLE
Add helpers to instantiate unions in TS

### DIFF
--- a/src/Fable.Transforms/Global/Babel.fs
+++ b/src/Fable.Transforms/Global/Babel.fs
@@ -177,6 +177,7 @@ type ModuleDeclaration =
 
 /// Note that an identifier may be an expression or a destructuring pattern.
 type Identifier =
+    // TODO: Move optional, named and typeAnnotation to Pattern.Identifier
     | Identifier of name: string * optional: bool * named: bool * typeAnnotation: TypeAnnotation option * loc: SourceLocation option
     member this.MapName(f) =
         match this with

--- a/src/fable-library/Choice.fs
+++ b/src/fable-library/Choice.fs
@@ -7,13 +7,13 @@ type Result<'T, 'TError> =
 
 module Result =
     [<CompiledName("Map")>]
-    let map mapping result = match result with Error e -> Error e | Ok x -> Ok (mapping x)
+    let map (mapping: 'a -> 'b) (result: Result<'a,'c>): Result<'b,'c> = match result with Error e -> Error e | Ok x -> Ok (mapping x)
 
     [<CompiledName("MapError")>]
-    let mapError mapping result = match result with Error e -> Error (mapping e) | Ok x -> Ok x
+    let mapError (mapping: 'a -> 'b) (result: Result<'c,'a>): Result<'c,'b> = match result with Error e -> Error (mapping e) | Ok x -> Ok x
 
     [<CompiledName("Bind")>]
-    let bind binder result = match result with Error e -> Error e | Ok x -> binder x
+    let bind (binder: 'a -> Result<'b,'c>) (result: Result<'a,'c>): Result<'b,'c> = match result with Error e -> Error e | Ok x -> binder x
 
 [<CompiledName("FSharpChoice`2")>]
 type Choice<'T1,'T2> =
@@ -61,9 +61,9 @@ type Choice<'T1,'T2,'T3,'T4,'T5,'T6,'T7> =
     | Choice7Of7 of 'T7
 
 module Choice =
-    let makeChoice1Of2 (x: 'T1) = Choice1Of2 x
+    let makeChoice1Of2 (x: 'T1): Choice<'T1,'a> = Choice1Of2 x
 
-    let makeChoice2Of2 (x: 'T2) = Choice2Of2 x
+    let makeChoice2Of2 (x: 'T2): Choice<'a,'T2> = Choice2Of2 x
 
     let tryValueIfChoice1Of2 (x: Choice<'T1, 'T2>): Option<'T1> =
         match x with


### PR DESCRIPTION
This makes it easier to instantiate unions from TypeScript and hopefully also makes the output cleaner. For example, this is how `Result.map` looks now (with non-mangled names):

```typescript
export function Result_Map<a, b, c>(mapping: (arg0: a) => b, result: Result<a, c>): Result<b, c> {
    if (result.tag === Result_Tag.Ok) {
        return Result_Ok<b, c>(mapping(result.fields[0]));
    }
    else {
        return Result_Error<b, c>(result.fields[0]);
    }
}
```

If it adds too much to the bundle size, we can make it an opt-in.