### PR TITLE
Moar TypeScript tests

### DIFF
--- a/src/Fable.Transforms/BabelPrinter.fs
+++ b/src/Fable.Transforms/BabelPrinter.fs
@@ -1013,6 +1013,8 @@ module PrinterExtensions =
                 printer.Print("]")
             | UnionTypeAnnotation(types) ->
                 printer.PrintArray(types, (fun p x -> p.Print(x)), (fun p -> p.Print(" | ")))
+            | IntersectionTypeAnnotation(types) ->
+                printer.PrintArray(types, (fun p x -> p.Print(x)), (fun p -> p.Print(" & ")))
             | FunctionTypeAnnotation(parameters, returnType, spread) ->
                 printer.PrintFunctionTypeAnnotation(parameters, returnType, ?spread=spread)
             | NullableTypeAnnotation(typeAnnotation) ->

--- a/src/Fable.Transforms/Dart/Replacements.fs
+++ b/src/Fable.Transforms/Dart/Replacements.fs
@@ -811,37 +811,37 @@ let fsFormat (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr op
         getFieldWith None t callee "input" |> Some
     | "PrintFormatToStringThen", _, _ ->
         match args with
-        | [_] -> Helper.LibCall(com, "String", "toText", t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
+        | [_] -> Helper.LibCall(com, "String", "toText", t, args, i.SignatureArgTypes, ?loc=r) |> Some
         | [cont; fmt] -> Helper.InstanceCall(fmt, "cont", t, [cont]) |> Some
         | _ -> None
     | "PrintFormatToString", _, _ ->
         match args with
         | [template] when template.Type = String -> Some template
-        | _ -> Helper.LibCall(com, "String", "toText", t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
+        | _ -> Helper.LibCall(com, "String", "toText", t, args, i.SignatureArgTypes, ?loc=r) |> Some
     | "PrintFormatLine", _, _ ->
-        Helper.LibCall(com, "String", "toConsole", t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
+        Helper.LibCall(com, "String", "toConsole", t, args, i.SignatureArgTypes, ?loc=r) |> Some
     | ("PrintFormatToError"|"PrintFormatLineToError"), _, _ ->
         // addWarning com ctx.FileName r "eprintf will behave as eprintfn"
-        Helper.LibCall(com, "String", "toConsoleError", t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
+        Helper.LibCall(com, "String", "toConsoleError", t, args, i.SignatureArgTypes, ?loc=r) |> Some
     | ("PrintFormatToTextWriter"|"PrintFormatLineToTextWriter"), _, _::args ->
         // addWarning com ctx.FileName r "fprintfn will behave as printfn"
-        Helper.LibCall(com, "String", "toConsole", t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
+        Helper.LibCall(com, "String", "toConsole", t, args, i.SignatureArgTypes, ?loc=r) |> Some
     | "PrintFormat", _, _ ->
         // addWarning com ctx.FileName r "Printf will behave as printfn"
-        Helper.LibCall(com, "String", "toConsole", t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
+        Helper.LibCall(com, "String", "toConsole", t, args, i.SignatureArgTypes, ?loc=r) |> Some
     | "PrintFormatThen", _, arg::callee::_ ->
         Helper.InstanceCall(callee, "cont", t, [arg]) |> Some
     | "PrintFormatToStringThenFail", _, _ ->
-        Helper.LibCall(com, "String", "toFail", t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
+        Helper.LibCall(com, "String", "toFail", t, args, i.SignatureArgTypes, ?loc=r) |> Some
     | ("PrintFormatToStringBuilder"      // bprintf
     |  "PrintFormatToStringBuilderThen"  // Printf.kbprintf
        ), _, _ -> fsharpModule com ctx r t i thisArg args
     | ".ctor", _, str::(Value(NewArray(ArrayValues templateArgs, _, MutableArray), _) as values)::_ ->
         match makeStringTemplateFrom [|"%s"; "%i"|] templateArgs str with
         | Some v -> makeValue r v |> Some
-        | None -> Helper.LibCall(com, "String", "interpolate", t, [str; values], i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
+        | None -> Helper.LibCall(com, "String", "interpolate", t, [str; values], i.SignatureArgTypes, ?loc=r) |> Some
     | ".ctor", _, arg::_ ->
-        Helper.LibCall(com, "String", "printf", t, [arg], i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
+        Helper.LibCall(com, "String", "printf", t, [arg], i.SignatureArgTypes, ?loc=r) |> Some
     | _ -> None
 
 let defaultValue com ctx r t defValue option =

--- a/src/Fable.Transforms/Fable.Transforms.fsproj
+++ b/src/Fable.Transforms/Fable.Transforms.fsproj
@@ -10,8 +10,8 @@
     <Compile Include="Global/Fable.Core.fs" />
     <Compile Include="Global/Metadata.fs" />
     <Compile Include="Global/Prelude.fs" />
-    <Compile Include="Python/Prelude.fs" />
     <Compile Include="Global/Compiler.fs" />
+    <Compile Include="Python/Prelude.fs" />
     <Compile Include="MonadicTrampoline.fs" />
     <Compile Include="Transforms.Util.fs" />
     <Compile Include="OverloadSuffix.fs" />

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -441,15 +441,16 @@ module Annotation =
 
     let makeTypeAnnotationIfTypeScript (com: IBabelCompiler) ctx typ expr =
         if com.Options.Language = TypeScript then
-            match expr with
+            match typ, expr with
+            | Fable.Option _, _ -> makeTypeAnnotation com ctx typ |> Some
             // Use type annotation for NullLiteral and enum cases
-            | Some(Literal(Literal.StringLiteral _))
-            | Some(Literal(StringTemplate _))
-            | Some(Literal(BooleanLiteral _))
-            | Some(Literal(NumericLiteral _))
-            | Some(Literal(RegExp _))
-            | Some(FunctionExpression _)
-            | Some(ArrowFunctionExpression _) -> None
+            | _, Some(Literal(Literal.StringLiteral _))
+            | _, Some(Literal(StringTemplate _))
+            | _, Some(Literal(BooleanLiteral _))
+            | _, Some(Literal(NumericLiteral _))
+            | _, Some(Literal(RegExp _))
+            | _, Some(FunctionExpression _)
+            | _, Some(ArrowFunctionExpression _) -> None
             | _ -> makeTypeAnnotation com ctx typ |> Some
         else None
 

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -427,9 +427,7 @@ module Annotation =
         | Fable.List genArg -> makeListTypeAnnotation com ctx genArg
         | Fable.GenericParam(name=name) -> makeAliasTypeAnnotation com ctx name
         | Fable.LambdaType(argType, returnType) ->
-            ([argType], returnType)
-            ||> FableTransforms.uncurryLambdaType
-            ||> makeFunctionTypeAnnotation com ctx typ
+            makeFunctionTypeAnnotation com ctx typ [argType] returnType
         | Fable.DelegateType(argTypes, returnType) ->
             makeFunctionTypeAnnotation com ctx typ argTypes returnType
         | Fable.AnonymousRecordType(fieldNames, genArgs, _isStruct) ->

--- a/src/Fable.Transforms/Global/Babel.fs
+++ b/src/Fable.Transforms/Global/Babel.fs
@@ -434,6 +434,7 @@ type TypeAnnotation =
     | NumberTypeAnnotation
     | BooleanTypeAnnotation
     | UnionTypeAnnotation of types: TypeAnnotation array
+    | IntersectionTypeAnnotation of types: TypeAnnotation array
     | ObjectTypeAnnotation of ObjectTypeAnnotation
     | FunctionTypeAnnotation of
         parameters: FunctionTypeParam array *

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -975,11 +975,11 @@ let getMangledNames (i: CallInfo) (thisArg: Expr option) =
 let bclType (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr option) (args: Expr list) =
     let moduleName, mangledName = getMangledNames i thisArg
     let args = match thisArg with Some callee -> callee::args | _ -> args
-    Helper.LibCall(com, moduleName, mangledName, t, args, i.SignatureArgTypes, ?loc=r) |> Some
+    Helper.LibCall(com, moduleName, mangledName, t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
 
 let fsharpModule (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (thisArg: Expr option) (args: Expr list) =
     let moduleName, mangledName = getMangledNames i thisArg
-    Helper.LibCall(com, moduleName, mangledName, t, args, i.SignatureArgTypes, ?loc=r) |> Some
+    Helper.LibCall(com, moduleName, mangledName, t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
 
 // TODO: This is likely broken
 let getPrecompiledLibMangledName entityName memberName overloadSuffix isStatic =
@@ -1043,7 +1043,7 @@ let operators (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr o
             match opt with
             | Some value -> Some value
             | None -> Some defValue
-        | _ -> Helper.LibCall(com, "Option", "defaultArg", t, args, i.SignatureArgTypes, ?loc=r) |> Some
+        | _ -> Helper.LibCall(com, "Option", "defaultArg", t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
     | "DefaultAsyncBuilder", _ ->
         makeImportLib com t "singleton" "AsyncBuilder" |> Some
     // Erased operators.
@@ -1205,7 +1205,7 @@ let operators (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr o
     | (Operators.greaterThanOrEqual | "Gte"), [left; right] -> booleanCompare com ctx r left right BinaryGreaterOrEqual |> Some
     | ("Min"|"Max"|"Clamp" as meth), _ ->
         let f = makeComparerFunction com ctx t
-        Helper.LibCall(com, "Util", Naming.lowerFirst meth, t, f::args, i.SignatureArgTypes, ?loc=r) |> Some
+        Helper.LibCall(com, "Util", Naming.lowerFirst meth, t, f::args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
     | "Not", [operand] -> // TODO: Check custom operator?
         makeUnOp r t operand UnaryNot |> Some
     | Patterns.SetContains Operators.standardSet, _ ->
@@ -1234,10 +1234,10 @@ let chars (com: ICompiler) (ctx: Context) r t (i: CallInfo) (_: Expr option) (ar
     | "IsHighSurrogate" | "IsLowSurrogate" | "IsSurrogate" ->
         let methName = Naming.lowerFirst i.CompiledName
         let methName = if List.length args > 1 then methName + "2" else methName
-        Helper.LibCall(com, "Char", methName, t, args, i.SignatureArgTypes, ?loc=r) |> Some
+        Helper.LibCall(com, "Char", methName, t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
     | "IsSurrogatePair" | "Parse" ->
         let methName = Naming.lowerFirst i.CompiledName
-        Helper.LibCall(com, "Char", methName, t, args, i.SignatureArgTypes, ?loc=r) |> Some
+        Helper.LibCall(com, "Char", methName, t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
     | _ -> None
 
 let implementedStringFunctions =
@@ -1299,20 +1299,20 @@ let strings (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr opt
                     "ToUpperInvariant", "toUpperCase"
                     "ToLower",          "toLocaleLowerCase"
                     "ToLowerInvariant", "toLowerCase" ] methName, Some c, args ->
-        Helper.InstanceCall(c, methName, t, args, i.SignatureArgTypes, ?loc=r) |> Some
+        Helper.InstanceCall(c, methName, t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
     | ("IndexOf" | "LastIndexOf"), Some c, _ ->
         match args with
         | [ExprType Char]
         | [ExprType String]
         | [ExprType Char; ExprType(Number(Int32, NumberInfo.Empty))]
         | [ExprType String; ExprType(Number(Int32, NumberInfo.Empty))] ->
-            Helper.InstanceCall(c, Naming.lowerFirst i.CompiledName, t, args, i.SignatureArgTypes, ?loc=r) |> Some
+            Helper.InstanceCall(c, Naming.lowerFirst i.CompiledName, t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
         | _ -> "The only extra argument accepted for String.IndexOf/LastIndexOf is startIndex."
                |> addErrorAndReturnNull com ctx.InlinePath r |> Some
     | ("Trim" | "TrimStart" | "TrimEnd"), Some c, _ ->
         let methName = Naming.lowerFirst i.CompiledName
         match args with
-        | [] -> Helper.InstanceCall(c, methName, t, [], i.SignatureArgTypes, ?loc=r) |> Some
+        | [] -> Helper.InstanceCall(c, methName, t, [], i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
         | head::tail ->
             let spread =
                 match head.Type, tail with
@@ -1334,7 +1334,7 @@ let strings (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr opt
                 match arg1.Type with
                 | Array _ -> arg1
                 | _ -> Value(NewArray(ArrayValues [arg1], String, MutableArray), None)
-            let args = [arg1; Value(Null Any, None); arg2]
+            let args = [arg1; emitExpr None Any [] "void 0"; arg2]
             Helper.LibCall(com, "String", "split", t, c::args, ?loc=r) |> Some
         | arg1::args ->
             let arg1 =
@@ -1367,7 +1367,7 @@ let stringModule (com: ICompiler) (ctx: Context) r t (i: CallInfo) (_: Expr opti
     | ("Iterate" | "IterateIndexed" | "ForAll" | "Exists"), _ ->
         // Cast the string to char[], see #1279
         let args = args |> List.replaceLast (fun e -> stringToCharArray e)
-        Helper.LibCall(com, "Seq", Naming.lowerFirst i.CompiledName, t, args, i.SignatureArgTypes, ?loc=r) |> Some
+        Helper.LibCall(com, "Seq", Naming.lowerFirst i.CompiledName, t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
     | ("Map" | "MapIndexed" | "Collect"), _ ->
         // Cast the string to char[], see #1279
         let args = args |> List.replaceLast (fun e -> stringToCharArray e)
@@ -1661,7 +1661,7 @@ let sets (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (thisArg: Exp
 let setModule (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (_: Expr option) (args: Expr list) =
     let meth = Naming.lowerFirst i.CompiledName
     let args = injectArg com ctx r "Set" meth i.GenericArgs args
-    Helper.LibCall(com, "Set", meth, t, args, i.SignatureArgTypes, ?loc=r) |> Some
+    Helper.LibCall(com, "Set", meth, t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
 
 let maps (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (thisArg: Expr option) (args: Expr list) =
     match i.CompiledName with
@@ -1675,7 +1675,7 @@ let maps (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (thisArg: Exp
 let mapModule (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (_: Expr option) (args: Expr list) =
     let meth = Naming.lowerFirst i.CompiledName
     let args = injectArg com ctx r "Map" meth i.GenericArgs args
-    Helper.LibCall(com, "Map", meth, t, args, i.SignatureArgTypes, ?loc=r) |> Some
+    Helper.LibCall(com, "Map", meth, t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
 
 let disposables (com: ICompiler) (_: Context) r (t: Type) (i: CallInfo) (thisArg: Expr option) (args: Expr list) =
     match i.CompiledName, thisArg with
@@ -1689,7 +1689,7 @@ let results (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (_: Expr o
         Some ("Result_" + meth)
     | _ -> None
     |> Option.map (fun meth ->
-        Helper.LibCall(com, "Choice", meth, t, args, i.SignatureArgTypes, ?loc=r))
+        Helper.LibCall(com, "Choice", meth, t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r))
 
 let nullables (com: ICompiler) (_: Context) r (t: Type) (i: CallInfo) (thisArg: Expr option) (args: Expr list) =
     match i.CompiledName, thisArg with
@@ -1711,39 +1711,40 @@ let options isStruct (com: ICompiler) (_: Context) r (t: Type) (i: CallInfo) (th
 
 let optionModule isStruct (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (_: Expr option) (args: Expr list) =
     let toArray r t arg =
-        Helper.LibCall(com, "Option", "toArray", Array(t, MutableArray), [arg], ?loc=r)
+        let genArgs = List.truncate 1 i.GenericArgs
+        Helper.LibCall(com, "Option", "toArray", Array(t, MutableArray), [arg], genArgs=genArgs, ?loc=r)
     match i.CompiledName, args with
     | "None", _ -> NewOption(None, t, isStruct) |> makeValue r |> Some
     | "GetValue", [c] ->
         Helper.LibCall(com, "Option", "value", t, args, ?loc=r) |> Some
     | ("OfObj" | "OfNullable"), _ ->
-        Helper.LibCall(com, "Option", "ofNullable", t, args, ?loc=r) |> Some
+        Helper.LibCall(com, "Option", "ofNullable", t, args, genArgs=i.GenericArgs, ?loc=r) |> Some
     | ("ToObj" | "ToNullable"), _ ->
-        Helper.LibCall(com, "Option", "toNullable", t, args, ?loc=r) |> Some
+        Helper.LibCall(com, "Option", "toNullable", t, args, genArgs=i.GenericArgs, ?loc=r) |> Some
     | "IsSome", [c] -> Test(c, OptionTest true, r) |> Some
     | "IsNone", [c] -> Test(c, OptionTest false, r) |> Some
     | ("Filter" | "Flatten" | "Map" | "Map2" | "Map3" | "Bind" as meth), args ->
-        Helper.LibCall(com, "Option", Naming.lowerFirst meth, t, args, i.SignatureArgTypes, ?loc=r) |> Some
+        Helper.LibCall(com, "Option", Naming.lowerFirst meth, t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
     | "ToArray", [arg] ->
         toArray r t arg |> Some
     | "ToList", [arg] ->
         let args = args |> List.replaceLast (toArray None t)
         Helper.LibCall(com, "List", "ofArray", t, args, ?loc=r) |> Some
     | "FoldBack", [folder; opt; state] ->
-        Helper.LibCall(com, "Seq", "foldBack", t, [folder; toArray None t opt; state], i.SignatureArgTypes, ?loc=r) |> Some
+        Helper.LibCall(com, "Seq", "foldBack", t, [folder; toArray None t opt; state], i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
     | "DefaultValue", _ ->
         Helper.LibCall(com, "Option", "defaultArg", t, List.rev args, ?loc=r) |> Some
     | "DefaultWith", _ ->
-        Helper.LibCall(com, "Option", "defaultArgWith", t, List.rev args, List.rev i.SignatureArgTypes, ?loc=r) |> Some
+        Helper.LibCall(com, "Option", "defaultArgWith", t, List.rev args, List.rev i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
     | "OrElse", _ ->
         Helper.LibCall(com, "Option", "orElse", t, List.rev args, ?loc=r) |> Some
     | "OrElseWith", _ ->
-        Helper.LibCall(com, "Option", "orElseWith", t, List.rev args, List.rev i.SignatureArgTypes, ?loc=r) |> Some
+        Helper.LibCall(com, "Option", "orElseWith", t, List.rev args, List.rev i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
     | ("Count" | "Contains" | "Exists" | "Fold" | "ForAll" | "Iterate" as meth), _ ->
         let meth = Naming.lowerFirst meth
         let args = args |> List.replaceLast (toArray None t)
         let args = injectArg com ctx r "Seq" meth i.GenericArgs args
-        Helper.LibCall(com, "Seq", meth, t, args, i.SignatureArgTypes, ?loc=r) |> Some
+        Helper.LibCall(com, "Seq", meth, t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
     | _ -> None
 
 let parseBool (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr option) (args: Expr list) =
@@ -2600,18 +2601,18 @@ let events (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (thisArg: E
     match i.CompiledName, thisArg with
     | ".ctor", _ -> Helper.LibCall(com, "Event", "default", t, args, i.SignatureArgTypes, isConstructor=true, ?loc=r) |> Some
     | "get_Publish", Some x -> getFieldWith r t x "Publish" |> Some
-    | meth, Some x -> Helper.InstanceCall(x, meth, t, args, i.SignatureArgTypes, ?loc=r) |> Some
-    | meth, None -> Helper.LibCall(com, "Event", Naming.lowerFirst meth, t, args, i.SignatureArgTypes, ?loc=r) |> Some
+    | meth, Some x -> Helper.InstanceCall(x, meth, t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
+    | meth, None -> Helper.LibCall(com, "Event", Naming.lowerFirst meth, t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
 
 let observable (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (_: Expr option) (args: Expr list) =
-    Helper.LibCall(com, "Observable", Naming.lowerFirst i.CompiledName, t, args, i.SignatureArgTypes, ?loc=r) |> Some
+    Helper.LibCall(com, "Observable", Naming.lowerFirst i.CompiledName, t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
 
 let mailbox (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr option) (args: Expr list) =
     match thisArg with
     | None ->
         match i.CompiledName with
         | ".ctor" -> Helper.LibCall(com, "MailboxProcessor", "default", t, args, i.SignatureArgTypes, isConstructor=true, ?loc=r) |> Some
-        | "Start" -> Helper.LibCall(com, "MailboxProcessor", "start", t, args, i.SignatureArgTypes, ?loc=r) |> Some
+        | "Start" -> Helper.LibCall(com, "MailboxProcessor", "start", t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
         | _ -> None
     | Some callee ->
         match i.CompiledName with
@@ -2622,7 +2623,7 @@ let mailbox (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr opt
                 then "startInstance"
                 else Naming.lowerFirst i.CompiledName
             Helper.LibCall(com, "MailboxProcessor", memb, t, args, i.SignatureArgTypes, thisArg=callee, ?loc=r) |> Some
-        | "Reply" -> Helper.InstanceCall(callee, "reply", t, args, i.SignatureArgTypes, ?loc=r) |> Some
+        | "Reply" -> Helper.InstanceCall(callee, "reply", t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
         | _ -> None
 
 let asyncBuilder (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr option) (args: Expr list) =
@@ -2630,22 +2631,22 @@ let asyncBuilder (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Exp
     | _, "Singleton", _ -> makeImportLib com t "singleton" "AsyncBuilder" |> Some
     // For Using we need to cast the argument to IDisposable
     | Some x, "Using", [arg; f] ->
-        Helper.InstanceCall(x, "Using", t, [arg; f], i.SignatureArgTypes, ?loc=r) |> Some
-    | Some x, meth, _ -> Helper.InstanceCall(x, meth, t, args, i.SignatureArgTypes, ?loc=r) |> Some
-    | None, meth, _ -> Helper.LibCall(com, "AsyncBuilder", Naming.lowerFirst meth, t, args, i.SignatureArgTypes, ?loc=r) |> Some
+        Helper.InstanceCall(x, "Using", t, [arg; f], i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
+    | Some x, meth, _ -> Helper.InstanceCall(x, meth, t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
+    | None, meth, _ -> Helper.LibCall(com, "AsyncBuilder", Naming.lowerFirst meth, t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
 
 let asyncs com (ctx: Context) r t (i: CallInfo) (_: Expr option) (args: Expr list) =
     match i.CompiledName with
     // TODO: Throw error for RunSynchronously
     | "Start" ->
         "Async.Start will behave as StartImmediate" |> addWarning com ctx.InlinePath r
-        Helper.LibCall(com, "Async", "start", t, args, i.SignatureArgTypes, ?loc=r) |> Some
+        Helper.LibCall(com, "Async", "start", t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
     // Make sure cancellationToken is called as a function and not a getter
     | "get_CancellationToken" -> Helper.LibCall(com, "Async", "cancellationToken", t, [], ?loc=r) |> Some
     // `catch` cannot be used as a function name in JS
-    | "Catch" -> Helper.LibCall(com, "Async", "catchAsync", t, args, i.SignatureArgTypes, ?loc=r) |> Some
+    | "Catch" -> Helper.LibCall(com, "Async", "catchAsync", t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
     // Fable.Core extensions
-    | meth -> Helper.LibCall(com, "Async", Naming.lowerFirst meth, t, args, i.SignatureArgTypes, ?loc=r) |> Some
+    | meth -> Helper.LibCall(com, "Async", Naming.lowerFirst meth, t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
 
 let guids (com: ICompiler) (ctx: Context) (r: SourceLocation option) t (i: CallInfo) (thisArg: Expr option) (args: Expr list) =
     let parseGuid (literalGuid: string) =
@@ -2706,7 +2707,7 @@ let uris (com: ICompiler) (ctx: Context) (r: SourceLocation option) t (i: CallIn
 let laziness (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr option) (args: Expr list) =
     match i.CompiledName, thisArg, args with
     | (".ctor"|"Create"),_,_ -> Helper.LibCall(com, "Util", "Lazy", t, args, i.SignatureArgTypes, isConstructor=true, ?loc=r) |> Some
-    | "CreateFromValue",_,_ -> Helper.LibCall(com, "Util", "lazyFromValue", t, args, i.SignatureArgTypes, ?loc=r) |> Some
+    | "CreateFromValue",_,_ -> Helper.LibCall(com, "Util", "lazyFromValue", t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
     | "Force", Some callee, _ -> getFieldWith r t callee "Value" |> Some
     | ("get_Value"|"get_IsValueCreated"), Some callee, _ ->
         Naming.removeGetSetPrefix i.CompiledName |> getFieldWith r t callee |> Some

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -1412,15 +1412,15 @@ let seqModule (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (thisArg
     match i.CompiledName, args with
     | "Cast", [arg] -> Some arg // Erase
     | "CreateEvent", [addHandler; removeHandler; createHandler] ->
-        Helper.LibCall(com, "Event", "createEvent", t, [addHandler; removeHandler], i.SignatureArgTypes, ?loc=r) |> Some
+        Helper.LibCall(com, "Event", "createEvent", t, [addHandler; removeHandler], i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
     | ("Distinct" | "DistinctBy" | "Except" | "GroupBy" | "CountBy" as meth), args ->
         let meth = Naming.lowerFirst meth
         let args = injectArg com ctx r "Seq2" meth i.GenericArgs args
-        Helper.LibCall(com, "Seq2", meth, t, args, i.SignatureArgTypes, ?loc=r) |> Some
+        Helper.LibCall(com, "Seq2", meth, t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?loc=r) |> Some
     | meth, _ ->
         let meth = Naming.lowerFirst meth
         let args = injectArg com ctx r "Seq" meth i.GenericArgs args
-        Helper.LibCall(com, "Seq", meth, t, args, i.SignatureArgTypes, ?thisArg=thisArg, ?loc=r) |> Some
+        Helper.LibCall(com, "Seq", meth, t, args, i.SignatureArgTypes, genArgs=i.GenericArgs, ?thisArg=thisArg, ?loc=r) |> Some
 
 let injectIndexOfArgs com ctx r genArgs args =
     let args =

--- a/src/fable-library/List.fs
+++ b/src/fable-library/List.fs
@@ -452,9 +452,9 @@ let partition f (xs: 'T list) =
     node2.SetConsTail List.Empty
     root1.Tail, root2.Tail
 
-let choose f (xs: 'T list) =
+let choose<'T, 'U> (f: 'T -> 'U option) (xs: 'T list) =
     let root = List.Empty
-    let folder (acc: 'T list) x =
+    let folder (acc: 'U list) x =
         match f x with
         | Some y -> acc.AppendConsNoTail y
         | None -> acc

--- a/src/fable-library/Seq.fs
+++ b/src/fable-library/Seq.fs
@@ -420,17 +420,17 @@ let findIndexBack predicate (xs: seq<'T>) =
     | Some x -> x
     | None -> indexNotFound(); -1
 
-let fold (folder: 'State -> 'T -> 'State) (state: 'State) (xs: seq<'T>) =
+let fold<'T, 'State> (folder: 'State -> 'T -> 'State) (state: 'State) (xs: seq<'T>) =
     use e = ofSeq xs
     let mutable acc = state
     while e.MoveNext() do
         acc <- folder acc e.Current
     acc
 
-let foldBack folder (xs: seq<'T>) state =
+let foldBack<'T, 'State> folder (xs: seq<'T>) state =
     Array.foldBack folder (toArray xs) state
 
-let fold2 (folder: 'State -> 'T1 -> 'T2 -> 'State) (state: 'State) (xs: seq<'T1>) (ys: seq<'T2>) =
+let fold2<'T1, 'T2, 'State> (folder: 'State -> 'T1 -> 'T2 -> 'State) (state: 'State) (xs: seq<'T1>) (ys: seq<'T2>) =
     use e1 = ofSeq xs
     use e2 = ofSeq ys
     let mutable acc = state

--- a/src/fable-library/String.ts
+++ b/src/fable-library/String.ts
@@ -282,14 +282,17 @@ export function fsFormat(str: string) {
   };
 }
 
-export function format(str: string, ...args: any[]) {
-  if (typeof str === "object" && args.length > 0) {
+export function format(str: string | object, ...args: any[]) {
+  let str2: string;
+  if (typeof str === "object") {
     // Called with culture info
-    str = args[0];
+    str2 = String(args[0]);
     args.shift();
+  } else {
+    str2 = str;
   }
 
-  return str.replace(formatRegExp, (_, idx: number, padLength, format, precision, pattern) => {
+  return str2.replace(formatRegExp, (_, idx: number, padLength, format, precision, pattern) => {
     if (idx < 0 || idx >= args.length) {
       throw new Error("Index must be greater or equal to zero and less than the arguments' length.")
     }

--- a/tests/Js/Main/ArrayTests.fs
+++ b/tests/Js/Main/ArrayTests.fs
@@ -103,10 +103,8 @@ let tests =
         let concaters1 = a |> Array.map (fun x y -> y + x)
         let concaters2 = a |> Array.map (fun x -> (fun y -> y + x))
         let concaters3 = a |> Array.map (fun x -> let f = (fun y -> y + x) in f)
-#if !FABLE_COMPILER_TYPESCRIPT // TODO!!!
         let concaters4 = a |> Array.map f
         concaters4.[0] "x" "y" |> equal "axy"
-#endif
         let concaters5 = b |> Array.mapi f
         concaters1.[0] "x" |> equal "xa"
         concaters2.[1] "x" |> equal "xb"

--- a/tests/Js/Main/ArrayTests.fs
+++ b/tests/Js/Main/ArrayTests.fs
@@ -103,17 +103,17 @@ let tests =
         let concaters1 = a |> Array.map (fun x y -> y + x)
         let concaters2 = a |> Array.map (fun x -> (fun y -> y + x))
         let concaters3 = a |> Array.map (fun x -> let f = (fun y -> y + x) in f)
-#if !FABLE_COMPILER_TYPESCRIPT // TODO!!!
-        let concaters4 = a |> Array.map f
-        concaters4.[0] "x" "y" |> equal "axy"
-#endif
         let concaters5 = b |> Array.mapi f
         concaters1.[0] "x" |> equal "xa"
         concaters2.[1] "x" |> equal "xb"
         concaters3.[2] "x" |> equal "xc"
         concaters5.[1] "x" |> equal "12x"
+#if !FABLE_COMPILER_TYPESCRIPT // TODO!!!
+        let concaters4 = a |> Array.map f
+        concaters4.[0] "x" "y" |> equal "axy"
         let f2 = f
         a |> Array.mapi f2 |> Array.item 2 <| "x" |> equal "2cx"
+#endif
 
     testCase "Mapping from typed arrays to non-numeric arrays doesn't coerce values" <| fun () -> // See #120, #171
         let xs = map string [|1;2|]

--- a/tests/Js/Main/ArrayTests.fs
+++ b/tests/Js/Main/ArrayTests.fs
@@ -103,17 +103,17 @@ let tests =
         let concaters1 = a |> Array.map (fun x y -> y + x)
         let concaters2 = a |> Array.map (fun x -> (fun y -> y + x))
         let concaters3 = a |> Array.map (fun x -> let f = (fun y -> y + x) in f)
+#if !FABLE_COMPILER_TYPESCRIPT // TODO!!!
+        let concaters4 = a |> Array.map f
+        concaters4.[0] "x" "y" |> equal "axy"
+#endif
         let concaters5 = b |> Array.mapi f
         concaters1.[0] "x" |> equal "xa"
         concaters2.[1] "x" |> equal "xb"
         concaters3.[2] "x" |> equal "xc"
         concaters5.[1] "x" |> equal "12x"
-#if !FABLE_COMPILER_TYPESCRIPT // TODO!!!
-        let concaters4 = a |> Array.map f
-        concaters4.[0] "x" "y" |> equal "axy"
         let f2 = f
         a |> Array.mapi f2 |> Array.item 2 <| "x" |> equal "2cx"
-#endif
 
     testCase "Mapping from typed arrays to non-numeric arrays doesn't coerce values" <| fun () -> // See #120, #171
         let xs = map string [|1;2|]

--- a/tests/Js/Main/ListTests.fs
+++ b/tests/Js/Main/ListTests.fs
@@ -8,11 +8,9 @@ type List(x: int) =
 
 type ExceptFoo = { Bar:string }
 
-#if !FABLE_COMPILER_TYPESCRIPT // TODO!!! Constrains in type parameters (a extends Iterable<b>)
 let testListChoose (xss: 'a option list): 'b list =
     let f xss: 'a list = xss |> List.choose (function Some a -> Some a | _ -> None)
     xss |> f |> List.collect (fun xs -> [ for s in xs do yield s ])
-#endif
 
 let rec sumFirstList (zs: float list) (n: int): float =
     match n with
@@ -560,11 +558,9 @@ let tests =
             [] = (List.truncate 0 []) |> equal true
             [] = (List.truncate 1 []) |> equal true
 
-#if !FABLE_COMPILER_TYPESCRIPT // TODO!!!
     testCase "List.choose works with generic arguments" <| fun () ->
         let res = testListChoose [ Some [ "a" ] ]
         equal ["a"] res
-#endif
 
     testCase "List.collect works" <| fun () ->
             let xs = [[1]; [2]; [3]; [4]]

--- a/tests/Js/Main/ListTests.fs
+++ b/tests/Js/Main/ListTests.fs
@@ -8,9 +8,11 @@ type List(x: int) =
 
 type ExceptFoo = { Bar:string }
 
-let testListChoose xss =
-    let f xss = xss |> List.choose (function Some a -> Some a | _ -> None)
+#if !FABLE_COMPILER_TYPESCRIPT // TODO!!! Constrains in type parameters (a extends Iterable<b>)
+let testListChoose (xss: 'a option list): 'b list =
+    let f xss: 'a list = xss |> List.choose (function Some a -> Some a | _ -> None)
     xss |> f |> List.collect (fun xs -> [ for s in xs do yield s ])
+#endif
 
 let rec sumFirstList (zs: float list) (n: int): float =
     match n with
@@ -558,9 +560,11 @@ let tests =
             [] = (List.truncate 0 []) |> equal true
             [] = (List.truncate 1 []) |> equal true
 
+#if !FABLE_COMPILER_TYPESCRIPT // TODO!!!
     testCase "List.choose works with generic arguments" <| fun () ->
         let res = testListChoose [ Some [ "a" ] ]
         equal ["a"] res
+#endif
 
     testCase "List.collect works" <| fun () ->
             let xs = [[1]; [2]; [3]; [4]]

--- a/tests/Js/Main/MapTests.fs
+++ b/tests/Js/Main/MapTests.fs
@@ -63,12 +63,12 @@ let tests =
             let xs = Map.empty.Add(1, 1)
             xs.Count
             |> equal 1
-
+#if !FABLE_COMPILER_TYPESCRIPT
         testCase "Map.TryGetValue works" <| fun () ->
             let xs = Map.empty.Add(1, 1)
             xs.TryGetValue(1)
             |> equal (true, 1)
-
+#endif
         testCase "Map.containsKey works" <| fun () ->
             let xs = Map.empty |> Map.add 1 1
             xs |> Map.containsKey 1 |> equal true
@@ -247,7 +247,7 @@ let tests =
             let zs = Map.values ys
             zs.Count |> equal xs.Length
             Seq.item 2 zs |> equal (snd xs.[2])
-
+#if !FABLE_COMPILER_TYPESCRIPT
         testCase "Map can be casted to IDictionary" <| fun () -> // See #1729, #1857
             let map = Map [ "a", 1; "b", 2; "c", 3]
             let dic = map :> System.Collections.Generic.IDictionary<_,_>
@@ -255,7 +255,7 @@ let tests =
             dic.TryGetValue("d") |> fst |> equal false
             dic.Keys |> Seq.toList |> equal ["a"; "b"; "c"]
             dic.Values |> Seq.toList |> equal [1; 2; 3]
-
+#endif
         testCase "KeyValuePair can be referenced" <| fun () ->
             let r2 = { kv = new KeyValuePair<_,_>("bar",25) }
             r2.kv.Key |> equal "bar"

--- a/tests/Js/Main/OptionTests.fs
+++ b/tests/Js/Main/OptionTests.fs
@@ -180,7 +180,7 @@ let tests =
         Option.flatten o1 |> equal (Some 1)
         Option.flatten o2 |> equal None
         Option.flatten o3 |> equal None
-
+#if !FABLE_COMPILER_TYPESCRIPT
     testCase "Option.toObj works" <| fun () ->
         let o1: string option = Some "foo"
         let o2: string option = None
@@ -358,5 +358,6 @@ let tests =
         isActualJsUndefined y |> equal true
         isActualJsNull z |> equal false
         isActualJsUndefined z |> equal true
+#endif
 #endif
   ]

--- a/tests/Js/Main/ResultTests.fs
+++ b/tests/Js/Main/ResultTests.fs
@@ -18,7 +18,7 @@ let tests =
 
         let error = Error 10
         Error 10 |> equal error
-
+#if !FABLE_COMPILER_TYPESCRIPT
     testCase "pattern matching works" <| fun () ->
         let ok = Ok "foo"
         match ok with
@@ -31,7 +31,7 @@ let tests =
         | Ok _ -> None
         | Error y -> Some y
         |> equal (Some 10)
-
+#endif
     testCase "map function can be generated" <| fun () ->
         let f = (+) 1
         Ok 9 |> Result.map f |> equal (Ok 10)

--- a/tests/Js/Main/SeqTests.fs
+++ b/tests/Js/Main/SeqTests.fs
@@ -224,7 +224,6 @@ let tests =
         let total = xs |> Seq.fold (+) 0.
         total |> equal 10.
 
-#if !FABLE_COMPILER_TYPESCRIPT // TODO!!!
     testCase "Seq.fold with tupled arguments works" <| fun () ->
         let a, b =
             ((1, 5), [1;2;3;4])
@@ -232,7 +231,6 @@ let tests =
                 a * i, b + i)
         equal 24 a
         equal 15 b
-#endif
 
     testCase "Seq.forall works" <| fun () ->
         let xs = [1.; 2.; 3.; 4.]

--- a/tests/Js/Main/SeqTests.fs
+++ b/tests/Js/Main/SeqTests.fs
@@ -224,6 +224,7 @@ let tests =
         let total = xs |> Seq.fold (+) 0.
         total |> equal 10.
 
+#if !FABLE_COMPILER_TYPESCRIPT // TODO!!!
     testCase "Seq.fold with tupled arguments works" <| fun () ->
         let a, b =
             ((1, 5), [1;2;3;4])
@@ -231,6 +232,7 @@ let tests =
                 a * i, b + i)
         equal 24 a
         equal 15 b
+#endif
 
     testCase "Seq.forall works" <| fun () ->
         let xs = [1.; 2.; 3.; 4.]

--- a/tests/Rust/tests/src/StringTests.fs
+++ b/tests/Rust/tests/src/StringTests.fs
@@ -129,15 +129,15 @@ let ``ksprintf works`` () =
 //     linef "open %s" "Foo"
 //     lines |> Seq.toList |> equal ["open Foo"]
 
-[<Fact>]
-let ``kbprintf works`` () =
-    let sb = Text.StringBuilder()
-    let mutable i = 0
-    let f () = i <- i + 1
-    Printf.kbprintf f sb "Hello"
-    Printf.kbprintf f sb " %s!" "world"
-    i |> equal 2
-    sb.ToString() |> equal "Hello world!"
+// [<Fact>]
+// let ``kbprintf works`` () =
+//     let sb = Text.StringBuilder()
+//     let mutable i = 0
+//     let f () = i <- i + 1
+//     Printf.kbprintf f sb "Hello"
+//     Printf.kbprintf f sb " %s!" "world"
+//     i |> equal 2
+//     sb.ToString() |> equal "Hello world!"
 
 [<Fact>]
 let ``ksprintf curries correctly`` () =
@@ -147,12 +147,12 @@ let ``ksprintf curries correctly`` () =
     let result = step2 "The answer is: "
     result |> equal "The answer is: 42"
 
-[<Fact>]
-let ``bprintf works`` () =
-    let sb = Text.StringBuilder(10)
-    Printf.bprintf sb "Hello"
-    Printf.bprintf sb " %s!" "world"
-    sb.ToString() |> equal "Hello world!"
+// [<Fact>]
+// let ``bprintf works`` () =
+//     let sb = Text.StringBuilder(10)
+//     Printf.bprintf sb "Hello"
+//     Printf.bprintf sb " %s!" "world"
+//     sb.ToString() |> equal "Hello world!"
 
 [<Fact>]
 let ``sprintf works`` () =
@@ -165,11 +165,11 @@ let ``sprintf works`` () =
     printer "morning" |> equal "Hi Alfonso, good morning!"
     printer "evening" |> equal "Hi Alfonso, good evening!"
 
-[<Fact>]
-let ``sprintf works II`` () =
-    let printer2 = sprintf "Hi %s, good %s%s" "Maxime"
-    let printer2 = printer2 "afternoon"
-    printer2 "?" |> equal "Hi Maxime, good afternoon?"
+// [<Fact>]
+// let ``sprintf works II`` () =
+//     let printer2 = sprintf "Hi %s, good %s%s" "Maxime"
+//     let printer2 = printer2 "afternoon"
+//     printer2 "?" |> equal "Hi Maxime, good afternoon?"
 
 [<Fact>]
 let ``sprintf with different decimal digits works`` () = // See #1932
@@ -207,11 +207,11 @@ let ``sprintf without arguments works`` () =
 //         formatStr
 //     equal "/hello/%s" (pathScan "/hello/%s")
 
-[<Fact>]
-let ``sprintf with escaped percent symbols works`` () = // See #195
-    let r, r1, r2 = "Ratio", 0.213849, 0.799898
-    sprintf "%s1: %.2f%% %s2: %.2f%%" r (r1*100.) r (r2*100.)
-    |> equal "Ratio1: 21.38% Ratio2: 79.99%"
+// [<Fact>]
+// let ``sprintf with escaped percent symbols works`` () = // See #195
+//     let r, r1, r2 = "Ratio", 0.213849, 0.799898
+//     sprintf "%s1: %.2f%% %s2: %.2f%%" r (r1*100.) r (r2*100.)
+//     |> equal "Ratio1: 21.38% Ratio2: 79.99%"
 
 [<Fact>]
 let ``sprintf with percent symbols in arguments works`` () = // See #329

--- a/tests/TypeScript/Fable.Tests.TypeScript.fsproj
+++ b/tests/TypeScript/Fable.Tests.TypeScript.fsproj
@@ -13,6 +13,13 @@
     <Compile Include="../Js/Main/ArithmeticTests.fs" />
     <Compile Include="../Js/Main/ArrayTests.fs" />
     <Compile Include="../Js/Main/ListTests.fs" />
+    <Compile Include="../Js/Main/MapTests.fs" />
+    <!-- <Compile Include="../Js/Main/MiscTests.fs" /> -->
+    <!-- <Compile Include="../Js/Main/OptionTests.fs" /> -->
+    <Compile Include="../Js/Main/RecordTypeTests.fs" />
+    <Compile Include="../Js/Main/RegexTests.fs" />
+    <Compile Include="../Js/Main/ResizeArrayTests.fs" />
+    <Compile Include="../Js/Main/ResultTests.fs" />
     <Compile Include="../Js/Main/SeqExpressionTests.fs" />
     <Compile Include="../Js/Main/SeqTests.fs" />
     <Compile Include="Main.fs" />

--- a/tests/TypeScript/Fable.Tests.TypeScript.fsproj
+++ b/tests/TypeScript/Fable.Tests.TypeScript.fsproj
@@ -13,6 +13,8 @@
     <Compile Include="../Js/Main/ArithmeticTests.fs" />
     <Compile Include="../Js/Main/ArrayTests.fs" />
     <Compile Include="../Js/Main/ListTests.fs" />
+    <Compile Include="../Js/Main/SeqExpressionTests.fs" />
+    <Compile Include="../Js/Main/SeqTests.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
 </Project>

--- a/tests/TypeScript/Fable.Tests.TypeScript.fsproj
+++ b/tests/TypeScript/Fable.Tests.TypeScript.fsproj
@@ -15,13 +15,17 @@
     <Compile Include="../Js/Main/ListTests.fs" />
     <Compile Include="../Js/Main/MapTests.fs" />
     <!-- <Compile Include="../Js/Main/MiscTests.fs" /> -->
-    <!-- <Compile Include="../Js/Main/OptionTests.fs" /> -->
+    <Compile Include="../Js/Main/OptionTests.fs" />
     <Compile Include="../Js/Main/RecordTypeTests.fs" />
     <Compile Include="../Js/Main/RegexTests.fs" />
     <Compile Include="../Js/Main/ResizeArrayTests.fs" />
     <Compile Include="../Js/Main/ResultTests.fs" />
     <Compile Include="../Js/Main/SeqExpressionTests.fs" />
     <Compile Include="../Js/Main/SeqTests.fs" />
+    <Compile Include="../Js/Main/SetTests.fs" />
+    <Compile Include="../Js/Main/StringTests.fs" />
+    <Compile Include="../Js/Main/SudokuTest.fs" />
+    <Compile Include="../Js/Main/TailCallTests.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
 </Project>

--- a/tests/TypeScript/Fable.Tests.TypeScript.fsproj
+++ b/tests/TypeScript/Fable.Tests.TypeScript.fsproj
@@ -12,6 +12,7 @@
     <Compile Include="../Js/Main/Util/UtilTests.fs" />
     <Compile Include="../Js/Main/ArithmeticTests.fs" />
     <Compile Include="../Js/Main/ArrayTests.fs" />
+    <Compile Include="../Js/Main/ListTests.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
 </Project>

--- a/tests/TypeScript/Main.fs
+++ b/tests/TypeScript/Main.fs
@@ -11,7 +11,7 @@ let allTests =
     Maps.tests
     // Misc.tests
     // Observable.tests
-    // Option.tests
+    Option.tests
     // Queue.tests
     RecordTypes.tests
     // Reflection.tests
@@ -20,6 +20,11 @@ let allTests =
     Result.tests
     SeqExpressions.tests
     Seqs.tests
+    Sets.tests
+    // Stack.tests
+    Strings.tests
+    Sudoku.tests
+    TailCalls.tests
   |]
 
 #if FABLE_COMPILER

--- a/tests/TypeScript/Main.fs
+++ b/tests/TypeScript/Main.fs
@@ -7,6 +7,7 @@ let allTests =
   [|
     Arithmetic.tests
     Arrays.tests
+    Lists.tests
   |]
 
 #if FABLE_COMPILER

--- a/tests/TypeScript/Main.fs
+++ b/tests/TypeScript/Main.fs
@@ -8,6 +8,16 @@ let allTests =
     Arithmetic.tests
     Arrays.tests
     Lists.tests
+    Maps.tests
+    // Misc.tests
+    // Observable.tests
+    // Option.tests
+    // Queue.tests
+    RecordTypes.tests
+    // Reflection.tests
+    Regex.tests
+    ResizeArrays.tests
+    Result.tests
     SeqExpressions.tests
     Seqs.tests
   |]

--- a/tests/TypeScript/Main.fs
+++ b/tests/TypeScript/Main.fs
@@ -8,6 +8,8 @@ let allTests =
     Arithmetic.tests
     Arrays.tests
     Lists.tests
+    SeqExpressions.tests
+    Seqs.tests
   |]
 
 #if FABLE_COMPILER


### PR DESCRIPTION
I realized in the optimization phase we were moving lambdas with local generics without resolving them, which caused issues with the type system of some of the target languages. I've tried to solve it by [checking the arguments](https://github.com/fable-compiler/Fable/blob/f320c01a331b9253ce740fc0751d93ce93870065/src/Fable.Transforms/FSharp2Fable.fs#L698-L712) and [applied values](https://github.com/fable-compiler/Fable/blob/f320c01a331b9253ce740fc0751d93ce93870065/src/Fable.Transforms/FSharp2Fable.fs#L550) in the FSharp2Fable step. Then when inlining a value I make sure [its type matches the one of the replaced ident](https://github.com/fable-compiler/Fable/blob/f320c01a331b9253ce740fc0751d93ce93870065/src/Fable.Transforms/FableTransforms.fs#L71-L74).

This seems to work with TypeScript and Dart, but unfortunately I broke Rust again 😞 @ncave Could you please have a look if possible? It may happen that some corrections are not longer necessary. For example, in TypeScript we no longer need to [uncurry all lambda types just in case](https://github.com/fable-compiler/Fable/pull/3360/files#diff-5c1d432616b2869d7a3e9828fcf99f13d2e4eb3e88d6abbd135f5cced457a628R430).

> Example: In [this test](https://github.com/fable-compiler/Fable/blob/f320c01a331b9253ce740fc0751d93ce93870065/tests/Dart/src/OptionTests.fs#L267), the `x2` argument of the inner `test` function is generic, but when [it's applied](https://github.com/fable-compiler/Fable/blob/f320c01a331b9253ce740fc0751d93ce93870065/tests/Dart/src/OptionTests.fs#L304) it becomes `unit` so if inlining we need to have the proper type.

**Edit**: See discussion [below](https://github.com/fable-compiler/Fable/pull/3360#discussion_r1133028636).