### PR TITLE
Allow imports in emit expressions

### DIFF
--- a/src/Fable.Core/Fable.Core.JS.fs
+++ b/src/Fable.Core/Fable.Core.JS.fs
@@ -20,6 +20,7 @@ module JSX =
 
     let create (componentOrTag: ElementType) (props: Prop list): Element = nativeOnly
     let html (template: string): Element = nativeOnly
+    let jsx (template: string): Element = nativeOnly
     let text (text: string): Element = nativeOnly
     let nothing: Element = nativeOnly
 

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -983,7 +983,7 @@ let fableCoreLib (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Exp
     | "Fable.Core.JSX", meth ->
         match meth with
         | "create" -> Helper.LibCall(com, "JSX", "create", t, args, ?loc=r) |> withTag "jsx" |> Some
-        | "html" -> Helper.LibCall(com, "JSX", "html", t, args, ?loc=r) |> withTag "jsx-template" |> Some
+        | "html" | "jsx" -> Helper.LibCall(com, "JSX", "html", t, args, ?loc=r) |> withTag "jsx-template" |> Some
         | "text" -> TypeCast(args.Head, t) |> Some
         | "nothing" -> makeNullTyped t |> Some
         | _ -> None


### PR DESCRIPTION
This allows including imports in Emit expressions or JSX. Fable will automatically move imports to the top and remove duplicates as with imports done with Fable helpers. For example, this allows the following code:

```fsharp
[<JSX.Component>]
let QrCode() =
    let value, setValue = Hooks.useState("https://shoelace.style/") |> asTuple

    Html.fragment [
        Html.input [
            Attr.className "input mb-5"
            Attr.typeText
            Attr.autoFocus true
            Attr.value (value)
            Ev.onTextChange setValue
        ]
        Html.div [
            JSX.jsx $"""
            import {{ SlQrCode }} from "@shoelace-style/shoelace/dist/react"
            <SlQrCode value={value} radius="0.5"></SlQrCode>
            """
        ]
    ]
```

> Note: For now I'm excluding emit statements from this behavior as in some cases users do want to emit the imports as such.