### PR TITLE
Fix: Compiler Exception when `!!`, Anon Record, & aliased `Ux<...>`

### DIFF
--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -1363,6 +1363,7 @@ module TypeHelpers =
                 // This is necessary because: `makeType` reduces Erased Unions (including Ux) to `Any` -> no type info any more
                 //
                 // Note: no handling of nested types: `U2<string, U<int, float>>` -> `int` & `float` don't get extract
+                let ty = ty.AbbreviatedType
                 match ty with
                 | UType tys ->
                     tys

--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -1380,8 +1380,8 @@ module TypeHelpers =
                 match ty with
                 | TypeDefinition tdef ->
                     match FsEnt.FullName tdef with
-                    | Types.valueOption -> Some(ty.GenericArguments[0], true)
-                    | Types.option -> Some(ty.GenericArguments[0], false)
+                    | Types.valueOption -> Some(ty.GenericArguments[0].AbbreviatedType, true)
+                    | Types.option -> Some(ty.GenericArguments[0].AbbreviatedType, false)
                     | _ -> None
                 | _ -> None
             and (|UType|_|) (ty: FSharpType) =
@@ -1400,6 +1400,7 @@ module TypeHelpers =
                 match ty with
                 | TypeDefinition UName ->
                     ty.GenericArguments
+                    |> Seq.map (fun t -> t.AbbreviatedType)
                     |> Seq.toList
                     |> Some
                 | _ -> None

--- a/tests/Integration/Compiler/AnonRecordInInterfaceTests.fs
+++ b/tests/Integration/Compiler/AnonRecordInInterfaceTests.fs
@@ -529,6 +529,86 @@ let tests =
           |> Assert.Is.errorOrWarning
           |> Assert.Exists.errorOrWarningMatching (Error.Regex.MissingField (interfaceName = i.Name, fieldName = "Required"))
       ]
+      testList "interface with field with aliased U2 type" [
+        let al = "type Value = U2<bool, string>"
+        let i = { Name = "Field8"; Properties = [ ReadOnly ("Value", "Value") ] }
+        let tys = [
+          al
+          yield! i |> Interface.format
+        ]
+        let aliasAndInterfaceAndAnonRecordAssignment value =
+          [
+            yield! tys
+            assignAnonRecord i [("Value", value)]
+          ]
+
+        testCase "no error for field with string" <| fun _ ->
+          aliasAndInterfaceAndAnonRecordAssignment "\"foo\""
+          |> concat
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "no error for field with bool" <| fun _ ->
+          aliasAndInterfaceAndAnonRecordAssignment "true"
+          |> concat
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "error for field with int" <| fun _ ->
+          aliasAndInterfaceAndAnonRecordAssignment "42"
+          |> concat
+          |> compile
+          |> Assert.Is.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedTypeMulti (interfaceName = i.Name, fieldName = "Value"))
+        testCase "no error for field with Value" <| fun _ ->
+          [
+            yield! tys
+            assign "value" "Value" "U2.Case1 true"
+            assignAnonRecord i [("Value", "value")]
+          ]
+          |> concat
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "no error for field with U2<bool, string>" <| fun _ ->
+          [
+            yield! tys
+            assign "value" "U2<bool, string>" "U2.Case1 true"
+            assignAnonRecord i [("Value", "value")]
+          ]
+          |> concat
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "no error for field with U2<int, string>" <| fun _ ->
+          [
+            yield! tys
+            assign "value" "U2<int, string>" "U2.Case1 42"
+            assignAnonRecord i [("Value", "value")]
+          ]
+          |> concat
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "no error for field with string & Aliased Value" <| fun _ ->
+          [
+
+            "type Root = U2<bool, string>"
+            "type Value = Root"
+            yield! i |> Interface.format
+            assignAnonRecord i [("Value", "\"foo\"")]
+          ]
+          |> concat
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "error for field with int & Aliased Value" <| fun _ ->
+          [
+
+            "type Root = U2<bool, string>"
+            "type Value = Root"
+            yield! i |> Interface.format
+            assignAnonRecord i [("Value", "42")]
+          ]
+          |> concat
+          |> compile
+          |> Assert.Is.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedTypeMulti (interfaceName = i.Name, fieldName = "Value"))
+      ]
     ]
 
     testList "Interface with EmitIndexer" [

--- a/tests/Integration/Compiler/AnonRecordInInterfaceTests.fs
+++ b/tests/Integration/Compiler/AnonRecordInInterfaceTests.fs
@@ -587,7 +587,6 @@ let tests =
           |> Assert.Is.strictSuccess
         testCase "no error for field with string & Aliased Value" <| fun _ ->
           [
-
             "type Root = U2<bool, string>"
             "type Value = Root"
             yield! i |> Interface.format
@@ -598,10 +597,33 @@ let tests =
           |> Assert.Is.strictSuccess
         testCase "error for field with int & Aliased Value" <| fun _ ->
           [
-
             "type Root = U2<bool, string>"
             "type Value = Root"
             yield! i |> Interface.format
+            assignAnonRecord i [("Value", "42")]
+          ]
+          |> concat
+          |> compile
+          |> Assert.Is.errorOrWarning
+          |> Assert.Exists.errorOrWarningMatching (Error.Regex.UnexpectedTypeMulti (interfaceName = i.Name, fieldName = "Value"))
+
+        testCase "no error for option field with string & aliased Value" <| fun _ ->
+          [
+            al
+            yield!
+              { Name = "Field8"; Properties = [ ReadOnly ("Value", "Value option") ] }
+              |> Interface.format
+            assignAnonRecord i [("Value", "\"foo\"")]
+          ]
+          |> concat
+          |> compile
+          |> Assert.Is.strictSuccess
+        testCase "error for option field with int & aliased Value" <| fun _ ->
+          [
+            al
+            yield!
+              { Name = "Field8"; Properties = [ ReadOnly ("Value", "Value option") ] }
+              |> Interface.format
             assignAnonRecord i [("Value", "42")]
           ]
           |> concat


### PR DESCRIPTION
```fsharp
type Value = U2<bool, string>
type I =
    abstract value: Value with get,set

let i: I = !!{|
    value = "foo"
|}
```
fails with compiler error:
> unreachable

[repl](https://fable.io/repl/#?code=PYBwpgdgBAYghgIwDZgHQGFgCcwFgBQoksiKG2aAUgM4CSEALmFqAW-gwJ7hQBqcSAK5goAXigBVAEwAeBMGBIANFGoMsASwgBzAHwEuPWmIJQzURGqxwAxgygA3AcIBcfZyIDuGhgAso2mAMStRB7Cj2Gm7G4gCEsQDeAD6m5k5CIuIARABmClkESQC+QA&html=Q&css=Q)


Issue is: `value` is recognized as `U2`, but `GenericArguments` is empty because type is `Value` (no gen args) and not `U2<...>` ([location in code](https://github.com/fable-compiler/Fable/blob/a183c2995ed4966d6c58be9e811e531a99ec1208/src/Fable.Transforms/FSharp2Fable.Util.fs#L1361-L1404))

This PR fixes that by looking at `AbbreviatedType` (which is `U2<...>`) instead
