### PR TITLE
Add tags to Operation expression

### DIFF
--- a/src/Fable.AST/Fable.fs
+++ b/src/Fable.AST/Fable.fs
@@ -619,7 +619,7 @@ type Expr =
     /// Application to local lambdas, function arguments will NOT be uncurried
     | CurriedApply of applied: Expr * args: Expr list * typ: Type * range: SourceLocation option
     /// Operations that can be defined with native operators
-    | Operation of kind: OperationKind * typ: Type * range: SourceLocation option
+    | Operation of kind: OperationKind * tags: string list * typ: Type * range: SourceLocation option
 
     // Imports and code emissions
     | Import of info: ImportInfo * typ: Type * range: SourceLocation option
@@ -657,7 +657,7 @@ type Expr =
         | TypeCast (_, t)
         | Import (_, t, _)
         | ObjectExpr (_, t, _)
-        | Operation (_, t, _)
+        | Operation (_, _, t, _)
         | Get (_, _, t, _)
         | Emit (_,t,_)
         | DecisionTreeSuccess (_, _, t) -> t
@@ -695,7 +695,7 @@ type Expr =
         | IfThenElse (_, _, _, r)
         | TryCatch (_, _, _, r)
         | Test (_, _, r)
-        | Operation (_, _, r)
+        | Operation (_, _, _, r)
         | Get (_, _, _, r)
         | Set (_, _, _, _, r)
         | ForLoop (_,_,_,_,_,r)

--- a/src/Fable.Transforms/Dart/Fable2Dart.fs
+++ b/src/Fable.Transforms/Dart/Fable2Dart.fs
@@ -1228,7 +1228,7 @@ module Util =
 
     let canTransformDecisionTreeAsSwitch expr =
         let (|Equals|_|) = function
-            | Fable.Operation(Fable.Binary(BinaryEqual, expr, right), _, _) ->
+            | Fable.Operation(Fable.Binary(BinaryEqual, expr, right), _, _, _) ->
                 match expr with
                 | Fable.Value((Fable.CharConstant _ | Fable.StringConstant _ | Fable.NumberConstant _), _) -> Some(expr, right)
                 | _ -> None
@@ -1551,7 +1551,7 @@ module Util =
         | Fable.Emit(info, t, _range) ->
             transformEmit com ctx t returnStrategy info
 
-        | Fable.Operation(kind, t, r) ->
+        | Fable.Operation(kind, _, t, r) ->
             transformOperation com ctx r t returnStrategy kind
 
         | Fable.Get(expr, kind, t, range) ->

--- a/src/Fable.Transforms/Dart/Replacements.fs
+++ b/src/Fable.Transforms/Dart/Replacements.fs
@@ -284,23 +284,23 @@ let getSubtractToDateMethodName = function
 
 let applyOp (com: ICompiler) (ctx: Context) r t opName (args: Expr list) =
     let unOp operator operand =
-        Operation(Unary(operator, operand), t, r)
+        Operation(Unary(operator, operand), Tags.empty, t, r)
     let binOp op left right =
-        Operation(Binary(op, left, right), t, r)
+        Operation(Binary(op, left, right), Tags.empty, t, r)
     let truncateUnsigned operation = // see #1550
         match t with
         | Number(UInt32,_) ->
-            Operation(Binary(BinaryShiftRightZeroFill,operation,makeIntConst 0), t, r)
+            Operation(Binary(BinaryShiftRightZeroFill,operation,makeIntConst 0), Tags.empty, t, r)
         | _ -> operation
     let logicOp op left right =
-        Operation(Logical(op, left, right), Boolean, r)
+        Operation(Logical(op, left, right), Tags.empty, Boolean, r)
     let nativeOp opName argTypes args =
         match opName, args with
         | Operators.addition, [left; right] ->
             match argTypes with
             | Char::_ ->
                 let toUInt16 e = toInt com ctx None UInt16.Number [e]
-                Operation(Binary(BinaryPlus, toUInt16 left, toUInt16 right), UInt16.Number, r) |> toChar
+                Operation(Binary(BinaryPlus, toUInt16 left, toUInt16 right), Tags.empty, UInt16.Number, r) |> toChar
             | _ -> binOp BinaryPlus left right
         | Operators.subtraction, [left; right] -> binOp BinaryMinus left right
         | Operators.multiply, [left; right] -> binOp BinaryMultiply left right
@@ -626,7 +626,7 @@ let tryReplacedEntityRef (com: Compiler) entFullName =
     | "System.Lazy`1" -> makeImportLib com MetaType "Lazy" "FSharp.Core" |> Some
     | _ -> None
 
-let tryEntityIdent com (ent: Fable.Entity) =
+let tryEntityIdent com (ent: Entity) =
     if FSharp2Fable.Util.isReplacementCandidate ent.Ref
     then tryReplacedEntityRef com ent.FullName
     else FSharp2Fable.Util.tryEntityIdentMaybeGlobalOrImported com ent
@@ -2110,7 +2110,7 @@ let debug (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr optio
         | [Value(BoolConstant false,_)] -> makeDebugger r |> Some
         | arg::_ ->
             // emit i "if (!$0) { debugger; }" i.args |> Some
-            let cond = Operation(Unary(UnaryNot, arg), Boolean, r)
+            let cond = Operation(Unary(UnaryNot, arg), Tags.empty, Boolean, r)
             IfThenElse(cond, makeDebugger r, unit, r) |> Some
     | _ -> None
 

--- a/src/Fable.Transforms/FSharp2Fable.fs
+++ b/src/Fable.Transforms/FSharp2Fable.fs
@@ -1595,15 +1595,15 @@ let resolveInlineExpr (com: IFableCompiler) ctx info expr =
         let args = List.map (resolveInlineExpr com ctx info) args
         Fable.CurriedApply(resolveInlineExpr com ctx info callee, args, resolveInlineType ctx typ, r)
 
-    | Fable.Operation(kind, t, r) ->
+    | Fable.Operation(kind, tags, t, r) ->
         let t = resolveInlineType ctx t
         match kind with
         | Fable.Unary(operator, operand) ->
-            Fable.Operation(Fable.Unary(operator, resolveInlineExpr com ctx info operand), t, r)
+            Fable.Operation(Fable.Unary(operator, resolveInlineExpr com ctx info operand), tags, t, r)
         | Fable.Binary(op, left, right) ->
-            Fable.Operation(Fable.Binary(op, resolveInlineExpr com ctx info left, resolveInlineExpr com ctx info right), t, r)
+            Fable.Operation(Fable.Binary(op, resolveInlineExpr com ctx info left, resolveInlineExpr com ctx info right), tags, t, r)
         | Fable.Logical(op, left, right) ->
-            Fable.Operation(Fable.Logical(op, resolveInlineExpr com ctx info left, resolveInlineExpr com ctx info right), t, r)
+            Fable.Operation(Fable.Logical(op, resolveInlineExpr com ctx info left, resolveInlineExpr com ctx info right), tags, t, r)
 
     | Fable.Get(e, kind, t, r) ->
         let kind =

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -864,7 +864,7 @@ module Util =
         ClassMember.classMethod(ClassPrimaryConstructor, Expression.identifier("constructor"), args, body)
 
     let callFunction com ctx r funcExpr genArgs (args: Expression list) =
-        let genArgs = Annotation.makeTypeParamInstantiationIfTypeScript com ctx genArgs
+        let genArgs = makeTypeParamInstantiationIfTypeScript com ctx genArgs
         Expression.callExpression(funcExpr, List.toArray args, ?typeParameters=genArgs, ?loc=r)
 
     let callFunctionWithThisContext r funcExpr (args: Expression list) =
@@ -1644,7 +1644,7 @@ module Util =
 
     let transformDecisionTreeAsSwitch expr =
         let (|Equals|_|) = function
-            | Fable.Operation(Fable.Binary(BinaryEqual, expr, right), _, _) ->
+            | Fable.Operation(Fable.Binary(BinaryEqual, expr, right), _, _, _) ->
                 match expr with
                 | Fable.Value((Fable.CharConstant _ | Fable.StringConstant _ | Fable.NumberConstant _), _) -> Some(expr, right)
                 | _ -> None
@@ -1839,7 +1839,7 @@ module Util =
         | Fable.CurriedApply(callee, args, _, range) ->
             transformCurriedApply com ctx range callee args
 
-        | Fable.Operation(kind, _, range) ->
+        | Fable.Operation(kind, _, _, range) ->
             transformOperation com ctx range kind
 
         | Fable.Get(expr, kind, typ, range) ->
@@ -1942,7 +1942,7 @@ module Util =
                 [|ExpressionStatement(e)|] // Ignore the return strategy
             else [|resolveExpr t returnStrategy e|]
 
-        | Fable.Operation(kind, t, range) ->
+        | Fable.Operation(kind, _, t, range) ->
             [|transformOperation com ctx range kind |> resolveExpr t returnStrategy|]
 
         | Fable.Get(expr, kind, t, range) ->

--- a/src/Fable.Transforms/Php/Fable2Php.fs
+++ b/src/Fable.Transforms/Php/Fable2Php.fs
@@ -518,7 +518,7 @@ let rec convertExpr (com: IPhpCompiler) (expr: Fable.Expr) =
         // this is a value (number / record instanciation ...)
         convertValue com value range
 
-    | Fable.Operation(Fable.Binary(op, left,right), t, _) ->
+    | Fable.Operation(Fable.Binary(op, left,right), _, t, _) ->
         // the result of a binary operation
         let opstr =
             match op with
@@ -544,7 +544,7 @@ let rec convertExpr (com: IPhpCompiler) (expr: Fable.Expr) =
             | BinaryOperator.BinaryShiftRightSignPropagating -> ">>"
             | BinaryOperator.BinaryShiftRightZeroFill -> ">>>"
         PhpBinaryOp(opstr, convertExpr com left, convertExpr com right)
-    | Fable.Operation(Fable.Unary(op, expr),_,_) ->
+    | Fable.Operation(Fable.Unary(op, expr),_,_,_) ->
         let opStr =
             match op with
             | UnaryOperator.UnaryNot -> "!"
@@ -554,7 +554,7 @@ let rec convertExpr (com: IPhpCompiler) (expr: Fable.Expr) =
             | UnaryOperator.UnaryAddressOf -> failwith "UnaryAddressOf not supported"
 
         PhpUnaryOp(opStr, convertExpr com expr)
-    | Fable.Operation(Fable.Logical(op, left, right),_,_) ->
+    | Fable.Operation(Fable.Logical(op, left, right),_,_,_) ->
         // this is a binary logical operation
         let opstr =
             match op with

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -506,7 +506,7 @@ module Helpers =
         if fields.Length < 1 then
             false
         else
-            match fields.[0].Type with
+            match fields[0].Type with
             | Fable.GenericParam _ -> true
             | Fable.Option _ -> true
             | Fable.Unit -> true
@@ -933,7 +933,7 @@ module Annotation =
                     | _ -> ()
                 makeGenericTypeAnnotation com ctx name genArgs repeatedGenerics, []
             else
-                match Lib.tryPyConstructor com ctx ent with
+                match tryPyConstructor com ctx ent with
                 | Some (entRef, stmts) ->
                     match entRef with
                     (*
@@ -1403,8 +1403,8 @@ module Util =
                 args
             else
                 { args with
-                    VarArg = Some { args.Args.[len - 1] with Annotation = None }
-                    Args = args.Args.[.. len - 2] }
+                    VarArg = Some { args.Args[len - 1] with Annotation = None }
+                    Args = args.Args[.. len - 2] }
 
         args, body, returnType
 
@@ -2544,7 +2544,7 @@ module Util =
     let transformDecisionTreeAsSwitch expr =
         let (|Equals|_|) =
             function
-            | Fable.Operation (Fable.Binary (BinaryEqual, expr, right), _, _) ->
+            | Fable.Operation (Fable.Binary (BinaryEqual, expr, right), _, _, _) ->
                 match expr with
                 | Fable.Value ((Fable.CharConstant _
                                | Fable.StringConstant _
@@ -2869,7 +2869,7 @@ module Util =
 
         | Fable.CurriedApply (callee, args, _, range) -> transformCurriedApply com ctx range callee args
 
-        | Fable.Operation (kind, _, range) -> transformOperation com ctx range kind
+        | Fable.Operation (kind, _, _, range) -> transformOperation com ctx range kind
 
         | Fable.Get (expr, kind, typ, range) -> transformGet com ctx range typ expr kind
 
@@ -3071,7 +3071,7 @@ module Util =
             else
                 stmts @ resolveExpr ctx t returnStrategy e
 
-        | Fable.Operation (kind, t, range) ->
+        | Fable.Operation (kind, _, t, range) ->
             let expr, stmts = transformOperation com ctx range kind
             stmts @ (expr |> resolveExpr ctx t returnStrategy)
 
@@ -3774,7 +3774,7 @@ module Util =
                    |> List.collecti (fun i field ->
                        let left = get com ctx None thisExpr (Naming.toSnakeCase field.Name) false
 
-                       let right = args.[i] |> wrapIntExpression field.FieldType
+                       let right = args[i] |> wrapIntExpression field.FieldType
                        assign None left right |> exprAsStatement ctx)) ]
 
         let args =

--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -351,18 +351,18 @@ let toSeq t (e: Expr) =
 
 let applyOp (com: ICompiler) (ctx: Context) r t opName (args: Expr list) =
     let unOp operator operand =
-        Operation(Unary(operator, operand), t, r)
+        Operation(Unary(operator, operand), Tags.empty, t, r)
 
     let binOp op left right =
-        Operation(Binary(op, left, right), t, r)
+        Operation(Binary(op, left, right), Tags.empty, t, r)
 
     let truncateUnsigned operation = // see #1550
         match t with
-        | Number (UInt32, _) -> Operation(Binary(BinaryShiftRightZeroFill, operation, makeIntConst 0), t, r)
+        | Number (UInt32, _) -> Operation(Binary(BinaryShiftRightZeroFill, operation, makeIntConst 0), Tags.empty, t, r)
         | _ -> operation
 
     let logicOp op left right =
-        Operation(Logical(op, left, right), Boolean, r)
+        Operation(Logical(op, left, right), Tags.empty, Boolean, r)
 
     let nativeOp opName argTypes args =
         match opName, args with
@@ -2980,7 +2980,7 @@ let debug (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr optio
         | [ Value (BoolConstant false, _) ] -> makeDebugger r |> Some
         | arg :: _ ->
             // emit i "if (!$0) { debugger; }" i.args |> Some
-            let cond = Operation(Unary(UnaryNot, arg), Boolean, r)
+            let cond = Operation(Unary(UnaryNot, arg), Tags.empty, Boolean, r)
             IfThenElse(cond, makeDebugger r, unit, r) |> Some
     | _ -> None
 
@@ -3296,7 +3296,7 @@ let regex com (ctx: Context) r t (i: CallInfo) (thisArg: Expr option) (args: Exp
         if isGroup
         // In JS Regex group values can be undefined, ensure they're empty strings #838
         then
-            Operation(Logical(LogicalOr, thisArg.Value, makeStrConst ""), t, r)
+            Operation(Logical(LogicalOr, thisArg.Value, makeStrConst ""), Tags.empty, t, r)
             |> Some
         else
             propInt 0 thisArg.Value |> Some

--- a/src/Fable.Transforms/Replacements.Util.fs
+++ b/src/Fable.Transforms/Replacements.Util.fs
@@ -106,20 +106,20 @@ let objExpr kvs =
     typedObjExpr Any kvs
 
 let add left right =
-    Operation(Binary(BinaryPlus, left, right), left.Type, None)
+    Operation(Binary(BinaryPlus, left, right), Tags.empty, left.Type, None)
 
 let sub left right =
-    Operation(Binary(BinaryMinus, left, right), left.Type, None)
+    Operation(Binary(BinaryMinus, left, right), Tags.empty, left.Type, None)
 
 let eq left right =
-    Operation(Binary(BinaryEqual, left, right), Boolean, None)
+    Operation(Binary(BinaryEqual, left, right), Tags.empty, Boolean, None)
 
 let neq left right =
-    Operation(Binary(BinaryUnequal, left, right), Boolean, None)
+    Operation(Binary(BinaryUnequal, left, right), Tags.empty, Boolean, None)
 
 let nullCheck r isNull expr =
     let op = if isNull then BinaryEqual else BinaryUnequal
-    Operation(Binary(op, expr, Value(Null expr.Type, None)), Boolean, r)
+    Operation(Binary(op, expr, Value(Null expr.Type, None)), Tags.empty, Boolean, r)
 
 let str txt = Value(StringConstant txt, None)
 
@@ -485,7 +485,7 @@ let rec (|MaybeInScopeStringConst|_|) ctx = function
     | MaybeInScope ctx expr ->
         match expr with
         | StringConst s -> Some s
-        | Operation(Binary(BinaryPlus, (MaybeInScopeStringConst ctx s1), (MaybeInScopeStringConst ctx s2)), _, _) -> Some(s1 + s2)
+        | Operation(Binary(BinaryPlus, (MaybeInScopeStringConst ctx s1), (MaybeInScopeStringConst ctx s2)), _, _, _) -> Some(s1 + s2)
         | Value(StringTemplate(None, start::parts, values),_) ->
             (Some [], values) ||> List.fold (fun acc value ->
                 match acc, value with
@@ -538,7 +538,7 @@ let (|RegexFlags|_|) e =
             | 16 -> Some [RegexSingleline]
             | 256 -> Some [] // ECMAScript flag (ignored)
             | _ -> None
-        | Operation(Binary(BinaryOrBitwise, flags1, flags2),_,_) ->
+        | Operation(Binary(BinaryOrBitwise, flags1, flags2),_,_,_) ->
             match getFlags flags1, getFlags flags2 with
             | Some flags1, Some flags2 -> Some(flags1 @ flags2)
             | _ -> None

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -479,16 +479,16 @@ module AST =
         ForLoop (ident, start, limit, body, isUp, range)
 
     let makeBinOp range typ left right op =
-        Operation(Binary(op, left, right), typ, range)
+        Operation(Binary(op, left, right), Tags.empty, typ, range)
 
     let makeUnOp range typ arg op =
-        Operation(Unary(op, arg), typ, range)
+        Operation(Unary(op, arg), Tags.empty, typ, range)
 
     let makeLogOp range left right op =
-        Operation(Logical(op, left, right), Boolean, range)
+        Operation(Logical(op, left, right), Tags.empty, Boolean, range)
 
     let makeEqOp range left right op =
-        Operation(Binary(op, left, right), Boolean, range)
+        Operation(Binary(op, left, right), Tags.empty, Boolean, range)
 
     let makeNullTyped t =
         Value(Null t, None)
@@ -928,14 +928,14 @@ module AST =
                 { info.CallInfo with ThisArg = Option.map f info.CallInfo.ThisArg
                                      Args = List.map f info.CallInfo.Args }
             Emit({ info with CallInfo = callInfo }, t, r)
-        | Operation(kind, t, r) ->
+        | Operation(kind, tags, t, r) ->
             match kind with
             | Unary(operator, operand) ->
-                Operation(Unary(operator, f operand), t, r)
+                Operation(Unary(operator, f operand), tags, t, r)
             | Binary(op, left, right) ->
-                Operation(Binary(op, f left, f right), t, r)
+                Operation(Binary(op, f left, f right), tags, t, r)
             | Logical(op, left, right) ->
-                Operation(Logical(op, f left, f right), t, r)
+                Operation(Logical(op, f left, f right), tags, t, r)
         | Get(e, kind, t, r) ->
             match kind with
             | ListHead | ListTail | OptionValue | TupleIndex _ | UnionTag


### PR DESCRIPTION
This way we can add specific info for each language. For example, if equality is strict in JS or by reference in Python. 