### PR TITLE
Enable erase unions with tags

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -534,9 +534,8 @@ let testPython() =
         "--lang Python"
     ]
 
-    runInDir buildDir "poetry run pytest -x"
-    // Testing in Windows
-    // runInDir buildDir "python -m pytest -x"
+    if isWindows then runInDir buildDir "python3 -m pytest -x"
+    else runInDir buildDir "poetry run pytest -x"
 
 type RustTestMode =
     | SingleThreaded
@@ -764,7 +763,7 @@ match BUILD_ARGS_LOWER with
 | "test-integration"::_ -> testIntegration()
 | "test-repos"::_ -> testRepos()
 | ("test-ts"|"test-typescript")::_ -> testTypeScript()
-| "test-py"::_ -> testPython()
+| ("test-py"|"test-python")::_ -> testPython()
 | "test-rust"::_ -> testRust SingleThreaded
 | "test-rust-default"::_ -> testRust SingleThreaded
 | "test-rust-threaded"::_ -> testRust MultiThreaded

--- a/src/Fable.Core/Fable.Core.Types.fs
+++ b/src/Fable.Core/Fable.Core.Types.fs
@@ -29,6 +29,7 @@ type AttachMembersAttribute() =
 type EraseAttribute() =
     inherit Attribute()
     new (caseRules: CaseRules) = EraseAttribute()
+    new (tag: bool) = EraseAttribute()
 
 /// Used for "tagged" union types, which is commonly used in TypeScript.
 type TypeScriptTaggedUnionAttribute(tagName: string, caseRules: CaseRules) =

--- a/src/Fable.Core/Fable.Core.Util.fs
+++ b/src/Fable.Core/Fable.Core.Util.fs
@@ -39,12 +39,44 @@ module Testing =
 
 
 module Reflection =
-    let isUnion (x: obj): bool = nativeOnly
-    let isRecord (x: obj): bool = nativeOnly
+    open FSharp.Reflection
 
-    let getCaseTag (x: obj): int = nativeOnly
-    let getCaseName (x: obj): string = nativeOnly
-    let getCaseFields (x: obj): obj[] = nativeOnly
+    let isUnion (x: obj): bool =
+#if FABLE_COMPILER
+        nativeOnly
+#else
+        FSharpType.IsUnion(x.GetType())
+#endif
+
+    let isRecord (x: obj): bool =
+#if FABLE_COMPILER
+        nativeOnly
+#else
+        FSharpType.IsRecord(x.GetType())
+#endif
+
+    let getCaseTag (x: obj): int =
+#if FABLE_COMPILER
+        nativeOnly
+#else
+        let uci, _ = FSharpValue.GetUnionFields(x, x.GetType())
+        uci.Tag
+#endif
+
+    let getCaseName (x: obj): string =
+#if FABLE_COMPILER
+        nativeOnly
+#else
+        let uci, _ = FSharpValue.GetUnionFields(x, x.GetType())
+        uci.Name
+#endif
+
+    let getCaseFields (x: obj): obj[] =
+#if FABLE_COMPILER
+        nativeOnly
+#else
+        FSharpValue.GetUnionFields(x, x.GetType()) |> snd
+#endif
 
 module Compiler =
     /// Compiler full version as string

--- a/src/quicktest/QuickTest.fs
+++ b/src/quicktest/QuickTest.fs
@@ -78,3 +78,103 @@ let measureTime (f: unit -> unit): unit = emitJsStatement () """
 // to Fable.Tests project. For example:
 // testCase "Addition works" <| fun () ->
 //     2 + 2 |> equal 4
+
+[<Erase>]
+type MyRecord =
+    { Foo: int }
+
+let testMyRecord (r: MyRecord) =
+    r.Foo
+
+testMyRecord { Foo = 5 } |> printfn "%i"
+
+[<Erase(tag=true)>]
+type Foo =
+    | Foo of foo: string * bar: int
+    | Zas of ja: float
+
+let test = function
+    | Foo(foo, bar) -> String.replicate bar foo
+    | Zas f -> $"It is a float: %.2f{f}"
+
+Zas 5.67890 |> test |> printfn "%s"
+Foo("oh", 3) |> test |> printfn "%s"
+
+(*
+module TaggedUnion =
+    type Base<'Kind> =
+        abstract kind: 'Kind
+
+    type Foo<'Kind> =
+        inherit Base<'Kind>
+        abstract foo: string
+
+    type Bar<'Kind> =
+        inherit Base<'Kind>
+        abstract bar: int
+
+    type Baz<'Kind> =
+        inherit Base<'Kind>
+        abstract baz: bool
+
+    [<RequireQualifiedAccess; TypeScriptTaggedUnion("kind")>]
+    type StringTagged =
+        | Foo of Foo<string>
+        | Bar of Bar<string>
+        | [<CompiledName("_baz")>] Baz of Baz<string>
+
+    [<RequireQualifiedAccess; TypeScriptTaggedUnion("kind")>]
+    type NumberTagged =
+        | [<CompiledValue(0)>] Foo of Foo<int>
+        | [<CompiledValue(1.0)>] Bar of Bar<int>
+        | [<CompiledValue(2)>] Baz of Baz<int>
+
+    [<RequireQualifiedAccess; TypeScriptTaggedUnion("kind")>]
+    type BoolTagged =
+        | [<CompiledValue(true)>] Foo of Foo<bool>
+        | [<CompiledValue(false)>] Bar of Bar<bool>
+
+module Tests =
+    testCase "Case testing with TS tagged unions of string tags works" <| fun () ->
+        let describe = function
+            | TaggedUnion.StringTagged.Foo x -> sprintf "foo: %s" x.foo
+            | TaggedUnion.StringTagged.Bar x -> sprintf "bar: %d" x.bar
+            | TaggedUnion.StringTagged.Baz x -> sprintf "baz: %b" x.baz
+        TaggedUnion.StringTagged.Foo !!{| kind = "foo"; foo = "hello" |} |> describe |> equal "foo: hello"
+        TaggedUnion.StringTagged.Bar !!{| kind = "bar"; bar = 42 |} |> describe |> equal "bar: 42"
+        TaggedUnion.StringTagged.Baz !!{| kind = "_baz"; baz = false |} |> describe |> equal "baz: false"
+
+    testCase "Case testing with TS tagged unions of number tags works" <| fun () ->
+        let describe = function
+            | TaggedUnion.NumberTagged.Foo x -> sprintf "foo: %s" x.foo
+            | TaggedUnion.NumberTagged.Bar x -> sprintf "bar: %d" x.bar
+            | TaggedUnion.NumberTagged.Baz x -> sprintf "baz: %b" x.baz
+        TaggedUnion.NumberTagged.Foo !!{| kind = 0; foo = "hello" |} |> describe |> equal "foo: hello"
+        TaggedUnion.NumberTagged.Bar !!{| kind = 1.0; bar = 42 |} |> describe |> equal "bar: 42"
+        TaggedUnion.NumberTagged.Baz !!{| kind = 2; baz = false |} |> describe |> equal "baz: false"
+
+    testCase "Case testing with TS tagged unions of boolean tags works" <| fun () ->
+        let describe = function
+            | TaggedUnion.BoolTagged.Foo x -> sprintf "foo: %s" x.foo
+            | TaggedUnion.BoolTagged.Bar x -> sprintf "bar: %d" x.bar
+        TaggedUnion.BoolTagged.Foo !!{| kind = true; foo = "hello" |} |> describe |> equal "foo: hello"
+        TaggedUnion.BoolTagged.Bar !!{| kind = false; bar = 42 |} |> describe |> equal "bar: 42"
+
+    // testCase "Case testing with TS tagged unions of mixed type tags works" <| fun () ->
+    //     let describe = function
+    //         | TaggedUnion.MixedTagged.Foo x -> sprintf "foo: %s" x.foo
+    //         | TaggedUnion.MixedTagged.Bar x -> sprintf "bar: %d" x.bar
+    //         | TaggedUnion.MixedTagged.Baz x -> sprintf "baz: %b" x.baz
+    //     TaggedUnion.MixedTagged.Foo !!{| kind = 0; foo = "hello" |} |> describe |> equal "foo: hello"
+    //     TaggedUnion.MixedTagged.Bar !!{| kind = "bar"; bar = 42 |} |> describe |> equal "bar: 42"
+    //     TaggedUnion.MixedTagged.Baz !!{| kind = false; baz = false |} |> describe |> equal "baz: false"
+
+    // testCase "Case testing with TS tagged unions of enum tags works" <| fun () ->
+    //     let describe = function
+    //         | TaggedUnion.EnumTagged.Foo x -> sprintf "foo: %s" x.foo
+    //         | TaggedUnion.EnumTagged.Bar x -> sprintf "bar: %d" x.bar
+    //         | TaggedUnion.EnumTagged.Baz x -> sprintf "baz: %b" x.baz
+    //     TaggedUnion.EnumTagged.Foo !!{| kind = TaggedUnion.Kind.Foo; foo = "hello" |} |> describe |> equal "foo: hello"
+    //     TaggedUnion.EnumTagged.Bar !!{| kind = TaggedUnion.Kind.Bar; bar = 42 |} |> describe |> equal "bar: 42"
+    //     TaggedUnion.EnumTagged.Baz !!{| kind = TaggedUnion.Kind.Baz; baz = false |} |> describe |> equal "baz: false"
+*)

--- a/src/quicktest/QuickTest.fs
+++ b/src/quicktest/QuickTest.fs
@@ -79,9 +79,12 @@ let measureTime (f: unit -> unit): unit = emitJsStatement () """
 // testCase "Addition works" <| fun () ->
 //     2 + 2 |> equal 4
 
-[<Erase>]
+// [<Erase>]
 type MyRecord =
     { Foo: int }
+
+type MyRecord2 =
+    { Bar: MyRecord }
 
 let testMyRecord (r: MyRecord) =
     r.Foo
@@ -99,6 +102,18 @@ let test = function
 
 Zas 5.67890 |> test |> printfn "%s"
 Foo("oh", 3) |> test |> printfn "%s"
+
+[<Erase>]
+type WrappedNum = Num of int with
+    static member ( + ) (Num x, Num y) = 2 * (x + y) |> Num
+
+let add1 (x: WrappedNum) y = x + y
+
+let add2 (x: WrappedNum) y = x + Num y
+
+testCase "Can resolve custom operators on erased types" <| fun () -> // See #2915
+    add1 (Num 4) (Num 5) |> equal (Num 18)
+    add2 (Num 4) 5 |> equal (Num 18)
 
 (*
 module TaggedUnion =

--- a/tests/Js/Main/CustomOperatorsTests.fs
+++ b/tests/Js/Main/CustomOperatorsTests.fs
@@ -20,7 +20,19 @@ type CustomPow =
     { Ok: bool }
     static member Pow(x: CustomPow, n: int) = { Ok = true }
 
+[<Fable.Core.Erase>]
+type WrappedNum = Num of int with
+    static member ( + ) (Num x, Num y) = 2 * (x + y) |> Num
+
+let addWrapped1 (x: WrappedNum) y = x + y
+
+let addWrapped2 (x: WrappedNum) y = x + Num y
+
 let typeOperators = [
+    testCase "Can resolve custom operators on erased types" <| fun () -> // See #2915
+        addWrapped1 (Num 4) (Num 5) |> equal (Num 18)
+        addWrapped2 (Num 4) 5 |> equal (Num 18)
+
     testCase "Custom operators with types work" <| fun () ->
         let p1 = { x=5.; y=10. }
         let p2 = { x=2.; y=1. }

--- a/tests/Js/Main/OptionTests.fs
+++ b/tests/Js/Main/OptionTests.fs
@@ -80,8 +80,24 @@ let tests =
         Option.isNone o2 |> equal false
         Option.isSome o2 |> equal true
 
+    testCase "ValueOption.isSome/isNone works" <| fun () ->
+        let o1: int voption = ValueNone
+        let o2 = ValueSome 5
+        ValueOption.isNone o1 |> equal true
+        ValueOption.isSome o1 |> equal false
+        ValueOption.isNone o2 |> equal false
+        ValueOption.isSome o2 |> equal true
+
     testCase "Option.IsSome/IsNone works" <| fun () ->
         let o1 = None
+        let o2 = Some 5
+        o1.IsNone |> equal true
+        o1.IsSome |> equal false
+        o2.IsNone |> equal false
+        o2.IsSome |> equal true
+
+    testCase "ValueOption.IsSome/IsNone works" <| fun () ->
+        let o1: int voption = ValueNone
         let o2 = Some 5
         o1.IsNone |> equal true
         o1.IsSome |> equal false

--- a/tests/Rust/tests/src/InteropTests.fs
+++ b/tests/Rust/tests/src/InteropTests.fs
@@ -44,12 +44,12 @@ module Subs =
         let sin (x: float): float = nativeOnly
 
 module Performance =
-    [<Erase; Emit("std::time::Duration")>]
+    [<Emit("std::time::Duration")>]
     type Duration =
         abstract as_millis: unit -> uint64 // actually u128
         abstract as_secs_f64: unit -> float
 
-    [<Erase; Emit("std::time::Instant")>]
+    [<Emit("std::time::Instant")>]
     type Instant =
         abstract duration_since: Instant -> Duration
         abstract elapsed: unit -> Duration


### PR DESCRIPTION
1. Allow building records with `Erase` attribute, compiling them as plain JS objects
2. Likewise, remove the limitation of `Erase` unions where multiple cases with multiple were not allowed. For this, I introduced the `tag` argument 
3. Fix #2914: Don't exclude erased types from Fable.AST.

Features 1 and 2 basically make possible what we [already tried in the past](https://github.com/fable-compiler/Fable/pull/2279) as an opt-in.

The last feature is the trickiest one because several patterns were relying on erased types being `Any` in Fable.AST. I managed to fix it for JS/TypeScript but for other languages I'm still [outputting `Any`](https://github.com/fable-compiler/Fable/blob/fa97e0822ba0330e449ed8db4e59485760675faf/src/Fable.Transforms/FSharp2Fable.Util.fs#L1160-L1163) until the tests are fixed. Another thing to note is I'm [wrapping new erased unions with a type cast](https://github.com/fable-compiler/Fable/blob/fa97e0822ba0330e449ed8db4e59485760675faf/src/Fable.Transforms/FSharp2Fable.fs#L62-L63) so the type info is not lost.

@dbrattli If you need the info from erased types, please [add Python here](https://github.com/fable-compiler/Fable/blob/fa97e0822ba0330e449ed8db4e59485760675faf/src/Fable.Transforms/FSharp2Fable.Util.fs#L1160-L1163) and check which tests fail. @ncave Unfortunately I broke the Rust tests again 😞 could you please have a look?

> NOTE: This has been split from #3279. Some previous discussion [here](https://github.com/fable-compiler/Fable/pull/3279#issuecomment-1321121386).
