### PR TITLE
TEST: Parse projects as .csproj

### DIFF
--- a/src/Fable.Cli/Fable.Cli.fsproj
+++ b/src/Fable.Cli/Fable.Cli.fsproj
@@ -17,6 +17,7 @@
     <AssemblyName>fable</AssemblyName>
     <PackAsTool>true</PackAsTool>
     <Description>F# to JS compiler</Description>
+    <OtherFlags>$(OtherFlags) --nowarn:3536</OtherFlags>
   </PropertyGroup>
   <ItemGroup Condition="'$(Pack)' == 'true'">
     <Content Include="..\..\build\fable-library\**\*.*" PackagePath="fable-library\" />
@@ -36,6 +37,7 @@
     <Compile Include="Main.fs" />
     <Compile Include="Entry.fs" />
     <Content Include="RELEASE_NOTES.md" />
+    <Content Include="Properties\launchSettings.json" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Fable.Transforms\Fable.Transforms.fsproj" />
@@ -44,7 +46,7 @@
     <Reference Include="../../lib/fcs/FSharp.Core.dll" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Buildalyzer" Version="4.1.5" />
+    <PackageReference Include="Buildalyzer" Version="4.1.6" />
     <PackageReference Include="FSharp.SystemTextJson" Version="0.17.4" />
     <PackageReference Include="source-map-sharp" Version="1.0.8" />
   </ItemGroup>

--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -343,6 +343,9 @@ type ProjectCracked(cliArgs: CliArgs, crackerResponse: CrackerResponse, sourceFi
         // We display "parsed" because "cracked" may not be understood by users
         Log.always $"Project and references ({result.ProjectOptions.SourceFiles.Length} source files) parsed in %i{ms}ms{Log.newLine}"
         Log.verbose(lazy $"""F# PROJECT: %s{cliArgs.ProjectFileAsRelativePath}
+FABLE LIBRARY: {result.FableLibDir}
+OUTPUT TYPE: {result.OutputType}
+
     %s{result.ProjectOptions.OtherOptions |> String.concat $"{Log.newLine}    "}
     %s{result.ProjectOptions.SourceFiles |> String.concat $"{Log.newLine}    "}{Log.newLine}""")
 

--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -320,16 +320,8 @@ type ProjectCracked(cliArgs: CliArgs, crackerResponse: CrackerResponse, sourceFi
         let fableLibDir = Path.getRelativePath currentFile crackerResponse.FableLibDir
         let watchDependencies = if cliArgs.IsWatch then Some(HashSet()) else None
 
-        let common = Path.getCommonBaseDir([currentFile; crackerResponse.FableLibDir])
-        let outputType =
-            // Everything within the Fable hidden directory will be compiled as Library. We do this since the files there will be
-            // compiled as part of the main project which might be a program (Exe) or library (Library).
-            if common.EndsWith(Naming.fableModules) then
-                Some "Library"
-            else
-                crackerResponse.OutputType
-
-        CompilerImpl(currentFile, project, opts, fableLibDir, ?watchDependencies=watchDependencies, ?outDir=cliArgs.OutDir, ?outType=outputType)
+        CompilerImpl(currentFile, project, opts, fableLibDir, crackerResponse.OutputType,
+                     ?outDir=cliArgs.OutDir, ?watchDependencies=watchDependencies)
 
     member _.MapSourceFiles(f) =
         ProjectCracked(cliArgs, crackerResponse, Array.map f sourceFiles)
@@ -348,6 +340,13 @@ OUTPUT TYPE: {result.OutputType}
 
     %s{result.ProjectOptions.OtherOptions |> String.concat $"{Log.newLine}    "}
     %s{result.ProjectOptions.SourceFiles |> String.concat $"{Log.newLine}    "}{Log.newLine}""")
+
+        // If targeting Python, make sure users are not compiling the project as library by mistake
+        // (imports won't work when running the code)
+        match cliArgs.CompilerOptions.Language, result.OutputType with
+        | Python, OutputType.Library ->
+            Log.always "Compiling project as Library. If you intend to run the code directly, please set OutputType to Exe."
+        | _ -> ()
 
         let sourceFiles = result.ProjectOptions.SourceFiles |> Array.map File
         ProjectCracked(cliArgs, result, sourceFiles)

--- a/src/Fable.Cli/Pipeline.fs
+++ b/src/Fable.Cli/Pipeline.fs
@@ -153,7 +153,8 @@ module Python =
             | Some Py.Naming.sitePackages -> true
             | _ -> false
 
-
+        // Everything within the Fable hidden directory will be compiled as Library. We do this since the files there will be
+        // compiled as part of the main project which might be a program (Exe) or library (Library).
         let isLibrary = com.OutputType = OutputType.Library || Naming.isInFableModules com.CurrentFile
         let isFableLibrary = isLibrary && List.contains "FABLE_LIBRARY" com.Options.Define
 

--- a/src/Fable.Cli/ProjectCracker.fs
+++ b/src/Fable.Cli/ProjectCracker.fs
@@ -597,7 +597,6 @@ let getFableLibraryPath (opts: CrackerOptions) =
             |> File.tryFindNonEmptyDirectoryUpwards {| matches = [buildDir; "build/" + buildDir]; exclude = ["src"] |}
             |> Option.defaultWith (fun () -> Fable.FableError "Cannot find fable-library" |> raise)
 
-        Log.verbose(lazy ("fable-library: " + fableLibrarySource))
         let fableLibraryTarget = IO.Path.Combine(opts.FableModulesDir, libDir)
         // Always overwrite fable-library in case it has been updated, see #3208
         copyDir false fableLibrarySource fableLibraryTarget

--- a/src/Fable.Cli/ProjectCracker.fs
+++ b/src/Fable.Cli/ProjectCracker.fs
@@ -12,8 +12,6 @@ open Fable.AST
 open Globbing.Operators
 open Buildalyzer
 
-let [<Literal>] TARGET_FRAMEWORK = "net6.0"
-
 type FablePackage =
     { Id: string
       Version: string
@@ -33,7 +31,7 @@ type CacheInfo =
         OutDir: string option
         FableLibDir: string
         FableModulesDir: string
-        OutputType: string option
+        OutputType: OutputType
         Exclude: string list
         SourceMaps: bool
         SourceMapsRoot: string option
@@ -61,8 +59,13 @@ type CacheInfo =
         | Some other -> this.GetTimestamp() > other.GetTimestamp()
 
 type CrackerOptions(cliArgs: CliArgs) =
+    let projDir = IO.Path.GetDirectoryName cliArgs.ProjectFile
+    let targetFramework =
+        match Process.runSyncWithOutput projDir "dotnet" ["--version"] with
+        | Naming.StartsWith "7" _ -> "net7.0"
+        | _ -> "net6.0"
+    let fableModulesDir = CrackerOptions.GetFableModulesFromProject(projDir, cliArgs.OutDir, cliArgs.NoCache)
     let builtDlls = HashSet()
-    let fableModulesDir = CrackerOptions.GetFableModulesFromProject(cliArgs.ProjectFile, cliArgs.OutDir, cliArgs.NoCache)
     let cacheInfo =
         if cliArgs.NoCache then None
         else CacheInfo.TryRead(fableModulesDir, cliArgs.CompilerOptions.DebugMode)
@@ -74,6 +77,7 @@ type CrackerOptions(cliArgs: CliArgs) =
     member _.FableLib: string option = cliArgs.FableLibraryPath
     member _.OutDir: string option = cliArgs.OutDir
     member _.Configuration: string = cliArgs.Configuration
+    member _.TargetFramework = targetFramework
     member _.Exclude: string list = cliArgs.Exclude
     member _.Replace: Map<string, string> = cliArgs.Replace
     member _.PrecompiledLib: string option = cliArgs.PrecompiledLib
@@ -98,10 +102,10 @@ type CrackerOptions(cliArgs: CliArgs) =
         IO.Path.Combine(baseDir, Naming.fableModules)
         |> Path.normalizePath
 
-    static member GetFableModulesFromProject(projFile: string, outDir: string option, noCache: bool): string =
+    static member GetFableModulesFromProject(projDir: string, outDir: string option, noCache: bool): string =
         let fableModulesDir =
             outDir
-            |> Option.defaultWith (fun () -> IO.Path.GetDirectoryName(projFile))
+            |> Option.defaultWith (fun () -> projDir)
             |> CrackerOptions.GetFableModulesFromDir
 
         if noCache then
@@ -120,7 +124,7 @@ type CrackerResponse =
       FableModulesDir: string
       References: string list
       ProjectOptions: FSharpProjectOptions
-      OutputType: string option
+      OutputType: OutputType
       PrecompiledInfo: PrecompiledInfoImpl option
       CanReuseCompiledFiles: bool }
 
@@ -320,6 +324,8 @@ let private extractUsefulOptionsAndSources (line: string) (accSources: string li
         if line.StartsWith("--nowarn") || line.StartsWith("--warnon") then
             accSources, line::accOptions
         elif line.StartsWith("--define:") then
+            // When parsing the project as .csproj there will be multiple defines in the same line,
+            // but the F# compiler seems to accept only one per line
             let defines = line.Substring(9).Split(';') |> Array.mapToList (fun d -> "--define:" + d)
             accSources, defines @ accOptions
         else
@@ -409,7 +415,7 @@ let getProjectOptionsFromProjectFile =
                 let options = AnalyzerManagerOptions(LogWriter = log)
                 let m = AnalyzerManager(options)
                 m.SetGlobalProperty("Configuration", opts.Configuration)
-                m.SetGlobalProperty("TargetFramework", TARGET_FRAMEWORK)
+                m.SetGlobalProperty("TargetFramework", opts.TargetFramework)
                 for define in opts.FableOptions.Define do
                     m.SetGlobalProperty(define, "true")
                 manager <- Some m
@@ -428,6 +434,8 @@ let getProjectOptionsFromProjectFile =
                    ProjectReferences = result.ProjectReferences
                    Properties = result.Properties |})
 
+        // Because Buildalyzer works better with .csproj, we first "dress up" the project as if it were a C# one
+        // and try to adapt the results. If it doesn't work, we try again to analyze the .fsproj directly
         let csprojResult =
             let csprojFile = projFile.Replace(".fsproj", ".csproj")
             if IO.File.Exists(csprojFile) then
@@ -435,7 +443,7 @@ let getProjectOptionsFromProjectFile =
             else
                 try
                     System.IO.File.Copy(projFile, csprojFile)
-                    projFile.Replace(".fsproj", ".csproj")
+                    csprojFile
                     |> tryGetResult (fun r ->
                         // Careful, options for .csproj start with / but so do root paths in unix
                         let reg = System.Text.RegularExpressions.Regex(@"^\/[^\/]+?(:?:|$)")
@@ -478,7 +486,7 @@ let fullCrack (opts: CrackerOptions): CrackedFsproj =
         Process.runSync (IO.Path.GetDirectoryName opts.ProjFile) "dotnet" [
             "restore"
             IO.Path.GetFileName opts.ProjFile
-            $"-p:TargetFramework={TARGET_FRAMEWORK}"
+            $"-p:TargetFramework={opts.TargetFramework}"
             for constant in opts.FableOptions.Define do
                 $"-p:{constant}=true"
         ] |> ignore
@@ -486,14 +494,8 @@ let fullCrack (opts: CrackerOptions): CrackedFsproj =
     let projOpts, projRefs, msbuildProps =
         getProjectOptionsFromProjectFile opts opts.ProjFile
 
-    // let targetFramework =
-    //     match Map.tryFind "TargetFramework" msbuildProps with
-    //     | Some targetFramework -> targetFramework
-    //     | None -> failwithf "Cannot find TargetFramework for project %s" projFile
-
-    let outputType = ReadOnlyDictionary.tryFind "OutputType" msbuildProps
-
-    getCrackedFsproj opts projOpts projRefs outputType
+    ReadOnlyDictionary.tryFind "OutputType" msbuildProps
+    |> getCrackedFsproj opts projOpts projRefs
 
 /// For project references of main project, ignore dll and package references
 let easyCrack (opts: CrackerOptions) dllRefs (projFile: string): CrackedFsproj =
@@ -818,9 +820,12 @@ let getFullProjectOpts (opts: CrackerOptions) =
                 else Some("-r:" + r))
             |> Seq.toArray
 
-        let outputType = mainProj.OutputType
         let projRefs = projRefs |> List.map (fun p -> p.ProjectFile)
         let otherOptions = Array.append otherOptions dllRefs
+        let outputType =
+            match mainProj.OutputType with
+            | Some "Library" -> OutputType.Library
+            | _ -> OutputType.Exe
 
         let cacheInfo: CacheInfo =
             {

--- a/src/Fable.Cli/Util.fs
+++ b/src/Fable.Cli/Util.fs
@@ -334,7 +334,7 @@ module Process =
         IO.Path.GetFullPath(dir) + (if isWindows() then ";" else ":") + currentPath
 
     // Adapted from https://github.com/enricosada/dotnet-proj-info/blob/1e6d0521f7f333df7eff3148465f7df6191e0201/src/dotnet-proj/Program.fs#L155
-    let private startProcess (envVars: (string * string) list) workingDir exePath (args: string list) =
+    let private startProcess redirectOutput (envVars: (string * string) list) workingDir exePath (args: string list) =
         let exePath, args =
             if isWindows() then "cmd", "/C"::exePath::args
             else exePath, args
@@ -351,6 +351,7 @@ module Process =
         psi.WorkingDirectory <- workingDir
         psi.CreateNoWindow <- false
         psi.UseShellExecute <- false
+        psi.RedirectStandardOutput <- redirectOutput
 
         // TODO: Make this output no logs if we've set silent verbosity
         Process.Start(psi)
@@ -377,7 +378,7 @@ module Process =
         fun (workingDir: string) (exePath: string) (args: string list) ->
             try
                 runningProcess |> Option.iter kill
-                let p = startProcess envVars workingDir exePath args
+                let p = startProcess false envVars workingDir exePath args
                 runningProcess <- Some p
             with ex ->
                 Log.always("Cannot run: " + ex.Message)
@@ -387,7 +388,7 @@ module Process =
 
     let runSyncWithEnv envVars (workingDir: string) (exePath: string) (args: string list) =
         try
-            let p = startProcess envVars workingDir exePath args
+            let p = startProcess false envVars workingDir exePath args
             p.WaitForExit()
             p.ExitCode
         with ex ->
@@ -397,6 +398,11 @@ module Process =
 
     let runSync (workingDir: string) (exePath: string) (args: string list) =
         runSyncWithEnv [] workingDir exePath args
+
+    let runSyncWithOutput workingDir exePath args =
+        let p = startProcess true [] workingDir exePath args
+        p.WaitForExit()
+        p.StandardOutput.ReadToEnd()
 
 [<RequireQualifiedAccess>]
 module Async =

--- a/src/Fable.Cli/Util.fs
+++ b/src/Fable.Cli/Util.fs
@@ -248,6 +248,11 @@ module File =
     let isDirectoryEmpty dir =
         not(Directory.Exists(dir)) || Directory.EnumerateFileSystemEntries(dir) |> Seq.isEmpty
 
+    let safeDelete path =
+        try
+            File.Delete(path)
+        with _ -> ()
+
     let withLock (dir: string) (action: unit -> 'T) =
         let mutable fileCreated = false
         let lockFile = Path.Join(dir, "fable.lock")

--- a/src/Fable.Transforms/Fable.Transforms.fsproj
+++ b/src/Fable.Transforms/Fable.Transforms.fsproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <OtherFlags>$(OtherFlags) --nowarn:3536</OtherFlags>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Global/Babel.fs" />

--- a/src/Fable.Transforms/Global/Compiler.fs
+++ b/src/Fable.Transforms/Global/Compiler.fs
@@ -36,8 +36,6 @@ type Severity =
 type OutputType =
     | Library
     | Exe
-    | Module
-    | Winexe
 
 open FSharp.Compiler.Symbols
 open Fable.AST

--- a/src/Fable.Transforms/State.fs
+++ b/src/Fable.Transforms/State.fs
@@ -176,17 +176,12 @@ type Log =
 
 /// Type with utilities for compiling F# files to JS.
 /// Not thread-safe, an instance must be created per file
-type CompilerImpl(currentFile, project: Project, options, fableLibraryDir: string, ?outDir: string, ?outType: string,
+type CompilerImpl(currentFile, project: Project, options, fableLibDir: string, ?outType: OutputType, ?outDir: string,
                         ?watchDependencies: HashSet<string>, ?logs: ResizeArray<Log>, ?isPrecompilingInlineFunction: bool) =
 
+    let outType = defaultArg outType OutputType.Exe
     let logs = Option.defaultWith ResizeArray logs
-    let fableLibraryDir = fableLibraryDir.TrimEnd('/')
-    let outputType =
-        match outType with
-        | Some "Exe" -> OutputType.Exe
-        | Some "Module" -> OutputType.Module
-        | Some "Winexe" -> OutputType.Winexe
-        | _ -> OutputType.Library
+    let fableLibraryDir = fableLibDir.TrimEnd('/')
 
     member _.Logs = logs.ToArray()
     member _.WatchDependencies =
@@ -198,7 +193,7 @@ type CompilerImpl(currentFile, project: Project, options, fableLibraryDir: strin
         member _.LibraryDir = fableLibraryDir
         member _.CurrentFile = currentFile
         member _.OutputDir = outDir
-        member _.OutputType = outputType
+        member _.OutputType = outType
         member _.ProjectFile = project.ProjectFile
         member _.SourceFiles =  project.SourceFiles
 
@@ -211,7 +206,7 @@ type CompilerImpl(currentFile, project: Project, options, fableLibraryDir: strin
                     Path.Combine(Path.GetDirectoryName(currentFile), fableLibraryDir)
                 else fableLibraryDir
                 |> Path.getRelativeFileOrDirPath false file true
-            CompilerImpl(file, project, options, fableLibraryDir, ?outDir=outDir, ?outType=outType,
+            CompilerImpl(file, project, options, fableLibraryDir, outType, ?outDir=outDir,
                 ?watchDependencies=watchDependencies, logs=logs, isPrecompilingInlineFunction=true)
 
         member _.GetImplementationFile(fileName) =

--- a/src/fable-library-py/fable_library/Fable.Library.fsproj
+++ b/src/fable-library-py/fable_library/Fable.Library.fsproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <OutputType>Library</OutputType>
     <TargetFramework>netstandard2.0</TargetFramework>
     <DefineConstants>$(DefineConstants);FABLE_COMPILER</DefineConstants>
     <DefineConstants>$(DefineConstants);FX_NO_BIGINT</DefineConstants>

--- a/tests/Python/Fable.Tests.Python.fsproj
+++ b/tests/Python/Fable.Tests.Python.fsproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>


### PR DESCRIPTION
It just crossed my mind that project parsing is almost the same in F# and C#, but the latter is going to be usually better supported so, what if we parse the project as if it were a C# one and tweak the results? In this PR I just copy the .fsproj into a .csproj file, pass it to Buildalyzer and with a few adjustments it seems to work. One of the main differences is the F# compiler inserts FSharp.Core when it's not explicitly referenced, but this is already done when restoring.

Another important advantage is Buildalyzer can do a design-time build for C# projects which is much faster. For F# projects parsing takes as long as a normal build (I experienced the same with Dotnet.ProjInfo and Ionide.ProjInfo). 

All the build jobs are working except for Python. @dbrattli Could you please have a look at the logs? But if the error message doesn't ring a bell immediately don't worry and I'll try to debug the Python build and compare the compiler args when parsing .fsproj or (fake) .csproj.

What do you think? Looks like a viable option or is too hacky? cc @ncave