### PR TITLE
Fix #3371: Copying struct records

### DIFF
--- a/src/Fable.Cli/Entry.fs
+++ b/src/Fable.Cli/Entry.fs
@@ -359,11 +359,11 @@ let clean (args: CliArgs) language rootDir =
         Log.always("Clean completed! Files deleted: " + string fileCount)
 
 let getStatus = function
-    | JavaScript -> "beta"
+    | JavaScript -> "stable"
     | Python -> "beta"
     | Rust -> "alpha"
     | Dart -> "beta"
-    | TypeScript -> "alpha"
+    | TypeScript -> "beta"
     | Php -> "experimental"
 
 [<EntryPoint>]

--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -608,16 +608,19 @@ module Helpers =
             typ.TypeDefinition.TryFullName = Some Types.unit
         else false
 
+    let isByRefType (typ: FSharpType) =
+        typ.HasTypeDefinition
+        && typ.TypeDefinition.IsByRef
+        // && ( typ.TypeDefinition.DisplayName = "byref" ||
+        //      typ.TypeDefinition.DisplayName = "inref" ||
+        //      typ.TypeDefinition.DisplayName = "outref")
+
     let isByRefValue (value: FSharpMemberOrFunctionOrValue) =
         // Value type "this" is passed as inref, so it has to be excluded
         // (Note: the non-abbreviated type of inref and outref is byref)
-        let typ = value.FullType
-        value.IsValue && not (value.IsMemberThisValue)
-        && typ.HasTypeDefinition
-        && typ.TypeDefinition.IsByRef
-        // && (typ.TypeDefinition.DisplayName = "byref" ||
-        //     typ.TypeDefinition.DisplayName = "inref" ||
-        //     typ.TypeDefinition.DisplayName = "outref")
+        value.IsValue
+        && not value.IsMemberThisValue
+        && isByRefType value.FullType
 
     let tryFindAtt fullName (atts: FSharpAttribute seq) =
         atts |> Seq.tryPick (fun att ->

--- a/src/Fable.Transforms/FSharp2Fable.fs
+++ b/src/Fable.Transforms/FSharp2Fable.fs
@@ -840,17 +840,11 @@ let private transformExpr (com: IFableCompiler) (ctx: Context) appliedGenArgs fs
         let fieldType = makeType Map.empty fsExpr.Type
         return Fable.Get(callee, Fable.FieldInfo.Create(fieldName, fieldType=fieldType), typ, r)
 
-    | FSharpExprPatterns.FSharpFieldGet(fsCallee, fsCalleeType, field) ->
+    | FSharpExprPatterns.FSharpFieldGet(callee, calleeType, field) ->
         let r = makeRangeFrom fsExpr
-        let! callee = transformCallee com ctx fsCallee fsCalleeType
+        let! callee = transformCallee com ctx callee calleeType
 //      let typ = makeType ctx.GenericArgs fsExpr.Type // Doesn't always work
-        let typ = resolveFieldType ctx fsCalleeType field.FieldType
-        let callee =
-            match fsCallee with
-            // Don't use fsCalleeType as it doesn't show the reference type
-            | Some fsCallee when isByRefType fsCallee.Type ->
-                Replacements.Api.getRefCell com None callee.Type callee
-            | _ -> callee
+        let typ = resolveFieldType ctx calleeType field.FieldType
         let kind = Fable.FieldInfo.Create(
             FsField.FSharpFieldName field,
             fieldType=makeType Map.empty field.FieldType,
@@ -1105,7 +1099,7 @@ let private transformExpr (com: IFableCompiler) (ctx: Context) appliedGenArgs fs
             else
                 if com.Options.Language = Rust
                 then return Replacements.Api.makeRefFromMutableValue com ctx r value.Type value
-                else return Replacements.Api.makeRefCellFromValue com r value
+                else return value // Replacements.Api.makeRefCellFromValue com r value
         // This matches passing fields by reference
         | FSharpExprPatterns.FSharpFieldGet(callee, calleeType, field) ->
             let r = makeRangeFrom fsExpr

--- a/src/fable-library/BigInt/z.fs
+++ b/src/fable-library/BigInt/z.fs
@@ -17,8 +17,10 @@ namespace BigInt
     // INVARIANT: signInt = 1 or -1
     //            value(z) = signInt * v
     // NOTE: 0 has two repns (+1,0) or (-1,0).
+#if !FABLE_COMPILER
     [<Struct>]
     [<CustomEquality; CustomComparison>]
+#endif
 #if !NETSTANDARD1_6
     [<StructuredFormatDisplay("{StructuredDisplayString}I")>]
 #endif

--- a/tests/Js/Main/TypeTests.fs
+++ b/tests/Js/Main/TypeTests.fs
@@ -234,6 +234,9 @@ type ValueType3 =
 [<Struct>]
 type StructUnion = Value of string
 
+[<Struct>]
+type SimpleRecord = { A: string; B: string }
+
 type Point2D =
    struct
       val X: float
@@ -831,6 +834,14 @@ let tests =
         t1 |> equal t2
 
         (compare t1 t2) |> equal 0
+
+    testCase "copying struct records works" <| fun () -> // See #3371
+        let simple : SimpleRecord = { A = ""; B = "B" }
+        let simpleRecord = { simple with A = "A" }
+        simpleRecord.A |> equal "A"
+        simpleRecord.B |> equal "B"
+        simple.A |> equal ""
+        simple.B |> equal "B"
 
     testCase "Custom F# exceptions work" <| fun () ->
         try


### PR DESCRIPTION
@ncave, can you please check if #3371 affects Rust? This seems to fix the issue for JS/TS. Although we are relying on the beta reduction so the ref copy created by the F# compiler when copying structs is removed and doesn't create a conflict with the typing. Example:

```ts
        const simple: SimpleRecord = new SimpleRecord("", "B");
        const inputRecord: FSharpRef<SimpleRecord> = simple;
```
