### PR TITLE
Several fixes

### DIFF
--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -199,7 +199,12 @@ module FileWatcherUtil =
         files
         // FCS may add files in temporary dirs to resolve nuget references in scripts
         // See https://github.com/fable-compiler/Fable/pull/2725#issuecomment-1015123642
-        |> List.filter (fun file -> not (file.EndsWith(".fsproj.fsx")))
+        |> List.filter (fun file -> not (
+            file.EndsWith(".fsproj.fsx")
+            // It looks like latest F# compiler puts generated files for resolution of packages
+            // in scripts in $HOME/.packagemanagement. See #3222
+            || file.Contains(".packagemanagement")
+        ))
         |> List.map IO.Path.GetDirectoryName
         |> List.distinct
         |> List.sortBy (fun f -> f.Length)
@@ -215,7 +220,7 @@ module FileWatcherUtil =
                     if restDirs |> List.forall (fun d -> (withTrailingSep d).StartsWith dir') then dir
                     else
                         match IO.Path.GetDirectoryName(dir) with
-                        | null -> failwith "No common base dir"
+                        | null -> failwith "No common base dir, please run again with --verbose option and report"
                         | dir -> getCommonDir dir
                 getCommonDir dir
 

--- a/src/Fable.Cli/ProjectCoreCracker.fs
+++ b/src/Fable.Cli/ProjectCoreCracker.fs
@@ -154,5 +154,9 @@ let rec private projInfo additionalMSBuildProps (file: string) =
       let projRefs = p2ps |> List.map (fun p2p -> p2p.ProjectReferenceFullPath)
       projOptions, projRefs, props
 
-let GetProjectOptionsFromProjectFile configuration (file : string) =
-    projInfo ["Configuration", configuration; "FABLE_COMPILER", "true"] file
+let GetProjectOptionsFromProjectFile configuration define (file : string) =
+    projInfo [
+        "Configuration", configuration
+        for constant in define do
+            constant, "true"
+    ] file

--- a/src/Fable.Cli/ProjectCracker.fs
+++ b/src/Fable.Cli/ProjectCracker.fs
@@ -399,10 +399,15 @@ let fullCrack (opts: CrackerOptions): CrackedFsproj =
     let projName = IO.Path.GetFileName projFile
 
     if not opts.NoRestore then
-        Process.runSync projDir "dotnet" ["restore"; projName; "-p:FABLE_COMPILER=true"] |> ignore
+        Process.runSync projDir "dotnet" [
+            "restore"
+            projName;
+            for constant in opts.FableOptions.Define do
+                $"-p:{constant}=true"
+        ] |> ignore
 
     let projOpts, projRefs, msbuildProps =
-        ProjectCoreCracker.GetProjectOptionsFromProjectFile opts.Configuration projFile
+        ProjectCoreCracker.GetProjectOptionsFromProjectFile opts.Configuration opts.FableOptions.Define projFile
 
     // let targetFramework =
     //     match Map.tryFind "TargetFramework" msbuildProps with
@@ -416,7 +421,7 @@ let fullCrack (opts: CrackerOptions): CrackedFsproj =
 /// For project references of main project, ignore dll and package references
 let easyCrack (opts: CrackerOptions) dllRefs (projFile: string): CrackedFsproj =
     let projOpts, projRefs, _msbuildProps =
-        ProjectCoreCracker.GetProjectOptionsFromProjectFile opts.Configuration projFile
+        ProjectCoreCracker.GetProjectOptionsFromProjectFile opts.Configuration opts.FableOptions.Define projFile
 
     let outputType = Map.tryFind "OutputType" _msbuildProps
     let sourceFiles, otherOpts =

--- a/src/Fable.Core/Fable.Core.JS.fs
+++ b/src/Fable.Core/Fable.Core.JS.fs
@@ -541,6 +541,13 @@ module JS =
     let [<Emit("debugger")>] debugger () : unit = nativeOnly
     let [<Emit("void 0")>] undefined<'a> : 'a = nativeOnly
 
+    /// Embeds literal JS code into F#. Code will be printed as statements,
+    /// if you want to return a value use JS `return` keyword within a function.
+    let js (template: string): 'T = nativeOnly
+
+    /// Embeds a literal JS expression into F#
+    let expr_js (template: string): 'T = nativeOnly
+
     [<Literal>]
     let private CONSTRUCTORS_WARNING = "JS constructors are now in Fable.Core.JS.Constructors module to prevent conflicts with modules with same name"
 

--- a/src/Fable.Core/Fable.Core.Py.fs
+++ b/src/Fable.Core/Fable.Core.Py.fs
@@ -43,6 +43,9 @@ module Py =
     /// if you want to return a value use Python `return` keyword within a function.
     let python (template: string): 'T = nativeOnly
 
+    /// Embeds a literal Python expression into F#
+    let expr_python (template: string): 'T = nativeOnly
+
     /// Defines a Jupyter-like code cell. Translates to `# %%`
     /// https://code.visualstudio.com/docs/python/jupyter-support-py
     [<Emit("# %%", isStatement=true)>]

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -1308,7 +1308,7 @@ module Util =
             Expression.logicalExpression(left, op, right, ?loc=range)
 
     let transformEmit (com: IBabelCompiler) ctx range (info: Fable.EmitInfo) =
-        let macro = info.Macro
+        let macro = stripImports com ctx range info.Macro
         let info = info.CallInfo
         let thisArg = info.ThisArg |> Option.map (fun e -> com.TransformAsExpr(ctx, e)) |> Option.toList
         CallInfo(info, info.MemberRef |> Option.bind com.TryGetMember)
@@ -1878,9 +1878,7 @@ module Util =
 
         | Fable.Emit(info, _, range) ->
             if info.IsStatement then iife com ctx expr
-            else
-                let info = { info with Macro = stripImports com ctx range info.Macro }
-                transformEmit com ctx range info
+            else transformEmit com ctx range info
 
         // These cannot appear in expression position in JS, must be wrapped in a lambda
         | Fable.WhileLoop _ | Fable.ForLoop _ | Fable.TryCatch _ -> iife com ctx expr

--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -945,10 +945,11 @@ let fableCoreLib (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Exp
         | "typedArrays" -> makeBoolConst com.Options.TypedArrays |> Some
         | "extension" -> makeStrConst com.Options.FileExtension |> Some
         | _ -> None
-    | "Fable.Core.Py", "python" ->
+    | "Fable.Core.Py", ("python" | "expr_python" as meth) ->
+        let isStatement = meth <> "expr_python"
         match args with
         | RequireStringConstOrTemplate com ctx r template::_ ->
-            emitTemplate r t [] true template  |> Some
+            emitTemplate r t [] isStatement template  |> Some
         | _ -> None
     | "Fable.Core.PyInterop", _
     | "Fable.Core.JsInterop", _ ->

--- a/src/Fable.Transforms/Replacements.Util.fs
+++ b/src/Fable.Transforms/Replacements.Util.fs
@@ -507,7 +507,9 @@ let rec (|RequireStringConst|) com (ctx: Context) r e =
 let rec (|RequireStringConstOrTemplate|) com (ctx: Context) r e =
     match e with
     | MaybeInScopeStringConst ctx s -> [s], []
-    | MaybeInScope ctx (Value(StringTemplate(None, parts, values),_)) -> parts, values
+    // If any of the interpolated values can have side effects, beta binding reduction won't work
+    // so we don't check interpolation in scope
+    | Value(StringTemplate(None, parts, values),_) -> parts, values
     | _ ->
         addError com ctx.InlinePath r "Expecting string literal"
         [""], []

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -887,6 +887,12 @@ let fableCoreLib (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Exp
         | "extension" -> makeStrConst com.Options.FileExtension |> Some
         | "triggeredByDependency" -> makeBoolConst com.Options.TriggeredByDependency |> Some
         | _ -> None
+    | "Fable.Core.JS", ("js" | "expr_js" as meth) ->
+        let isStatement = meth <> "expr_js"
+        match args with
+        | RequireStringConstOrTemplate com ctx r template::_ ->
+            emitTemplate r t [] isStatement template  |> Some
+        | _ -> None
     | "Fable.Core.JsInterop", meth ->
         match meth, args with
         | "importDynamic", [path] ->


### PR DESCRIPTION
- Fix #3222: Ignore files in .packagemanagement in `getCommonBaseDir
 - Pass `--define` constants also when parsing .fsproj
- Add `Js.js`/`JS.expr_js` helpers (similar to `Py.python`)
- Process JS imports also for emit statements (see #3214)
- Don't capture interpolation from scope as values may have side-effect