### PR TITLE
[Python] Handle static getters

### DIFF
--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -2046,7 +2046,10 @@ module Util =
                 $"Unexpected static interface/override call: %s{memb.FullName}"
                 |> attachRange r |> failwith
         let info = getAbstractMemberInfo com entity memb
-        if not info.isMangled && info.isGetter then
+
+        // Python do not support static getters, so we need to call the getter function
+        let pythonStaticGetter = com.Options.Language = Python && not memb.IsInstanceMember
+        if not info.isMangled && info.isGetter && not pythonStaticGetter then
             // Set the field as maybe calculated so it's not displaced by beta reduction
             let kind = Fable.FieldInfo.Create(
                 info.name,

--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -2047,9 +2047,9 @@ module Util =
                 |> attachRange r |> failwith
         let info = getAbstractMemberInfo com entity memb
 
-        // Python do not support static getters, so we need to call the getter function
-        let pythonStaticGetter = com.Options.Language = Python && not memb.IsInstanceMember
-        if not info.isMangled && info.isGetter && not pythonStaticGetter then
+        // Python do not support static getters, so we need to call a getter function instead
+        let isPythonStaticMember = com.Options.Language = Python && not memb.IsInstanceMember
+        if not info.isMangled && info.isGetter && not isPythonStaticMember then
             // Set the field as maybe calculated so it's not displaced by beta reduction
             let kind = Fable.FieldInfo.Create(
                 info.name,

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -3655,7 +3655,7 @@ module Util =
 
         let arguments =
             if isStatic then
-                args
+                { args with Args = [] }
             else
                 let self = Arg.arg "self"
                 { args with Args = self :: args.Args }

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -3660,18 +3660,9 @@ module Util =
                 let self = Arg.arg "self"
                 { args with Args = self :: args.Args }
 
-        // Python do not support static getters.
-        if isStatic && isGetter then
-            match body with
-            | [ Statement.Return { Value = Some x } ] ->
-                let ta, stmts = typeAnnotation com ctx None memb.Body.Type
-
-                stmts
-                @ [ Statement.assign (Expression.name key, ta, x) ]
-            | _ -> failwith "Statements not supported for static class properties"
-        else
-            Statement.functionDef (key, arguments, body = body, decoratorList = decorators, returns = returnType)
-            |> List.singleton
+        // Python do not support static getters, so make it a function instead
+        Statement.functionDef (key, arguments, body = body, decoratorList = decorators, returns = returnType)
+        |> List.singleton
 
     let transformAttachedMethod (com: IPythonCompiler) ctx (info: Fable.MemberFunctionOrValue) (memb: Fable.MemberDecl) =
         // printfn "transformAttachedMethod: %A" memb

--- a/tests/Python/TestMisc.fs
+++ b/tests/Python/TestMisc.fs
@@ -456,6 +456,13 @@ let sideEffect() = ()
 
 type Union_TestUnionTag = Union_TestUnionTag of int
 
+[<AttachMembers>]
+type FooWithAttachedMembers () =
+    member x.Bar = 42
+
+    static member Foo = FooWithAttachedMembers()
+
+
 #if FABLE_COMPILER
 
 [<Fact>]
@@ -1358,3 +1365,10 @@ let ``test Module mutable option values work`` () =
     Util.mutableValueOpt.Value |> equal 3
     Util.mutableValueOpt <- None
     Util.mutableValueOpt.IsNone |> equal true
+
+
+[<Fact>]
+let ``test attached static getters works`` () =
+
+    let result = FooWithAttachedMembers.Foo.Bar
+    result |> equal 42


### PR DESCRIPTION
Python do not support static getters (e.g for types with attached members) so rewrite to a static method instead. This fixes #3255