### PR TITLE
Unify and improve (un)currying

### DIFF
--- a/src/Fable.Cli/Properties/launchSettings.json
+++ b/src/Fable.Cli/Properties/launchSettings.json
@@ -8,7 +8,11 @@
       // "commandLineArgs": "src/fable-library --outDir build/fable-library-ts --fableLib build/fable-library-ts --lang TypeScript --typedArrays false --exclude Fable.Core --define FX_NO_BIGINT --define FABLE_LIBRARY --noCache"
 
       // test-ts
-      "commandLineArgs": "tests/TypeScript --outDir build/tests/TypeScript --lang TypeScript --exclude Fable.Core --noCache"
+      //"commandLineArgs": "tests/TypeScript --outDir build/tests/TypeScript --lang TypeScript --exclude Fable.Core --noCache",
+
+      // quicktest-ts
+      "commandLineArgs": "src/quicktest --lang TypeScript --exclude Fable.Core --noCache"
+
     }
   }
 }

--- a/src/Fable.Cli/Properties/launchSettings.json
+++ b/src/Fable.Cli/Properties/launchSettings.json
@@ -2,8 +2,13 @@
   "profiles": {
     "Fable.Cli": {
       "commandName": "Project",
-      "commandLineArgs": "src/fable-library --outDir build/fable-library-ts --fableLib build/fable-library-ts --lang TypeScript --typedArrays false --exclude Fable.Core --define FX_NO_BIGINT --define FABLE_LIBRARY",
-      "workingDirectory": "../.."
+      "workingDirectory": "../..",
+
+      // fable-library-ts
+      // "commandLineArgs": "src/fable-library --outDir build/fable-library-ts --fableLib build/fable-library-ts --lang TypeScript --typedArrays false --exclude Fable.Core --define FX_NO_BIGINT --define FABLE_LIBRARY --noCache"
+
+      // test-ts
+      "commandLineArgs": "tests/TypeScript --outDir build/tests/TypeScript --lang TypeScript --exclude Fable.Core --noCache"
     }
   }
 }

--- a/src/Fable.Transforms/Dart/Fable2Dart.fs
+++ b/src/Fable.Transforms/Dart/Fable2Dart.fs
@@ -1479,7 +1479,7 @@ module Util =
         | Fable.Extended(kind, _range) ->
             match kind with
             | Fable.Curry(e, arity) ->
-                Dart.Replacements.curryExprAtRuntime com arity e
+                Replacements.Api.curryExprAtRuntime com arity e
                 |> transform com ctx returnStrategy
             | Fable.Throw(None, t) ->
                 [Expression.rethrowExpression(transformType com ctx t) |> Statement.ExpressionStatement], None
@@ -2283,6 +2283,7 @@ module Compiler =
             member _.OutputType = com.OutputType
             member _.ProjectFile = com.ProjectFile
             member _.SourceFiles = com.SourceFiles
+            member _.IncrementCounter() = com.IncrementCounter()
             member _.IsPrecompilingInlineFunction = com.IsPrecompilingInlineFunction
             member _.WillPrecompileInlineFunction(file) = com.WillPrecompileInlineFunction(file)
             member _.GetImplementationFile(fileName) = com.GetImplementationFile(fileName)

--- a/src/Fable.Transforms/FSharp2Fable.fs
+++ b/src/Fable.Transforms/FSharp2Fable.fs
@@ -309,11 +309,11 @@ let private transformDelegate com ctx (delegateType: FSharpType) expr =
         | _ -> expr
 
     match makeType ctx.GenericArgs delegateType with
-    | Fable.DelegateType(argTypes, _) as t ->
+    | Fable.DelegateType(argTypes, _) ->
         let arity = List.length argTypes |> max 1
         match expr with
         | LambdaUncurriedAtCompileTime (Some arity) lambda -> return lambda
-        | _ when arity > 1 -> return Replacements.Api.uncurryExprAtRuntime com t arity expr
+        | _ when arity > 1 -> return Replacements.Api.uncurryExprAtRuntime com arity expr
         | _ -> return expr
     | _ -> return expr
   }
@@ -1895,6 +1895,7 @@ type FableCompiler(com: Compiler) =
         member _.OutputType = com.OutputType
         member _.ProjectFile = com.ProjectFile
         member _.SourceFiles = com.SourceFiles
+        member _.IncrementCounter() = com.IncrementCounter()
         member _.IsPrecompilingInlineFunction = com.IsPrecompilingInlineFunction
         member _.WillPrecompileInlineFunction(file) = com.WillPrecompileInlineFunction(file)
         member _.GetImplementationFile(fileName) = com.GetImplementationFile(fileName)

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -2648,6 +2648,7 @@ module Compiler =
             member _.OutputType = com.OutputType
             member _.ProjectFile = com.ProjectFile
             member _.SourceFiles = com.SourceFiles
+            member _.IncrementCounter() = com.IncrementCounter()
             member _.IsPrecompilingInlineFunction = com.IsPrecompilingInlineFunction
             member _.WillPrecompileInlineFunction(file) = com.WillPrecompileInlineFunction(file)
             member _.GetImplementationFile(fileName) = com.GetImplementationFile(fileName)

--- a/src/Fable.Transforms/Global/Compiler.fs
+++ b/src/Fable.Transforms/Global/Compiler.fs
@@ -59,6 +59,7 @@ type Compiler =
     abstract SourceFiles: string[]
     abstract Options: CompilerOptions
     abstract Plugins: CompilerPlugins
+    abstract IncrementCounter: unit -> int
     abstract IsPrecompilingInlineFunction: bool
     abstract WillPrecompileInlineFunction: file: string -> Compiler
     abstract GetImplementationFile: fileName: string -> FSharpImplementationFileDeclaration list

--- a/src/Fable.Transforms/Global/Prelude.fs
+++ b/src/Fable.Transforms/Global/Prelude.fs
@@ -171,6 +171,8 @@ module Result =
 module Patterns =
     let (|Try|_|) (f: 'a -> 'b option) a = f a
 
+    let (|Run|) (f: 'a -> 'b) a = f a
+
     let (|DicContains|_|) (dic: System.Collections.Generic.IDictionary<'k,'v>) key =
         let success, value = dic.TryGetValue key
         if success then Some value else None

--- a/src/Fable.Transforms/Php/Fable2Php.fs
+++ b/src/Fable.Transforms/Php/Fable2Php.fs
@@ -1626,6 +1626,7 @@ type PhpCompiler(com: Fable.Compiler) =
         member this.Require = Set.toList require
         member this.NsUse = Set.toList nsUse
 
+        member this.IncrementCounter() = com.IncrementCounter()
         member this.IsPrecompilingInlineFunction = com.IsPrecompilingInlineFunction
         member this.WillPrecompileInlineFunction(file) = com.WillPrecompileInlineFunction(file)
         member this.AddLog(msg,severity, rang, fileName, tag) = com.AddLog(msg,severity, ?range = rang, ?fileName= fileName, ?tag = tag)

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -17,10 +17,6 @@ type ReturnStrategy =
     | Assign of Expression
     | Target of Identifier
 
-type ArgsInfo =
-    | CallInfo of Fable.CallInfo
-    | NoCallInfo of args: Fable.Expr list
-
 type Import =
     { Module: string
       LocalIdent: Identifier option
@@ -734,7 +730,7 @@ module Annotation =
         | Fable.String -> Expression.name "str", []
         | Fable.Number (kind, info) -> makeNumberTypeAnnotation com ctx kind info
         | Fable.LambdaType (argType, returnType) ->
-            let argTypes, returnType = uncurryLambdaType System.Int32.MaxValue [ argType ] returnType
+            let argTypes, returnType = uncurryLambdaType -1 [ argType ] returnType
             stdlibModuleTypeHint com ctx "typing" "Callable" (argTypes @ [ returnType ])
         | Fable.DelegateType (argTypes, returnType) -> stdlibModuleTypeHint com ctx "typing" "Callable" (argTypes @ [ returnType ])
         | Fable.Option (genArg, _) -> stdlibModuleTypeHint com ctx "typing" "Optional" [ genArg ]
@@ -1754,7 +1750,7 @@ module Util =
                 | Fable.IdentExpr id -> com.GetIdentifierAsExpr(ctx, id.Name), []
                 | _ -> transformAsExpr com ctx baseRef
 
-            let expr, keywords, stmts' = transformCallArgs com ctx None (CallInfo info)
+            let expr, keywords, stmts' = transformCallArgs com ctx info
 
             Some(baseExpr, (expr, keywords, stmts @ stmts'))
         | Some (Fable.ObjectExpr ([], Fable.Unit, None)), _ ->
@@ -1876,13 +1872,9 @@ module Util =
 
         Expression.call (Expression.name name), [ stmt ] @ stmts
 
-    let transformCallArgs (com: IPythonCompiler) ctx r (info: ArgsInfo) : Expression list * Keyword list * Statement list =
-        let paramsInfo, args =
-            match info with
-            | NoCallInfo args -> None, args
-            | CallInfo callInfo ->
-                let paramsInfo = callInfo.MemberRef |> Option.bind com.TryGetMember |> Option.map getParamsInfo
-                paramsInfo, callInfo.Args
+    let transformCallArgs (com: IPythonCompiler) ctx (callInfo: Fable.CallInfo) : Expression list * Keyword list * Statement list =
+        let paramsInfo = callInfo.MemberRef |> Option.bind com.TryGetMember |> Option.map getParamsInfo
+        let args = callInfo.Args
 
         let args, objArg, stmts =
             paramsInfo
@@ -2049,7 +2041,7 @@ module Util =
             |> Option.toList
             |> Helpers.unzipArgs
 
-        let exprs, _, stmts' = transformCallArgs com ctx range (CallInfo info)
+        let exprs, _, stmts' = transformCallArgs com ctx info
 
         if macro.StartsWith("functools") then
             com.GetImportExpr(ctx, "functools") |> ignore
@@ -2061,7 +2053,7 @@ module Util =
         // printfn "transformCall: %A" (callee, callInfo)
         let callee', stmts = com.TransformAsExpr(ctx, callee)
 
-        let args, kw, stmts' = transformCallArgs com ctx range (CallInfo callInfo)
+        let args, kw, stmts' = transformCallArgs com ctx callInfo
 
         match callee, callInfo.ThisArg with
         | Fable.Get (expr, Fable.FieldGet { Name = "Dispose" }, _, _), _ ->
@@ -2085,12 +2077,15 @@ module Util =
         | _, None -> callFunction range callee' args kw, stmts @ stmts'
 
     let transformCurriedApply com ctx range (TransformExpr com ctx (applied, stmts)) args =
-        match transformCallArgs com ctx range (NoCallInfo args) with
-        | [], kw, stmts' -> callFunction range applied [] kw, stmts @ stmts'
-        | args, kw, stmts' ->
-            (applied, args)
-            ||> List.fold (fun e arg -> callFunction range e [ arg ] kw),
-            stmts @ stmts'
+        ((applied, stmts), args) ||> List.fold (fun (applied, stmts) arg ->
+            let args, stmts' =
+                match arg with
+                // TODO: If arg type is unit but it's an expression with potential
+                // side-effects, we need to extract it and execute it before the call
+                | Fable.Value(Fable.UnitConstant,_) -> [], []
+                | Fable.IdentExpr ident when ident.Type = Fable.Unit -> [], []
+                | TransformExpr com ctx (arg, stmts') -> [arg], stmts'
+            callFunction range applied args [], stmts @ stmts')
 
     let transformCallAsStatements com ctx range t returnStrategy callee callInfo =
         let argsLen (i: Fable.CallInfo) =

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -4185,9 +4185,8 @@ module Compiler =
             member _.OutputType = com.OutputType
             member _.ProjectFile = com.ProjectFile
             member _.SourceFiles = com.SourceFiles
-
+            member _.IncrementCounter() = com.IncrementCounter()
             member _.IsPrecompilingInlineFunction = com.IsPrecompilingInlineFunction
-
             member _.WillPrecompileInlineFunction(file) = com.WillPrecompileInlineFunction(file)
             member _.GetImplementationFile(fileName) = com.GetImplementationFile(fileName)
             member _.GetRootModule(fileName) = com.GetRootModule(fileName)

--- a/src/Fable.Transforms/Replacements.Api.fs
+++ b/src/Fable.Transforms/Replacements.Api.fs
@@ -30,11 +30,6 @@ let partialApplyAtRuntime (com: Compiler) t arity (fn: Expr) (args: Expr list) =
         Helper.LibCall(com, "Util", "partialApply", t, [makeIntConst arity; fn; args])
     | _ -> Replacements.Util.partialApplyAtRuntime com t arity fn args
 
-let checkArity (com: Compiler) t arity expr =
-    match com.Options.Language with
-    | JavaScript | TypeScript -> Helper.LibCall(com, "Util", "checkArity", t, [makeIntConst arity; expr]) |> Some
-    | _ -> None // anonymous record fields are not uncurried for Rust, so nothing to do
-
 let tryField (com: ICompiler) returnTyp ownerTyp fieldName =
     match com.Options.Language with
     | Rust -> Rust.Replacements.tryField com returnTyp ownerTyp fieldName

--- a/src/Fable.Transforms/Replacements.Util.fs
+++ b/src/Fable.Transforms/Replacements.Util.fs
@@ -372,6 +372,59 @@ let compose (com: ICompiler) ctx r t (f1: Expr) (f2: Expr) =
         |> curriedApply r retType (IdentExpr capturedFun2Var)
     Let(capturedFun1Var, f1, Let(capturedFun2Var, f2, Lambda(arg, body, None)))
 
+let partialApplyAtRuntime (com: Compiler) t arity (expr: Expr) (partialArgs: Expr list) =
+    // Check if argTypes.Length < arity?
+    let argTypes, returnType = uncurryLambdaType arity [] t
+    let argIdents = argTypes |> List.map (fun t -> makeTypedIdent t $"x{com.IncrementCounter()}$")
+    let args = argIdents |> List.map Fable.IdentExpr
+    Helper.Application(expr, returnType, partialArgs @ args)
+    |> makeLambda argIdents
+
+let curryExprAtRuntime (com: Compiler) arity (expr: Expr) =
+    if arity = 1 then expr
+    else
+        match expr with
+        | Value(Null _, _) -> expr
+        | Value(NewOption(value, t, isStruct), r) ->
+            match value with
+            | None -> expr
+            | Some v ->
+                let curried = partialApplyAtRuntime com t arity v []
+                Value(NewOption(Some curried, t, isStruct), r)
+        | ExprType(Option(t, isStruct)) ->
+            let uncurriedType =
+                let argTypes, returnType = uncurryLambdaType arity [] t
+                DelegateType(argTypes, returnType)
+            let f = makeTypedIdent uncurriedType "f"
+            let curried = partialApplyAtRuntime com t arity (IdentExpr f) []
+            let fn = Delegate([f], curried, None, Tags.empty)
+            // TODO: This may be different per language
+            Helper.LibCall(com, "Option", "map", Option(curried.Type, isStruct), [fn; expr])
+        | _ -> partialApplyAtRuntime com expr.Type arity expr []
+
+let uncurryExprAtRuntime (com: Compiler) arity (expr: Expr) =
+    let uncurry (expr: Expr) =
+        // Check if argTypes.Length < arity?
+        let argTypes, returnType = uncurryLambdaType arity [] expr.Type
+        let argIdents = argTypes |> List.map (fun t -> makeTypedIdent t $"x{com.IncrementCounter()}$")
+        let args = argIdents |> List.map IdentExpr
+        let body = curriedApply None returnType expr args
+        Delegate(argIdents, body, None, Tags.empty)
+
+    match expr with
+    | Value(Null _, _) -> expr
+    | Value(NewOption(value, t, isStruct), r) ->
+        match value with
+        | None -> expr
+        | Some v -> Value(NewOption(Some(uncurry v), t, isStruct), r)
+    | ExprType(Option(t, isStruct)) ->
+        let f = makeTypedIdent t "f"
+        let uncurried = uncurry (IdentExpr f)
+        let fn = Delegate([f], uncurried, None, Tags.empty)
+        // TODO: This may be different per language
+        Helper.LibCall(com, "Option", "map", Option(uncurried.Type, isStruct), [fn; expr])
+    | expr -> uncurry expr
+
 let (|Namesof|_|) com ctx e = namesof com ctx [] e
 let (|Nameof|_|) com ctx e = namesof com ctx [] e |> Option.bind List.tryLast
 

--- a/src/Fable.Transforms/Rust/Fable2Rust.fs
+++ b/src/Fable.Transforms/Rust/Fable2Rust.fs
@@ -4225,6 +4225,7 @@ module Compiler =
             member _.OutputType = com.OutputType
             member _.ProjectFile = com.ProjectFile
             member _.SourceFiles = com.SourceFiles
+            member _.IncrementCounter() = com.IncrementCounter()
             member _.IsPrecompilingInlineFunction = com.IsPrecompilingInlineFunction
             member _.WillPrecompileInlineFunction(file) = com.WillPrecompileInlineFunction(file)
             member _.GetImplementationFile(fileName) = com.GetImplementationFile(fileName)

--- a/src/Fable.Transforms/State.fs
+++ b/src/Fable.Transforms/State.fs
@@ -192,6 +192,7 @@ type Log =
 type CompilerImpl(currentFile, project: Project, options, fableLibDir: string, ?outType: OutputType, ?outDir: string,
                         ?watchDependencies: HashSet<string>, ?logs: ResizeArray<Log>, ?isPrecompilingInlineFunction: bool) =
 
+    let mutable counter = -1
     let outType = defaultArg outType OutputType.Exe
     let logs = Option.defaultWith ResizeArray logs
     let fableLibraryDir = fableLibDir.TrimEnd('/')
@@ -209,6 +210,10 @@ type CompilerImpl(currentFile, project: Project, options, fableLibDir: string, ?
         member _.OutputType = outType
         member _.ProjectFile = project.ProjectFile
         member _.SourceFiles =  project.SourceFiles
+
+        member _.IncrementCounter() =
+            counter <- counter + 1
+            counter
 
         member _.IsPrecompilingInlineFunction =
             defaultArg isPrecompilingInlineFunction false

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -285,13 +285,13 @@ module AST =
 
     let rec uncurryLambdaType maxArity (revArgTypes: Type list) (returnType: Type) =
         match returnType with
-        | LambdaType(argType, returnType) when maxArity > 0 ->
+        | LambdaType(argType, returnType) when maxArity <> 0 ->
             uncurryLambdaType (maxArity - 1) (argType::revArgTypes) returnType
         | t -> List.rev revArgTypes, t
 
     let (|NestedLambdaType|_|) = function
         | LambdaType(argType, returnType) ->
-            Some(uncurryLambdaType System.Int32.MaxValue [argType] returnType)
+            Some(uncurryLambdaType -1 [argType] returnType)
         | _ -> None
 
     /// In lambdas with tuple arguments, F# compiler deconstructs the tuple before the next nested lambda.

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -550,6 +550,10 @@ module AST =
         (args, body) ||> List.foldBack (fun arg body ->
             Lambda(arg, body, None))
 
+    let makeLambdaType (argTypes: Type list) (returnType: Type) =
+        (argTypes, returnType) ||> List.foldBack (fun arg returnType ->
+            LambdaType(arg, returnType))
+
     let makeBoolConst (x: bool) = BoolConstant x |> makeValue None
     let makeStrConst (x: string) = StringConstant x |> makeValue None
     let makeIntConst (x: int) = NumberConstant (x, Int32, NumberInfo.Empty) |> makeValue None

--- a/src/fable-library-dart/Util.dart
+++ b/src/fable-library-dart/Util.dart
@@ -1,5 +1,142 @@
 // ignore_for_file: file_names
 
+final _curried = Expando();
+
+TResult Function(T1, T2) uncurry2<T1, T2, TResult>(TResult Function(T2) Function(T1) f) {
+  f2(T1 a1, T2 a2) => f(a1)(a2);
+  _curried[f2] = f;
+  return f2;
+}
+
+TResult Function(T2) Function(T1) curry2<T1, T2, TResult>(TResult Function(T1, T2) f) {
+  var c = _curried[f];
+  if (c == null) {
+    return (T1 a1) => (T2 a2) => f(a1, a2);
+  } else {
+    return c as TResult Function(T2) Function(T1);
+  }
+}
+
+TResult Function(T1, T2, T3) uncurry3<T1, T2, T3, TResult>(TResult Function(T3) Function(T2) Function(T1) f) {
+  f2(T1 a1, T2 a2, T3 a3) => f(a1)(a2)(a3);
+  _curried[f2] = f;
+  return f2;
+}
+
+TResult Function(T3) Function(T2) Function(T1) curry3<T1, T2, T3, TResult>(TResult Function(T1, T2, T3) f) {
+  var c = _curried[f];
+  if (c == null) {
+    return (T1 a1) => (T2 a2) => (T3 a3) => f(a1, a2, a3);
+  } else {
+    return c as TResult Function(T3) Function(T2) Function(T1);
+  }
+}
+
+TResult Function(T1, T2, T3, T4) uncurry4<T1, T2, T3, T4, TResult>(TResult Function(T4) Function(T3) Function(T2) Function(T1) f) {
+  f2(T1 a1, T2 a2, T3 a3, T4 a4) => f(a1)(a2)(a3)(a4);
+  _curried[f2] = f;
+  return f2;
+}
+
+TResult Function(T4) Function(T3) Function(T2) Function(T1) curry4<T1, T2, T3, T4, TResult>(TResult Function(T1, T2, T3, T4) f) {
+  var c = _curried[f];
+  if (c == null) {
+    return (T1 a1) => (T2 a2) => (T3 a3) => (T4 a4) => f(a1, a2, a3, a4);
+  } else {
+    return c as TResult Function(T4) Function(T3) Function(T2) Function(T1);
+  }
+}
+
+TResult Function(T1, T2, T3, T4, T5) uncurry5<T1, T2, T3, T4, T5, TResult>(TResult Function(T5) Function(T4) Function(T3) Function(T2) Function(T1) f) {
+  f2(T1 a1, T2 a2, T3 a3, T4 a4, T5 a5) => f(a1)(a2)(a3)(a4)(a5);
+  _curried[f2] = f;
+  return f2;
+}
+
+TResult Function(T5) Function(T4) Function(T3) Function(T2) Function(T1) curry5<T1, T2, T3, T4, T5, TResult>(TResult Function(T1, T2, T3, T4, T5) f) {
+  var c = _curried[f];
+  if (c == null) {
+    return (T1 a1) => (T2 a2) => (T3 a3) => (T4 a4) => (T5 a5) => f(a1, a2, a3, a4, a5);
+  } else {
+    return c as TResult Function(T5) Function(T4) Function(T3) Function(T2) Function(T1);
+  }
+}
+
+TResult Function(T1, T2, T3, T4, T5, T6) uncurry6<T1, T2, T3, T4, T5, T6, TResult>(TResult Function(T6) Function(T5) Function(T4) Function(T3) Function(T2) Function(T1) f) {
+  f2(T1 a1, T2 a2, T3 a3, T4 a4, T5 a5, T6 a6) => f(a1)(a2)(a3)(a4)(a5)(a6);
+  _curried[f2] = f;
+  return f2;
+}
+
+TResult Function(T6) Function(T5) Function(T4) Function(T3) Function(T2) Function(T1) curry6<T1, T2, T3, T4, T5, T6, TResult>(TResult Function(T1, T2, T3, T4, T5, T6) f) {
+  var c = _curried[f];
+  if (c == null) {
+    return (T1 a1) => (T2 a2) => (T3 a3) => (T4 a4) => (T5 a5) => (T6 a6) => f(a1, a2, a3, a4, a5, a6);
+  } else {
+    return c as TResult Function(T6) Function(T5) Function(T4) Function(T3) Function(T2) Function(T1);
+  }
+}
+
+TResult Function(T1, T2, T3, T4, T5, T6, T7) uncurry7<T1, T2, T3, T4, T5, T6, T7, TResult>(TResult Function(T7) Function(T6) Function(T5) Function(T4) Function(T3) Function(T2) Function(T1) f) {
+  f2(T1 a1, T2 a2, T3 a3, T4 a4, T5 a5, T6 a6, T7 a7) => f(a1)(a2)(a3)(a4)(a5)(a6)(a7);
+  _curried[f2] = f;
+  return f2;
+}
+
+TResult Function(T7) Function(T6) Function(T5) Function(T4) Function(T3) Function(T2) Function(T1) curry7<T1, T2, T3, T4, T5, T6, T7, TResult>(TResult Function(T1, T2, T3, T4, T5, T6, T7) f) {
+  var c = _curried[f];
+  if (c == null) {
+    return (T1 a1) => (T2 a2) => (T3 a3) => (T4 a4) => (T5 a5) => (T6 a6) => (T7 a7) => f(a1, a2, a3, a4, a5, a6, a7);
+  } else {
+    return c as TResult Function(T7) Function(T6) Function(T5) Function(T4) Function(T3) Function(T2) Function(T1);
+  }
+}
+
+TResult Function(T1, T2, T3, T4, T5, T6, T7, T8) uncurry8<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(TResult Function(T8) Function(T7) Function(T6) Function(T5) Function(T4) Function(T3) Function(T2) Function(T1) f) {
+  f2(T1 a1, T2 a2, T3 a3, T4 a4, T5 a5, T6 a6, T7 a7, T8 a8) => f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8);
+  _curried[f2] = f;
+  return f2;
+}
+
+TResult Function(T8) Function(T7) Function(T6) Function(T5) Function(T4) Function(T3) Function(T2) Function(T1) curry8<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(TResult Function(T1, T2, T3, T4, T5, T6, T7, T8) f) {
+  var c = _curried[f];
+  if (c == null) {
+    return (T1 a1) => (T2 a2) => (T3 a3) => (T4 a4) => (T5 a5) => (T6 a6) => (T7 a7) => (T8 a8) => f(a1, a2, a3, a4, a5, a6, a7, a8);
+  } else {
+    return c as TResult Function(T8) Function(T7) Function(T6) Function(T5) Function(T4) Function(T3) Function(T2) Function(T1);
+  }
+}
+
+TResult Function(T1, T2, T3, T4, T5, T6, T7, T8, T9) uncurry9<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(TResult Function(T9) Function(T8) Function(T7) Function(T6) Function(T5) Function(T4) Function(T3) Function(T2) Function(T1) f) {
+  f2(T1 a1, T2 a2, T3 a3, T4 a4, T5 a5, T6 a6, T7 a7, T8 a8, T9 a9) => f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9);
+  _curried[f2] = f;
+  return f2;
+}
+
+TResult Function(T9) Function(T8) Function(T7) Function(T6) Function(T5) Function(T4) Function(T3) Function(T2) Function(T1) curry9<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(TResult Function(T1, T2, T3, T4, T5, T6, T7, T8, T9) f) {
+  var c = _curried[f];
+  if (c == null) {
+    return (T1 a1) => (T2 a2) => (T3 a3) => (T4 a4) => (T5 a5) => (T6 a6) => (T7 a7) => (T8 a8) => (T9 a9) => f(a1, a2, a3, a4, a5, a6, a7, a8, a9);
+  } else {
+    return c as TResult Function(T9) Function(T8) Function(T7) Function(T6) Function(T5) Function(T4) Function(T3) Function(T2) Function(T1);
+  }
+}
+
+TResult Function(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) uncurry10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(TResult Function(T10) Function(T9) Function(T8) Function(T7) Function(T6) Function(T5) Function(T4) Function(T3) Function(T2) Function(T1) f) {
+  f2(T1 a1, T2 a2, T3 a3, T4 a4, T5 a5, T6 a6, T7 a7, T8 a8, T9 a9, T10 a10) => f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10);
+  _curried[f2] = f;
+  return f2;
+}
+
+TResult Function(T10) Function(T9) Function(T8) Function(T7) Function(T6) Function(T5) Function(T4) Function(T3) Function(T2) Function(T1) curry10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(TResult Function(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) f) {
+  var c = _curried[f];
+  if (c == null) {
+    return (T1 a1) => (T2 a2) => (T3 a3) => (T4 a4) => (T5 a5) => (T6 a6) => (T7 a7) => (T8 a8) => (T9 a9) => (T10 a10) => f(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10);
+  } else {
+    return c as TResult Function(T10) Function(T9) Function(T8) Function(T7) Function(T6) Function(T5) Function(T4) Function(T3) Function(T2) Function(T1);
+  }
+}
+
 void ignore([dynamic _]) {}
 
 T value<T>(T? value) => value!;

--- a/src/fable-library/Util.ts
+++ b/src/fable-library/Util.ts
@@ -687,6 +687,7 @@ export function clear<T>(col: Iterable<T>) {
 const curried = new WeakMap<object, object>();
 
 export function uncurry2<T1, T2, TResult>(f: (a1: T1) => (a2: T2) => TResult) {
+  if (f == null) { return null as unknown as (a1: T1, a2: T2) => TResult }
   const f2 = (a1: T1, a2: T2) => f(a1)(a2);
   curried.set(f2, f);
   return f2;
@@ -697,6 +698,7 @@ export function curry2<T1, T2, TResult>(f: (a1: T1, a2: T2) => TResult) {
 }
 
 export function uncurry3<T1, T2, T3, TResult>(f: (a1: T1) => (a2: T2) => (a3: T3) => TResult) {
+  if (f == null) { return null as unknown as (a1: T1, a2: T2, a3: T3) => TResult }
   const f2 = (a1: T1, a2: T2, a3: T3) => f(a1)(a2)(a3);
   curried.set(f2, f);
   return f2;
@@ -710,6 +712,7 @@ export function curry3<T1, T2, T3, TResult>(f: (a1: T1, a2: T2, a3: T3) => TResu
 export function uncurry4<T1, T2, T3, T4, TResult>(
   f: (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => TResult
 ) {
+  if (f == null) { return null as unknown as (a1: T1, a2: T2, a3: T3, a4: T4) => TResult }
   const f2 = (a1: T1, a2: T2, a3: T3, a4: T4) => f(a1)(a2)(a3)(a4);
   curried.set(f2, f);
   return f2;
@@ -723,6 +726,7 @@ export function curry4<T1, T2, T3, T4, TResult>(f: (a1: T1, a2: T2, a3: T3, a4: 
 export function uncurry5<T1, T2, T3, T4, T5, TResult>(
   f: (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => TResult
 ) {
+  if (f == null) { return null as unknown as (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5) => TResult }
   const f2 = (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5) => f(a1)(a2)(a3)(a4)(a5);
   curried.set(f2, f);
   return f2;
@@ -736,6 +740,7 @@ export function curry5<T1, T2, T3, T4, T5, TResult>(f: (a1: T1, a2: T2, a3: T3, 
 export function uncurry6<T1, T2, T3, T4, T5, T6, TResult>(
   f: (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => TResult
 ) {
+  if (f == null) { return null as unknown as (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6) => TResult }
   const f2 = (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6) => f(a1)(a2)(a3)(a4)(a5)(a6);
   curried.set(f2, f);
   return f2;
@@ -749,6 +754,7 @@ export function curry6<T1, T2, T3, T4, T5, T6, TResult>(f: (a1: T1, a2: T2, a3: 
 export function uncurry7<T1, T2, T3, T4, T5, T6, T7, TResult>(
   f: (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => TResult
 ) {
+  if (f == null) { return null as unknown as (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7) => TResult }
   const f2 = (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7) => f(a1)(a2)(a3)(a4)(a5)(a6)(a7);
   curried.set(f2, f);
   return f2;
@@ -762,6 +768,7 @@ export function curry7<T1, T2, T3, T4, T5, T6, T7, TResult>(f: (a1: T1, a2: T2, 
 export function uncurry8<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(
   f: (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => TResult
 ) {
+  if (f == null) { return null as unknown as (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8) => TResult }
   const f2 = (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8) => f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8);
   curried.set(f2, f);
   return f2;
@@ -775,6 +782,7 @@ export function curry8<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(f: (a1: T1, a2: 
 export function uncurry9<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(
   f: (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => TResult
 ) {
+  if (f == null) { return null as unknown as (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9) => TResult }
   const f2 = (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9) => f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9);
   curried.set(f2, f);
   return f2;
@@ -788,6 +796,7 @@ export function curry9<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(f: (a1: T1, 
 export function uncurry10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(
   f: (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => TResult
 ) {
+  if (f == null) { return null as unknown as (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10) => TResult }
   const f2 = (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10) => f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10);
   curried.set(f2, f);
   return f2;
@@ -797,72 +806,6 @@ export function curry10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(f: (a1
   return curried.get(f) as (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => TResult
     ?? ((a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => f(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10));
 }
-
-const CURRIED = Symbol("curried");
-
-export function uncurry(arity: number, f: Option<Function>): any {
-  // f may be a function option with None value
-  if (f == null) {
-    return f;
-  }
-  const f2 = value(f);
-  if (f2.length > 1) {
-    return f2;
-  }
-  const uncurried = (...args: any[]) => {
-    let res = f2;
-    for (let i = 0; i < arity; i++) {
-      res = res(args[i]);
-    }
-    return res;
-  }
-  (uncurried as any)[CURRIED] = f2;
-  return uncurried;
-}
-
-function _curry(args: any[],  arity: number, f: Function): (x: any) => any {
-  return (arg: any) => arity === 1
-    ? f(...args.concat([arg]))
-    // Note it's important to generate a new args array every time
-    // because a partially applied function can be run multiple times
-    : _curry(args.concat([arg]), arity - 1, f);
-}
-
-export function curry(arity: number, f: Option<Function>): any {
-  if (f == null) {
-    return f;
-  }
-  const f2 = value(f);
-  if (f2.length === 1) {
-    return f2;
-  }
-  else if (CURRIED in f2) {
-    return (f2 as any)[CURRIED];
-  } else {
-    return _curry([], arity, f2);
-  }
-}
-
-export function checkArity(arity: number, f: Function): any {
-  return f.length > arity
-    ? (...args1: any[]) => (...args2: any[]) => f.apply(undefined, args1.concat(args2))
-    : f;
-}
-
-export function partialApply(arity: number, f: Function, args: any[]): any {
-  if (f == null) {
-    return undefined;
-  } else if (CURRIED in f) {
-    f = (f as any)[CURRIED];
-    for (let i = 0; i < args.length; i++) {
-      f = f(args[i]);
-    }
-    return f;
-  } else {
-    return _curry(args, arity, f);
-  }
-}
-
 
 // More performant method to copy arrays, see #2352
 export function copyToArray<T>(source: T[], sourceIndex: number, target: T[], targetIndex: number, count: number): void {

--- a/src/fable-library/Util.ts
+++ b/src/fable-library/Util.ts
@@ -684,6 +684,120 @@ export function clear<T>(col: Iterable<T>) {
   }
 }
 
+const curried = new WeakMap<object, object>();
+
+export function uncurry2<T1, T2, TResult>(f: (a1: T1) => (a2: T2) => TResult) {
+  const f2 = (a1: T1, a2: T2) => f(a1)(a2);
+  curried.set(f2, f);
+  return f2;
+}
+
+export function curry2<T1, T2, TResult>(f: (a1: T1, a2: T2) => TResult) {
+  return curried.get(f) as ((a1: T1) => (a2: T2) => TResult) ?? ((a1: T1) => (a2: T2) => f(a1, a2));
+}
+
+export function uncurry3<T1, T2, T3, TResult>(f: (a1: T1) => (a2: T2) => (a3: T3) => TResult) {
+  const f2 = (a1: T1, a2: T2, a3: T3) => f(a1)(a2)(a3);
+  curried.set(f2, f);
+  return f2;
+}
+
+export function curry3<T1, T2, T3, TResult>(f: (a1: T1, a2: T2, a3: T3) => TResult) {
+  return curried.get(f) as (a1: T1) => (a2: T2) => (a3: T3) => TResult
+    ?? ((a1: T1) => (a2: T2) => (a3: T3) => f(a1, a2, a3));
+}
+
+export function uncurry4<T1, T2, T3, T4, TResult>(
+  f: (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => TResult
+) {
+  const f2 = (a1: T1, a2: T2, a3: T3, a4: T4) => f(a1)(a2)(a3)(a4);
+  curried.set(f2, f);
+  return f2;
+}
+
+export function curry4<T1, T2, T3, T4, TResult>(f: (a1: T1, a2: T2, a3: T3, a4: T4) => TResult) {
+  return curried.get(f) as (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => TResult
+    ?? ((a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => f(a1, a2, a3, a4));
+}
+
+export function uncurry5<T1, T2, T3, T4, T5, TResult>(
+  f: (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => TResult
+) {
+  const f2 = (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5) => f(a1)(a2)(a3)(a4)(a5);
+  curried.set(f2, f);
+  return f2;
+}
+
+export function curry5<T1, T2, T3, T4, T5, TResult>(f: (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5) => TResult) {
+  return curried.get(f) as (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => TResult
+    ?? ((a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => f(a1, a2, a3, a4, a5));
+}
+
+export function uncurry6<T1, T2, T3, T4, T5, T6, TResult>(
+  f: (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => TResult
+) {
+  const f2 = (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6) => f(a1)(a2)(a3)(a4)(a5)(a6);
+  curried.set(f2, f);
+  return f2;
+}
+
+export function curry6<T1, T2, T3, T4, T5, T6, TResult>(f: (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6) => TResult) {
+  return curried.get(f) as (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => TResult
+    ?? ((a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => f(a1, a2, a3, a4, a5, a6));
+}
+
+export function uncurry7<T1, T2, T3, T4, T5, T6, T7, TResult>(
+  f: (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => TResult
+) {
+  const f2 = (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7) => f(a1)(a2)(a3)(a4)(a5)(a6)(a7);
+  curried.set(f2, f);
+  return f2;
+}
+
+export function curry7<T1, T2, T3, T4, T5, T6, T7, TResult>(f: (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7) => TResult) {
+  return curried.get(f) as (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => TResult
+    ?? ((a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => f(a1, a2, a3, a4, a5, a6, a7));
+}
+
+export function uncurry8<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(
+  f: (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => TResult
+) {
+  const f2 = (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8) => f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8);
+  curried.set(f2, f);
+  return f2;
+}
+
+export function curry8<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(f: (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8) => TResult) {
+  return curried.get(f) as (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => TResult
+    ?? ((a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => f(a1, a2, a3, a4, a5, a6, a7, a8));
+}
+
+export function uncurry9<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(
+  f: (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => TResult
+) {
+  const f2 = (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9) => f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9);
+  curried.set(f2, f);
+  return f2;
+}
+
+export function curry9<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(f: (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9) => TResult) {
+  return curried.get(f) as (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => TResult
+    ?? ((a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => f(a1, a2, a3, a4, a5, a6, a7, a8, a9));
+}
+
+export function uncurry10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(
+  f: (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => TResult
+) {
+  const f2 = (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10) => f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10);
+  curried.set(f2, f);
+  return f2;
+}
+
+export function curry10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(f: (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10) => TResult) {
+  return curried.get(f) as (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => TResult
+    ?? ((a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => f(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10));
+}
+
 const CURRIED = Symbol("curried");
 
 export function uncurry(arity: number, f: Option<Function>): any {
@@ -749,30 +863,6 @@ export function partialApply(arity: number, f: Function, args: any[]): any {
   }
 }
 
-type CurriedArgMapping = [number, number] | 0; // expected arity, actual arity
-
-export function mapCurriedArgs(fn: Function, mappings: CurriedArgMapping[]) {
-  function mapArg(fn: Function, arg: any, mappings: CurriedArgMapping[], idx: number) {
-    const mapping = mappings[idx];
-    if (mapping !== 0) {
-      const expectedArity = mapping[0];
-      const actualArity = mapping[1];
-      if (expectedArity > 1) {
-        arg = curry(expectedArity, arg);
-      }
-      if (actualArity > 1) {
-        arg = uncurry(actualArity, arg);
-      }
-    }
-    const res = fn(arg);
-    if (idx + 1 === mappings.length) {
-      return res;
-    } else {
-      return (arg: any) => mapArg(res, arg, mappings, idx + 1);
-    }
-  }
-  return (arg: any) => mapArg(fn, arg, mappings, 0);
-}
 
 // More performant method to copy arrays, see #2352
 export function copyToArray<T>(source: T[], sourceIndex: number, target: T[], targetIndex: number, count: number): void {

--- a/src/fable-library/Util.ts
+++ b/src/fable-library/Util.ts
@@ -729,7 +729,7 @@ export function curry(arity: number, f: Option<Function>): any {
   }
 }
 
-export function checkArity(arity: number, f: Function): Function {
+export function checkArity(arity: number, f: Function): any {
   return f.length > arity
     ? (...args1: any[]) => (...args2: any[]) => f.apply(undefined, args1.concat(args2))
     : f;

--- a/tests/Js/Main/ApplicativeTests.fs
+++ b/tests/Js/Main/ApplicativeTests.fs
@@ -1100,7 +1100,19 @@ let tests7 = [
           add (next())
         let add = adder ()
         let result = add 1 + add 2 + add 3
-        // let result = useAdder adder 1 2 3 // TODO: May need a weak ptr to curried func
+        result |> equal 6
+        counter |> equal 1
+
+    testCase "Partially applied functions don't duplicate side effects locally II" <| fun () ->
+        let mutable counter = 0
+        let next () =
+          let result = counter
+          counter <- counter + 1
+          result
+        let adder () =
+          let add a b = a + b
+          add (next())
+        let result = useAdder adder 1 2 3 // TODO: May need a weak ptr to curried func
         result |> equal 6
         counter |> equal 1
 

--- a/tests/Js/Main/ApplicativeTests.fs
+++ b/tests/Js/Main/ApplicativeTests.fs
@@ -1112,7 +1112,7 @@ let tests7 = [
         let adder () =
           let add a b = a + b
           add (next())
-        let result = useAdder adder 1 2 3 // TODO: May need a weak ptr to curried func
+        let result = useAdder adder 1 2 3
         result |> equal 6
         counter |> equal 1
 

--- a/tests/Js/Main/ApplicativeTests.fs
+++ b/tests/Js/Main/ApplicativeTests.fs
@@ -1296,7 +1296,7 @@ let tests7 = [
 
         doMapRunTimes |> equal 1
         setStateAccumulated |> equal "FooBarBaz"
-#endif
+
     testCase "Fix lambda uncurry/curry semantic #1836" <| fun () ->
         let map (mapSetState: int -> (int -> unit))  =
             mapSetState 1

--- a/tests/Js/Main/ApplicativeTests.fs
+++ b/tests/Js/Main/ApplicativeTests.fs
@@ -1015,7 +1015,8 @@ type RFoo2<'a> = { foo: 'a }
 let applyFooInRecord (f: RFoo<'a,'b>) (a: 'a) = f.foo a
 let applyFooInRecord2 (f: RFoo2<'a -> 'b>) (a: 'a) = f.foo a
 let applyFooInRecord3 (f: RFoo2<'a -> 'b -> 'c>) (a: 'a) (b: 'b) = f.foo a b
-let applyFooInAnonRecord (f: {| foo: 'a -> 'b|}) (a: 'a) = f.foo a
+let applyFooInAnonRecord (f: {| foo: 'a -> 'b |}) (a: 'a) = f.foo a
+let applyFooInAnonRecord3 (f: {| foo: 'a -> 'b -> 'c |}) (a: 'a) (b: 'b) = f.foo a b
 
 type Wrapper() =
     member _.doesNotWorki = wrap
@@ -1354,6 +1355,10 @@ let tests7 = [
         applyFooInAnonRecord {| foo = fun x y -> x ** y |} 5. 2. |> equal 25.
         let f = applyFooInAnonRecord {| foo = fun x y -> x ** y |} 5.
         f 3. |> equal 125.
+
+        applyFooInAnonRecord3 {| foo = fun x y z -> x ** y - z |} 5. 2. 1. |> equal 24.
+        let f = applyFooInAnonRecord3 {| foo = fun x y z -> x ** y - z |} 5.
+        f 3. 3. |> equal 122.
 
     testCase "Curried functions being mangled via DU, List.fold and match combination #2356" <| fun _ ->
         let testData = [ In (fun b i -> "fly"); Out (fun b i -> "fade")]

--- a/tests/Js/Main/ApplicativeTests.fs
+++ b/tests/Js/Main/ApplicativeTests.fs
@@ -1296,7 +1296,7 @@ let tests7 = [
 
         doMapRunTimes |> equal 1
         setStateAccumulated |> equal "FooBarBaz"
-
+#endif
     testCase "Fix lambda uncurry/curry semantic #1836" <| fun () ->
         let map (mapSetState: int -> (int -> unit))  =
             mapSetState 1
@@ -1560,8 +1560,10 @@ module Uncurry =
     let private add2WithLambda (adder: int->int->int) (arg1: int) (arg2: int): int =
         adder arg1 arg2
 
+
     let add_2 =
-        add2WithLambda (JsInterop.import "add2Arguments" "./js/1foo.js")
+        let add2Arguments (x: int) (y: int): int = JsInterop.importMember "./js/1foo.js"
+        add2WithLambda add2Arguments
 
     let private add10WithLambda
         (adder: int->int->int->int->int->int->int->int->int->int->int)
@@ -1580,7 +1582,8 @@ module Uncurry =
         adder arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10
 
     let add_10 =
-        add10WithLambda (JsInterop.import "add10Arguments" "./js/1foo.js")
+        let add10Arguments (x1: int) (x2: int) (x3: int) (x4: int) (x5: int) (x6: int) (x7: int) (x8: int) (x9: int) (x10: int): int = JsInterop.importMember "./js/1foo.js"
+        add10WithLambda add10Arguments
 
     let tests =
         [

--- a/tests/Python/Fable.Tests.Python.fsproj
+++ b/tests/Python/Fable.Tests.Python.fsproj
@@ -9,7 +9,7 @@
     <RootNamespace>Fable.Tests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="6.0.1" />
+    <PackageReference Include="FSharp.Core" Version="6.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="XUnit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">


### PR DESCRIPTION
**EDIT**: This PR doesn't try to inline (un)currying for all languages (only for Rust atm) because of the issue with side effects (see below) but it does try to make things more consistent and improve the mechanism.

-----------------------------------------

This is an attempt to resolve currying/uncurrying directly in Fable AST instead of using specific helpers for each language. This is basically what Rust already did only a bit improved (hopefully). The main advantage is we can share the complex mechanism and have proper typings. I'm almost there, it's working for the typed languages (interestingly something broke for the dynamic languages, I will check).

The bad news is I haven't been able so far to resolve the problem of side effects running multiple times when partial applying a function that has been previously uncurried. The way this is currently solved in currently solved for JS and Python is to add a property with a reference to the curried function so when partial applying we can [check if the curried version is available](https://github.com/fable-compiler/Fable/blob/746c9d98f14becc13b382aca315bddfa4a1fb616/src/fable-library/Util.ts#L741-L745).

However, this is not possible for the typed languages because we cannot add extra properties to the functions. Any ideas? @ncave @dbrattli @alexswan10k Maybe keep a global dictionary with the references to the curried functions instead?