### PR TITLE
TypeScript Array tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,8 @@
             "request": "launch",
             "preLaunchTask": "build",
             "program": "${workspaceFolder}/src/Fable.Cli/bin/Debug/net6.0/fable.dll",
-            "args": ["watch", "--cwd", "src/quicktest", "--exclude", "Fable.Core", "--noCache", "--runScript"],
+            // "args": ["watch", "--cwd", "src/quicktest", "--exclude", "Fable.Core", "--noCache", "--runScript"],
+            "args": ["src/fable-library", "--outDir", "build/fable-library-ts", "--fableLib", "build/fable-library-ts", "--lang", "TypeScript", "--typedArrays", "false", "--exclude", "Fable.Core", "--define", "FX_NO_BIGINT", "--define", "FABLE_LIBRARY"],
             "cwd": "${workspaceFolder}",
             "stopAtEntry": true,
             "console": "internalConsole"

--- a/build.fsx
+++ b/build.fsx
@@ -496,7 +496,7 @@ let testJs() =
     if envVarOrNone "CI" |> Option.isSome then
         testStandaloneFast()
 
-let testTypeScript() =
+let testTypeScript isWatch =
     buildLibraryTsIfNotExists()
 
     let projectDir = "tests/TypeScript"
@@ -505,20 +505,19 @@ let testTypeScript() =
 
     cleanDirs [buildDir; buildDir2]
 
-    runFableWithArgs projectDir [
+    copyFile (projectDir </> "tsconfig.json") (buildDir </> "tsconfig.json")
+
+    runFableWithArgsInDirAs (not isWatch) "." [
+        projectDir
         "--lang ts"
         "--outDir " + buildDir
         "--exclude Fable.Core"
+        if isWatch then
+            "--watch"
+            $"--runWatch npm run test-ts"
     ]
 
-    copyFile (projectDir </> "tsconfig.json") buildDir
-
-    runNpmScript "tsc" [
-        $"-p {buildDir}"
-        $"--outDir {buildDir2}"
-    ]
-
-    runMocha (buildDir2 </> "build/tests/TypeScript/")
+    runNpmScript "test-ts" []
 
 let testPython() =
     buildLibraryPyIfNotExists() // NOTE: fable-library-py needs to be built separately.
@@ -770,7 +769,8 @@ match BUILD_ARGS_LOWER with
 | "test-configs"::_ -> testProjectConfigs()
 | "test-integration"::_ -> testIntegration()
 | "test-repos"::_ -> testRepos()
-| ("test-ts"|"test-typescript")::_ -> testTypeScript()
+| ("test-ts"|"test-typescript")::_ -> testTypeScript(false)
+| ("watch-test-ts"|"watch-test-typescript")::_ -> testTypeScript(true)
 | "test-py"::_ -> testPython()
 | "test-rust"::_ -> testRust SingleThreaded
 | "test-rust-default"::_ -> testRust SingleThreaded

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "postbuild-compiler-js": "rollup build/fable-compiler-js/out/app.js --file src/fable-compiler-js/dist/app.js --format umd --name Fable",
     "minify-compiler-js": "terser src/fable-compiler-js/dist/app.js -o src/fable-compiler-js/dist/app.min.js --mangle --compress",
     "test-js": "node src/fable-compiler-js/dist/app.js tests/Main/Fable.Tests.fsproj build/tests-js",
-    "posttest-js": "mocha build/tests-js --reporter dot -t 10000"
+    "posttest-js": "mocha build/tests-js --reporter dot -t 10000",
+    "test-ts": "tsc -p build/tests/TypeScript --outDir build/tests/TypeScriptCompiled",
+    "posttest-ts": "mocha build/tests/TypeScriptCompiled/build/tests/TypeScript -reporter dot -t 10000"
   },
   "dependencies": {
     "@types/node": "^18.11.18",

--- a/src/Fable.Cli/Properties/launchSettings.json
+++ b/src/Fable.Cli/Properties/launchSettings.json
@@ -2,8 +2,8 @@
   "profiles": {
     "Fable.Cli": {
       "commandName": "Project",
-      "commandLineArgs": "src/quicktest-dart --lang dart --noCache --exclude Fable.Core",
-      "workingDirectory": "../../../../.."
+      "commandLineArgs": "src/fable-library --outDir build/fable-library-ts --fableLib build/fable-library-ts --lang TypeScript --typedArrays false --exclude Fable.Core --define FX_NO_BIGINT --define FABLE_LIBRARY",
+      "workingDirectory": "../.."
     }
   }
 }

--- a/src/Fable.PublishUtils/PublishUtils.fs
+++ b/src/Fable.PublishUtils/PublishUtils.fs
@@ -262,12 +262,14 @@ let copyDirRecursive (source: string) (target: string): unit =
 let copyFile (source: string) (target: string): unit =
     if IO.Directory.Exists source then
         failwith "Source is a directory, use copyDirRecursive"
+    if not (IO.File.Exists(source)) then
+        failwith "Source file does not exist"
     let target =
         if IO.Directory.Exists target then
             target </> filename source
-        else target
-    if not (IO.File.Exists(source)) then
-        failwith "Source file does not exist"
+        else
+            IO.Directory.CreateDirectory(IO.Path.GetDirectoryName(target))
+            target
     IO.File.Copy(source, target, true)
 
 let writeFile (filePath: string) (txt: string): unit =

--- a/src/Fable.Transforms/BabelPrinter.fs
+++ b/src/Fable.Transforms/BabelPrinter.fs
@@ -86,8 +86,6 @@ module PrinterExtensions =
 
         member printer.PrintOptional(item: Expression option, ?before: string) =
             printer.PrintOptional(item, (fun p i -> p.Print(i)), ?before=before)
-        member printer.PrintOptional(item: TypeParameterDeclaration option, ?before: string) =
-            printer.PrintOptional(item, (fun p i -> p.Print(i)), ?before=before)
         member printer.PrintOptional(item: TypeAnnotation option, ?before: string) =
             printer.PrintOptional(item, (fun p i -> p.Print(i)), ?before=before)
         member printer.PrintOptional(item: Identifier option, ?before: string) =
@@ -95,8 +93,6 @@ module PrinterExtensions =
         member printer.PrintOptional(item: Literal option, ?before: string) =
             printer.PrintOptional(item, (fun p i -> p.PrintLiteral(i)), ?before=before)
         member printer.PrintOptional(item: StringLiteral option, ?before: string) =
-            printer.PrintOptional(item, (fun p i -> p.Print(i)), ?before=before)
-        member printer.PrintOptional(item: TypeParameterInstantiation option, ?before: string) =
             printer.PrintOptional(item, (fun p i -> p.Print(i)), ?before=before)
         member printer.PrintOptional(item: Statement option, ?before: string) =
             printer.PrintOptional(item, (fun p i -> p.Print(i)), ?before=before)
@@ -115,21 +111,31 @@ module PrinterExtensions =
                 if i < items.Length - 1 then
                     printSeparator printer
 
-        member printer.PrintPatterns(items: Pattern array) =
+        member printer.PrintParameters(items: Parameter array, ?accessModifers: AccessModifier[]) =
+            let accessModifiers = defaultArg accessModifers [||]
             let len = items.Length
             let mutable i = 0
             let mutable foundNamed = false
 
-            let printPattern (p: Printer) (x: Pattern) =
-                if x.IsNamed && not foundNamed then
-                    p.Print("{ ")
+            let printParameter (printer: Printer) (Parameter.Parameter(name, isOptional, isNamed, isSpread, annotation)) =
+                if isNamed && not foundNamed then
+                    printer.Print("{ ")
                     foundNamed <- true
-                p.PrintPattern(x)
+                elif isSpread then
+                    printer.Print("...")
+
+                Array.tryItem i accessModifiers
+                |> printer.PrintAccessModifier
+
+                printer.Print(name)
+                if isOptional then printer.Print("?")
+                printer.PrintOptional(annotation, ": ")
+
                 i <- i + 1
                 if i = len && foundNamed then
-                    p.Print(" }")
+                    printer.Print(" }")
 
-            printer.PrintArray(items, printPattern, fun p -> p.Print(", "))
+            printer.PrintArray(items, printParameter, fun p -> p.Print(", "))
 
         member printer.PrintCommaSeparatedArray(items: ImportSpecifier array) =
             printer.PrintArray(items, (fun p x ->
@@ -155,19 +161,19 @@ module PrinterExtensions =
             printer.PrintArray(items, (fun p x -> p.Print(x)), (fun p -> p.Print(", ")))
 
         member printer.PrintClass(id: Identifier option,
-                                  superClass: Expression option,
-                                  typeParameters: TypeParameterDeclaration option,
+                                  superClass: SuperClass option,
+                                  typeParameters: TypeParameter[],
                                   implements: ClassImplements array option,
                                   members: ClassMember array,
                                   loc) =
             printer.Print("class", ?loc=loc)
             printer.PrintOptional(id, " ")
-            printer.PrintOptional(typeParameters)
-            match superClass with
-            | Some (Expression.Identifier(Identifier(typeAnnotation=Some(typeAnnotation)))) ->
-                printer.Print(" extends ")
-                printer.Print(typeAnnotation)
-            | _ -> printer.PrintOptional(superClass, " extends ")
+            printer.Print(typeParameters)
+            printer.PrintOptional(superClass, (fun p s ->
+                match s with
+                | SuperType item -> p.Print(item)
+                | SuperExpression item -> p.Print(item)
+            ), " extends ")
             // printer.PrintOptional(superTypeParameters)
             match implements with
             | Some implements when not (Array.isEmpty implements) ->
@@ -177,8 +183,8 @@ module PrinterExtensions =
             printer.Print(" ")
             printer.PrintBlock(members, (fun p x -> p.PrintClassMember(x)), (fun p -> p.PrintStatementSeparator()))
 
-        member printer.PrintFunction(id: Identifier option, parameters: Pattern array, body: BlockStatement,
-                typeParameters: TypeParameterDeclaration option, returnType: TypeAnnotation option, loc, ?isDeclaration, ?isArrow) =
+        member printer.PrintFunction(id: Identifier option, parameters: Parameter array, body: BlockStatement,
+                typeParameters: TypeParameter[], returnType: TypeAnnotation option, loc, ?isDeclaration, ?isArrow) =
 
             let (|ImmediatelyApplied|_|) = function
                 | CallExpression(callee, appliedArgs, _typeParameters, _) when parameters.Length = appliedArgs.Length ->
@@ -187,8 +193,7 @@ module PrinterExtensions =
                     | Expression.Identifier(_) ->
                         Array.zip parameters appliedArgs
                         |> Array.forall (function
-                            | Pattern.Identifier(Identifier(name=name1), None),
-                              Expression.Identifier(Identifier(name=name2)) -> name1 = name2
+                            | Parameter.Parameter(name=name1), Expression.Identifier(Identifier(name=name2)) -> name1 = name2
                             | _ -> false)
                         |> function true -> Some callee | false -> None
                     | _ -> None
@@ -204,9 +209,9 @@ module PrinterExtensions =
                 printer.Print(e)
             | _ when isArrow ->
                 // Remove parens if we only have one argument? (and no annotation)
-                printer.PrintOptional(typeParameters)
+                printer.Print(typeParameters)
                 printer.Print("(")
-                printer.PrintPatterns(parameters)
+                printer.PrintParameters(parameters)
                 printer.Print(")")
                 printer.PrintOptional(returnType, ": ")
                 printer.Print(" => ")
@@ -214,18 +219,18 @@ module PrinterExtensions =
                 | [| ReturnStatement(argument, _loc) |] ->
                     match argument with
                     | ObjectExpression(_) -> printer.WithParens(argument)
-                    | MemberExpression(object, property, computed, loc) ->
+                    | MemberExpression(object, property, isComputed, loc) ->
                         match object with
-                        | ObjectExpression(_) -> printer.PrintMemberExpression(object, property, computed, loc, objectWithParens=true)
+                        | ObjectExpression(_) -> printer.PrintMemberExpression(object, property, isComputed, loc, objectWithParens=true)
                         | _ -> printer.Print(argument)
                     | _ -> printer.ComplexExpressionWithParens(argument)
                 | _ -> printer.PrintBlock(body.Body, skipNewLineAtEnd=true)
             | _ ->
                 printer.Print("function ")
                 printer.PrintOptional(id)
-                printer.PrintOptional(typeParameters)
+                printer.Print(typeParameters)
                 printer.Print("(")
-                printer.PrintPatterns(parameters)
+                printer.PrintParameters(parameters)
                 printer.Print(")")
                 printer.PrintOptional(returnType, ": ")
                 printer.Print(" ")
@@ -351,28 +356,28 @@ module PrinterExtensions =
             | Literal(n) -> printer.PrintLiteral(n)
             | Undefined(loc) -> printer.Print("undefined", ?loc=loc)
             | Expression.Identifier(n) -> printer.PrintIdent(n)
-            | NewExpression(callee, args, typeParameters, loc) ->
-                printer.PrintNewExpression(callee, args, typeParameters, loc)
+            | NewExpression(callee, args, typeArguments, loc) ->
+                printer.PrintNewExpression(callee, args, typeArguments, loc)
             | SpreadElement(argument, loc) ->
                 printer.Print("...", ?loc = loc)
                 printer.ComplexExpressionWithParens(argument)
             | ThisExpression(loc) -> printer.Print("this", ?loc = loc)
-            | CallExpression(callee, args, typeParameters, loc) ->
-                printer.PrintCallExpression(callee, args, typeParameters, loc)
+            | CallExpression(callee, args, typeArguments, loc) ->
+                printer.PrintCallExpression(callee, args, typeArguments, loc)
             | EmitExpression(value, args, loc) ->
                 printer.PrintEmitExpression(value, args, loc)
             | ArrayExpression(elements, loc) ->
                 printer.Print("[", ?loc = loc)
                 printer.PrintCommaSeparatedArray(elements)
                 printer.Print("]")
-            | ClassExpression(body, id, superClass, implements, typeParameters, loc) ->
-                printer.PrintClass(id, superClass, typeParameters, implements, body, loc)
+            | ClassExpression(body, id, superClass, implements, typeArguments, loc) ->
+                printer.PrintClass(id, superClass, typeArguments, implements, body, loc)
             | Expression.ClassImplements(n) -> printer.Print(n)
             | UnaryExpression(argument, operator, loc) -> printer.PrintUnaryExpression(argument, operator, loc)
             | UpdateExpression(prefix, argument, operator, loc) -> printer.PrintUpdateExpression(prefix, argument, operator, loc)
             | ObjectExpression(properties, loc) -> printer.PrintObjectExpression(properties, loc)
             | BinaryExpression(left, right, operator, loc) ->  printer.PrintOperation(left, operator, right, loc)
-            | MemberExpression(object, property, computed, loc) -> printer.PrintMemberExpression(object, property, computed, loc)
+            | MemberExpression(object, property, isComputed, loc) -> printer.PrintMemberExpression(object, property, isComputed, loc)
             | LogicalExpression(left, operator, right, loc) -> printer.PrintOperation(left, operator, right, loc)
             | SequenceExpression(expressions, loc) ->
                 // A comma-separated sequence of expressions.
@@ -390,28 +395,12 @@ module PrinterExtensions =
                         if i < last then
                             printer.Print(", ")
                     printer.Print(")")
-            | FunctionExpression(id, parameters, body, typeParameters, returnType, loc) ->
-                printer.PrintFunction(id, parameters, body, returnType, typeParameters, loc)
             | AssignmentExpression(left, right, operator, loc) -> printer.PrintOperation(left, operator, right, loc)
             | ConditionalExpression(test, consequent, alternate, loc) -> printer.PrintConditionalExpression(test, consequent, alternate, loc)
+            | FunctionExpression(id, parameters, body, typeParameters, returnType, loc) ->
+                printer.PrintFunction(id, parameters, body, returnType, typeParameters, loc)
             | ArrowFunctionExpression(parameters, body, returnType, typeParameters, loc) ->
                 printer.PrintArrowFunctionExpression(parameters, body, returnType, typeParameters, loc)
-
-        member printer.PrintPattern(pattern: Pattern) =
-            match pattern with
-            | Pattern.Identifier(p, accessModifier) ->
-                printer.PrintOptional(accessModifier, fun p m ->
-                    p.PrintAccessModifier(m)
-                    p.Print(" "))
-                let (Identifier(name, optional, _named, typeAnnotation, loc)) = p
-                printer.Print(name, ?loc=loc)
-                if optional then
-                    printer.Print("?")
-                printer.PrintOptional(typeAnnotation, ": ")
-            // TODO: Should we try to destructure an array literal here?
-            | RestElement(argument) ->
-                printer.Print("...")
-                printer.PrintPattern(argument)
 
         member printer.PrintLiteral(literal: Literal) =
             match literal with
@@ -607,7 +596,7 @@ module PrinterExtensions =
                 printSegment printer value 0 value.Length
 
         member printer.PrintIdent(identifier: Identifier) =
-            let (Identifier(name, _optional, _named, _typeAnnotation, loc)) = identifier
+            let (Identifier(name, loc)) = identifier
             printer.Print(name, ?loc=loc)
 
         member printer.PrintRegExp(pattern, flags, loc) =
@@ -702,10 +691,11 @@ module PrinterExtensions =
 
 // Exceptions
         member printer.Print(node: CatchClause) =
-            let (CatchClause(param, body, loc)) = node
+            let (CatchClause(param, annotation, body, loc)) = node
             // "catch" is being printed by TryStatement
             printer.Print("(", ?loc = loc)
-            printer.PrintPattern(param)
+            printer.Print(param)
+            printer.PrintOptional(annotation, ": ")
             printer.Print(") ")
             printer.Print(body)
 
@@ -719,12 +709,21 @@ module PrinterExtensions =
 
         member printer.Print(node: VariableDeclaration) =
             let (VariableDeclaration(declarations, kind, loc)) = node
+            let kind =
+                match kind with
+                | Var -> "var"
+                | Let -> "let"
+                | Const -> "const"
             printer.Print(kind + " ", ?loc = loc)
             let canConflict = declarations.Length > 1
 
             for i = 0 to declarations.Length - 1 do
-                let (VariableDeclarator(id, init)) = declarations[i]
-                printer.PrintPattern(id)
+                let (VariableDeclarator(name, annotation, typeParams, init)) = declarations[i]
+                printer.Print(name)
+                printer.PrintOptional(annotation, (fun p a ->
+                    p.Print(typeParams)
+                    p.Print(a)
+                ), ": ")
 
                 match init with
                 | None -> ()
@@ -765,12 +764,12 @@ module PrinterExtensions =
 
         member printer.Print(node: ObjectMember) =
             match node with
-            | ObjectProperty(key, value, computed) -> printer.PrintObjectProperty(key, value, computed)
-            | ObjectMethod(kind, key, parameters, body, computed, returnType, typeParameters, loc)  ->
-                printer.PrintObjectMethod(kind, key, parameters, body, computed, returnType, typeParameters, loc)
+            | ObjectProperty(key, value, isComputed) -> printer.PrintObjectProperty(key, value, isComputed)
+            | ObjectMethod(kind, key, parameters, body, isComputed, returnType, typeParameters, loc)  ->
+                printer.PrintObjectMethod(kind, key, parameters, body, isComputed, returnType, typeParameters, loc)
 
-        member printer.PrintObjectProperty(key, value, computed) =
-            if computed then
+        member printer.PrintObjectProperty(key, value, isComputed) =
+            if isComputed then
                 printer.Print("[")
                 printer.Print(key)
                 printer.Print("]")
@@ -779,34 +778,36 @@ module PrinterExtensions =
             printer.Print(": ")
             printer.Print(value)
 
-        member printer.PrintObjectMethod(kind, key, parameters, body, computed, returnType, typeParameters, loc) =
+        member printer.PrintObjectMethod(kind, key, parameters, body, isComputed, returnType, typeParameters, loc) =
             printer.AddLocation(loc)
 
-            if kind <> "method" then
-                printer.Print(kind + " ")
+            match kind with
+            | ObjectGetter -> printer.Print("get ")
+            | ObjectSetter -> printer.Print("set ")
+            | ObjectMeth -> ()
 
-            if computed then
+            if isComputed then
                 printer.Print("[")
                 printer.Print(key)
                 printer.Print("]")
             else
                printer.Print(key)
 
-            printer.PrintOptional(typeParameters)
+            printer.Print(typeParameters)
             printer.Print("(")
-            printer.PrintPatterns(parameters)
+            printer.PrintParameters(parameters)
             printer.Print(")")
             printer.PrintOptional(returnType, ": ")
             printer.Print(" ")
 
             printer.PrintBlock(body.Body, skipNewLineAtEnd=true)
 
-        member printer.PrintMemberExpression(object, property, computed, loc, ?objectWithParens: bool) =
+        member printer.PrintMemberExpression(object, property, isComputed, loc, ?objectWithParens: bool) =
             printer.AddLocation(loc)
             match objectWithParens, object with
             | Some true, _ | _, Literal(NumericLiteral(_)) -> printer.WithParens(object)
             | _ -> printer.ComplexExpressionWithParens(object)
-            if computed then
+            if isComputed then
                 printer.Print("[")
                 printer.Print(property)
                 printer.Print("]")
@@ -843,18 +844,18 @@ module PrinterExtensions =
                 printer.Print(" : ")
                 printer.ComplexExpressionWithParens(alternate)
 
-        member printer.PrintCallExpression(callee, args, typeParameters, loc) =
+        member printer.PrintCallExpression(callee, args, typeArguments, loc) =
             printer.AddLocation(loc)
             printer.ComplexExpressionWithParens(callee)
-            printer.PrintOptional(typeParameters)
+            printer.Print(typeArguments)
             printer.Print("(")
             printer.PrintCommaSeparatedArray(args)
             printer.Print(")")
 
-        member printer.PrintNewExpression(callee, args, typeParameters, loc) =
+        member printer.PrintNewExpression(callee, args, typeArguments, loc) =
             printer.Print("new ", ?loc=loc)
             printer.ComplexExpressionWithParens(callee)
-            printer.PrintOptional(typeParameters)
+            printer.Print(typeArguments)
             printer.Print("(")
             printer.PrintCommaSeparatedArray(args)
             printer.Print(")")
@@ -877,33 +878,39 @@ module PrinterExtensions =
 
         member printer.PrintClassMember(memb: ClassMember) =
             match memb with
-            | ClassMethod(kind, key, parameters, body, computed, ``static``, ``abstract``, returnType, typeParameters, loc) ->
-                printer.PrintClassMethod(kind, key, parameters, body, computed, ``static``, ``abstract``, returnType, typeParameters, loc)
-            | ClassProperty(key, value, computed, ``static``, optional, typeAnnotation, accessModifier, loc) ->
-                printer.PrintClassProperty(key, value, computed, ``static``, optional, typeAnnotation, accessModifier, loc)
+            | ClassMethod(kind, parameters, body, isStatic, isAbstract, returnType, typeParameters, loc) ->
+                printer.PrintClassMethod(kind, parameters, body, isStatic=isStatic, isAbstract=isAbstract, returnType=returnType, typeParameters=typeParameters, loc=loc)
+            | ClassProperty(key, value, isComputed, isStatic, isOptional, typeAnnotation, accessModifier, loc) ->
+                printer.PrintClassProperty(key, value, isComputed, isStatic=isStatic, isOptional=isOptional, typeAnnotation=typeAnnotation, accessModifier=accessModifier, loc=loc)
 
-        member printer.PrintClassMethod(kind, key, parameters, body, computed, ``static``, ``abstract``, returnType, typeParameters, loc) =
+        member printer.PrintClassMethod(kind, parameters, body, isStatic, isAbstract, returnType, typeParameters, loc) =
             printer.AddLocation(loc)
 
-            let keywords = [
-                if ``static`` = Some true then yield "static"
-                if ``abstract`` = Some true then yield "abstract"
-                if kind = "get" || kind = "set" then yield kind
-            ]
+            if isStatic then printer.Print("static ")
+            if isAbstract then printer.Print("abstract ")
+            match kind with
+            | ClassSetter _ -> printer.Print("set ")
+            | ClassGetter _ -> printer.Print("get ")
+            | ClassPrimaryConstructor _ | ClassFunction _ -> ()
 
-            if not (List.isEmpty keywords) then
-                printer.Print((String.concat " " keywords) + " ")
+            let key, isComputed, accessModifiers =
+                match kind with
+                | ClassSetter(key, isComputed)
+                | ClassGetter(key, isComputed)
+                | ClassFunction(key, isComputed) -> key, isComputed, [||]
+                | ClassPrimaryConstructor accessModifiers ->
+                    Expression.stringLiteral("constructor"), false, accessModifiers
 
-            if computed then
+            if isComputed then
                 printer.Print("[")
                 printer.Print(key)
                 printer.Print("]")
             else
                 printer.Print(key)
 
-            printer.PrintOptional(typeParameters)
+            printer.Print(typeParameters)
             printer.Print("(")
-            printer.PrintPatterns(parameters)
+            printer.PrintParameters(parameters, accessModifiers)
             printer.Print(")")
             printer.PrintOptional(returnType, ": ")
             printer.Print(" ")
@@ -911,25 +918,24 @@ module PrinterExtensions =
             printer.Print(body)
 
         member printer.PrintAccessModifier = function
-            | Public -> printer.Print("public")
-            | Private -> printer.Print("private")
-            | Protected -> printer.Print("protected")
-            | Readonly -> printer.Print("readonly")
+            | None -> ()
+            | Some Public -> printer.Print("public ")
+            | Some Private -> printer.Print("private ")
+            | Some Protected -> printer.Print("protected ")
+            | Some Readonly -> printer.Print("readonly ")
 
-        member printer.PrintClassProperty(key, value, computed, ``static``, optional, typeAnnotation, accessModifier, loc) =
+        member printer.PrintClassProperty(key, value, isComputed, isStatic, isOptional, typeAnnotation, accessModifier, loc) =
             printer.AddLocation(loc)
-            if ``static`` then
+            if isStatic then
                 printer.Print("static ")
-            printer.PrintOptional(accessModifier, fun p m ->
-                p.PrintAccessModifier(m)
-                p.Print(" "))
-            if computed then
+            printer.PrintAccessModifier(accessModifier)
+            if isComputed then
                 printer.Print("[")
                 printer.Print(key)
                 printer.Print("]")
             else
                 printer.Print(key)
-            if optional then
+            if isOptional then
                 printer.Print("?")
             printer.PrintOptional(typeAnnotation, ": ")
             printer.PrintOptional(value, " = ")
@@ -937,7 +943,7 @@ module PrinterExtensions =
         member printer.Print(node: ClassImplements) =
             let (ClassImplements(id, typeParameters)) = node
             printer.PrintIdent(id)
-            printer.PrintOptional(typeParameters)
+            printer.Print(typeParameters)
 
         member printer.PrintImportMemberSpecific(local, imported) =
             // Don't print the braces, node will be done in the import declaration
@@ -1007,8 +1013,8 @@ module PrinterExtensions =
                 printer.Print("]")
             | UnionTypeAnnotation(types) ->
                 printer.PrintArray(types, (fun p x -> p.Print(x)), (fun p -> p.Print(" | ")))
-            | FunctionTypeAnnotation(parameters, returnType, typeParameters, rest) ->
-                printer.PrintFunctionTypeAnnotation(parameters, returnType, typeParameters, rest)
+            | FunctionTypeAnnotation(parameters, returnType, spread) ->
+                printer.PrintFunctionTypeAnnotation(parameters, returnType, ?spread=spread)
             | NullableTypeAnnotation(typeAnnotation) ->
                 printer.Print("?")
                 printer.Print(typeAnnotation)
@@ -1032,50 +1038,54 @@ module PrinterExtensions =
             printer.PrintOptional(bound, " extends ")
             // printer.PrintOptional(``default``)
 
-        member printer.Print(parameters: TypeParameterDeclaration) =
+        member printer.Print(parameters: TypeParameter[]) =
             if parameters.Length > 0 then
                 printer.Print("<")
                 printer.PrintCommaSeparatedArray(parameters)
                 printer.Print(">")
 
-        member printer.Print(parameters: TypeParameterInstantiation) =
+        member printer.Print(parameters: TypeAnnotation[]) =
             if parameters.Length > 0 then
                 printer.Print("<")
                 printer.PrintCommaSeparatedArray(parameters)
                 printer.Print(">")
 
         member printer.Print(node: FunctionTypeParam) =
-            let (FunctionTypeParam(name, typeAnnotation, optional)) = node
+            let (FunctionTypeParam(name, typeAnnotation, isOptional)) = node
             printer.PrintIdent(name)
-            if optional = Some true then
+            if isOptional then
                 printer.Print("?")
             printer.Print(": ")
             printer.Print(typeAnnotation)
 
-        member printer.PrintFunctionTypeAnnotation(parameters, returnType, typeParameters, rest) =
+        member printer.PrintFunctionTypeAnnotation(parameters, returnType, ?typeParameters, ?spread) =
+            let typeParameters = defaultArg typeParameters [||]
             printer.Print(typeParameters)
-            printer.Print("(")
+            printer.Print("((")
             printer.PrintCommaSeparatedArray(parameters)
-            if Option.isSome rest then
+            match spread with
+            | Some spread ->
                 printer.Print("...")
-                printer.Print(rest.Value)
+                printer.Print(spread)
+            | None -> ()
             printer.Print(") => ")
             printer.Print(returnType)
+            printer.Print(")")
 
         member printer.Print(node: ObjectTypeProperty) =
-            let (ObjectTypeProperty(key, value, kind, computed, ``static``, optional, _proto, _method)) = node
+            let (ObjectTypeProperty(key, value, kind, isComputed, isStatic, isOptional, _proto, _method)) = node
 
-            if ``static`` then
+            if isStatic then
                 printer.Print("static ")
             if Option.isSome kind then
                 printer.Print(kind.Value + " ")
-            if computed then
+            if isComputed then
                 printer.Print("[")
                 printer.Print(key)
                 printer.Print("]")
             else
                 printer.Print(key)
-            if optional then
+            if isOptional then
                 printer.Print("?")
             // TODO: proto, method
             printer.Print(": ")
@@ -1099,12 +1109,12 @@ module PrinterExtensions =
         member printer.Print(node: InterfaceExtends) =
             let (InterfaceExtends(id, typeParameters)) = node
             printer.PrintIdent(id)
-            printer.PrintOptional(typeParameters)
+            printer.Print(typeParameters)
 
         member printer.PrintInterfaceDeclaration(id, body, extends, implements, typeParameters) =
             printer.Print("interface ")
             printer.PrintIdent(id)
-            printer.PrintOptional(typeParameters)
+            printer.Print(typeParameters)
 
             if not (Array.isEmpty extends) then
                 printer.Print(" extends ")

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -38,7 +38,6 @@ type Context =
     HoistVars: Fable.Ident list -> bool
     TailCallOpportunity: ITailCallOpportunity option
     OptimizeTailCall: unit -> unit
-    IsParamType: bool
     ScopedTypeParams: Set<string> }
 
 type IBabelCompiler =
@@ -48,15 +47,15 @@ type IBabelCompiler =
     abstract TransformAsExpr: Context * Fable.Expr -> Expression
     abstract TransformAsStatements: Context * ReturnStrategy option * Fable.Expr -> Statement array
     abstract TransformImport: Context * selector:string * path:string -> Expression
-    abstract TransformFunction: Context * string option * Fable.Ident list * Fable.Expr -> (Pattern array) * BlockStatement
+    abstract TransformFunction: Context * string option * Fable.Ident list * Fable.Expr -> (Parameter array) * BlockStatement
     abstract WarnOnlyOnce: string * ?range: SourceLocation -> unit
 
 module Lib =
 
     let libCall (com: IBabelCompiler) ctx r moduleName memberName genArgs args =
-        let typeParamInst = Annotation.makeTypeParamInstantiationIfTypeScript com ctx genArgs
+        let typeArguments = Annotation.makeTypeParamInstantiationIfTypeScript com ctx genArgs
         let callee = com.TransformImport(ctx, memberName, getLibPath com moduleName)
-        Expression.callExpression(callee, List.toArray args, ?typeParameters=typeParamInst, ?loc=r)
+        Expression.callExpression(callee, List.toArray args, ?typeArguments=typeArguments, ?loc=r)
 
     let libValue (com: IBabelCompiler) ctx moduleName memberName =
         com.TransformImport(ctx, memberName, getLibPath com moduleName)
@@ -375,14 +374,12 @@ module Annotation =
         | _ -> false
 
     let makeTypeParamDecl (_com: IBabelCompiler) (ctx: Context) genArgs =
-        if ctx.IsParamType then [||]
-        else
-            // TODO: Keep inheritance constraint
-            // Maybe there's a way to represent measurements in TypeScript
-            genArgs |> List.chooseToArray (function
-                | Fable.GenericParam(name, isMeasure, _constraints) when not isMeasure ->
-                    TypeParameter.typeParameter(name) |> Some
-                | _ -> None)
+        // TODO: Keep inheritance constraint
+        // Maybe there's a way to represent measurements in TypeScript
+        genArgs |> List.chooseToArray (function
+            | Fable.GenericParam(name, isMeasure, _constraints) when not isMeasure ->
+                TypeParameter.typeParameter(name) |> Some
+            | _ -> None)
 
     let makeTypeParamInstantiation (com: IBabelCompiler) ctx genArgs =
         genArgs |> List.chooseToArray (function
@@ -399,7 +396,7 @@ module Annotation =
 
     let getGenericTypeAnnotation com ctx name genArgs =
         let typeParamInst = makeTypeParamInstantiation com ctx genArgs
-        TypeAnnotation.aliasTypeAnnotation(Identifier.identifier(name), typeParameters=typeParamInst)
+        TypeAnnotation.aliasTypeAnnotation(Identifier.identifier(name), typeArguments=typeParamInst)
 
     let makeTypeAnnotation com ctx typ: TypeAnnotation =
         match typ with
@@ -410,7 +407,7 @@ module Annotation =
         | Fable.Boolean -> BooleanTypeAnnotation
         | Fable.Char -> StringTypeAnnotation
         | Fable.String -> StringTypeAnnotation
-        | Fable.Regex -> makeSimpleTypeAnnotation com ctx "RegExp"
+        | Fable.Regex -> makeAliasTypeAnnotation com ctx "RegExp"
         | Fable.Number(Int64,_) -> makeImportTypeAnnotation com ctx [] "Long" "int64"
         | Fable.Number(UInt64,_) -> makeImportTypeAnnotation com ctx [] "Long" "uint64"
         | Fable.Number(Decimal,_) -> makeImportTypeAnnotation com ctx [] "Decimal" "decimal"
@@ -420,7 +417,7 @@ module Annotation =
         | Fable.Tuple(genArgs,_) -> makeTupleTypeAnnotation com ctx genArgs
         | Fable.Array(genArg, kind) -> makeArrayTypeAnnotation com ctx genArg kind
         | Fable.List genArg -> makeListTypeAnnotation com ctx genArg
-        | Fable.GenericParam(name=name) -> makeSimpleTypeAnnotation com ctx name
+        | Fable.GenericParam(name=name) -> makeAliasTypeAnnotation com ctx name
         | Fable.LambdaType(argType, returnType) ->
             ([argType], returnType)
             ||> FableTransforms.uncurryLambdaType
@@ -436,12 +433,38 @@ module Annotation =
             let ent = com.GetEntity(entRef)
             makeEntityTypeAnnotation com ctx ent genArgs
 
-    let makeSimpleTypeAnnotation _com _ctx name =
+    let makeTypeAnnotationIfTypeScript (com: IBabelCompiler) ctx typ expr =
+        if com.Options.Language = TypeScript then
+            match expr with
+            // Use type annotation for NullLiteral and enum cases
+            | Some(Literal(Literal.StringLiteral _))
+            | Some(Literal(StringTemplate _))
+            | Some(Literal(BooleanLiteral _))
+            | Some(Literal(NumericLiteral _))
+            | Some(Literal(RegExp _))
+            | Some(FunctionExpression _)
+            | Some(ArrowFunctionExpression _) -> None
+            | _ -> makeTypeAnnotation com ctx typ |> Some
+        else None
+
+    let makeTypeAnnotationWithParametersIfTypeScript (com: IBabelCompiler) ctx typ expr =
+        match makeTypeAnnotationIfTypeScript com ctx typ expr with
+        | Some(FunctionTypeAnnotation _) as annotation ->
+            let _, typeParams =
+                match typ with
+                | Fable.LambdaType(argType, returnType) -> [argType; returnType]
+                | Fable.DelegateType(argTypes, returnType) -> argTypes @ [returnType]
+                | _ -> []
+                |> Util.getTypeParameters ctx
+            annotation, makeTypeParamDecl com ctx typeParams
+        | annotation -> annotation, [||]
+
+    let makeAliasTypeAnnotation _com _ctx name =
         TypeAnnotation.aliasTypeAnnotation(Identifier.identifier(name))
 
     let makeGenericTypeAnnotation com ctx genArgs id =
         let typeParamInst = makeTypeParamInstantiation com ctx genArgs
-        TypeAnnotation.aliasTypeAnnotation(id, typeParameters=typeParamInst)
+        TypeAnnotation.aliasTypeAnnotation(id, typeArguments=typeParamInst)
 
     let makeNativeTypeAnnotation com ctx genArgs typeName =
         Identifier.identifier(typeName)
@@ -474,7 +497,7 @@ module Annotation =
     let makeArrayTypeAnnotation com ctx genArg kind =
         match genArg with
         | JS.Replacements.TypedArrayCompatible com kind name ->
-            makeSimpleTypeAnnotation com ctx name
+            makeAliasTypeAnnotation com ctx name
         | _ ->
             // makeNativeTypeAnnotation com ctx [genArg] "Array"
             makeTypeAnnotation com ctx genArg |> ArrayTypeAnnotation
@@ -490,9 +513,9 @@ module Annotation =
         match kind with
         | Replacements.Util.BclGuid -> StringTypeAnnotation
         | Replacements.Util.BclTimeSpan -> NumberTypeAnnotation
-        | Replacements.Util.BclDateTime -> makeSimpleTypeAnnotation com ctx "Date"
-        | Replacements.Util.BclDateTimeOffset -> makeSimpleTypeAnnotation com ctx "Date"
-        | Replacements.Util.BclDateOnly -> makeSimpleTypeAnnotation com ctx "Date"
+        | Replacements.Util.BclDateTime -> makeAliasTypeAnnotation com ctx "Date"
+        | Replacements.Util.BclDateTimeOffset -> makeAliasTypeAnnotation com ctx "Date"
+        | Replacements.Util.BclDateOnly -> makeAliasTypeAnnotation com ctx "Date"
         | Replacements.Util.BclTimeOnly -> NumberTypeAnnotation
         | Replacements.Util.BclTimer -> makeImportTypeAnnotation com ctx [] "Timer" "Timer"
         | Replacements.Util.BclHashSet key -> makeImportTypeAnnotation com ctx [key] "Util" "ISet"
@@ -519,11 +542,8 @@ module Annotation =
                     Identifier.identifier("arg" + (string i)),
                     makeTypeAnnotation com ctx argType))
             |> List.toArray
-        let ctx = { ctx with IsParamType = true };
-        let genParams = Util.getGenericTypeParams ctx (argTypes @ [returnType])
         let returnType = makeTypeAnnotation com ctx returnType
-        let typeParamDecl = makeTypeParamDecl com ctx genParams
-        TypeAnnotation.functionTypeAnnotation(funcTypeParams, returnType, typeParameters=typeParamDecl)
+        TypeAnnotation.functionTypeAnnotation(funcTypeParams, returnType)
 
     let makeInterfaceTypeAnnotation com ctx (ent: Fable.Entity) genArgs =
         match ent.FullName with
@@ -591,21 +611,14 @@ module Annotation =
     let makeAnonymousRecordTypeAnnotation _com _ctx _fieldNames _genArgs =
          AnyTypeAnnotation // TODO:
 
-    let typedIdentWith (com: IBabelCompiler) ctx r typ name =
-        let ta =
-            if com.Options.Language = TypeScript then
-                makeTypeAnnotation com ctx typ |> Some
-            else None
-        Identifier.identifier(name, ?typeAnnotation=ta, ?loc=r)
-
-    let typedIdent (com: IBabelCompiler) ctx (id: Fable.Ident) =
-        typedIdentWith com ctx id.Range id.Type id.Name
-
     let transformFunctionWithAnnotations (com: IBabelCompiler) ctx name typeParams (args: Fable.Ident list) (body: Fable.Expr) =
         if com.Options.Language = TypeScript then
             let argTypes = args |> List.map (fun id -> id.Type)
-            let genParams = typeParams |> Option.defaultWith (fun () ->
-                Util.getGenericTypeParams ctx (argTypes @ [body.Type]))
+            let scopedTypeParams, genParams =
+                match typeParams with
+                | Some typeParams -> ctx.ScopedTypeParams, typeParams
+                | None -> Util.getTypeParameters ctx (argTypes @ [body.Type])
+            let ctx = { ctx with ScopedTypeParams = scopedTypeParams }
             let args', body' = com.TransformFunction(ctx, name, args, body)
             let returnType = makeTypeAnnotation com ctx body.Type
             let typeParamDecl = makeTypeParamDecl com ctx genParams
@@ -736,15 +749,6 @@ module Util =
     let identAsExpr (id: Fable.Ident) =
         Expression.identifier(id.Name, ?loc=id.Range)
 
-    let identAsPattern (id: Fable.Ident) =
-        Pattern.identifier(id.Name, ?loc=id.Range)
-
-    let typedIdentAsExpr com ctx (id: Fable.Ident) =
-        typedIdent com ctx id |> Expression.Identifier
-
-    let typedIdentAsPattern com ctx (id: Fable.Ident) =
-        Pattern.Identifier(typedIdent com ctx id, None)
-
     let thisExpr =
         Expression.thisExpression()
 
@@ -767,15 +771,15 @@ module Util =
         memberFromNameComputeStrings false memberName
 
     let get r left memberName =
-        let expr, computed = memberFromNameComputeStrings true memberName
-        Expression.memberExpression(left, expr, computed, ?loc=r)
+        let expr, isComputed = memberFromNameComputeStrings true memberName
+        Expression.memberExpression(left, expr, isComputed, ?loc=r)
 
     let getExpr r (object: Expression) (expr: Expression) =
-        let expr, computed =
+        let expr, isComputed =
             match expr with
             | Literal(Literal.StringLiteral(StringLiteral(value, _))) -> memberFromNameComputeStrings true value
             | e -> e, true
-        Expression.memberExpression(object, expr, computed, ?loc=r)
+        Expression.memberExpression(object, expr, isComputed, ?loc=r)
 
     let rec getParts (parts: string list) (expr: Expression) =
         match parts with
@@ -824,8 +828,8 @@ module Util =
 
     let makeJsObject pairs =
         pairs |> Seq.map (fun (name, value) ->
-            let prop, computed = memberFromName name
-            ObjectMember.objectProperty(prop, value, computed_=computed))
+            let prop, isComputed = memberFromName name
+            ObjectMember.objectProperty(prop, value, isComputed=isComputed))
         |> Seq.toArray
         |> Expression.objectExpression
 
@@ -838,21 +842,16 @@ module Util =
         // Use an arrow function in case we need to capture `this`
         Expression.callExpression(Expression.arrowFunctionExpression([||], body), [||])
 
-    let multiVarDeclaration kind (variables: (Identifier * Expression option) list) =
+    let multiVarDeclaration (com: IBabelCompiler) ctx kind (variables: (Fable.Ident * Expression option) seq) =
         let varDeclarators =
             // TODO: Log error if there're duplicated non-empty var declarations
             variables
-            |> List.distinctBy (fun (Identifier(name=name), _value) -> name)
-            |> List.mapToArray (fun (id, value) ->
-                VariableDeclarator(Pattern.Identifier(id, None), value))
+            |> Seq.distinctBy (fun (id, _) -> id.Name)
+            |> Seq.map (fun (id, value) ->
+                let ta, tp = makeTypeAnnotationWithParametersIfTypeScript com ctx id.Type value
+                VariableDeclarator.variableDeclarator(id.Name, ?annotation=ta, typeParameters=tp, ?init=value))
+            |> Seq.toArray
         Statement.variableDeclaration(kind, varDeclarators)
-
-    let varDeclaration (var: Pattern) (isMutable: bool) value =
-        let kind = if isMutable then Let else Const
-        VariableDeclaration.variableDeclaration(var, value, kind)
-
-    let restElement (var: Pattern) =
-        Pattern.restElement(var)
 
     let callSuper (args: Expression list) =
         Expression.callExpression(Super(None), List.toArray args)
@@ -860,12 +859,9 @@ module Util =
     let callSuperAsStatement (args: Expression list) =
         ExpressionStatement(callSuper args)
 
-    let makeClassConstructor args body =
-        ClassMember.classMethod(ClassPrimaryConstructor, Expression.identifier("constructor"), args, body)
-
     let callFunction com ctx r funcExpr genArgs (args: Expression list) =
         let genArgs = makeTypeParamInstantiationIfTypeScript com ctx genArgs
-        Expression.callExpression(funcExpr, List.toArray args, ?typeParameters=genArgs, ?loc=r)
+        Expression.callExpression(funcExpr, List.toArray args, ?typeArguments=genArgs, ?loc=r)
 
     let callFunctionWithThisContext r funcExpr (args: Expression list) =
         let args = thisExpr::args |> List.toArray
@@ -878,26 +874,27 @@ module Util =
 //        Undefined(?loc=range) :> Expression
         UnaryExpression(Expression.numericLiteral(0.), "void", range)
 
-    // TODO: See Fable2Dart for alternative gen param resolution
-    let getGenericTypeParams (ctx: Context) (types: Fable.Type list) =
+    let getTypeParameters (ctx: Context) (types: Fable.Type list) =
         let rec getGenParams = function
             | Fable.GenericParam (_, false, _) as p -> [p]
             | t -> t.Generics |> List.collect getGenParams
-        let mutable dedupSet = ctx.ScopedTypeParams
-        types
-        |> List.collect getGenParams
-        |> List.filter (function
-            | Fable.GenericParam(name=name) ->
-                if Set.contains name dedupSet then false
-                else dedupSet <- Set.add name dedupSet; true
-            | _ -> false)
+        let mutable scopedTypeParams = ctx.ScopedTypeParams
+        let typeParams =
+            types
+            |> List.collect getGenParams
+            |> List.filter (function
+                | Fable.GenericParam(name=name) ->
+                    if Set.contains name scopedTypeParams then false
+                    else scopedTypeParams <- Set.add name scopedTypeParams; true
+                | _ -> false)
+        scopedTypeParams, typeParams
 
     type MemberKind =
         | ClassConstructor
         | NonAttached of funcName: string
         | Attached of isStatic: bool
 
-    let getMemberArgsAndBody (com: IBabelCompiler) ctx kind (info: Fable.MemberFunctionOrValue) (args: Fable.Ident list) (body: Fable.Expr) =
+    let getMemberArgsAndBody (com: IBabelCompiler) ctx kind (classEnt: Fable.Entity option) (info: Fable.MemberFunctionOrValue) (args: Fable.Ident list) (body: Fable.Expr) =
         let funcName, args, body =
             match kind, args with
             | Attached(isStatic=false), (thisArg::args) ->
@@ -909,33 +906,52 @@ module Util =
                     else body
                 None, args, body
             | Attached(isStatic=true), _
+            | Attached _, _ -> None, args, body
             | ClassConstructor, _ -> None, args, body
             | NonAttached funcName, _ -> Some funcName, args, body
-            | _ -> None, args, body
 
-        let typeParams =
-            if com.Options.Language = TypeScript then
-                let genParams =
-                    match info.DeclaringEntity with
-                    | Some e ->
-                        let e = com.GetEntity(e)
-                        if not e.IsFSharpModule then e.GenericParameters @ info.GenericParameters
-                        else info.GenericParameters
-                    | None -> info.GenericParameters
-                genParams |> List.map (fun g -> Fable.GenericParam(g.Name, g.IsMeasure, g.Constraints)) |> Some
-            else None
+        let isTypeScript = com.Options.Language = TypeScript
+        let ctx, typeParams =
+            if isTypeScript then
+                let isAttached, entGenParams =
+                    match classEnt with
+                    | None ->
+                        match info.DeclaringEntity with
+                        | Some e ->
+                            let e = com.GetEntity(e)
+                            false, if e.IsFSharpModule then [] else e.GenericParameters
+                        | None -> false, []
+                    | Some e -> true, e.GenericParameters
+                let scopedTypeParams = List.append entGenParams info.GenericParameters |> List.map (fun g -> g.Name) |> set
+                let declaredTypeParams =
+                    if isAttached then info.GenericParameters else entGenParams @ info.GenericParameters
+                    |> List.map (fun g -> Fable.GenericParam(g.Name, g.IsMeasure, g.Constraints)) |> Some
+                { ctx with ScopedTypeParams = scopedTypeParams  }, declaredTypeParams
+            else
+                ctx, None
 
         let args, body, returnType, typeParamDecl =
             transformFunctionWithAnnotations com ctx funcName typeParams args body
 
         let args =
-            let len = Array.length args
-            if not info.HasSpread || len = 0 then args
-            else [|
-                if len > 1 then
-                    yield! args[..len-2]
-                yield restElement args[len-1]
-            |]
+            let argsLen = Array.length args
+            if argsLen = 0 then
+                args
+            elif info.HasSpread then
+                [|
+                    if argsLen > 1 then
+                        yield! args[..argsLen-2]
+                    yield args[argsLen-1].AsSpread
+                |]
+            elif isTypeScript then
+                let parameters = List.concat info.CurriedParameterGroups |> List.toArray
+                if argsLen = parameters.Length then
+                    Array.zip args parameters
+                    |> Array.map (fun (a, p) ->
+                        // TODO: IsNamed, DefaultValue (both for JS and TS)
+                        if p.IsOptional then a.AsOptional else a)
+                else args
+            else args
 
         args, body, returnType, typeParamDecl
 
@@ -986,7 +1002,7 @@ module Util =
         [|
             // First declare temp variables
             for (KeyValue(argId, tempVar)) in tempVars do
-                yield varDeclaration (Pattern.identifier(tempVar)) false (Expression.identifier(argId)) |> Declaration.VariableDeclaration |> Declaration
+                yield Statement.variableDeclaration(Const, tempVar, init=Expression.identifier(argId))
             // Then assign argument expressions to the original argument identifiers
             // See https://github.com/fable-compiler/Fable/issues/1368#issuecomment-434142713
             for (argId, arg) in zippedArgs do
@@ -1111,7 +1127,7 @@ module Util =
                 if com.Options.Language = TypeScript && (ent.FullName = Types.refCell)
                 then makeTypeParamInstantiation com ctx genArgs |> Some
                 else None
-            Expression.newExpression(consRef, values, ?typeParameters=typeParamInst, ?loc=r)
+            Expression.newExpression(consRef, values, ?typeArguments=typeParamInst, ?loc=r)
         | Fable.NewAnonymousRecord(values, fieldNames, _genArgs, _isStruct) ->
             let values = List.mapToArray (fun x -> com.TransformAsExpr(ctx, x)) values
             Array.zip fieldNames values |> makeJsObject
@@ -1127,7 +1143,7 @@ module Util =
                 | Some helperRef ->
                     let values = values |> List.mapToArray (transformAsExpr com ctx)
                     let typeParams = makeTypeParamInstantiation com ctx genArgs
-                    Expression.callExpression(helperRef, values, typeParameters=typeParams)
+                    Expression.callExpression(helperRef, values, typeArguments=typeParams)
                 | None -> transformNewUnion com ctx r ent tag values
             else
                 transformNewUnion com ctx r ent tag values
@@ -1136,16 +1152,21 @@ module Util =
         let enumerator = Expression.callExpression(get None (Expression.identifier("this")) "GetEnumerator", [||])
         BlockStatement([| Statement.returnStatement(libCall com ctx None "Util" "toIterator" [] [enumerator])|])
 
-    let extractBaseExprFromBaseCall (com: IBabelCompiler) (ctx: Context) (baseType: Fable.DeclaredType option) baseCall =
+    let extractSuperClassFromBaseCall (com: IBabelCompiler) (ctx: Context) (baseType: Fable.DeclaredType option) baseCall =
         match baseCall, baseType with
         | Some (Fable.Call(baseRef, info, _, _)), _ ->
             let baseExpr =
-                match baseRef, baseType with
-                | Fable.IdentExpr id, Some d ->
-                    let typ = Fable.DeclaredType(d.Entity, d.GenericArgs)
-                    typedIdentAsExpr com ctx { id with Type = typ }
-                | Fable.IdentExpr id, _ -> typedIdentAsExpr com ctx id
-                | _ -> transformAsExpr com ctx baseRef
+                match com.Options.Language, baseType, baseRef with
+                | TypeScript, Some d, _ ->
+                    Fable.DeclaredType(d.Entity, d.GenericArgs)
+                    |> makeTypeAnnotation com ctx
+                    |> SuperType
+                | TypeScript, None, Fable.IdentExpr id ->
+                    makeTypeAnnotation com ctx id.Type
+                    |> SuperType
+                | _ ->
+                    transformAsExpr com ctx baseRef
+                    |> SuperExpression
             let args = CallInfo(info, info.MemberRef |> Option.bind com.TryGetMember) |> transformCallArgs com ctx
             Some (baseExpr, args)
         | Some (Fable.Value _), Some baseType ->
@@ -1167,10 +1188,10 @@ module Util =
 
     let transformObjectExpr (com: IBabelCompiler) ctx (members: Fable.ObjectExprMember list) baseCall: Expression =
 
-        let makeMethod kind prop computed (info: Fable.MemberFunctionOrValue) args body =
+        let makeMethod kind prop isComputed (info: Fable.MemberFunctionOrValue) args body =
             let args, body, returnType, typeParamDecl =
-                getMemberArgsAndBody com ctx (Attached(isStatic=false)) info args body
-            ObjectMember.objectMethod(kind, prop, args, body, computed_=computed,
+                getMemberArgsAndBody com ctx (Attached(isStatic=false)) None info args body
+            ObjectMember.objectMethod(kind, prop, args, body, isComputed=isComputed,
                 ?returnType=returnType, ?typeParameters=typeParamDecl)
 
         let members = members |> List.map (fun memb -> memb, com.GetMember(memb.MemberRef))
@@ -1182,24 +1203,24 @@ module Util =
 
         let members =
             members |> List.collect (fun (memb, info) ->
-                let prop, computed = memberFromName memb.Name
+                let prop, isComputed = memberFromName memb.Name
                 // If compileAsClass is false, it means getters don't have side effects
                 // and can be compiled as object fields (see condition above)
                 if not memb.IsMangled && (info.IsValue || (not compileAsClass && info.IsGetter)) then
-                    [ObjectMember.objectProperty(prop, com.TransformAsExpr(ctx, memb.Body), computed_=computed)]
+                    [ObjectMember.objectProperty(prop, com.TransformAsExpr(ctx, memb.Body), isComputed=isComputed)]
                 elif not memb.IsMangled && info.IsGetter then
-                    [makeMethod ObjectGetter prop computed info memb.Args memb.Body]
+                    [makeMethod ObjectGetter prop isComputed info memb.Args memb.Body]
                 elif not memb.IsMangled && info.IsSetter then
-                    [makeMethod ObjectSetter prop computed info memb.Args memb.Body]
+                    [makeMethod ObjectSetter prop isComputed info memb.Args memb.Body]
                 elif info.FullName = "System.Collections.Generic.IEnumerable.GetEnumerator" then
-                    let method = makeMethod ObjectMeth prop computed info memb.Args memb.Body
+                    let method = makeMethod ObjectMeth prop isComputed info memb.Args memb.Body
                     let iterator =
-                        let prop, computed = memberFromName "Symbol.iterator"
+                        let prop, isComputed = memberFromName "Symbol.iterator"
                         let body = enumerableThisToIterator com ctx
-                        ObjectMember.objectMethod(ObjectMeth, prop, [||], body, computed_=computed)
+                        ObjectMember.objectMethod(ObjectMeth, prop, [||], body, isComputed=isComputed)
                     [method; iterator]
                 else
-                    [makeMethod ObjectMeth prop computed info memb.Args memb.Body]
+                    [makeMethod ObjectMeth prop isComputed info memb.Args memb.Body]
             )
 
         if not compileAsClass then
@@ -1207,23 +1228,22 @@ module Util =
         else
             let classMembers =
                 members |> List.choose (function
-                    | ObjectProperty(key, value, computed) ->
-                        ClassMember.classProperty(key, value, computed_=computed) |> Some
-                    | ObjectMethod(kind, key, parameters, body, computed, returnType, typeParameters, _) ->
+                    | ObjectProperty(key, value, isComputed) ->
+                        ClassMember.classProperty(key, value, isComputed=isComputed) |> Some
+                    | ObjectMethod(kind, key, parameters, body, isComputed, returnType, typeParameters, _) ->
                         let kind =
                             match kind with
-                            | "get" -> ClassGetter
-                            | "set" -> ClassSetter
-                            | _ -> ClassFunction
-                        ClassMember.classMethod(kind, key, parameters, body, computed_=computed,
-                            ?returnType=returnType, ?typeParameters=typeParameters) |> Some)
+                            | ObjectGetter -> ClassGetter(key, isComputed)
+                            | ObjectSetter -> ClassSetter(key, isComputed)
+                            | _ -> ClassFunction(key, isComputed)
+                        ClassMember.classMethod(kind, parameters, body, ?returnType=returnType, typeParameters=typeParameters) |> Some)
 
             let baseExpr, classMembers =
                 baseCall
-                |> extractBaseExprFromBaseCall com ctx None
+                |> extractSuperClassFromBaseCall com ctx None
                 |> Option.map (fun (baseExpr, baseArgs) ->
                     let consBody = BlockStatement([|callSuperAsStatement baseArgs|])
-                    let cons = makeClassConstructor [||]  consBody
+                    let cons = ClassMember.classMethod(ClassPrimaryConstructor [||], [||], consBody)
                     Some baseExpr, cons::classMembers
                 )
                 |> Option.defaultValue (None, classMembers)
@@ -1415,7 +1435,7 @@ module Util =
                         match typ with
                         | Fable.DeclaredType(_entRef, genArgs) -> makeTypeParamInstantiationIfTypeScript com ctx genArgs
                         | _ -> None
-                    Expression.newExpression(callee, List.toArray args, ?typeParameters=typeParamInst, ?loc=range)
+                    Expression.newExpression(callee, List.toArray args, ?typeArguments=typeParamInst, ?loc=range)
                 | None -> callFunction com ctx range callee callInfo.GenericArgs args
                 | Some(TransformExpr com ctx thisArg) -> callFunction com ctx range callee callInfo.GenericArgs (thisArg::args)
 
@@ -1457,9 +1477,9 @@ module Util =
         // try .. catch statements cannot be tail call optimized
         let ctx = { ctx with TailCallOpportunity = None }
         let handler =
-            catch |> Option.map (fun (param, body) ->
-                let e: Fable.Ident = { param with Type = Fable.Any } // intentionally set catch type to 'any'
-                CatchClause.catchClause(typedIdentAsPattern com ctx e, transformBlock com ctx returnStrategy body))
+            catch |> Option.map (fun (param: Fable.Ident, body) ->
+                let ta = makeTypeAnnotationIfTypeScript com ctx Fable.Any None // intentionally set catch type to 'any'
+                CatchClause.catchClause(param.Name, ?annotation=ta, body=transformBlock com ctx returnStrategy body))
         let finalizer =
             finalizer |> Option.map (transformBlock com ctx None)
         [|Statement.tryStatement(transformBlock com ctx returnStrategy body,
@@ -1551,14 +1571,15 @@ module Util =
 
     let transformBindingAsStatements (com: IBabelCompiler) ctx (var: Fable.Ident) (value: Fable.Expr) =
         if isJsStatement ctx false value then
-            let varPattern, varExpr = typedIdentAsPattern com ctx var, identAsExpr var
-            let decl = Statement.variableDeclaration(varPattern)
-            let body = com.TransformAsStatements(ctx, Some(Assign varExpr), value)
+            let ta, tp = makeTypeAnnotationWithParametersIfTypeScript com ctx var.Type None
+            let decl = Statement.variableDeclaration(Let, var.Name, ?annotation=ta, typeParameters=tp)
+            let body = com.TransformAsStatements(ctx, Some(Assign(identAsExpr var)), value)
             Array.append [|decl|] body
         else
             let value = transformBindingExprBody com ctx var value
-            let decl = varDeclaration (typedIdentAsPattern com ctx var) var.IsMutable value |> Declaration.VariableDeclaration |> Declaration
-            [|decl|]
+            let ta, tp = makeTypeAnnotationWithParametersIfTypeScript com ctx var.Type (Some value)
+            let kind = if var.IsMutable then Let else Const
+            [| Statement.variableDeclaration(kind, var.Name, ?annotation=ta, typeParameters=tp, init=value) |]
 
     let transformTest (com: IBabelCompiler) ctx range kind expr: Expression =
         match kind with
@@ -1751,8 +1772,8 @@ module Util =
         let targetId = getUniqueNameInDeclarationScope ctx "matchResult" |> makeIdent
         let multiVarDecl =
             let boundIdents = targets |> List.collect (fun (idents,_) ->
-                idents |> List.map (fun id -> typedIdent com ctx id, None))
-            multiVarDeclaration Let ((typedIdent com ctx targetId, None)::boundIdents)
+                idents |> List.map (fun id -> id, None))
+            multiVarDeclaration com ctx Let ((targetId, None)::boundIdents)
         // Transform targets as switch
         let switch2 =
             // TODO: Declare the last case as the default case?
@@ -2017,11 +2038,12 @@ module Util =
 
             [|Statement.forStatement(
                 transformBlock com ctx None body,
-                start |> varDeclaration (typedIdentAsPattern com ctx var) true,
+                VariableDeclaration.variableDeclaration(Let, var.Name, init=start,
+                    ?annotation = makeTypeAnnotationIfTypeScript com ctx var.Type (Some start)),
                 Expression.binaryExpression(op1, identAsExpr var, limit),
                 Expression.updateExpression(op2, false, identAsExpr var), ?loc=range)|]
 
-    let transformFunction com ctx name (args: Fable.Ident list) (body: Fable.Expr): Pattern array * BlockStatement =
+    let transformFunction com ctx name (args: Fable.Ident list) (body: Fable.Expr): Parameter array * BlockStatement =
         let tailcallChance =
             Option.map (fun name ->
                 NamedTailCallOpportunity(com, ctx, name, args) :> ITailCallOpportunity) name
@@ -2031,8 +2053,7 @@ module Util =
         let ctx =
             { ctx with TailCallOpportunity = tailcallChance
                        HoistVars = fun ids -> declaredVars.AddRange(ids); true
-                       OptimizeTailCall = fun () -> isTailCallOptimized <- true
-                       IsParamType = true }
+                       OptimizeTailCall = fun () -> isTailCallOptimized <- true }
         let body =
             if body.Type = Fable.Unit then
                 transformBlock com ctx (Some ReturnUnit) body
@@ -2047,12 +2068,12 @@ module Util =
                 let args' =
                     List.zip args tc.Args
                     |> List.map (fun (id, tcArg) ->
-                        makeTypedIdent id.Type tcArg |> typedIdentAsPattern com ctx)
+                        let ta = makeTypeAnnotationIfTypeScript com ctx id.Type None
+                        Parameter.parameter(tcArg, ?typeAnnotation=ta))
                 let varDecls =
                     List.zip args tc.Args
-                    |> List.map (fun (id, tcArg) ->
-                        id |> typedIdent com ctx, Some (Expression.identifier(tcArg)))
-                    |> multiVarDeclaration Const
+                    |> List.map (fun (id, tcArg) -> id, Some (Expression.identifier(tcArg)))
+                    |> multiVarDeclaration com ctx Const
 
                 let body = Array.append [|varDecls|] body.Body
                 // Make sure we don't get trapped in an infinite loop, see #1624
@@ -2062,11 +2083,13 @@ module Util =
                     |> Array.singleton |> BlockStatement
                 args', body
             | _ ->
-                args |> List.map (typedIdentAsPattern com ctx), body
+                args |> List.map (fun a ->
+                    let ta = makeTypeAnnotationIfTypeScript com ctx a.Type None
+                    Parameter.parameter(a.Name, ?typeAnnotation=ta)), body
         let body =
             if declaredVars.Count = 0 then body
             else
-                let varDeclStatement = multiVarDeclaration Let [for v in declaredVars -> typedIdent com ctx v, None]
+                let varDeclStatement = declaredVars |> Seq.map (fun v -> v, None) |> multiVarDeclaration com ctx Let
                 BlockStatement(Array.append [|varDeclStatement|] body.Body)
         args |> List.toArray, body
 
@@ -2088,7 +2111,7 @@ module Util =
                 body,
                 id = Identifier.identifier(membName),
                 ?superClass = superClass,
-                ?typeParameters = typeParameters,
+                typeParameters = typeParameters,
                 ?implements = implements)
         | FunctionExpression(_, parameters, body, returnType, typeParameters, _) ->
             Declaration.functionDeclaration(
@@ -2096,11 +2119,10 @@ module Util =
                 body,
                 id = Identifier.identifier(membName),
                 ?returnType = returnType,
-                ?typeParameters = typeParameters)
+                typeParameters = typeParameters)
         | _ ->
-            let var = Pattern.identifier(membName)
-            varDeclaration var isMutable expr
-            |> Declaration.VariableDeclaration
+            let kind = if isMutable then Let else Const
+            Declaration.variableDeclaration(kind, membName, init=expr)
 
         |> asModuleDeclaration isPublic
 
@@ -2108,11 +2130,11 @@ module Util =
         // let mkNative genArgs typeName =
         //     let id = Identifier.identifier(typeName)
         //     let typeParamInst = makeTypeParamInstantiationIfTypeScript com ctx genArgs
-        //     ClassImplements.classImplements(id, ?typeParameters=typeParamInst) |> Some
+        //     ClassImplements.classImplements(id, ?typeArguments=typeParamInst) |> Some
         let mkImport genArgs moduleName typeName =
             let id = makeImportTypeId com ctx moduleName typeName
             let typeParamInst = makeTypeParamInstantiationIfTypeScript com ctx genArgs
-            ClassImplements.classImplements(id, ?typeParameters=typeParamInst) |> Some
+            ClassImplements.classImplements(id, ?typeArguments=typeParamInst) |> Some
 
         ent.AllInterfaces |> Seq.choose (fun ifc ->
             match ifc.Entity.FullName with
@@ -2132,35 +2154,35 @@ module Util =
             id)
         |> Seq.toArray
 
-    let declareClassWithParams (com: IBabelCompiler) ctx (ent: Fable.Entity) entName (consArgs: Pattern[]) (consBody: BlockStatement) (baseExpr: Expression option) classMembers typeParamDecl =
+    let declareClassWithParams (com: IBabelCompiler) ctx (ent: Fable.Entity) entName (consArgs: Parameter[]) (consArgsModifiers: AccessModifier[]) (consBody: BlockStatement) (superClass: SuperClass option) classMembers typeParamDecl =
         let implements =
             if com.Options.Language = TypeScript then
                 let implements = Util.getClassImplements com ctx ent |> Seq.toArray
                 if Array.isEmpty implements then None else Some implements
             else None
-        let classCons = makeClassConstructor consArgs consBody
+        let classCons = ClassMember.classMethod(ClassPrimaryConstructor consArgsModifiers, consArgs, consBody)
         let classFields =
             if com.Options.Language = TypeScript && not ent.IsFSharpUnion then
                 ent.FSharpFields |> List.mapToArray (fun field ->
-                    let prop, computed = memberFromName field.Name
+                    let prop, isComputed = memberFromName field.Name
                     let ta = makeTypeAnnotation com ctx field.FieldType
                     // Static fields need to be initialized by static constructor
                     let am = if field.IsMutable || field.IsStatic then None else Some Readonly
-                    ClassMember.classProperty(prop, computed_=computed, ``static``=field.IsStatic, typeAnnotation=ta, ?accessModifier=am)
+                    ClassMember.classProperty(prop, isComputed=isComputed, isStatic=field.IsStatic, typeAnnotation=ta, ?accessModifier=am)
                 )
             else Array.empty
         Expression.classExpression([|
             yield! classFields
             classCons
             yield! classMembers
-        |], ?superClass=baseExpr, ?typeParameters=typeParamDecl, ?implements=implements)
+        |], ?superClass=superClass, ?typeParameters=typeParamDecl, ?implements=implements)
         |> declareModuleMember ent.IsPublic entName false
 
-    let declareClass (com: IBabelCompiler) ctx ent entName consArgs consBody baseExpr classMembers =
+    let declareClass (com: IBabelCompiler) ctx ent entName consArgs consBody superClass classMembers =
         if com.Options.Language = TypeScript
         then FSharp2Fable.Util.getEntityGenArgs ent |> makeTypeParamDecl com ctx |> Some
         else None
-        |> declareClassWithParams com ctx ent entName consArgs consBody baseExpr classMembers
+        |> declareClassWithParams com ctx ent entName consArgs [||] consBody superClass classMembers
 
     let declareTypeReflection (com: IBabelCompiler) ctx (ent: Fable.Entity) entName: ModuleDeclaration =
         let ta =
@@ -2170,12 +2192,12 @@ module Util =
         let genArgs = Array.init (ent.GenericParameters.Length) (fun i -> "gen" + string i |> makeIdent)
         let generics = genArgs |> Array.map identAsExpr
         let body = transformReflectionInfo com ctx None ent generics
-        let args = genArgs |> Array.map (fun x -> Pattern.identifier(x.Name, ?typeAnnotation=ta))
+        let args = genArgs |> Array.map (fun x -> Parameter.parameter(x.Name, ?typeAnnotation=ta))
         let returnType = ta
         makeFunctionExpression None (args, body, returnType, None)
         |> declareModuleMember ent.IsPublic (entName + Naming.reflectionSuffix) false
 
-    let declareType (com: IBabelCompiler) ctx (ent: Fable.Entity) entName (consArgs: Pattern[]) (consBody: BlockStatement) baseExpr classMembers: ModuleDeclaration list =
+    let declareType (com: IBabelCompiler) ctx (ent: Fable.Entity) entName (consArgs: Parameter[]) (consBody: BlockStatement) baseExpr classMembers: ModuleDeclaration list =
         let typeDeclaration = declareClass com ctx ent entName consArgs consBody baseExpr classMembers
         if com.Options.NoReflection then
             [typeDeclaration]
@@ -2202,7 +2224,7 @@ module Util =
                 [propsArg], FableTransforms.replaceValues replacements body
 
         let args, body, returnType, typeParamDecl =
-            getMemberArgsAndBody com ctx (NonAttached membName) info args body
+            getMemberArgsAndBody com ctx (NonAttached membName) None info args body
 
         Expression.functionExpression(args, body, ?returnType=returnType, ?typeParameters=typeParamDecl)
 
@@ -2217,24 +2239,22 @@ module Util =
               |> ExpressionStatement |> PrivateModuleDeclaration ]
         else statements |> Array.mapToList (fun x -> PrivateModuleDeclaration(x))
 
-    let transformAttachedProperty (com: IBabelCompiler) ctx (info: Fable.MemberFunctionOrValue) (memb: Fable.MemberDecl) =
+    let transformAttachedProperty (com: IBabelCompiler) ctx classEnt (info: Fable.MemberFunctionOrValue) (memb: Fable.MemberDecl) =
         let isStatic = not info.IsInstance
-        let kind = if info.IsGetter then ClassGetter else ClassSetter
+        let key, isComputed = memberFromName memb.Name
+        let kind = if info.IsGetter then ClassGetter(key, isComputed) else ClassSetter(key, isComputed)
         let args, body, returnType, _typeParamDecl =
-            getMemberArgsAndBody com ctx (Attached isStatic) info memb.Args memb.Body
-        let key, computed = memberFromName memb.Name
-        ClassMember.classMethod(kind, key, args, body, computed_=computed, ``static``=isStatic,
-            ?returnType=returnType) //, ?typeParameters=typeParamDecl)
+            getMemberArgsAndBody com ctx (Attached isStatic) (Some classEnt) info memb.Args memb.Body
+        ClassMember.classMethod(kind, args, body, isStatic=isStatic, ?returnType=returnType) //, ?typeParameters=typeParamDecl)
         |> Array.singleton
 
-    let transformAttachedMethod (com: IBabelCompiler) ctx (info: Fable.MemberFunctionOrValue) (memb: Fable.MemberDecl) =
+    let transformAttachedMethod (com: IBabelCompiler) ctx classEnt (info: Fable.MemberFunctionOrValue) (memb: Fable.MemberDecl) =
         let isStatic = not info.IsInstance
-        let makeMethod name args body returnType _typeParamDecl =
-            let key, computed = memberFromName name
-            ClassMember.classMethod(ClassFunction, key, args, body, computed_=computed, ``static``=isStatic,
-                ?returnType=returnType) //, ?typeParameters=typeParamDecl)
+        let makeMethod name args body returnType typeParamDecl =
+            let key, isComputed = memberFromName name
+            ClassMember.classMethod(ClassFunction(key, isComputed), args, body, isStatic=isStatic, ?returnType=returnType, ?typeParameters=typeParamDecl)
         let args, body, returnType, typeParamDecl =
-            getMemberArgsAndBody com ctx (Attached isStatic) info memb.Args memb.Body
+            getMemberArgsAndBody com ctx (Attached isStatic) (Some classEnt) info memb.Args memb.Body
         [|
             yield makeMethod memb.Name args body returnType typeParamDecl
             if info.FullName = "System.Collections.Generic.IEnumerable.GetEnumerator" then
@@ -2242,7 +2262,7 @@ module Util =
         |]
 
     let transformUnion (com: IBabelCompiler) ctx (ent: Fable.Entity) (entName: string) classMembers =
-        let baseExpr = libValue com ctx "Types" "Union" |> Some
+        let baseExpr = libValue com ctx "Types" "Union" |> SuperExpression |> Some
         let cases =
             let body =
                 ent.UnionCases
@@ -2251,14 +2271,14 @@ module Util =
                 |> Statement.returnStatement
                 |> Array.singleton
                 |> BlockStatement
-            ClassMember.classMethod(ClassFunction, Expression.identifier("cases"), [||], body)
+            ClassMember.classMethod(ClassFunction(Expression.identifier("cases"), false), [||], body)
 
         if com.Options.Language = TypeScript then
             // Merge this with makeTypeParamDecl/makeTypeParamInstantiation?
             let entParams = ent.GenericParameters |> List.chooseToArray (fun p ->
                 if not p.IsMeasure then Some p.Name else None)
             let entParamsDecl = entParams |> Array.map TypeParameter.typeParameter
-            let entParamsInst = entParams |> Array.map (makeSimpleTypeAnnotation com ctx)
+            let entParamsInst = entParams |> Array.map (makeAliasTypeAnnotation com ctx)
             let union_tag = entName + "_Tag" |> Identifier.identifier
             let union_fields = entName + "_Fields" |> Identifier.identifier
             let union_cons = entName + "_Cons" |> Identifier.identifier
@@ -2275,12 +2295,13 @@ module Util =
 
             let isPublic = ent.IsPublic
             let union_fields_alias = AliasTypeAnnotation(union_fields, entParamsInst)
-            let tagArgTa = makeSimpleTypeAnnotation com ctx "Tag"
+            let tagArgTa = makeAliasTypeAnnotation com ctx "Tag"
             let fieldsArgTa = IndexedTypeAnnotation(union_fields_alias, tagArgTa)
             let consArgs = [|
-                Pattern.identifier("tag", typeAnnotation=tagArgTa, accessModifier=Readonly)
-                Pattern.identifier("fields", typeAnnotation=fieldsArgTa, accessModifier=Readonly)
+                Parameter.parameter("tag", typeAnnotation=tagArgTa)
+                Parameter.parameter("fields", typeAnnotation=fieldsArgTa)
             |]
+            let consArgsModifiers = [| Readonly; Readonly |]
             let consBody = BlockStatement [| callSuperAsStatement [] |]
             let classMembers = Array.append [|cases|] classMembers
             let unionConsTypeParams = Some(Array.append entParamsDecl [|
@@ -2293,26 +2314,26 @@ module Util =
 
                 // Helpers to instantiate union
                 for case in ent.UnionCases do
-                    let args = case.UnionCaseFields |> List.mapToArray (fun fi -> typedIdentWith com ctx None fi.FieldType fi.Name)
                     let tag = EnumCaseLiteral(union_tag, case.Name)
-                    let passedArgs = args |> Array.map Expression.Identifier |> Expression.arrayExpression
-                    let consTypeParams = Array.append entParamsInst [|LiteralTypeAnnotation tag|]
+                    let passedArgs = case.UnionCaseFields |> List.mapToArray (fun fi -> Expression.identifier(fi.Name)) |> Expression.arrayExpression
+                    let consTypeArgs = Array.append entParamsInst [|LiteralTypeAnnotation tag|]
                     let body = BlockStatement [|
-                       Expression.newExpression(Expression.Identifier union_cons, [|Expression.Literal tag; passedArgs|], typeParameters=consTypeParams)
+                       Expression.newExpression(Expression.Identifier union_cons, [|Expression.Literal tag; passedArgs|], typeArguments=consTypeArgs)
                        |> Statement.returnStatement
                     |]
-                    let args = args |> Array.map (fun a -> Pattern.Identifier(a, None))
+                    let parameters = case.UnionCaseFields |> List.mapToArray (fun fi ->
+                        Parameter.parameter(fi.Name, typeAnnotation=makeTypeAnnotation com ctx fi.FieldType))
                     let fnId = entName + "_" + case.Name |> Identifier.identifier
-                    Declaration.functionDeclaration(args, body, fnId, typeParameters=entParamsDecl)
+                    Declaration.functionDeclaration(parameters, body, fnId, typeParameters=entParamsDecl)
                     |> asModuleDeclaration isPublic
 
                 // Actual class
-                declareClassWithParams com ctx ent union_cons.Name consArgs consBody baseExpr classMembers unionConsTypeParams
+                declareClassWithParams com ctx ent union_cons.Name consArgs consArgsModifiers consBody baseExpr classMembers unionConsTypeParams
                 if not com.Options.NoReflection then
                     declareTypeReflection com ctx ent entName
             ]
         else
-            let args = [| Pattern.identifier("tag"); Pattern.identifier("fields") |]
+            let args = [| Parameter.parameter("tag"); Parameter.parameter("fields") |]
             let body = BlockStatement [|
                 callSuperAsStatement []
                 yield! ["tag"; "fields"] |> List.map (fun name ->
@@ -2328,9 +2349,9 @@ module Util =
         let args = fieldIds |> Array.map identAsExpr
         let baseExpr =
             if ent.IsFSharpExceptionDeclaration
-            then libValue com ctx "Types" "FSharpException" |> Some
+            then libValue com ctx "Types" "FSharpException" |> SuperExpression |> Some
             elif ent.IsFSharpRecord || ent.IsValueType
-            then libValue com ctx "Types" "Record" |> Some
+            then libValue com ctx "Types" "Record" |> SuperExpression |> Some
             else None
         let body =
             BlockStatement([|
@@ -2342,14 +2363,15 @@ module Util =
                     assign None left right |> ExpressionStatement)
                 |> Seq.toArray
             |])
-        let args = fieldIds |> Array.map (typedIdentAsPattern com ctx)
+        let args = fieldIds |> Array.map (fun fi ->
+            Parameter.parameter(fi.Name, ?typeAnnotation=makeTypeAnnotationIfTypeScript com ctx fi.Type None))
         declareType com ctx ent entName args body baseExpr classMembers
 
     let transformClassWithPrimaryConstructor (com: IBabelCompiler) ctx (classEnt: Fable.Entity) (classDecl: Fable.ClassDecl) classMembers (cons: Fable.MemberDecl) =
         let consInfo = com.GetMember(cons.MemberRef)
         let classIdent = Expression.identifier(classDecl.Name)
         let consArgs, consBody, returnType, _typeParamDecl =
-            getMemberArgsAndBody com ctx ClassConstructor consInfo cons.Args cons.Body
+            getMemberArgsAndBody com ctx ClassConstructor (Some classEnt) consInfo cons.Args cons.Body
 
         let returnType, typeParamDecl =
             // change constructor's return type from void to entity type
@@ -2368,9 +2390,10 @@ module Util =
 
         let baseExpr, consBody =
             classDecl.BaseCall
-            |> extractBaseExprFromBaseCall com ctx classEnt.BaseType
+            |> extractSuperClassFromBaseCall com ctx classEnt.BaseType
             |> Option.orElseWith (fun () ->
-                if classEnt.IsValueType then Some(libValue com ctx "Types" "Record", [])
+                if classEnt.IsValueType then
+                    Some(libValue com ctx "Types" "Record" |> SuperExpression, [])
                 else None)
             |> Option.map (fun (baseExpr, baseArgs) ->
                 let consBody =
@@ -2456,8 +2479,8 @@ module Util =
                                 | None -> [||]
                                 | Some info ->
                                     if not memb.IsMangled && (info.IsGetter || info.IsSetter)
-                                    then transformAttachedProperty com ctx info memb
-                                    else transformAttachedMethod com ctx info memb)
+                                    then transformAttachedProperty com ctx ent info memb
+                                    else transformAttachedMethod com ctx ent info memb)
 
                 match decl.Constructor with
                 | Some cons ->
@@ -2613,7 +2636,6 @@ module Compiler =
             HoistVars = fun _ -> false
             TailCallOpportunity = None
             OptimizeTailCall = fun () -> ()
-            IsParamType = false
             ScopedTypeParams = Set.empty }
         let rootDecls = List.collect (transformDeclaration com ctx) file.Declarations
         let importDecls = com.GetAllImports() |> transformImports

--- a/src/Fable.Transforms/Global/Babel.fs
+++ b/src/Fable.Transforms/Global/Babel.fs
@@ -30,9 +30,9 @@ type Expression =
     | ClassExpression of
         members: ClassMember array *
         id: Identifier option *
-        superClass: Expression option *
+        superClass: SuperClass option *
         implements: ClassImplements array option *
-        typeParameters: TypeParameterDeclaration option *
+        typeParameters: TypeParameter array *
         loc: SourceLocation option
     | ClassImplements of ClassImplements
     | Super of loc: SourceLocation option
@@ -43,48 +43,52 @@ type Expression =
     | ObjectExpression of properties: ObjectMember array * loc: SourceLocation option
     | SequenceExpression of expressions: Expression array * loc: SourceLocation option
     | EmitExpression of value: string * args: Expression array * loc: SourceLocation option
-    | CallExpression of callee: Expression * args: Expression array * typeParameters: TypeParameterInstantiation option * loc: SourceLocation option
+    | CallExpression of callee: Expression * args: Expression array * typeArguments: TypeAnnotation array * loc: SourceLocation option
     | UnaryExpression of argument: Expression * operator: string * loc: SourceLocation option
     | UpdateExpression of prefix: bool * argument: Expression * operator: string * loc: SourceLocation option
     | BinaryExpression of left: Expression * right: Expression * operator: string * loc: SourceLocation option
     | LogicalExpression of left: Expression * operator: string * right: Expression * loc: SourceLocation option
     | AssignmentExpression of left: Expression * right: Expression * operator: string * loc: SourceLocation option
     | ConditionalExpression of test: Expression * consequent: Expression * alternate: Expression * loc: SourceLocation option
-    | MemberExpression of object: Expression * property: Expression * computed: bool * loc: SourceLocation option
-    | NewExpression of callee: Expression * args: Expression array * typeParameters: TypeParameterInstantiation option * loc: SourceLocation option
+    | MemberExpression of object: Expression * property: Expression * isComputed: bool * loc: SourceLocation option
+    | NewExpression of callee: Expression * args: Expression array * typeArguments: TypeAnnotation array * loc: SourceLocation option
     | FunctionExpression of
         id: Identifier option *
-        parameters: Pattern array *
+        parameters: Parameter array *
         body: BlockStatement *
         returnType: TypeAnnotation option *
-        typeParameters: TypeParameterDeclaration option *
+        typeParameters: TypeParameter array *
         loc: SourceLocation option
     | ArrowFunctionExpression of
-        parameters: Pattern array *
+        parameters: Parameter array *
         body: BlockStatement *
         returnType: TypeAnnotation option *
-        typeParameters: TypeParameterDeclaration option *
+        typeParameters: TypeParameter array *
         loc: SourceLocation option
 
-type Pattern =
-    | RestElement of argument: Pattern
-    | Identifier of name: Identifier * accessModifier: AccessModifier option
+type Parameter =
+    | Parameter of name: string * isOptional: bool * isNamed: bool * isSpread: bool * typeAnnotation: TypeAnnotation option
 
     member this.Name =
         match this with
-        | RestElement(argument) -> argument.Name
-        | Identifier(Identifier.Identifier(name=name), _) -> name
+        | Parameter(name=name) -> name
 
     member this.IsNamed =
         match this with
-        | Identifier(Identifier.Identifier(named=named), _) -> named
-        | RestElement _ -> false
+        | Parameter(isNamed=isNamed) -> isNamed
 
     member this.AsNamed =
         match this with
-        | Identifier(Identifier.Identifier(name, optional, _named, typeAnnotation, loc), accessModifier) ->
-            Identifier(Identifier.Identifier(name, optional, true, typeAnnotation, loc), accessModifier)
-        | RestElement argument -> argument.AsNamed // Named arguments cannot be spread
+        | Parameter(id, isOptional, _isNamed, isSpread, typeAnnotation) -> Parameter(id, isOptional, true, isSpread, typeAnnotation)
+
+    member this.AsOptional =
+        match this with
+        | Parameter(id, _isOptional, isNamed, isSpread, typeAnnotation) -> Parameter(id, true, isNamed, isSpread, typeAnnotation)
+
+    member this.AsSpread =
+        match this with
+        | Parameter(id, isOptional, isNamed, _isSpread, typeAnnotation) -> Parameter(id, isOptional, isNamed, true, typeAnnotation)
+
 
 type Literal =
     | StringLiteral of StringLiteral
@@ -117,37 +121,38 @@ type Declaration =
     | ClassDeclaration of
         members: ClassMember array *
         id: Identifier option *
-        superClass: Expression option *
+        superClass: SuperClass option *
         implements: ClassImplements array option *
-        typeParameters: TypeParameterDeclaration option *
+        typeParameters: TypeParameter array *
         loc: SourceLocation option
-    | VariableDeclaration of VariableDeclaration
+    | VariableDeclaration of
+        var: VariableDeclaration
     | FunctionDeclaration of
-        parameters: Pattern array *
+        parameters: Parameter array *
         body: BlockStatement *
         id: Identifier *
         returnType: TypeAnnotation option *
-        typeParameters: TypeParameterDeclaration option *
+        typeParameters: TypeParameter array *
         loc: SourceLocation option
     | InterfaceDeclaration of
         id: Identifier *
         body: ObjectTypeAnnotation *
         extends: InterfaceExtends array *
         implements: ClassImplements array *
-        typeParameters: TypeParameterDeclaration option
+        typeParameters: TypeParameter array
     | EnumDeclaration of
         name: string *
         cases: (string * Expression) array *
         isConst: bool
     | TypeAliasDeclaration of
         name: string *
-        typeParameters: TypeParameterDeclaration *
+        typeParameters: TypeParameter array *
         alias: TypeAnnotation
 
 /// A module import or export declaration.
 type ModuleDeclaration =
     | PrivateModuleDeclaration of statement: Statement
-    /// An export named declaration, e.g., export {foo, bar};, export {foo} from "mod"; or export var foo = 1;.
+    /// An export isNamed declaration, e.g., export {foo, bar};, export {foo} from "mod"; or export var foo = 1;.
     /// Note: Having declaration populated with non-empty specifiers or non-null source results in an invalid state.
     | ExportNamedDeclaration of declaration: Declaration
     | ExportAllDeclaration of source: Literal * loc: SourceLocation option
@@ -177,8 +182,7 @@ type ModuleDeclaration =
 
 /// Note that an identifier may be an expression or a destructuring pattern.
 type Identifier =
-    // TODO: Move optional, named and typeAnnotation to Pattern.Identifier
-    | Identifier of name: string * optional: bool * named: bool * typeAnnotation: TypeAnnotation option * loc: SourceLocation option
+    | Identifier of name: string * loc: SourceLocation option
 
 type StringLiteral =
     | StringLiteral of value: string * loc: SourceLocation option
@@ -226,11 +230,11 @@ type SwitchCase =
 
 /// A catch clause following a try block.
 type CatchClause =
-    | CatchClause of param: Pattern * body: BlockStatement * loc: SourceLocation option
+    | CatchClause of param: string * annotation: TypeAnnotation option * body: BlockStatement * loc: SourceLocation option
 
 // Declarations
 type VariableDeclarator =
-    | VariableDeclarator of id: Pattern * init: Expression option
+    | VariableDeclarator of name: string * annotation: TypeAnnotation option * typeParameters: TypeParameter array * init: Expression option
 
 type VariableDeclarationKind =
     | Var
@@ -238,7 +242,7 @@ type VariableDeclarationKind =
     | Const
 
 type VariableDeclaration =
-    | VariableDeclaration of declarations: VariableDeclarator array * kind: string * loc: SourceLocation option
+    | VariableDeclaration of declarations: VariableDeclarator array * kind: VariableDeclarationKind * loc: SourceLocation option
 
 // Loops
 
@@ -311,15 +315,15 @@ type VariableDeclaration =
 //    member _.Argument: Expression = argument
 
 type ObjectMember =
-    | ObjectProperty of key: Expression * value: Expression * computed: bool
+    | ObjectProperty of key: Expression * value: Expression * isComputed: bool
     | ObjectMethod of
-        kind: string *
+        kind: ObjectMethodKind *
         key: Expression *
-        parameters: Pattern array *
+        parameters: Parameter array *
         body: BlockStatement *
-        computed: bool *
+        isComputed: bool *
         returnType: TypeAnnotation option *
-        typeParameters: TypeParameterDeclaration option *
+        typeParameters: TypeParameter array *
         loc: SourceLocation option
 
 //    let shorthand = defaultArg shorthand_ false
@@ -356,39 +360,41 @@ type AccessModifier =
     | Protected
     | Readonly
 
+type SuperClass =
+    | SuperType of TypeAnnotation
+    | SuperExpression of Expression
+
 type ClassMember =
     | ClassMethod of
-        kind: string *
-        key: Expression *
-        parameters: Pattern array *
+        kind: ClassMethodKind *
+        parameters: Parameter array *
         body: BlockStatement *
-        computed: bool *
-        ``static``: bool option *
-        ``abstract``: bool option *
+        isStatic: bool *
+        isAbstract: bool *
         returnType: TypeAnnotation option *
-        typeParameters: TypeParameterDeclaration option *
+        typeParameters: TypeParameter array *
         loc: SourceLocation option
     | ClassProperty of
         key: Expression *
         value: Expression option *
-        computed: bool *
-        ``static``: bool *
-        optional: bool *
+        isComputed: bool *
+        isStatic: bool *
+        isOptional: bool *
         typeAnnotation: TypeAnnotation option *
         accessModifier: AccessModifier option *
         loc: SourceLocation option
 
 type ClassMethodKind =
-    | ClassPrimaryConstructor | ClassFunction | ClassGetter | ClassSetter
-
-    // This appears in astexplorer.net but it's not documented
-    // member _.Expression: bool = false
+    | ClassPrimaryConstructor of AccessModifier[]
+    | ClassFunction of key: Expression * isComputed: bool
+    | ClassGetter of key: Expression * isComputed: bool
+    | ClassSetter of key: Expression * isComputed: bool
 
 /// ES Class Fields & Static Properties
 /// https://github.com/jeffmo/es-class-fields-and-static-properties
 /// e.g, class MyClass { static myStaticProp = 5; myProp /* = 10 */; }
 type ClassImplements =
-    | ClassImplements of id: Identifier * typeParameters: TypeParameterInstantiation option
+    | ClassImplements of id: Identifier * typeArguments: TypeAnnotation array
 
 // type MetaProperty(meta, property, ?loc) =
 //     interface Expression with
@@ -421,7 +427,7 @@ type ExportSpecifier =
 
 // Type Annotations
 type TypeAnnotation =
-    | AliasTypeAnnotation of id: Identifier * typeParameters: TypeParameterInstantiation
+    | AliasTypeAnnotation of id: Identifier * typeArguments: TypeAnnotation array
     | AnyTypeAnnotation
     | VoidTypeAnnotation
     | StringTypeAnnotation
@@ -432,8 +438,7 @@ type TypeAnnotation =
     | FunctionTypeAnnotation of
         parameters: FunctionTypeParam array *
         returnType: TypeAnnotation *
-        typeParameters: TypeParameterDeclaration *
-        rest: FunctionTypeParam option
+        spread: FunctionTypeParam option
     | NullableTypeAnnotation of typeAnnotation: TypeAnnotation
     | ArrayTypeAnnotation of TypeAnnotation
     | TupleTypeAnnotation of types: TypeAnnotation array
@@ -445,32 +450,28 @@ type TypeAnnotation =
 type TypeParameter =
     | TypeParameter of name: string * bound: TypeAnnotation option * ``default``: TypeAnnotation option
 
-type TypeParameterDeclaration = TypeParameter array
-
-type TypeParameterInstantiation = TypeAnnotation array
-
 type FunctionTypeParam =
-    | FunctionTypeParam of name: Identifier * typeAnnotation: TypeAnnotation * optional: bool option
+    | FunctionTypeParam of name: Identifier * typeAnnotation: TypeAnnotation * isOptional: bool
 
 type ObjectTypeProperty =
     | ObjectTypeProperty of
         key: Expression *
         value: TypeAnnotation *
         kind: string option *
-        computed: bool *
-        ``static``: bool *
-        optional: bool *
+        isComputed: bool *
+        isStatic: bool *
+        isOptional: bool *
         proto: bool *
         method: bool
 
 type ObjectTypeIndexer =
-    | ObjectTypeIndexer of id: Identifier option * key: Identifier * value: TypeAnnotation * ``static``: bool option
+    | ObjectTypeIndexer of id: Identifier option * key: Identifier * value: TypeAnnotation * isStatic: bool
 
 type ObjectTypeCallProperty =
-    | ObjectTypeCallProperty of value: TypeAnnotation * ``static``: bool option
+    | ObjectTypeCallProperty of value: TypeAnnotation * isStatic: bool
 
 type ObjectTypeInternalSlot =
-    | ObjectTypeInternalSlot of id: Identifier * value: TypeAnnotation * optional: bool * ``static``: bool * method: bool
+    | ObjectTypeInternalSlot of id: Identifier * value: TypeAnnotation * isOptional: bool * isStatic: bool * method: bool
 
 type ObjectTypeAnnotation =
     | ObjectTypeAnnotation of
@@ -480,7 +481,7 @@ type ObjectTypeAnnotation =
         internalSlots: ObjectTypeInternalSlot array *
         exact: bool
 type InterfaceExtends =
-    | InterfaceExtends of id: Identifier * typeParameters: TypeParameterInstantiation option
+    | InterfaceExtends of id: Identifier * typeArguments: TypeAnnotation array
 
 //    let mixins = defaultArg mixins_ [||]
 //    member _.Mixins: InterfaceExtends array = mixins
@@ -498,14 +499,14 @@ module Helpers =
         static member booleanLiteral(value, ?loc) = BooleanLiteral (value, loc) |> Literal
         static member stringLiteral(value, ?loc) = Literal.stringLiteral (value, ?loc=loc) |> Literal
         static member arrayExpression(elements, ?loc) = ArrayExpression(elements, ?loc=loc)
-        static member identifier(name, ?typeAnnotation, ?loc) =
-            Identifier.identifier(name, ?typeAnnotation = typeAnnotation, ?loc = loc)
+        static member identifier(name, ?loc) =
+            Identifier.identifier(name, ?loc = loc)
             |> Expression.Identifier
         static member regExpLiteral(pattern, flags_, ?loc) =
             Literal.regExpLiteral(pattern, flags_, ?loc=loc) |> Literal
         /// A function or method call expression.
-        static member callExpression(callee, args, ?typeParameters, ?loc) =
-            CallExpression(callee, args, typeParameters, loc)
+        static member callExpression(callee, args, ?typeArguments, ?loc) =
+            CallExpression(callee, args, defaultArg typeArguments [||], loc)
         static member assignmentExpression(operator_, left, right, ?loc) =
             let operator =
                 match operator_ with
@@ -534,22 +535,22 @@ module Helpers =
 
             LogicalExpression(left, operator, right, loc)
         static member objectExpression(properties, ?loc) = ObjectExpression(properties, loc)
-        static member newExpression(callee, args, ?typeParameters, ?loc) = NewExpression(callee, args, typeParameters, loc)
+        static member newExpression(callee, args, ?typeArguments, ?loc) = NewExpression(callee, args, defaultArg typeArguments [||], loc)
         /// A fat arrow function expression, e.g., let foo = (bar) => { /* body */ }.
         static member arrowFunctionExpression(parameters, body: BlockStatement, ?returnType, ?typeParameters, ?loc) = //?async_, ?generator_,
-            ArrowFunctionExpression(parameters, body, returnType, typeParameters, loc)
+            ArrowFunctionExpression(parameters, body, returnType, defaultArg typeParameters [||], loc)
         static member arrowFunctionExpression(parameters, body: Expression, ?returnType, ?typeParameters, ?loc): Expression =
             let body = BlockStatement [| Statement.returnStatement(body) |]
             Expression.arrowFunctionExpression(parameters, body, ?returnType = returnType, ?typeParameters = typeParameters, ?loc = loc)
-        /// If computed is true, the node corresponds to a computed (a[b]) member expression and property is an Expression.
-        /// If computed is false, the node corresponds to a static (a.b) member expression and property is an Identifier.
-        static member memberExpression(object, property, ?computed_, ?loc) =
-            let computed = defaultArg computed_ false
-            MemberExpression(object, property, computed, loc)
+        /// If isComputed is true, the node corresponds to a isComputed (a[b]) member expression and property is an Expression.
+        /// If isComputed is false, the node corresponds to a static (a.b) member expression and property is an Identifier.
+        static member memberExpression(object, property, ?isComputed, ?loc) =
+            let isComputed = defaultArg isComputed false
+            MemberExpression(object, property, isComputed, loc)
         static member functionExpression(parameters, body, ?id, ?returnType, ?typeParameters, ?loc) = //?generator_, ?async_
-            FunctionExpression(id, parameters, body, returnType, typeParameters, loc)
+            FunctionExpression(id, parameters, body, returnType, defaultArg typeParameters [||], loc)
         static member classExpression(body, ?id, ?superClass, ?typeParameters, ?implements, ?loc) =
-            ClassExpression(body, id, superClass, implements, typeParameters, loc)
+            ClassExpression(body, id, superClass, implements, defaultArg typeParameters [||], loc)
         static member spreadElement(argument, ?loc) =
             SpreadElement(argument, ?loc=loc)
         static member conditionalExpression(test, consequent, alternate, ?loc): Expression =
@@ -596,8 +597,8 @@ module Helpers =
         member this.Name =
             let (Identifier(name=name)) = this
             name
-        static member identifier(name, ?typeAnnotation, ?loc) : Identifier =
-            Identifier(name, optional=false, named=false, typeAnnotation=typeAnnotation, loc=loc)
+        static member identifier(name, ?loc) : Identifier =
+            Identifier(name, loc=loc)
 
     type Statement with
         static member blockStatement(body) = BlockStatement body |> Statement.BlockStatement
@@ -605,7 +606,7 @@ module Helpers =
         static member continueStatement(label, ?loc) = ContinueStatement(Some label, loc)
         static member tryStatement(block, ?handler, ?finalizer, ?loc) = TryStatement(block, handler, finalizer, loc)
         static member ifStatement(test, consequent, ?alternate, ?loc): Statement = IfStatement(test, consequent, alternate, loc)
-        /// Break can optionally take a label of a loop to break
+        /// Break can optional take a label of a loop to break
         static member breakStatement(?label, ?loc) = BreakStatement(label, loc)
         /// Statement (typically loop) prefixed with a label (for continue and break)
         static member labeledStatement(label, body): Statement = LabeledStatement (body, label)
@@ -615,8 +616,8 @@ module Helpers =
         static member variableDeclaration(kind, declarations, ?loc): Statement =
             Declaration.variableDeclaration(kind, declarations, ?loc = loc)
             |> Declaration
-        static member variableDeclaration(var, ?init, ?kind, ?loc): Statement =
-            Declaration.variableDeclaration(var, ?init = init, ?kind = kind, ?loc = loc)
+        static member variableDeclaration(kind, var, ?annotation, ?typeParameters, ?init, ?loc): Statement =
+            Declaration.variableDeclaration(kind, var, ?annotation=annotation, ?typeParameters=typeParameters, ?init=init, ?loc=loc)
             |> Declaration
         static member forStatement(body, ?init, ?test, ?update, ?loc) = ForStatement(body, init, test, update, loc)
         static member throwStatement(argument, ?loc) = ThrowStatement(argument, loc)
@@ -632,84 +633,72 @@ module Helpers =
             body
 
     type CatchClause with
-        static member catchClause(param, body, ?loc) =
-            CatchClause(param, body, loc)
+        static member catchClause(param, body, ?annotation, ?loc) =
+            CatchClause(param, annotation, body, loc)
 
     type SwitchCase with
         static member switchCase(?consequent, ?test, ?loc) =
             SwitchCase(test, defaultArg consequent Array.empty, loc)
 
-    type Pattern with
-        static member identifier(name, ?optional, ?named, ?typeAnnotation, ?accessModifier, ?loc) =
-            let ident = Identifier(name, optional = defaultArg optional false, named = defaultArg named false, ?typeAnnotation = typeAnnotation, ?loc = loc)
-            Pattern.Identifier(ident, accessModifier)
-        static member restElement(argument: Pattern) =
-            RestElement(argument)
+    type Parameter with
+        static member parameter(name, ?isOptional, ?isNamed, ?isSpread, ?typeAnnotation) =
+            Parameter(name, isOptional=defaultArg isOptional false, isNamed=defaultArg isNamed false, isSpread=defaultArg isSpread false, typeAnnotation=typeAnnotation)
 
     type ClassImplements with
-        static member classImplements(id, ?typeParameters) =
-            ClassImplements(id, typeParameters)
+        static member classImplements(id, ?typeArguments) =
+            ClassImplements(id, defaultArg typeArguments [||])
 
     type Declaration with
         static member variableDeclaration(kind, declarations, ?loc) : Declaration =
-            VariableDeclaration.variableDeclaration(kind, declarations, ?loc = loc) |> Declaration.VariableDeclaration
-        static member variableDeclaration(var, ?init, ?kind, ?loc) =
-            Declaration.variableDeclaration(
-                defaultArg kind Let,
-                [| VariableDeclarator(var, init) |],
-                ?loc = loc
-            )
+            VariableDeclaration.variableDeclaration(kind, declarations, ?loc = loc)
+            |> Declaration.VariableDeclaration
+        static member variableDeclaration(kind, var, ?annotation, ?typeParameters, ?init, ?loc) =
+            VariableDeclaration.variableDeclaration(kind, var, ?annotation=annotation, ?typeParameters=typeParameters, ?init=init, ?loc=loc)
+            |> Declaration.VariableDeclaration
         static member functionDeclaration(parameters, body, id, ?returnType, ?typeParameters, ?loc) =
-            FunctionDeclaration(parameters, body, id, returnType, typeParameters, loc)
+            FunctionDeclaration(parameters, body, id, returnType, defaultArg typeParameters [||], loc)
         static member classDeclaration(body, ?id, ?superClass, ?typeParameters, ?implements, ?loc) =
-            ClassDeclaration(body, id, superClass, implements, typeParameters, loc)
+            ClassDeclaration(body, id, superClass, implements, defaultArg typeParameters [||], loc)
         static member interfaceDeclaration(id, body, ?extends_, ?typeParameters, ?implements_): Declaration = // ?mixins_,
             let extends = defaultArg extends_ [||]
             let implements = defaultArg implements_ [||]
-            InterfaceDeclaration(id, body, extends, implements, typeParameters)
+            InterfaceDeclaration(id, body, extends, implements, defaultArg typeParameters [||])
         static member enumDeclaration(name, cases, ?isConst) =
             EnumDeclaration(name, cases, defaultArg isConst false)
 
     type VariableDeclaration with
         static member variableDeclaration(kind, declarations, ?loc) : VariableDeclaration =
-            let kind =
-                match kind with
-                | Var -> "var"
-                | Let -> "let"
-                | Const -> "const"
             VariableDeclaration(declarations, kind, loc)
 
-        static member variableDeclaration(var, ?init, ?kind, ?loc) =
-            VariableDeclaration.variableDeclaration(defaultArg kind Let, [| VariableDeclarator(var, init) |], ?loc = loc)
+        static member variableDeclaration(kind, var, ?annotation, ?typeParameters, ?init, ?loc) =
+            VariableDeclaration.variableDeclaration(
+                kind,
+                [| VariableDeclarator.variableDeclarator(var, ?annotation=annotation, ?typeParameters=typeParameters, ?init=init) |],
+                ?loc = loc
+            )
 
     type VariableDeclarator with
-        static member variableDeclarator(id, ?init) = VariableDeclarator(id, init)
+        static member variableDeclarator(id, ?annotation, ?typeParameters, ?init) =
+            VariableDeclarator(id, annotation, defaultArg typeParameters [||], init)
 
     type ObjectTypeIndexer with
-        static member objectTypeIndexer(key, value, ?id, ?``static``) =
-            ObjectTypeIndexer(id, key, value, ``static``)
+        static member objectTypeIndexer(key, value, ?id, ?isStatic) =
+            ObjectTypeIndexer(id, key, value, defaultArg isStatic false)
 
     type InterfaceExtends with
-        static member interfaceExtends(id, ?typeParameters) =
-            InterfaceExtends(id, typeParameters)
+        static member interfaceExtends(id, ?typeArguments) =
+            InterfaceExtends(id, defaultArg typeArguments [||])
 
     type FunctionTypeParam with
-        static member functionTypeParam(name, typeInfo, ?optional) =
-            FunctionTypeParam(name, typeInfo, optional)
+        static member functionTypeParam(name, typeInfo, ?isOptional) =
+            FunctionTypeParam(name, typeInfo, defaultArg isOptional false)
 
     type ClassMember with
-        static member classMethod(kind_, key, parameters, body, ?computed_, ?``static``, ?``abstract``, ?returnType, ?typeParameters, ?loc) : ClassMember =
-            let kind =
-                match kind_ with
-                | ClassPrimaryConstructor -> "constructor"
-                | ClassGetter -> "get"
-                | ClassSetter -> "set"
-                | ClassFunction -> "method"
-            let computed = defaultArg computed_ false
-            ClassMethod(kind, key, parameters, body, computed, ``static``, ``abstract``, returnType, typeParameters, loc)
-        static member classProperty(key, ?value, ?computed_, ?``static``, ?optional, ?typeAnnotation, ?accessModifier, ?loc): ClassMember =
-            let computed = defaultArg computed_ false
-            ClassProperty(key, value, computed, defaultArg ``static`` false, defaultArg optional false, typeAnnotation, accessModifier, loc)
+        static member classMethod(kind, parameters, body, ?isStatic, ?isAbstract, ?returnType, ?typeParameters, ?loc) : ClassMember =
+            ClassMethod(kind, parameters, body, defaultArg isStatic false, defaultArg isAbstract false, returnType, defaultArg typeParameters [||], loc)
+        static member classProperty(key, ?value, ?isComputed, ?isStatic, ?isOptional, ?typeAnnotation, ?accessModifier, ?loc): ClassMember =
+            let isComputed = defaultArg isComputed false
+            ClassProperty(key, value, isComputed, defaultArg isStatic false, defaultArg isOptional false, typeAnnotation, accessModifier, loc)
 
     type Literal with
         static member nullLiteral(?loc) = NullLiteral loc
@@ -731,26 +720,21 @@ module Helpers =
         static member stringLiteral(value, ?loc) = StringLiteral(value, loc)
 
     type ObjectMember with
-        static member objectProperty(key, value, ?computed_) = // ?shorthand_,
-            let computed = defaultArg computed_ false
-            ObjectProperty(key, value, computed)
-        static member objectMethod(kind_, key, parameters, body, ?computed_, ?returnType, ?typeParameters, ?loc) =
-            let kind =
-                match kind_ with
-                | ObjectGetter -> "get"
-                | ObjectSetter -> "set"
-                | ObjectMeth -> "method"
-            let computed = defaultArg computed_ false
-            ObjectMethod(kind, key, parameters, body, computed, returnType, typeParameters, loc)
+        static member objectProperty(key, value, ?isComputed) = // ?shorthand_,
+            let isComputed = defaultArg isComputed false
+            ObjectProperty(key, value, isComputed)
+        static member objectMethod(kind, key, parameters, body, ?isComputed, ?returnType, ?typeParameters, ?loc) =
+            let isComputed = defaultArg isComputed false
+            ObjectMethod(kind, key, parameters, body, isComputed, returnType, defaultArg typeParameters [||], loc)
 
     type ObjectTypeProperty with
-        static member objectTypeProperty(key, value, ?computed_, ?kind, ?``static``, ?optional, ?proto, ?method) =
-            let computed = defaultArg computed_ false
-            let optional = defaultArg optional false
+        static member objectTypeProperty(key, value, ?isComputed, ?kind, ?isStatic, ?isOptional, ?proto, ?method) =
+            let isComputed = defaultArg isComputed false
+            let isOptional = defaultArg isOptional false
             let method = defaultArg method false
-            let ``static`` = defaultArg ``static`` false
+            let isStatic = defaultArg isStatic false
             let proto = defaultArg proto false
-            ObjectTypeProperty(key, value, kind, computed, ``static``, optional, proto, method)
+            ObjectTypeProperty(key, value, kind, isComputed, isStatic, isOptional, proto, method)
 
     type ModuleDeclaration with
         static member exportAllDeclaration(source, ?loc) = ExportAllDeclaration(source, loc)
@@ -758,10 +742,10 @@ module Helpers =
             ExportNamedReferences(specifiers, source)
 
     type TypeAnnotation with
-        static member aliasTypeAnnotation(id, ?typeParameters) =
-            AliasTypeAnnotation(id, defaultArg typeParameters [||])
-        static member functionTypeAnnotation(parameters, returnType, ?typeParameters, ?rest): TypeAnnotation =
-            FunctionTypeAnnotation(parameters,returnType, defaultArg typeParameters [||], rest)
+        static member aliasTypeAnnotation(id, ?typeArguments) =
+            AliasTypeAnnotation(id, defaultArg typeArguments [||])
+        static member functionTypeAnnotation(parameters, returnType, ?spread): TypeAnnotation =
+            FunctionTypeAnnotation(parameters, returnType, spread)
 
     type ObjectTypeAnnotation with
         static member objectTypeAnnotation(properties, ?indexers_, ?callProperties_, ?internalSlots_, ?exact_) =

--- a/src/fable-library/Array.fs
+++ b/src/fable-library/Array.fs
@@ -20,7 +20,7 @@ let private differentLengths() =
 // if implementing via native JS array .concat() and .filter() do not fall behind due to js-native transitions.
 
 // Don't use native JS Array.prototype.concat as it doesn't work with typed arrays
-let append (array1: 'T[]) (array2: 'T[]) ([<Inject>] cons: Cons<'T>): 'T[] =
+let append (array1: 'T[]) (array2: 'T[]) ([<OptionalArgument; Inject>] cons: Cons<'T>): 'T[] =
     let len1 = array1.Length
     let len2 = array2.Length
     let newArray = allocateArrayFromCons cons (len1 + len2)
@@ -48,49 +48,49 @@ let tryLast (array: 'T[]) =
     if array.Length = 0 then None
     else Some array.[array.Length-1]
 
-let mapIndexed (f: int -> 'T -> 'U) (source: 'T[]) ([<Inject>] cons: Cons<'U>): 'U[] =
+let mapIndexed (f: int -> 'T -> 'U) (source: 'T[]) ([<OptionalArgument; Inject>] cons: Cons<'U>): 'U[] =
     let len = source.Length
     let target = allocateArrayFromCons cons len
     for i = 0 to (len - 1) do
         target.[i] <- f i source.[i]
     target
 
-let map (f: 'T -> 'U) (source: 'T[]) ([<Inject>] cons: Cons<'U>): 'U[] =
+let map (f: 'T -> 'U) (source: 'T[]) ([<OptionalArgument; Inject>] cons: Cons<'U>): 'U[] =
     let len = source.Length
     let target = allocateArrayFromCons cons len
     for i = 0 to (len - 1) do
         target.[i] <- f source.[i]
     target
 
-let mapIndexed2 (f: int->'T1->'T2->'U) (source1: 'T1[]) (source2: 'T2[]) ([<Inject>] cons: Cons<'U>): 'U[] =
+let mapIndexed2 (f: int->'T1->'T2->'U) (source1: 'T1[]) (source2: 'T2[]) ([<OptionalArgument; Inject>] cons: Cons<'U>): 'U[] =
     if source1.Length <> source2.Length then failwith "Arrays had different lengths"
     let result = allocateArrayFromCons cons source1.Length
     for i = 0 to source1.Length - 1 do
         result.[i] <- f i source1.[i] source2.[i]
     result
 
-let map2 (f: 'T1->'T2->'U) (source1: 'T1[]) (source2: 'T2[]) ([<Inject>] cons: Cons<'U>): 'U[] =
+let map2 (f: 'T1->'T2->'U) (source1: 'T1[]) (source2: 'T2[]) ([<OptionalArgument; Inject>] cons: Cons<'U>): 'U[] =
     if source1.Length <> source2.Length then failwith "Arrays had different lengths"
     let result = allocateArrayFromCons cons source1.Length
     for i = 0 to source1.Length - 1 do
         result.[i] <- f source1.[i] source2.[i]
     result
 
-let mapIndexed3 (f: int->'T1->'T2->'T3->'U) (source1: 'T1[]) (source2: 'T2[]) (source3: 'T3[]) ([<Inject>] cons: Cons<'U>): 'U[] =
+let mapIndexed3 (f: int->'T1->'T2->'T3->'U) (source1: 'T1[]) (source2: 'T2[]) (source3: 'T3[]) ([<OptionalArgument; Inject>] cons: Cons<'U>): 'U[] =
     if source1.Length <> source2.Length || source2.Length <> source3.Length then failwith "Arrays had different lengths"
     let result = allocateArrayFromCons cons source1.Length
     for i = 0 to source1.Length - 1 do
         result.[i] <- f i source1.[i] source2.[i] source3.[i]
     result
 
-let map3 (f: 'T1->'T2->'T3->'U) (source1: 'T1[]) (source2: 'T2[]) (source3: 'T3[]) ([<Inject>] cons: Cons<'U>): 'U[] =
+let map3 (f: 'T1->'T2->'T3->'U) (source1: 'T1[]) (source2: 'T2[]) (source3: 'T3[]) ([<OptionalArgument; Inject>] cons: Cons<'U>): 'U[] =
     if source1.Length <> source2.Length || source2.Length <> source3.Length then failwith "Arrays had different lengths"
     let result = allocateArrayFromCons cons source1.Length
     for i = 0 to source1.Length - 1 do
         result.[i] <- f source1.[i] source2.[i] source3.[i]
     result
 
-let mapFold<'T, 'State, 'Result> (mapping: 'State -> 'T -> 'Result * 'State) state (array: 'T[]) ([<Inject>] cons: Cons<'Result>) =
+let mapFold<'T, 'State, 'Result> (mapping: 'State -> 'T -> 'Result * 'State) state (array: 'T[]) ([<OptionalArgument; Inject>] cons: Cons<'Result>) =
     match array.Length with
     | 0 -> [| |], state
     | len ->
@@ -102,7 +102,7 @@ let mapFold<'T, 'State, 'Result> (mapping: 'State -> 'T -> 'Result * 'State) sta
             acc <- s
         res, acc
 
-let mapFoldBack<'T, 'State, 'Result> (mapping: 'T -> 'State -> 'Result * 'State) (array: 'T[]) state ([<Inject>] cons: Cons<'Result>) =
+let mapFoldBack<'T, 'State, 'Result> (mapping: 'T -> 'State -> 'Result * 'State) (array: 'T[]) state ([<OptionalArgument; Inject>] cons: Cons<'Result>) =
     match array.Length with
     | 0 -> [| |], state
     | len ->
@@ -125,7 +125,7 @@ let truncate (count: int) (array: 'T[]): 'T[] =
     let count = max 0 count
     subArrayImpl array 0 count
 
-let concat (arrays: 'T[] seq) ([<Inject>] cons: Cons<'T>): 'T[] =
+let concat (arrays: 'T[] seq) ([<OptionalArgument; Inject>] cons: Cons<'T>): 'T[] =
     let arrays =
         if isDynamicArrayImpl arrays then arrays :?> 'T[][] // avoid extra copy
         else arrayFrom arrays
@@ -144,7 +144,7 @@ let concat (arrays: 'T[] seq) ([<Inject>] cons: Cons<'T>): 'T[] =
                 totalIdx <- totalIdx + 1
         result
 
-let collect (mapping: 'T -> 'U[]) (array: 'T[]) ([<Inject>] cons: Cons<'U>): 'U[] =
+let collect (mapping: 'T -> 'U[]) (array: 'T[]) ([<OptionalArgument; Inject>] cons: Cons<'U>): 'U[] =
     let mapped = map mapping array Unchecked.defaultof<_>
     concat mapped cons
     // collectImpl mapping array // flatMap not widely available yet
@@ -169,12 +169,12 @@ let contains<'T> (value: 'T) (array: 'T[]) ([<Inject>] eq: IEqualityComparer<'T>
 
 let empty cons = allocateArrayFromCons cons 0
 
-let singleton value ([<Inject>] cons: Cons<'T>) =
+let singleton value ([<OptionalArgument; Inject>] cons: Cons<'T>) =
     let ar = allocateArrayFromCons cons 1
     ar.[0] <- value
     ar
 
-let initialize count initializer ([<Inject>] cons: Cons<'T>) =
+let initialize count initializer ([<OptionalArgument; Inject>] cons: Cons<'T>) =
     if count < 0 then invalidArg "count" LanguagePrimitives.ErrorStrings.InputMustBeNonNegativeString
     let result = allocateArrayFromCons cons count
     for i = 0 to count - 1 do
@@ -190,7 +190,7 @@ let pairwise (array: 'T[]) =
             result.[i] <- array.[i], array.[i+1]
         result
 
-let replicate count initial ([<Inject>] cons: Cons<'T>) =
+let replicate count initial ([<OptionalArgument; Inject>] cons: Cons<'T>) =
     // Shorthand version: = initialize count (fun _ -> initial)
     if count < 0 then invalidArg "count" LanguagePrimitives.ErrorStrings.InputMustBeNonNegativeString
     let result: 'T array = allocateArrayFromCons cons count
@@ -222,21 +222,21 @@ let reverse (array: 'T[]) =
     // else
     copyImpl array |> reverseImpl
 
-let scan<'T, 'State> folder (state: 'State) (array: 'T[]) ([<Inject>] cons: Cons<'State>) =
+let scan<'T, 'State> folder (state: 'State) (array: 'T[]) ([<OptionalArgument; Inject>] cons: Cons<'State>) =
     let res = allocateArrayFromCons cons (array.Length + 1)
     res.[0] <- state
     for i = 0 to array.Length - 1 do
         res.[i + 1] <- folder res.[i] array.[i]
     res
 
-let scanBack<'T, 'State> folder (array: 'T[]) (state: 'State) ([<Inject>] cons: Cons<'State>) =
+let scanBack<'T, 'State> folder (array: 'T[]) (state: 'State) ([<OptionalArgument; Inject>] cons: Cons<'State>) =
     let res = allocateArrayFromCons cons (array.Length + 1)
     res.[array.Length] <- state
     for i = array.Length - 1 downto 0 do
         res.[i] <- folder array.[i] res.[i + 1]
     res
 
-let skip count (array: 'T[]) ([<Inject>] cons: Cons<'T>) =
+let skip count (array: 'T[]) ([<OptionalArgument; Inject>] cons: Cons<'T>) =
     if count > array.Length then invalidArg "count" "count is greater than array length"
     if count = array.Length then
         allocateArrayFromCons cons 0
@@ -244,7 +244,7 @@ let skip count (array: 'T[]) ([<Inject>] cons: Cons<'T>) =
         let count = if count < 0 then 0 else count
         skipImpl array count
 
-let skipWhile predicate (array: 'T[]) ([<Inject>] cons: Cons<'T>) =
+let skipWhile predicate (array: 'T[]) ([<OptionalArgument; Inject>] cons: Cons<'T>) =
     let mutable count = 0
     while count < array.Length && predicate array.[count] do
         count <- count + 1
@@ -253,7 +253,7 @@ let skipWhile predicate (array: 'T[]) ([<Inject>] cons: Cons<'T>) =
     else
         skipImpl array count
 
-let take count (array: 'T[]) ([<Inject>] cons: Cons<'T>) =
+let take count (array: 'T[]) ([<OptionalArgument; Inject>] cons: Cons<'T>) =
     if count < 0 then invalidArg "count" LanguagePrimitives.ErrorStrings.InputMustBeNonNegativeString
     if count > array.Length then invalidArg "count" "count is greater than array length"
     if count = 0 then
@@ -261,7 +261,7 @@ let take count (array: 'T[]) ([<Inject>] cons: Cons<'T>) =
     else
         subArrayImpl array 0 count
 
-let takeWhile predicate (array: 'T[]) ([<Inject>] cons: Cons<'T>) =
+let takeWhile predicate (array: 'T[]) ([<OptionalArgument; Inject>] cons: Cons<'T>) =
     let mutable count = 0
     while count < array.Length && predicate array.[count] do
         count <- count + 1
@@ -304,7 +304,7 @@ let removeAllInPlace predicate (array: 'T[]) =
             count
     countRemoveAll 0
 
-let partition (f: 'T -> bool) (source: 'T[]) ([<Inject>] cons: Cons<'T>) =
+let partition (f: 'T -> bool) (source: 'T[]) ([<OptionalArgument; Inject>] cons: Cons<'T>) =
     let len = source.Length
     let res1 = allocateArrayFromCons cons len
     let res2 = allocateArrayFromCons cons len
@@ -390,7 +390,7 @@ let tryFindIndexBack predicate (array: _[]) =
         else loop (i - 1)
     loop (array.Length - 1)
 
-let choose (chooser: 'T->'U option) (array: 'T[]) ([<Inject>] cons: Cons<'U>) =
+let choose (chooser: 'T->'U option) (array: 'T[]) ([<OptionalArgument; Inject>] cons: Cons<'U>) =
     let res: 'U[] = [||]
     for i = 0 to array.Length - 1 do
         match chooser array.[i] with
@@ -401,7 +401,7 @@ let choose (chooser: 'T->'U option) (array: 'T[]) ([<Inject>] cons: Cons<'U>) =
     | null -> res // avoid extra copy
     | _ -> map id res cons
 
-let foldIndexed folder (state: 'State) (array: 'T[]) =
+let foldIndexed<'T, 'State> folder (state: 'State) (array: 'T[]) =
     // if isTypedArrayImpl array then
     //     let mutable acc = state
     //     for i = 0 to array.Length - 1 do
@@ -410,7 +410,7 @@ let foldIndexed folder (state: 'State) (array: 'T[]) =
     // else
     foldIndexedImpl (fun acc x i -> folder i acc x) state array
 
-let fold folder (state: 'State) (array: 'T[]) =
+let fold<'T, 'State> folder (state: 'State) (array: 'T[]) =
     // if isTypedArrayImpl array then
     //     let mutable acc = state
     //     for i = 0 to array.Length - 1 do
@@ -427,12 +427,12 @@ let iterateIndexed action (array: 'T[]) =
     for i = 0 to array.Length - 1 do
         action i array.[i]
 
-let iterate2 action (array1: 'T[]) (array2: 'T[]) =
+let iterate2 action (array1: 'T1[]) (array2: 'T2[]) =
     if array1.Length <> array2.Length then differentLengths()
     for i = 0 to array1.Length - 1 do
         action array1.[i] array2.[i]
 
-let iterateIndexed2 action (array1: 'T[]) (array2: 'T[]) =
+let iterateIndexed2 action (array1: 'T1[]) (array2: 'T2[]) =
     if array1.Length <> array2.Length then differentLengths()
     for i = 0 to array1.Length - 1 do
         action i array1.[i] array2.[i]
@@ -553,7 +553,7 @@ let zip (array1: 'T[]) (array2: 'U[]) =
         result.[i] <- array1.[i], array2.[i]
     result
 
-let zip3 (array1: 'T[]) (array2: 'U[]) (array3: 'U[]) =
+let zip3 (array1: 'T[]) (array2: 'U[]) (array3: 'V[]) =
     // Shorthand version: map3 (fun x y z -> x, y, z) array1 array2 array3
     if array1.Length <> array2.Length || array2.Length <> array3.Length then differentLengths()
     let result = allocateArray array1.Length
@@ -800,7 +800,7 @@ let splitInto (chunks: int) (array: 'T[]): 'T[][] =
             pushImpl result slice |> ignore
         result
 
-let transpose (arrays: 'T[] seq) ([<Inject>] cons: Cons<'T>): 'T[][] =
+let transpose (arrays: 'T[] seq) ([<OptionalArgument; Inject>] cons: Cons<'T>): 'T[][] =
     let arrays =
         if isDynamicArrayImpl arrays then arrays :?> 'T[][] // avoid extra copy
         else arrayFrom arrays
@@ -819,7 +819,7 @@ let transpose (arrays: 'T[] seq) ([<Inject>] cons: Cons<'T>): 'T[][] =
                 result.[i].[j] <- arrays.[j].[i]
         result
 
-let insertAt (index: int) (y: 'T) (xs: 'T[]) ([<Inject>] cons: Cons<'T>): 'T[] =
+let insertAt (index: int) (y: 'T) (xs: 'T[]) ([<OptionalArgument; Inject>] cons: Cons<'T>): 'T[] =
     let len = xs.Length
     if index < 0 || index > len then
         invalidArg "index" SR.indexOutOfBounds
@@ -831,7 +831,7 @@ let insertAt (index: int) (y: 'T) (xs: 'T[]) ([<Inject>] cons: Cons<'T>): 'T[] =
         target.[i + 1] <- xs.[i]
     target
 
-let insertManyAt (index: int) (ys: seq<'T>) (xs: 'T[]) ([<Inject>] cons: Cons<'T>): 'T[] =
+let insertManyAt (index: int) (ys: seq<'T>) (xs: 'T[]) ([<OptionalArgument; Inject>] cons: Cons<'T>): 'T[] =
     let len = xs.Length
     if index < 0 || index > len then
         invalidArg "index" SR.indexOutOfBounds
@@ -880,7 +880,7 @@ let removeManyAt (index: int) (count: int) (xs: 'T[]): 'T[] =
         invalidArg arg SR.indexOutOfBounds
     ys
 
-let updateAt (index: int) (y: 'T) (xs: 'T[]) ([<Inject>] cons: Cons<'T>): 'T[] =
+let updateAt (index: int) (y: 'T) (xs: 'T[]) ([<OptionalArgument; Inject>] cons: Cons<'T>): 'T[] =
     let len = xs.Length
     if index < 0 || index >= len then
         invalidArg "index" SR.indexOutOfBounds

--- a/tests/Js/Main/ArrayTests.fs
+++ b/tests/Js/Main/ArrayTests.fs
@@ -103,12 +103,14 @@ let tests =
         let concaters1 = a |> Array.map (fun x y -> y + x)
         let concaters2 = a |> Array.map (fun x -> (fun y -> y + x))
         let concaters3 = a |> Array.map (fun x -> let f = (fun y -> y + x) in f)
+#if !FABLE_COMPILER_TYPESCRIPT // TODO!!!
         let concaters4 = a |> Array.map f
+        concaters4.[0] "x" "y" |> equal "axy"
+#endif
         let concaters5 = b |> Array.mapi f
         concaters1.[0] "x" |> equal "xa"
         concaters2.[1] "x" |> equal "xb"
         concaters3.[2] "x" |> equal "xc"
-        concaters4.[0] "x" "y" |> equal "axy"
         concaters5.[1] "x" |> equal "12x"
         let f2 = f
         a |> Array.mapi f2 |> Array.item 2 <| "x" |> equal "2cx"
@@ -966,11 +968,12 @@ let tests =
 
     testCase "Arrays are independent from being binded to a name" <| fun () ->
         let intList = [1;2;3]
-        intList  |> List.toArray  |> equal [|1;2;3|]
-        [1;2;3]  |> List.toArray  |> equal [|1;2;3|]
+        intList |> List.toArray |> equal [|1;2;3|]
+        [1;2;3] |> List.toArray |> equal [|1;2;3|]
 
     testCase "Functions on arrays should behave the same whether binded to a name or not" <| fun () ->
-        let fromArrayToListAndBack a = a |> Array.toList |> List.toArray
+        // TODO: Fix inlined generic local functions in TypeScript
+        let fromArrayToListAndBack (a: int[]) = a |> Array.toList |> List.toArray
         [|1;2|] |> Array.toList |> List.toArray  |> equal ([|1;2|] |> fromArrayToListAndBack)
 
     testCase "Array.skip works" <| fun () ->

--- a/tests/TypeScript/Fable.Tests.TypeScript.fsproj
+++ b/tests/TypeScript/Fable.Tests.TypeScript.fsproj
@@ -11,6 +11,7 @@
     <Compile Include="../Js/Main/Util/Util.fs" />
     <Compile Include="../Js/Main/Util/UtilTests.fs" />
     <Compile Include="../Js/Main/ArithmeticTests.fs" />
+    <Compile Include="../Js/Main/ArrayTests.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
 </Project>

--- a/tests/TypeScript/Main.fs
+++ b/tests/TypeScript/Main.fs
@@ -6,6 +6,7 @@ open Fable.Tests
 let allTests =
   [|
     Arithmetic.tests
+    Arrays.tests
   |]
 
 #if FABLE_COMPILER


### PR DESCRIPTION
This enables ArrayTests for TypeScript, will a couple of caveats that I will check later.
- A complex pattern where an array is mapped resulting in an array of curried functions is failing and [I disabled it for now](https://github.com/fable-compiler/Fable/blob/d4dfa2afc8cab793a547b6d0188cd2c8faadd477/tests/Js/Main/ArrayTests.fs#L106-L109)
- I had to add type annotations in F# to [a local function](https://github.com/fable-compiler/Fable/blob/d4dfa2afc8cab793a547b6d0188cd2c8faadd477/tests/Js/Main/ArrayTests.fs#L975-L976) because it was being inlined but the generics were not resolved.

While making the fixes, I tried to improve the Babel AST and as usual I touched a lot of code. The main changes are:
- Remove `Pattern` because we were not using it (we are not using destructuring in compiled code) and it was complicating things.
- Add `Parameter` instead of Pattern for function declarations.
- Remove type annotation from `Identifier` as type annotations are only needed for parameters and variable declarations.
- For a similar reason, remove type parameters from type annotation, as they're only needed in specific cases.