### PR TITLE
[Python] fixes for Literal[None] is the same as None

### DIFF
--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -3273,8 +3273,8 @@ module Util =
                             match arg.Annotation with
                             | Some (Expression.Name {Id = Identifier name}) -> arg.Annotation
                             | Some (Expression.Subscript {Value=value; Slice=Expression.Name {Id = Identifier name}}) when name.StartsWith("_") ->
-                                Expression.subscript(value, Expression.any) |> Some
-                            | _ -> Some (Expression.any)
+                                Expression.subscript(value, stdlibModuleAnnotation com ctx "typing" "Any" []) |> Some
+                            | _ -> Some (stdlibModuleAnnotation com ctx "typing" "Any" [])
                         (Arg.arg (name, ?annotation = annotation), Expression.name (name)) |> Some)
                 |> List.unzip
             | _ -> [], []

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -3354,12 +3354,9 @@ module Util =
         let arguments =
             match args, isUnit with
             | [], _ ->
-                let ta =
-                    stdlibModuleAnnotation com ctx "typing" "Literal" [ Expression.name "None" ]
-
                 Arguments.arguments (
                     args =
-                        Arg.arg (Identifier("__unit"), annotation = ta)
+                        Arg.arg (Identifier("__unit"), annotation = Expression.name "None")
                         :: tcArgs,
                     defaults = Expression.none :: tcDefaults
                 )

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -982,7 +982,7 @@ module Annotation =
         // In Python a generic type arg must appear both in the argument and the return type (cannot appear only once)
         let repeatedGenerics =
             Util.getRepeatedGenericTypeParams ctx (argTypes @ [ body.Type ])
-        // printfn "repeatedGenerics: %A" (repeatedGenerics, argTypes, body.Type)
+        // printfn "repeatedGenerics: %A" (name, repeatedGenerics, argTypes, body.Type)
 
         let args', body' = com.TransformFunction(ctx, name, args, body, repeatedGenerics)
         let returnType, stmts = typeAnnotation com ctx (Some repeatedGenerics) body.Type
@@ -3268,7 +3268,14 @@ module Util =
                     match name with
                     | "tupled_arg_m" -> None // Remove these arguments (not sure why)
                     | _ ->
-                        (Arg.arg (name, ?annotation = arg.Annotation), Expression.name (name)) |> Some)
+                        let annotation =
+                            // Cleanup type annotations to avoid non-repeated generics
+                            match arg.Annotation with
+                            | Some (Expression.Name {Id = Identifier name}) -> arg.Annotation
+                            | Some (Expression.Subscript {Value=value; Slice=Expression.Name {Id = Identifier name}}) when name.StartsWith("_") ->
+                                Expression.subscript(value, Expression.any) |> Some
+                            | _ -> Some (Expression.any)
+                        (Arg.arg (name, ?annotation = annotation), Expression.name (name)) |> Some)
                 |> List.unzip
             | _ -> [], []
 

--- a/src/Fable.Transforms/Python/Prelude.fs
+++ b/src/Fable.Transforms/Python/Prelude.fs
@@ -93,7 +93,8 @@ module Naming =
 
     // Other global builtins we should avoid https://docs.python.org/3/library/functions.html
     let pyBuiltins =
-        System.Collections.Generic.HashSet [ "len"
+        System.Collections.Generic.HashSet [ "abs"
+                                             "len"
                                              "str"
                                              "int"
                                              "float"

--- a/src/Fable.Transforms/Python/PythonPrinter.fs
+++ b/src/Fable.Transforms/Python/PythonPrinter.fs
@@ -269,6 +269,7 @@ module PrinterExtensions =
             printer.Print("[")
 
             match node.Slice with
+            | Tuple { Elements = [] } -> printer.Print("()")
             | Tuple { Elements = elems } -> printer.PrintCommaSeparatedList(elems)
             | _ -> printer.Print(node.Slice)
 

--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -1245,8 +1245,11 @@ let operators (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr o
             match genArg with
             | Char -> "Range", "rangeChar", args
             | Number(Decimal,_) -> "Range", "rangeDecimal", addStep args
-            | Number(BigInt,_) -> "Range", "rangeBigInt", addStep args
-            | Number(Int,_) -> "Range", "rangeBigInt", addStep args
+            | Number(BigInt,_)
+            | Number(Int32,_)
+            | Number(UInt32,_) -> "Range", "range_big_int", addStep args
+            | Number(Int64,_)
+            | Number(UInt64,_) -> "Range", "range_int64", addStep args
             | _ -> "Range", "rangeDouble", addStep args
 
         Helper.LibCall(com, modul, meth, t, args, i.SignatureArgTypes, ?loc = r)
@@ -1333,16 +1336,8 @@ let operators (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr o
         makeBinOp r t dividend divisor BinaryDivide
         |> Some
     | "Abs", _ ->
-        match args with
-        | ExprType(Number (Int64|Decimal as kind,_))::_ ->
-            let modName =
-                match kind with
-                | Decimal -> "decimal"
-                | _ -> "long"
-            Helper.LibCall(com, modName, "abs", t, args, i.SignatureArgTypes, ?thisArg=thisArg, ?loc=r) |> Some
-        | _ ->
-            Helper.GlobalCall("abs", t, args, [ t ], ?loc = r)
-            |> Some
+        Helper.GlobalCall("abs", t, args, [ t ], ?loc = r)
+        |> Some
     | "Acos", _
     | "Asin", _
     | "Atan", _

--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -1246,6 +1246,7 @@ let operators (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr o
             | Char -> "Range", "rangeChar", args
             | Number(Decimal,_) -> "Range", "rangeDecimal", addStep args
             | Number(BigInt,_) -> "Range", "rangeBigInt", addStep args
+            | Number(Int,_) -> "Range", "rangeBigInt", addStep args
             | _ -> "Range", "rangeDouble", addStep args
 
         Helper.LibCall(com, modul, meth, t, args, i.SignatureArgTypes, ?loc = r)

--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -4047,7 +4047,7 @@ let tryCall (com: ICompiler) (ctx: Context) r t (info: CallInfo) (thisArg: Expr 
 
 let tryBaseConstructor com ctx (ent: EntityRef) (argTypes: Lazy<Type list>) genArgs args =
     match ent.FullName with
-    | Types.exception_ -> Some(makeImportLib com Any "Exception" "Types", args)
+    | Types.exception_ -> Some(makeIdentExpr("Exception"), args)
     | Types.attribute -> Some(makeImportLib com Any "Attribute" "Types", args)
     | Types.dictionary ->
         let args =

--- a/src/fable-library-py/fable_library/decimal.py
+++ b/src/fable-library-py/fable_library/decimal.py
@@ -70,10 +70,6 @@ def equals(a: Decimal, b: Decimal) -> bool:
     return a == b
 
 
-def abs(a: Decimal) -> Decimal:
-    return builtins.abs(a)
-
-
 __all__ = [
     "equals",
     "try_parse",
@@ -83,5 +79,4 @@ __all__ = [
     "op_addition",
     "from_parts",
     "op_division",
-    "abs",
 ]

--- a/src/fable-library-py/fable_library/task_builder.py
+++ b/src/fable-library-py/fable_library/task_builder.py
@@ -75,7 +75,7 @@ class TaskBuilder:
     def Return(self, value: _T) -> Awaitable[_T]:
         ...
 
-    def Return(self, value: Optional[_T] = None) -> Awaitable[Optional[_T]]:
+    def Return(self, value: Any = None) -> Awaitable[Any]:
         return from_result(value)
 
     def ReturnFrom(self, computation: Awaitable[_T]) -> Awaitable[_T]:

--- a/src/fable-library-py/fable_library/types.py
+++ b/src/fable-library-py/fable_library/types.py
@@ -248,23 +248,6 @@ def to_string(x: Union_[Iterable[Any], Any], call_stack: int = 0) -> str:
     return str(x)
 
 
-class Exception(Exception):
-    def __init__(self, msg: str = "") -> None:
-        self.msg = msg
-
-    def __eq__(self, other: Any) -> bool:
-        if self is other:
-            return True
-
-        if other is None:
-            return False
-
-        return self.msg == other.msg
-
-    def __str__(self) -> str:
-        return self.msg
-
-
 class FSharpException(Exception, IComparable):
     def __init__(self) -> None:
         self.Data0: Any = None
@@ -397,7 +380,6 @@ def is_exception(x: Any):
 __all__ = [
     "Attribute",
     "Array",
-    "Exception",
     "is_exception",
     "char",
     "int8",


### PR DESCRIPTION
- Simplify code since the type annotation `Literal[None]` is the same as just `None`
- Fixes for async typing. Make generic values non-optional
- Fix for typing of tall-call args
- Also fix printing of 0-tuples