### PR TITLE
Fix #3274 and other features

### DIFF
--- a/src/Fable.Cli/Util.fs
+++ b/src/Fable.Cli/Util.fs
@@ -470,7 +470,7 @@ module Imports =
         let outDir = Path.normalizePath outDir
         // It may happen the importPath is already in outDir, for example package sources in fable_modules folder.
         // (Case insensitive comparison because in some Windows build servers paths can start with C:/ or c:/)
-        if importPath.StartsWith(outDir, StringComparison.OrdinalIgnoreCase) then importPath
+        if importPath.StartsWith(outDir + "/", StringComparison.OrdinalIgnoreCase) then importPath
         else
             let importDir = Path.GetDirectoryName(importPath)
             let targetDir = pathResolver.GetOrAddDeduplicateTargetDir(importDir, fun currentTargetDirs ->

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -1687,11 +1687,11 @@ let options isStruct (com: ICompiler) (_: Context) r (t: Type) (i: CallInfo) (th
     | "get_IsNone", Some c -> Test(c, OptionTest false, r) |> Some
     | _ -> None
 
-let optionModule (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (_: Expr option) (args: Expr list) =
+let optionModule isStruct (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (_: Expr option) (args: Expr list) =
     let toArray r t arg =
         Helper.LibCall(com, "Option", "toArray", Array(t, MutableArray), [arg], ?loc=r)
     match i.CompiledName, args with
-    | "None", _ -> NewOption(None, t, false) |> makeValue r |> Some
+    | "None", _ -> NewOption(None, t, isStruct) |> makeValue r |> Some
     | "GetValue", [c] ->
         Helper.LibCall(com, "Option", "value", t, args, ?loc=r) |> Some
     | ("OfObj" | "OfNullable"), _ ->
@@ -2900,7 +2900,8 @@ let private replacedModules =
     Types.option, options false
     Types.valueOption, options true
     "System.Nullable`1", nullables
-    "Microsoft.FSharp.Core.OptionModule", optionModule
+    "Microsoft.FSharp.Core.OptionModule", optionModule false
+    "Microsoft.FSharp.Core.ValueOption", optionModule true
     "Microsoft.FSharp.Core.ResultModule", results
     Types.bigint, bigints
     "Microsoft.FSharp.Core.NumericLiterals.NumericLiteralI", bigints

--- a/tests/Dart/src/OptionTests.fs
+++ b/tests/Dart/src/OptionTests.fs
@@ -74,8 +74,24 @@ let tests() =
         Option.isNone o2 |> equal false
         Option.isSome o2 |> equal true
 
+    testCase "ValueOption.isSome/isNone works" <| fun () ->
+        let o1: int voption = ValueNone
+        let o2 = ValueSome 5
+        ValueOption.isNone o1 |> equal true
+        ValueOption.isSome o1 |> equal false
+        ValueOption.isNone o2 |> equal false
+        ValueOption.isSome o2 |> equal true
+
     testCase "Option.IsSome/IsNone works" <| fun () ->
         let o1: int option = None
+        let o2 = Some 5
+        o1.IsNone |> equal true
+        o1.IsSome |> equal false
+        o2.IsNone |> equal false
+        o2.IsSome |> equal true
+
+    testCase "ValueOption.IsSome/IsNone works" <| fun () ->
+        let o1: int voption = ValueNone
         let o2 = Some 5
         o1.IsNone |> equal true
         o1.IsSome |> equal false

--- a/tests/Js/Main/OptionTests.fs
+++ b/tests/Js/Main/OptionTests.fs
@@ -80,8 +80,24 @@ let tests =
         Option.isNone o2 |> equal false
         Option.isSome o2 |> equal true
 
+    testCase "ValueOption.isSome/isNone works" <| fun () ->
+        let o1: int voption = ValueNone
+        let o2 = ValueSome 5
+        ValueOption.isNone o1 |> equal true
+        ValueOption.isSome o1 |> equal false
+        ValueOption.isNone o2 |> equal false
+        ValueOption.isSome o2 |> equal true
+
     testCase "Option.IsSome/IsNone works" <| fun () ->
         let o1 = None
+        let o2 = Some 5
+        o1.IsNone |> equal true
+        o1.IsSome |> equal false
+        o2.IsNone |> equal false
+        o2.IsSome |> equal true
+
+    testCase "ValueOption.IsSome/IsNone works" <| fun () ->
+        let o1: int voption = ValueNone
         let o2 = Some 5
         o1.IsNone |> equal true
         o1.IsSome |> equal false


### PR DESCRIPTION
1. Fix #3274: Output files are not put into outDir when this is a prefix of the project dir
2. Check `Condition` when manually parsing .fsproj in Fable packages. The condition is only evaluated if the property is one of the constants defined by Fable or user. Not sure if we will use this feature but I implemented it in case we decide to publish packages with [different files for each target language](https://github.com/fable-compiler/Fable/discussions/3219#discussion-4447898).
3. Support for `ValueOption` module
