### PR TITLE
Fix list slice when indexes are out of bounds

### DIFF
--- a/src/fable-library-dart/List.fs
+++ b/src/fable-library-dart/List.fs
@@ -620,11 +620,14 @@ let truncate count (xs: 'T list) =
 
 let getSlice (startIndex: int option) (endIndex: int option) (xs: 'T list) =
     let len = length xs
-    let startIndex = defaultArg startIndex 0
-    let endIndex = defaultArg endIndex (len - 1)
-    if startIndex < 0 then invalidArg "startIndex" SR.indexOutOfBounds
-    elif endIndex >= len then invalidArg "endIndex" SR.indexOutOfBounds
-    elif endIndex < startIndex then List.Empty
+    let startIndex =
+        let index = defaultArg startIndex 0
+        if index < 0 then 0 else index
+    let endIndex =
+        let index = defaultArg endIndex (len - 1)
+        if index >= len then len - 1 else index
+
+    if endIndex < startIndex then List.Empty
     else xs |> skip startIndex |> take (endIndex - startIndex + 1)
 
 let splitAt index (xs: 'T list) =

--- a/src/fable-library/List.fs
+++ b/src/fable-library/List.fs
@@ -623,11 +623,14 @@ let truncate count (xs: 'T list) =
 
 let getSlice (startIndex: int option) (endIndex: int option) (xs: 'T list) =
     let len = length xs
-    let startIndex = defaultArg startIndex 0
-    let endIndex = defaultArg endIndex (len - 1)
-    if startIndex < 0 then invalidArg "startIndex" SR.indexOutOfBounds
-    elif endIndex >= len then invalidArg "endIndex" SR.indexOutOfBounds
-    elif endIndex < startIndex then List.Empty
+    let startIndex =
+        let index = defaultArg startIndex 0
+        if index < 0 then 0 else index
+    let endIndex =
+        let index = defaultArg endIndex (len - 1)
+        if index >= len then len - 1 else index
+
+    if endIndex < startIndex then List.Empty
     else xs |> skip startIndex |> take (endIndex - startIndex + 1)
 
 let splitAt index (xs: 'T list) =

--- a/tests/Dart/src/ListTests.fs
+++ b/tests/Dart/src/ListTests.fs
@@ -539,6 +539,9 @@ let tests() =
             xs.[2..] |> List.sum |> equal 7
             xs.[1..2] |> List.sum |> equal 5
             xs.[0..-1] |> List.sum |> equal 0
+            xs.[-1..-1] |> List.sum |> equal 0
+            xs.[-1..2] |> List.sum |> equal 6
+            xs.[0..5] |> List.sum |> equal 10
 
     testCase "List.truncate works" <| fun () ->
             [1..3] = (List.truncate 3 [1..5]) |> equal true

--- a/tests/Js/Main/ListTests.fs
+++ b/tests/Js/Main/ListTests.fs
@@ -546,6 +546,9 @@ let tests =
             xs.[2..] |> List.sum |> equal 7
             xs.[1..2] |> List.sum |> equal 5
             xs.[0..-1] |> List.sum |> equal 0
+            xs.[-1..-1] |> List.sum |> equal 0
+            xs.[-1..2] |> List.sum |> equal 6
+            xs.[0..5] |> List.sum |> equal 10
 
     testCase "List.truncate works" <| fun () ->
             [1..3] = (List.truncate 3 [1..5]) |> equal true

--- a/tests/Python/TestList.fs
+++ b/tests/Python/TestList.fs
@@ -637,6 +637,9 @@ let ``test List slice works`` () =
     xs.[2..] |> List.sum |> equal 7
     xs.[1..2] |> List.sum |> equal 5
     xs.[0..-1] |> List.sum |> equal 0
+    xs.[-1..-1] |> List.sum |> equal 0
+    xs.[-1..2] |> List.sum |> equal 6
+    xs.[0..5] |> List.sum |> equal 10
 
 [<Fact>]
 let ``test List.truncate works`` () =


### PR DESCRIPTION
Slicing should be tolerant and not throw exceptions. From: https://learn.microsoft.com/en-us/dotnet/fsharp/language-reference/slices. Fixes #3295

> C# developers may expect these to throw an exception rather than produce an empty slice. This is a design decision rooted in the fact that empty collections compose in F#. An empty F# list can be composed with another F# list, an empty string can be added to an existing string, and so on. It can be common to take slices based on values passed in as parameters, and being tolerant of out-of-bounds > by producing an empty collection fits with the compositional nature of F# code."