### PR TITLE
[Python] Use enumerable instead of array

### DIFF
--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -1594,7 +1594,14 @@ module Util =
         | Fable.DeclaredType (ent, [ _ ]) ->
             match ent.FullName, e with
             | Types.ienumerableGeneric, Replacements.Util.ArrayOrListLiteral (exprs, typ) ->
-                makeArray com ctx exprs Fable.ImmutableArray typ
+                let expr, stmts =
+                    exprs
+                    |> List.map (fun e -> com.TransformAsExpr(ctx, e))
+                    |> Helpers.unzipArgs
+
+                let xs = Expression.list expr
+                libCall com ctx None "util" "to_enumerable" [ xs ], stmts
+
             | _ -> com.TransformAsExpr(ctx, e)
         | _ -> com.TransformAsExpr(ctx, e)
 
@@ -1678,7 +1685,6 @@ module Util =
                 libCall com ctx r "list" "cons" [ head; tail ], stmts @ stmts'
             | exprs, Some (TransformExpr com ctx (tail, stmts)) ->
                 let expr, stmts' = makeList com ctx exprs
-
                 [ expr; tail ]
                 |> libCall com ctx r "list" "ofArrayWithTail",
                 stmts @ stmts'

--- a/src/fable-library-py/fable_library/util.py
+++ b/src/fable-library-py/fable_library/util.py
@@ -429,19 +429,14 @@ def pad_left_and_right_with_zeros(i: int, length_left: int, length_right: int) -
 
 
 class Atom(Generic[_T], Protocol):
-    def __call__(
-        self,
-        *value: _T
-    ) -> Optional[_T]:
+    def __call__(self, *value: _T) -> Optional[_T]:
         ...
 
 
 def create_atom(value: _T) -> Atom[_T]:
     atom = value
 
-    def wrapper(
-        *value: _T
-    ) -> Optional[_T]:
+    def wrapper(*value: _T) -> Optional[_T]:
         nonlocal atom
 
         if len(value) == 0:
@@ -451,6 +446,7 @@ def create_atom(value: _T) -> Atom[_T]:
         return None
 
     return wrapper
+
 
 def create_obj(fields: List[Tuple[Any, Any]]):
     return dict(fields)
@@ -533,7 +529,7 @@ class IEnumerator(Iterator[_T], IDisposable):
     def System_Collections_IEnumerator_Reset(self) -> None:
         ...
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[_T]:
         return self
 
     def __next__(self) -> _T:
@@ -602,6 +598,29 @@ class Enumerator(IEnumerator[_T]):
 
     def Dispose(self) -> None:
         return
+
+    def __next__(self) -> _T:
+        return next(self.iter)
+
+    def __iter__(self) -> Iterator[_T]:
+        return self
+
+
+class Enumerable(IEnumerable_1[_T]):
+    __slots__ = "xs"
+
+    def __init__(self, xs: Iterable[_T]) -> None:
+        self.xs = xs
+
+    def GetEnumerator(self) -> IEnumerator[_T]:
+        return Enumerator(iter(self.xs))
+
+    def __iter__(self) -> Iterator[_T]:
+        return iter(self.xs)
+
+
+def to_enumerable(e: Iterable[_T]) -> IEnumerable_1[_T]:
+    return Enumerable(e)
 
 
 def get_enumerator(o: Iterable[Any]) -> Enumerator[Any]:

--- a/tests/Python/TestApplicative.fs
+++ b/tests/Python/TestApplicative.fs
@@ -1479,10 +1479,10 @@ module FSharpPlus =
 
 open FSharpPlus
 
-//[<Fact>]
-//let ``test FSharpPlus regression`` () = // See #2471
-//    let expected = Some(seq [1; 2])
-//    sequence (seq [Some 1; Some 2]) |> equal expected
+[<Fact>]
+let ``test FSharpPlus regression`` () = // See #2471
+    let expected = Some(seq [1; 2] |> List.ofSeq)
+    sequence (seq [Some 1; Some 2]) |> Option.map List.ofSeq |> equal expected
 
 module Curry =
     let addString (value : string) (f : string -> 'T) =


### PR DESCRIPTION
-  Make seq cast into enumerable (not array)