### PR TITLE
[Rust] Added small string type

### DIFF
--- a/src/fable-library-rust/Cargo.toml
+++ b/src/fable-library-rust/Cargo.toml
@@ -5,14 +5,15 @@ edition = "2021"
 
 [features]
 atomic = []
-no_std = ["dep:hashbrown"]
-threaded = ["atomic", "dep:futures"]
-guid = ["dep:uuid"]
-date = ["dep:chrono"]
 bigint = ["dep:num-bigint", "dep:num-integer", "dep:num-traits"]
+date = ["dep:chrono"]
 decimal = ["dep:rust_decimal"]
 default = ["guid", "date", "decimal", "bigint"]
+guid = ["dep:uuid"]
+no_std = ["dep:hashbrown"]
+small_string = []
 static_do_bindings = ["dep:startup"]
+threaded = ["atomic", "dep:futures"]
 
 [dependencies]
 startup = { version = "0.1.1", path = "vendored/startup", optional = true }

--- a/tests/Rust/tests/src/ApplicativeTests.fs
+++ b/tests/Rust/tests/src/ApplicativeTests.fs
@@ -1476,7 +1476,7 @@ module FSharpPlus =
             | Some f, Some x -> Some (f x)
             | _              -> None
 
-    module Array =
+    module Array_ =
         let apply f x =
             let lenf, lenx = Array.length f, Array.length x
             Array.init (lenf * lenx) (fun i -> f[i / lenx] x[i % lenx])
@@ -1499,7 +1499,7 @@ module FSharpPlus =
 
     type Apply =
         static member ``<*>`` (f: option<_>, x: option<'T>, _output: option<'U>, _mthd: Apply) = Option.apply f x : option<'U>
-        static member ``<*>`` (f: _ []     , x: 'T []     , _output: 'U []     , _mthd: Apply) = Array.apply  f x  : 'U []
+        static member ``<*>`` (f: _ []     , x: 'T []     , _output: 'U []     , _mthd: Apply) = Array_.apply f x  : 'U []
 
         static member inline Invoke (f: '``Applicative<'T -> 'U>``) (x: '``Applicative<'T>``) : '``Applicative<'U>`` =
             let inline call (mthd : ^M, input1: ^I1, input2: ^I2, output: ^R) =


### PR DESCRIPTION
- Eliminated some intermediate string allocations.
- Added an alternative string type (enabled with feature `small_string`).
