### PR TITLE
Fixed #3301

### DIFF
--- a/src/Fable.Transforms/FSharp2Fable.fs
+++ b/src/Fable.Transforms/FSharp2Fable.fs
@@ -594,7 +594,8 @@ let private transformExpr (com: IFableCompiler) (ctx: Context) fsExpr =
         // we replace with immutable bindings instead which generates better code
         // and increases the chances of the tuple being removed in beta reduction
         | FSharpExprPatterns.NewTuple(tupleType, tupleValues) as tupleExpr
-            when var.IsCompilerGenerated && var.CompiledName = "matchValue" ->
+            when var.IsCompilerGenerated &&
+                (var.CompiledName = "matchValue" || var.CompiledName = "patternInput") ->
 
             let! tupleValues = transformExprList com ctx tupleValues
 
@@ -845,8 +846,8 @@ let private transformExpr (com: IFableCompiler) (ctx: Context) fsExpr =
         let tupleElemValue =
             match tupleExpr with
             | FSharpExprPatterns.Value tupleIdent
-                    when tupleIdent.IsCompilerGenerated
-                    && tupleIdent.CompiledName = "matchValue" ->
+                when tupleIdent.IsCompilerGenerated &&
+                    (tupleIdent.CompiledName = "matchValue" || tupleIdent.CompiledName = "patternInput") ->
                 tryGetValueFromScope ctx tupleIdent
                 |> Option.bind (function
                     | Fable.Value(Fable.NewTuple(values,_),_) ->

--- a/src/Fable.Transforms/FableTransforms.fs
+++ b/src/Fable.Transforms/FableTransforms.fs
@@ -262,14 +262,12 @@ module private Transforms =
             let canEraseBinding =
                 match value with
                 | Import(i,_,_) -> i.IsCompilerGenerated
-                // Don't move local functions declared by user
-                | Lambda _ -> ident.IsCompilerGenerated && canInlineArg com ident.Name value letBody
-//                | NestedLambda lambdaBody ->
-//                    match lambdaBody with
-//                    | Import(i,_,_) -> i.IsCompilerGenerated
-//                    // Check the lambda doesn't reference itself recursively
-//                    | _ -> countReferences 0 ident.Name lambdaBody = 0
-//                           && canInlineArg com ident.Name value letBody
+                | NestedLambda(args, lambdaBody, name) ->
+                    match lambdaBody with
+                    | Import(i,_,_) -> i.IsCompilerGenerated
+                    // Check the lambda doesn't reference itself recursively
+                    | _ -> countReferences 0 ident.Name lambdaBody = 0
+                        && canInlineArg com ident.Name value letBody
                 | _ -> canInlineArg com ident.Name value letBody
             if canEraseBinding then
                 let value =

--- a/src/Fable.Transforms/FableTransforms.fs
+++ b/src/Fable.Transforms/FableTransforms.fs
@@ -262,10 +262,12 @@ module private Transforms =
             let canEraseBinding =
                 match value, com.Options.Language with
                 | Import(i,_,_), _ -> i.IsCompilerGenerated
-                // Don't move local functions declared by user
+                // Don't move local functions declared by user (Dart/Python only)
+                // TODO: remove this for Dart/Python when the next match is fixed
                 | Lambda _, (Dart|Python) ->
                     ident.IsCompilerGenerated && canInlineArg com ident.Name value letBody
-                // For now restricted to JS/TS/Rust // TODO: fix issues in Dart and Python tests
+                // Replace non-recursive lambda bindings (JS/TS/Rust only)
+                // TODO: fix issues with Dart/Python tests and enable for Dart/Python
                 | NestedLambda(args, lambdaBody, name), (JavaScript|TypeScript|Rust) ->
                     match lambdaBody with
                     | Import(i,_,_) -> i.IsCompilerGenerated


### PR DESCRIPTION
- Fixes #3301 issues with beta reduction.
- Beta reduction fix is causing some issues with `Dart/Python` tests, so for now is only enabled for `JS/TS/Rust`.