### PR TITLE
Added Double.Pow static

### DIFF
--- a/src/Fable.Transforms/Dart/Replacements.fs
+++ b/src/Fable.Transforms/Dart/Replacements.fs
@@ -1565,6 +1565,8 @@ let parseNum (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr op
             |> addWarning com ctx.InlinePath r
         let style = int System.Globalization.NumberStyles.Any
         parseCall meth str args style
+    | "Pow", _ ->
+        Helper.GlobalCall("Math", t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, memb="pow", ?loc=r) |> Some
     | "ToString", [ExprTypeAs(String, format)] ->
         let format = emitExpr r String [format] "'{0:' + $0 + '}'"
         Helper.LibCall(com, "String", "format", t, [format; thisArg.Value], [format.Type; thisArg.Value.Type], ?loc=r) |> Some

--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -2186,6 +2186,9 @@ let parseNum (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr op
 
         let style = int System.Globalization.NumberStyles.Any
         parseCall meth str args style
+    | "Pow", _ ->
+        Helper.ImportedCall("math", "pow", t, args, i.SignatureArgTypes, ?loc = r)
+        |> Some
     | "ToString", [ ExprTypeAs (String, format) ] ->
         let format = emitExpr r String [ format ] "'{0:' + $0 + '}'"
 

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -1783,6 +1783,8 @@ let parseNum (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr op
             |> addWarning com ctx.InlinePath r
         let style = int System.Globalization.NumberStyles.Any
         parseCall meth str args style
+    | "Pow", _ ->
+        Helper.GlobalCall("Math", t, args, i.SignatureArgTypes, memb="pow", ?loc=r) |> Some
     | "ToString", [ExprTypeAs(String, format)] ->
         let format = emitExpr r String [format] "'{0:' + $0 + '}'"
         Helper.LibCall(com, "String", "format", t, [format; thisArg.Value], [format.Type; thisArg.Value.Type], ?loc=r) |> Some

--- a/src/Fable.Transforms/Rust/Replacements.fs
+++ b/src/Fable.Transforms/Rust/Replacements.fs
@@ -1749,6 +1749,8 @@ let parseNum (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr op
             |> addWarning com ctx.InlinePath r
         let style = int System.Globalization.NumberStyles.Any
         parseCall meth str args style
+    | "Pow", (thisArg::restArgs) ->
+        makeInstanceCall r t i thisArg "powf" restArgs |> Some
     | "ToString", [ExprTypeAs(String, format)] ->
         let format = emitExpr r String [format] "'{0:' + $0 + '}'"
         Helper.LibCall(com, "String", "format", t, [format; thisArg.Value], [format.Type; thisArg.Value.Type], ?loc=r) |> Some


### PR DESCRIPTION
- Added `Double.Pow` static (as F#/.NET 7 seems to use that instead of `PowDouble`).