### PR TITLE
Address byref replacements and Babel optimization for const byrefs

### DIFF
--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -949,7 +949,6 @@ module Util =
     /// Wrap int expressions with `| 0` to help optimization of JS VMs
     let wrapIntExpression typ (e: Expression) =
         match e, typ with
-        | NewExpression(Expression.Identifier (Identifier("FSharpRef", _, _, _, _)), _, _, _), _
         | Literal(NumericLiteral(_)), _ -> e
         // TODO: Unsigned ints seem to cause problems, should we check only Int32 here?
         | _, Fable.Number((Int8 | Int16 | Int32),_) ->

--- a/src/Fable.Transforms/Replacements.Util.fs
+++ b/src/Fable.Transforms/Replacements.Util.fs
@@ -48,6 +48,10 @@ type Helper =
             | Some false | None -> None
         let info = CallInfo.Create(?thisArg=thisArg, args=args, ?sigArgTypes=argTypes, ?genArgs=genArgs, ?memberRef=memberRef, ?isCons=isConstructor)
         Call(callee, info, returnType, loc)
+        
+    static member FSharpRef(com, t, args, ?loc) =
+        let byrefType = DeclaredType({ FullName = Types.byref; Path = CoreAssemblyName "System" }, [ t ])
+        Helper.LibCall(com, "Types", "FSharpRef", byrefType, args, isConstructor=true, ?loc=loc)
 
     static member ImportedValue(com, coreModule: string, coreMember: string, returnType: Type) =
         makeImportUserGenerated None Any coreMember coreModule

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -76,7 +76,7 @@ let setRefCell com r (expr: Expr) (value: Expr) =
     setExpr r expr (makeStrConst "contents") value
 
 let makeRefCell com r typ (value: Expr) =
-    Helper.LibCall(com, "Types", "FSharpRef", typ, [value], isConstructor=true, ?loc=r)
+    Helper.FSharpRef(com, typ, [value], ?loc=r)
 
 let makeRefFromMutableValue com ctx r t (value: Expr) =
     let getter =
@@ -84,7 +84,7 @@ let makeRefFromMutableValue com ctx r t (value: Expr) =
     let setter =
         let v = makeUniqueIdent ctx t "v"
         Delegate([v], Set(value, ValueSet, t, IdentExpr v, None), None, Tags.empty)
-    Helper.LibCall(com, "Types", "FSharpRef", t, [getter; setter], isConstructor=true)
+    Helper.FSharpRef(com, t, [getter; setter])
 
 let makeRefFromMutableField com ctx r t callee key =
     let getter =
@@ -92,7 +92,7 @@ let makeRefFromMutableField com ctx r t callee key =
     let setter =
         let v = makeUniqueIdent ctx t "v"
         Delegate([v], Set(callee, FieldSet(key), t, IdentExpr v, r), None, Tags.empty)
-    Helper.LibCall(com, "Types", "FSharpRef", t, [getter; setter], isConstructor=true)
+    Helper.FSharpRef(com, t, [getter; setter])
 
 // Mutable and public module values are compiled as functions, because
 // values imported from ES2015 modules cannot be modified (see #986)
@@ -107,7 +107,7 @@ let makeRefFromMutableFunc com ctx r t (value: Expr) =
         let info = makeCallInfo None args [t; Boolean]
         let value = makeCall r Unit info value
         Delegate([v], value, None, Tags.empty)
-    Helper.LibCall(com, "Types", "FSharpRef", t, [getter; setter], isConstructor=true)
+    Helper.FSharpRef(com, t, [getter; setter])
 
 let toChar (arg: Expr) =
     match arg.Type with


### PR DESCRIPTION
Issue for context: https://github.com/fable-compiler/Fable/issues/3328

These changes are a proposed fix for the byref placement behavior when byrefs are converted into their contents in instances the byref should remain unchanged. This behavior is most noticeable for inline functions that take a byref parameter, as the inlined expression will create a variable of a byref type, which gets de-referenced into its contents when it's used.

There is also a second change to address the behavior where a const byref variable will be optimized with `| 0` in the F# -> Babel replacements, casting the byref to 0. @BillHally has also included some tests to verify the behavior of byrefs in the scenarios that caused errors

I've used a string literal for the match comparison in the second commit, and the first commit includes an indexed access into the GenericArguments array after isByRefValue succeeds. Please let me know if there's any changes you'd like to see to the fix such as the FSharpRef match done differently or if the GenericArgs access should check for the length first as an added safety
