### PR TITLE
Add ability to produce non-English identifiers

### DIFF
--- a/src/Fable.Transforms/Global/Naming.fs
+++ b/src/Fable.Transforms/Global/Naming.fs
@@ -46,6 +46,10 @@ module Naming =
         || (97 <= code && code <= 122)  // A-Z
         // Digits are not allowed in first position, see #1397
         || (index > 0 && 48 <= code && code <= 57) // 0-9
+        || match Compiler.Language with
+            | Dart -> false
+            | Rust -> false
+            | _ -> Char.IsLetter c
 
     let hasIdentForbiddenChars (ident: string) =
         let mutable found = false

--- a/src/Fable.Transforms/Global/Naming.fs
+++ b/src/Fable.Transforms/Global/Naming.fs
@@ -48,7 +48,6 @@ module Naming =
         || (index > 0 && 48 <= code && code <= 57) // 0-9
         || match Compiler.Language with
             | Dart -> false
-            | Rust -> false
             | _ -> Char.IsLetter c
 
     let hasIdentForbiddenChars (ident: string) =


### PR DESCRIPTION
I would like to preserve non-English identifiers where possible in JS/TS/Python because these languages support Unicode identifiers. Dart does not support them and Rust seems to have only partial support. So this is partial work.