### PR TITLE
[Python] Fix reference equal with literals

### DIFF
--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -2802,7 +2802,6 @@ let objects (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr opt
     | ".ctor", _, _ -> typedObjExpr t [] |> Some
     | "ToString", Some arg, _ -> toString com ctx r [ arg ] |> Some
     | "ReferenceEquals", _, [ left; right ] ->
-        //makeEqOp r left right BinaryEqual |> Some
         emitExpr None t [ left; right ] "$0 is $1" |> Some
     | "Equals", Some arg1, [ arg2 ]
     | "Equals", None, [ arg1; arg2 ] -> equals com ctx r true arg1 arg2 |> Some


### PR DESCRIPTION
@alfonsogarciacaro do you think it would it be possible to represent reference equals in the Fable AST? Current I need to handle it using Emit, and then do transformations on emit which is not very nice. The reason is that for Python a reference equals is written as `is` (except with literals that needs to use `==`) while equals is `==`. So for e.g `a == b` or `a is b` I have no way of knowing if it's one or the other when using `BinaryEqual`. 