### PR TITLE
Setup TS tests in build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,8 +40,8 @@ jobs:
     - name: Setup Node.js environment
       uses: actions/setup-node@v2.4.1
 
-    - name: Fable Library - TypeScript
-      run: dotnet fsi build.fsx library-ts
+    - name: Fable Tests - TypeScript
+      run: dotnet fsi build.fsx test-ts
 
     # - name: Fable Tests - TypeScript
     #   run: dotnet fsi build.fsx test-ts

--- a/build.fsx
+++ b/build.fsx
@@ -496,6 +496,30 @@ let testJs() =
     if envVarOrNone "CI" |> Option.isSome then
         testStandaloneFast()
 
+let testTypeScript() =
+    buildLibraryTsIfNotExists()
+
+    let projectDir = "tests/TypeScript"
+    let buildDir = "build/tests/TypeScript"
+    let buildDir2 = "build/tests/TypeScriptCompiled"
+
+    cleanDirs [buildDir; buildDir2]
+
+    runFableWithArgs projectDir [
+        "--lang ts"
+        "--outDir " + buildDir
+        "--exclude Fable.Core"
+    ]
+
+    copyFile (projectDir </> "tsconfig.json") buildDir
+
+    runNpmScript "tsc" [
+        $"-p {buildDir}"
+        $"--outDir {buildDir2}"
+    ]
+
+    runMocha (buildDir2 </> "build/tests/TypeScript/")
+
 let testPython() =
     buildLibraryPyIfNotExists() // NOTE: fable-library-py needs to be built separately.
 
@@ -739,6 +763,7 @@ match BUILD_ARGS_LOWER with
 | "test-configs"::_ -> testProjectConfigs()
 | "test-integration"::_ -> testIntegration()
 | "test-repos"::_ -> testRepos()
+| ("test-ts"|"test-typescript")::_ -> testTypeScript()
 | "test-py"::_ -> testPython()
 | "test-rust"::_ -> testRust SingleThreaded
 | "test-rust-default"::_ -> testRust SingleThreaded

--- a/src/Fable.Transforms/Global/Babel.fs
+++ b/src/Fable.Transforms/Global/Babel.fs
@@ -179,10 +179,6 @@ type ModuleDeclaration =
 type Identifier =
     // TODO: Move optional, named and typeAnnotation to Pattern.Identifier
     | Identifier of name: string * optional: bool * named: bool * typeAnnotation: TypeAnnotation option * loc: SourceLocation option
-    member this.MapName(f) =
-        match this with
-            | Identifier(name, optional, named, typeAnnotation, loc) ->
-                Identifier(f name, optional, named, typeAnnotation, loc)
 
 type StringLiteral =
     | StringLiteral of value: string * loc: SourceLocation option

--- a/tests/Js/Main/ArithmeticTests.fs
+++ b/tests/Js/Main/ArithmeticTests.fs
@@ -2,7 +2,9 @@ module Fable.Tests.Arithmetic
 
 open System
 open Util.Testing
+#if !FABLE_COMPILER_TYPESCRIPT
 open Fable.Tests.Util
+#endif
 
 let [<Literal>] aLiteral = 5
 let notALiteral = 5
@@ -581,6 +583,7 @@ let tests =
         decr i
         !i |> equal 4
 
+#if !FABLE_COMPILER_TYPESCRIPT
     testCase "System.Random works" <| fun () ->
         let rnd = System.Random()
         let x = rnd.Next()
@@ -626,6 +629,7 @@ let tests =
         buffer |> equal [|152uy; 238uy; 227uy; 30uy|]
 
         throwsAnyError <| fun () -> System.Random().NextBytes(null)
+#endif
 
     testCase "Long integers equality works" <| fun () ->
         let x = 5L
@@ -710,6 +714,7 @@ let tests =
         sign -1. |> equal -1
         sign -89. |> equal -1
 
+#if !FABLE_COMPILER_TYPESCRIPT
     testCase "Formatting of decimal works" <| fun () ->
 
         let formatNumber (d:decimal) =
@@ -742,4 +747,5 @@ let tests =
         formatEuro 0.020M |> equal "0,02 €"
         formatEuro 0.20M |> equal "0,20 €"
         formatEuro 2.0M |> equal "2,00 €"
+#endif
 ]

--- a/tests/TypeScript/Fable.Tests.TypeScript.fsproj
+++ b/tests/TypeScript/Fable.Tests.TypeScript.fsproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <DefineConstants>FABLE_COMPILER;FABLE_COMPILER_TYPESCRIPT;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/Fable.Core/Fable.Core.fsproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="../Js/Main/Util/Util.Testing.fs" />
+    <!-- <Compile Include="../Js/Main/Util/Util.fs" />
+    <Compile Include="../Js/Main/Util/UtilTests.fs" /> -->
+    <Compile Include="../Js/Main/ArithmeticTests.fs" />
+    <Compile Include="Main.fs" />
+  </ItemGroup>
+</Project>

--- a/tests/TypeScript/Main.fs
+++ b/tests/TypeScript/Main.fs
@@ -1,0 +1,54 @@
+module Fable.Tests.TypeScript.Main
+
+open System
+open Fable.Tests
+
+let allTests =
+  [|
+    Arithmetic.tests
+  |]
+
+#if FABLE_COMPILER
+
+open Fable.Core
+open Fable.Core.JsInterop
+
+// Import a polyfill for atob and btoa, used by fable-library
+// but not available in node.js runtime
+importSideEffects "../Js/Main/js/polyfill.js"
+
+let [<Global>] describe (name: string) (f: unit->unit) : unit = jsNative
+let [<Global>] it (msg: string) (f: unit->unit) : unit = jsNative
+
+// TODO: Emit declarations automatically when there are global variables
+emitJsStatement () """
+declare var it: any;
+declare var describe: any;
+"""
+
+let rec flattenTest (test: Util.Testing.TestKind) : unit =
+    match test with
+    | Util.Testing.TestKind.TestList(name, tests) ->
+        describe name (fun () ->
+          for t in tests do
+            flattenTest t)
+    | Util.Testing.TestKind.TestCase (name, test) ->
+        it name (unbox test)
+
+
+let run () =
+    for t in allTests do
+        flattenTest t
+run()
+
+#else
+
+open Expecto
+
+[<EntryPoint>]
+let main args =
+    Array.toList allTests
+    |> testList "All"
+    |> runTestsWithArgs defaultConfig args
+
+#endif

--- a/tests/TypeScript/tsconfig.json
+++ b/tests/TypeScript/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+      "target": "es2015",
+      "module": "es2015",
+      "sourceMap": false,
+      "allowJs": true,
+      "esModuleInterop": true,
+      "strict": true,
+      "skipLibCheck": true,
+      "noImplicitReturns": true,
+      "noFallthroughCasesInSwitch": true,
+      "noEmitOnError": true,
+      "newLine": "lf",
+      "forceConsistentCasingInFileNames": true,
+      "preserveWatchOutput": true
+    }
+  }


### PR DESCRIPTION
@ncave This is the initial setup to start porting the JS tests to TypeScript. Instead of writing new files as we've done for other languages, it's probably easier to just reuse the JS ones. I tried to run the TS tests directly with ts-mocha but I couldn't make it work so there are 2 compilation steps at the moment: F# to TS and TS to JS.