### PR TITLE
Added printAst flag

### DIFF
--- a/src/Fable.Cli/Entry.fs
+++ b/src/Fable.Cli/Entry.fs
@@ -77,6 +77,7 @@ let knownCliArgs() = [
 
   // Hidden args
   ["--precompiledLib"], []
+  ["--printAst"], []
   ["--noReflection"], []
   ["--noParallelTypeCheck"], []
   ["--typescript"], []
@@ -265,6 +266,7 @@ type Runner =
           IsWatch = watch
           Precompile = precompile
           PrecompiledLib = precompiledLib
+          PrintAst = args.FlagEnabled "--printAst"
           SourceMaps = args.FlagEnabled "-s" || args.FlagEnabled "--sourceMaps"
           SourceMapsRoot = args.Value "--sourceMapsRoot"
           NoRestore = args.FlagEnabled "--noRestore"

--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -457,6 +457,12 @@ and FableCompiler(projCracked: ProjectCracked, fableProj: Project, checker: Inte
                 | FSharpFileTypeChecked file ->
                     Log.verbose(lazy $"Type checked: {IO.Path.GetRelativePath(projCracked.CliArgs.RootDir, file.FileName)}")
 
+                    // Print F# AST to file
+                    if projCracked.CliArgs.PrintAst then
+                        let outPath = getOutPath projCracked.CliArgs state.PathResolver file.FileName
+                        let outDir = IO.Path.GetDirectoryName(outPath)
+                        Printers.printAst outDir [file]
+
                     // It seems when there's a pair .fsi/.fs the F# compiler gives the .fsi extension to the implementation file
                     let fileName = file.FileName |> Path.normalizePath |> Path.ensureFsExtension
                     let state =

--- a/src/Fable.Cli/Util.fs
+++ b/src/Fable.Cli/Util.fs
@@ -18,6 +18,7 @@ type CliArgs =
       IsWatch: bool
       Precompile: bool
       PrecompiledLib: string option
+      PrintAst: bool
       FableLibraryPath: string option
       Configuration: string
       NoRestore: bool

--- a/src/fable-compiler-js/src/app.fs
+++ b/src/fable-compiler-js/src/app.fs
@@ -199,11 +199,6 @@ let parseFiles projectFileName options =
     async {
         for fileName in fileNames do
 
-            // print F# AST
-            if options.printAst then
-                let fsAstStr = fable.FSharpAstToString(parseRes, fileName)
-                printfn "%s Typed AST: %s" fileName fsAstStr
-
             // transform F# AST to target language AST
             let res, ms2 = measureTime parseFable (parseRes, fileName)
             printfn "File: %s, Fable time: %d ms" fileName ms2
@@ -217,6 +212,12 @@ let parseFiles projectFileName options =
                 | Some outDir ->
                     let absPath = Imports.getTargetAbsolutePath getOrAddDeduplicateTargetDir fileName projDir outDir
                     Path.ChangeExtension(absPath, fileExt)
+
+            // print F# AST to file
+            if options.printAst then
+                let fsAstStr = fable.FSharpAstToString(parseRes, fileName)
+                let astPath = outPath |> Fable.Naming.replaceSuffix fileExt ".fs.ast"
+                writeAllText astPath fsAstStr
 
             // print target language AST to writer
             let writer = new SourceWriter(fileName, outPath, projDir, options, fileExt, getOrAddDeduplicateTargetDir)

--- a/src/fable-compiler-js/src/app.fs
+++ b/src/fable-compiler-js/src/app.fs
@@ -216,7 +216,7 @@ let parseFiles projectFileName options =
             // print F# AST to file
             if options.printAst then
                 let fsAstStr = fable.FSharpAstToString(parseRes, fileName)
-                let astPath = outPath |> Fable.Naming.replaceSuffix fileExt ".fs.ast"
+                let astPath = outPath.Substring(0, outPath.LastIndexOf(fileExt)) + ".fs.ast"
                 writeAllText astPath fsAstStr
 
             // print target language AST to writer

--- a/src/fable-standalone/src/Main.fs
+++ b/src/fable-standalone/src/Main.fs
@@ -131,7 +131,12 @@ let makeCompiler fableLibrary typedArrays language fsharpOptions project fileNam
         if x.StartsWith("--define:") || x.StartsWith("-d:")
         then x[(x.IndexOf(':') + 1)..] |> Some
         else None) |> Array.toList
-    let options = Fable.CompilerOptionsHelper.Make(language=language, define=define, ?typedArrays=typedArrays)
+    let debugMode = define |> List.contains "DEBUG"
+    let options = Fable.CompilerOptionsHelper.Make(
+        language = language,
+        define = define,
+        debugMode = debugMode,
+        ?typedArrays = typedArrays)
     CompilerImpl(fileName, project, options, fableLibrary)
 
 let makeProject (projectOptions: FSharpProjectOptions) (checkResults: FSharpCheckProjectResults) =

--- a/src/fable-standalone/test/bench-compiler/app.fs
+++ b/src/fable-standalone/test/bench-compiler/app.fs
@@ -183,11 +183,6 @@ let parseFiles projectFileName options =
     async {
         for fileName in fileNames do
 
-            // print F# AST
-            if options.printAst then
-                let fsAstStr = fable.FSharpAstToString(parseRes, fileName)
-                printfn "%s Typed AST: %s" fileName fsAstStr
-
             // transform F# AST to target language AST
             let res, ms2 = measureTime parseFable (parseRes, fileName)
             printfn "File: %s, Fable time: %d ms" fileName ms2
@@ -201,6 +196,12 @@ let parseFiles projectFileName options =
                 | Some outDir ->
                     let absPath = Imports.getTargetAbsolutePath getOrAddDeduplicateTargetDir fileName projDir outDir
                     Path.ChangeExtension(absPath, fileExt)
+
+            // print F# AST to file
+            if options.printAst then
+                let fsAstStr = fable.FSharpAstToString(parseRes, fileName)
+                let astPath = outPath |> Fable.Naming.replaceSuffix fileExt ".fs.ast"
+                writeAllText astPath fsAstStr
 
             // print target language AST to writer
             let writer = new SourceWriter(fileName, outPath, projDir, options, fileExt, getOrAddDeduplicateTargetDir)

--- a/src/fable-standalone/test/bench-compiler/app.fs
+++ b/src/fable-standalone/test/bench-compiler/app.fs
@@ -200,7 +200,7 @@ let parseFiles projectFileName options =
             // print F# AST to file
             if options.printAst then
                 let fsAstStr = fable.FSharpAstToString(parseRes, fileName)
-                let astPath = outPath |> Fable.Naming.replaceSuffix fileExt ".fs.ast"
+                let astPath = outPath.Substring(0, outPath.LastIndexOf(fileExt)) + ".fs.ast"
                 writeAllText astPath fsAstStr
 
             // print target language AST to writer

--- a/tests/Integration/Compiler/Util/Compiler.fs
+++ b/tests/Integration/Compiler/Util/Compiler.fs
@@ -45,6 +45,7 @@ module Compiler =
           IsWatch = false
           Precompile = false
           PrecompiledLib = None
+          PrintAst = false
           SourceMaps = false
           SourceMapsRoot = None
           NoRestore = false

--- a/tests/Js/Main/TailCallTests.fs
+++ b/tests/Js/Main/TailCallTests.fs
@@ -131,7 +131,6 @@ let tests =
     testCase "Tailcall works in tail position" <| fun () ->
         Issue3301.simple 100000 1 |> equal 100001
 
-    // TODO: temporary diabled until Fable-FCS issue is solved, see #3311
     testCase "Tailcall works with bindings" <| fun () ->
         Issue3301.binding 100000 1 |> equal 100001
 

--- a/tests/Js/Main/TailCallTests.fs
+++ b/tests/Js/Main/TailCallTests.fs
@@ -132,13 +132,11 @@ let tests =
         Issue3301.simple 100000 1 |> equal 100001
 
     // TODO: temporary diabled until Fable-FCS issue is solved, see #3311
-#if !FABLE_STANDALONE
     testCase "Tailcall works with bindings" <| fun () ->
         Issue3301.binding 100000 1 |> equal 100001
 
     testCase "Tailcall works with tuple deconstruction" <| fun () ->
         Issue3301.tupleDeconstruction 100000 1 |> equal 100001
-#endif
 
     testCase "Recursive functions can be tailcall optimized" <| fun () ->
         factorial1 1 10 |> equal 3628800


### PR DESCRIPTION
- Added `--printAst` (hidden) flag to save F# AST to file.
- Fixed #3311.