### PR TITLE
[Rust] Enable unused ident elimination

### DIFF
--- a/src/Fable.AST/Fable.fs
+++ b/src/Fable.AST/Fable.fs
@@ -377,6 +377,7 @@ type Ident =
     { Name: string
       Type: Type
       IsMutable: bool
+      IsModuleValue: bool
       IsThisArgument: bool
       IsCompilerGenerated: bool
       Range: SourceLocation option }

--- a/src/Fable.Transforms/Php/Fable2Php.fs
+++ b/src/Fable.Transforms/Php/Fable2Php.fs
@@ -233,7 +233,7 @@ let  convertMultiCaseUnion (com: IPhpCompiler) (decl: Fable.ClassDecl) (info: Fa
                     PhpFun.Args = []
                     PhpFun.Matchings = []
                     PhpFun.Static = true
-                    PhpFun.Body = 
+                    PhpFun.Body =
                         [ PhpStatement.PhpReturn(
                             PhpNewArray(
                                 info.UnionCases
@@ -970,7 +970,7 @@ let rec convertExpr (com: IPhpCompiler) (expr: Fable.Expr) =
 and convertArgs com (args: Fable.Expr list) =
     [ for arg in args do
         match arg with
-        | Fable.IdentExpr({ Name = "Array"; IsCompilerGenerated = true}) ->
+        | Fable.IdentExpr({ Name = "Array"; IsCompilerGenerated = true }) ->
             ()
         | _ ->
             match arg.Type with

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -469,6 +469,7 @@ module AST =
           Type = typ
           IsCompilerGenerated = true
           IsThisArgument = false
+          IsModuleValue = false
           IsMutable = false
           Range = None }
 


### PR DESCRIPTION
This helps eliminate unused idents (e.g. computation expression builders, etc.) from appearing in the generated code:
```fs
module Identity =
    let inline run expr = expr
    type IdentityBuilder() =
        member inline __.Return(value) = value

let identity = Identity.IdentityBuilder()

let f() = identity { return 3 } |> Identity.run
```