### PR TITLE
Use the latest minor version of .NET

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "6.0.100",
-    "rollForward": "minor"
+    "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
For some reason Fable started selecting the 6.0.110 version I had installed. I uninstalled it but then got the error:

```
❯ dotnet --version
Found .NET SDK, but did not find dotnet.dll at [C:\Program Files\dotnet\sdk\6.0.110\dotnet.dll]
```
There's probably something wrong with the uninstaller. Changing to `latestMinor` solved the problem. I feel this is what we would usually like. Now I get:

```
❯ dotnet --version
6.0.402
```

What do you think?

Ref: https://learn.microsoft.com/en-us/dotnet/core/tools/global-json