### PR TITLE
[JS/TS] Use native bigint type

### DIFF
--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -317,7 +317,7 @@ module Reflection =
         | Fable.Boolean -> jsTypeof "boolean" expr
         | Fable.Char | Fable.String _ -> jsTypeof "string" expr
         | Fable.Number(Decimal,_) -> jsInstanceof (libValue com ctx "Decimal" "default") expr
-        | Fable.Number(BigInt,_) -> jsInstanceof (libValue com ctx "BigInt/z" "BigInteger") expr
+        | Fable.Number(BigInt,_) -> jsTypeof "bigint" expr // jsInstanceof (libValue com ctx "BigInt/z" "BigInteger") expr
         | Fable.Number((Int64|UInt64),_) -> jsInstanceof (libValue com ctx "Long" "default") expr
         | Fable.Number _ -> jsTypeof "number" expr
         | Fable.Regex -> jsInstanceof (Expression.identifier("RegExp")) expr
@@ -423,7 +423,7 @@ module Annotation =
         | Fable.Number(Int64,_) -> makeImportTypeAnnotation com ctx [] "Long" "int64"
         | Fable.Number(UInt64,_) -> makeImportTypeAnnotation com ctx [] "Long" "uint64"
         | Fable.Number(Decimal,_) -> makeImportTypeAnnotation com ctx [] "Decimal" "decimal"
-        | Fable.Number(BigInt,_) -> makeImportTypeAnnotation com ctx [] "BigInt/z" "BigInteger"
+        | Fable.Number(BigInt,_) -> makeAliasTypeAnnotation com ctx "bigint" // makeImportTypeAnnotation com ctx [] "BigInt/z" "BigInteger"
         | Fable.Number(kind,_) -> makeNumericTypeAnnotation com ctx kind
         | Fable.Option(genArg,_) -> makeOptionTypeAnnotation com ctx genArg
         | Fable.Tuple(genArgs,_) -> makeTupleTypeAnnotation com ctx genArgs

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -2387,7 +2387,8 @@ module Util =
                         |> TupleTypeAnnotation
                     case_ta, (uci.Name, ofInt i), fields_ta
                 ) |> Array.unzip3
-
+            let base_ta = makeAliasTypeAnnotation com ctx "Union"
+            let union_ta = Array.append union_ta [| base_ta |]
             let isPublic = ent.IsPublic
             let union_fields_alias = AliasTypeAnnotation(union_fields, entParamsInst)
             let tagArgTa = makeAliasTypeAnnotation com ctx "Tag"
@@ -2420,7 +2421,8 @@ module Util =
                         let parameters = case.UnionCaseFields |> List.mapToArray (fun fi ->
                             Parameter.parameter(fi.Name, typeAnnotation=makeFieldAnnotation com ctx fi.FieldType))
                         let fnId = entName + "_" + case.Name |> Identifier.identifier
-                        Declaration.functionDeclaration(parameters, body, fnId, typeParameters=entParamsDecl)
+                        let returnType = AliasTypeAnnotation(Identifier.identifier(entName), entParamsInst)
+                        Declaration.functionDeclaration(parameters, body, fnId, returnType=returnType, typeParameters=entParamsDecl)
                         |> asModuleDeclaration isPublic
 
                 // Actual class

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -469,8 +469,7 @@ let rec equals (com: ICompiler) ctx r equal (left: Expr) (right: Expr) =
         Helper.LibCall(com, modName, "equals", Boolean, [left; right], ?loc=r) |> is equal
     | Builtin (BclGuid|BclTimeSpan|BclTimeOnly)
     | Boolean | Char | String | Number _ ->
-        let op = if equal then BinaryEqual else BinaryUnequal
-        makeBinOp r Boolean left right op
+        Helper.LibCall(com, "Util", "physicalEquality", Boolean, [left; right], ?loc=r) |> is equal
     | Builtin (BclDateTime|BclDateTimeOffset|BclDateOnly) ->
         Helper.LibCall(com, "Date", "equals", Boolean, [left; right], ?loc=r) |> is equal
     | Builtin (FSharpSet _|FSharpMap _) ->
@@ -1952,7 +1951,7 @@ let languagePrimitives (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisAr
     | "GenericEqualityWithComparer" | "GenericEqualityWithComparerIntrinsic"), [comp; left; right] ->
         Helper.InstanceCall(comp, "Equals", t, [left; right], i.SignatureArgTypes, ?loc=r) |> Some
     | ("PhysicalEquality" | "PhysicalEqualityIntrinsic"), [left; right] ->
-        makeEqOp r left right BinaryEqual |> Some
+        Helper.LibCall(com, "Util", "physicalEquality", Boolean, [left; right], ?loc=r) |> Some
     | ("PhysicalHash" | "PhysicalHashIntrinsic"), [arg] ->
         Helper.LibCall(com, "Util", "physicalHash", Int32.Number, [arg], ?loc=r) |> Some
     | ("GenericEqualityComparer"

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -1872,10 +1872,11 @@ let bigints (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (thisArg: 
         match i.SignatureArgTypes with
         | [Array _] ->
             Helper.LibCall(com, "BigInt", "fromByteArray", t, args, i.SignatureArgTypes, ?loc=r) |> Some
-        | [Number ((Int64|UInt64),_)] ->
-            Helper.LibCall(com, "BigInt", "fromInt64", t, args, i.SignatureArgTypes, ?loc=r) |> Some
+        | [Number (kind, _)] ->
+            let meth = "from" + kind.ToString()
+            Helper.LibCall(com, "BigInt", meth, t, args, i.SignatureArgTypes, ?loc=r) |> Some
         | _ ->
-            Helper.LibCall(com, "BigInt", "fromInt32", t, args, i.SignatureArgTypes, ?loc=r) |> Some
+            None
     | None, "op_Explicit" ->
         match t with
         | Number(kind,_) ->
@@ -1888,9 +1889,9 @@ let bigints (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (thisArg: 
             | Int128 | UInt128 | Float16 | BigInt | NativeInt | UNativeInt -> None
         | _ -> None
     | None, "DivRem" ->
-        Helper.LibCall(com, "BigInt", "divRem", t, args, i.SignatureArgTypes, ?loc=r) |> Some
-    | None, meth when meth.StartsWith("get_") ->
-        Helper.LibValue(com, "BigInt", meth, t) |> Some
+        Helper.LibCall(com, "BigInt", "divRemOut", t, args, i.SignatureArgTypes, ?loc=r) |> Some
+    // | None, meth when meth.StartsWith("get_") ->
+    //     Helper.LibValue(com, "BigInt", meth, t) |> Some
     | callee, meth ->
         let args =
             match callee, meth with

--- a/src/fable-library-rust/src/BigInt.rs
+++ b/src/fable-library-rust/src/BigInt.rs
@@ -95,6 +95,9 @@ pub mod BigInt_ {
     pub fn abs(x: bigint) -> bigint { x.abs().into() }
     pub fn sign(x: bigint) -> i32 { x.signum().to_i32().unwrap() }
 
+    pub fn max(x: bigint, y: bigint) -> bigint { x.max(y).into() }
+    pub fn min(x: bigint, y: bigint) -> bigint { x.min(y).into() }
+
     pub fn add(x: bigint, y: bigint) -> bigint { x + y }
     pub fn subtract(x: bigint, y: bigint) -> bigint { x - y }
     pub fn multiply(x: bigint, y: bigint) -> bigint { x * y }
@@ -102,20 +105,59 @@ pub mod BigInt_ {
     pub fn remainder(x: bigint, y: bigint) -> bigint { x % y }
     pub fn negate(x: bigint) -> bigint { -x }
 
-    pub fn max(x: bigint, y: bigint) -> bigint { x.max(y).into() }
-    pub fn min(x: bigint, y: bigint) -> bigint { x.min(y).into() }
-
     pub fn isZero(x: bigint) -> bool { x.is_zero() }
     pub fn isOne(x: bigint) -> bool { x.is_one() }
     pub fn isEven(x: bigint) -> bool { x.is_even() }
-    pub fn isOdd(x: bigint) -> bool { x.is_odd() }
-    // pub fn IsPowerOfTwo(x: bigint) -> bool { false } //TODO:
+    pub fn isPowerOfTwo(x: bigint) -> bool { isPow2(x) }
 
     pub fn isNegative(x: bigint) -> bool { x.is_negative() }
     pub fn isPositive(x: bigint) -> bool { x.is_positive() }
-    pub fn isEvenInteger(x: bigint) -> bool { x.is_even() } //TODO:
-    pub fn isOddInteger(x: bigint) -> bool { x.is_odd() } //TODO:
-    // pub fn isPow2(x: bigint) -> bool { false } //TODO:
+    pub fn isEvenInteger(x: bigint) -> bool { x.is_even() }
+    pub fn isOddInteger(x: bigint) -> bool { x.is_odd() }
+    pub fn isPow2(x: bigint) -> bool { (x.clone() & (x - one())).is_zero() }
+
+    pub fn fromZero() -> bigint { BigInt::zero().into() }
+    pub fn fromOne() -> bigint { BigInt::one().into() }
+
+    pub fn fromInt8(n: i8) -> bigint { BigInt::from_i8(n).unwrap().into() }
+    pub fn fromUInt8(n: u8) -> bigint { BigInt::from_u8(n).unwrap().into() }
+    pub fn fromInt16(n: i16) -> bigint { BigInt::from_i16(n).unwrap().into() }
+    pub fn fromUInt16(n: u16) -> bigint { BigInt::from_u16(n).unwrap().into() }
+    pub fn fromInt32(n: i32) -> bigint { BigInt::from_i32(n).unwrap().into() }
+    pub fn fromUInt32(n: u32) -> bigint { BigInt::from_u32(n).unwrap().into() }
+    pub fn fromInt64(n: i64) -> bigint { BigInt::from_i64(n).unwrap().into() }
+    pub fn fromUInt64(n: u64) -> bigint { BigInt::from_u64(n).unwrap().into() }
+    pub fn fromNativeInt(n: isize) -> bigint { BigInt::from_isize(n).unwrap().into() }
+    pub fn fromUNativeInt(n: usize) -> bigint { BigInt::from_usize(n).unwrap().into() }
+
+    pub fn fromFloat32(n: f32) -> bigint { BigInt::from_f32(n).unwrap().into() }
+    pub fn fromFloat64(n: f64) -> bigint { BigInt::from_f64(n).unwrap().into() }
+
+    pub fn fromDecimal(d: decimal) -> bigint {
+        BigInt::from_str_radix(truncate(d).to_string().as_str(), 10).unwrap().into()
+    }
+
+    pub fn fromBigInt(x: bigint) -> bigint { x }
+
+    pub fn fromBoolean(b: bool) -> bigint {
+        BigInt::from_u32(b as u32).unwrap().into()
+    }
+
+    pub fn fromChar(c: char) -> bigint {
+        BigInt::from_u32(c as u32).unwrap().into()
+    }
+
+    pub fn fromString(s: string) -> bigint {
+        BigInt::from_str_radix(s.trim(), 10).unwrap().into()
+    }
+
+    pub fn fromByteArray(bytes: Array<u8>) -> bigint {
+        BigInt::from_signed_bytes_le(bytes.as_ref()).into()
+    }
+
+    pub fn toByteArray(x: bigint) -> Array<u8> {
+        arrayFrom(x.to_signed_bytes_le())
+    }
 
     pub fn toInt8(x: bigint) -> i8 { x.to_i8().unwrap() }
     pub fn toUInt8(x: bigint) -> u8 { x.to_u8().unwrap() }
@@ -146,10 +188,6 @@ pub mod BigInt_ {
         toString_1(&x)
     }
 
-    pub fn toByteArray(x: bigint) -> Array<u8> {
-        arrayFrom(x.to_signed_bytes_le())
-    }
-
     pub fn tryParse(s: string, res: &MutCell<bigint>) -> bool {
         match BigInt::from_str_radix(s.trim(), 10) {
             Ok(d) => { res.set(d.into()); true },
@@ -162,47 +200,6 @@ pub mod BigInt_ {
             Ok(d) => d.into(),
             Err(e) => panic!("Input string was not in a correct format."),
         }
-    }
-
-    pub fn fromZero() -> bigint { BigInt::zero().into() }
-    pub fn fromOne() -> bigint { BigInt::one().into() }
-
-    pub fn fromByteArray(bytes: Array<u8>) -> bigint {
-        BigInt::from_signed_bytes_le(bytes.as_ref()).into()
-    }
-
-    pub fn fromInt8(n: i8) -> bigint { BigInt::from_i8(n).unwrap().into() }
-    pub fn fromUInt8(n: u8) -> bigint { BigInt::from_u8(n).unwrap().into() }
-    pub fn fromInt16(n: i16) -> bigint { BigInt::from_i16(n).unwrap().into() }
-    pub fn fromUInt16(n: u16) -> bigint { BigInt::from_u16(n).unwrap().into() }
-    pub fn fromInt32(n: i32) -> bigint { BigInt::from_i32(n).unwrap().into() }
-    pub fn fromUInt32(n: u32) -> bigint { BigInt::from_u32(n).unwrap().into() }
-    pub fn fromInt64(n: i64) -> bigint { BigInt::from_i64(n).unwrap().into() }
-    pub fn fromUInt64(n: u64) -> bigint { BigInt::from_u64(n).unwrap().into() }
-    pub fn fromNativeInt(n: isize) -> bigint { BigInt::from_isize(n).unwrap().into() }
-    pub fn fromUNativeInt(n: usize) -> bigint { BigInt::from_usize(n).unwrap().into() }
-
-    pub fn fromFloat32(n: f32) -> bigint { BigInt::from_f32(n).unwrap().into() }
-    pub fn fromFloat64(n: f64) -> bigint { BigInt::from_f64(n).unwrap().into() }
-
-    pub fn fromDecimal(d: decimal) -> bigint {
-        BigInt::from_str_radix(truncate(d).to_string().as_str(), 10).unwrap().into()
-    }
-
-    pub fn fromBigInt(x: bigint) -> bigint {
-        x
-    }
-
-    pub fn fromBoolean(b: bool) -> bigint {
-        BigInt::from_u32(b as u32).unwrap().into()
-    }
-
-    pub fn fromChar(c: char) -> bigint {
-        BigInt::from_u32(c as u32).unwrap().into()
-    }
-
-    pub fn fromString(s: string) -> bigint {
-        BigInt::from_str_radix(s.trim(), 10).unwrap().into()
     }
 
     pub fn pow(x: bigint, n: i32) -> bigint {

--- a/src/fable-library/BigInt.ts
+++ b/src/fable-library/BigInt.ts
@@ -1,0 +1,294 @@
+import { FSharpRef } from "./Types.js";
+import { int8, int16, int32, uint8, uint16, uint32, float32, float64 } from "./Int32.js";
+import { fromBits, fromNumber, int64, uint64, nativeint, unativeint } from "./Long.js";
+import { decimal, fromParts } from "./Decimal.js";
+import { stringHash } from "./Util.js";
+
+const isBigEndian = false;
+
+(BigInt.prototype as any).toJSON = function () {
+    return `${this.toString()}`;
+};
+
+const zero: bigint = 0n;
+const one: bigint = 1n;
+const two: bigint = 2n;
+const minusOne: bigint = -1n;
+
+export function isBigInt(x: any): boolean {
+    return typeof x === "bigint";
+}
+
+export function hash(x: bigint): int32 {
+    return stringHash(x.toString(32));
+}
+
+export function equals(x: bigint, y: bigint): boolean {
+    return x === y;
+}
+
+export function compare(x: bigint, y: bigint): int32 {
+    return x < y ? -1 : x > y ? 1 : 0;
+}
+
+export function abs(x: bigint): bigint { return x < zero ? -x : x; }
+export function sign(x: bigint): int32 { return x < zero ? -1 : x > zero ? 1 : 0; }
+
+export function max(x: bigint, y: bigint): bigint { return x > y ? x : y; }
+export function min(x: bigint, y: bigint): bigint { return x < y ? x : y; }
+
+export function add(x: bigint, y: bigint): bigint { return x + y }
+export function subtract(x: bigint, y: bigint): bigint { return x - y }
+export function multiply(x: bigint, y: bigint): bigint { return x * y }
+export function divide(x: bigint, y: bigint): bigint { return x / y }
+export function remainder(x: bigint, y: bigint): bigint { return x % y }
+export function negate(x: bigint): bigint { return -x }
+
+export function op_Addition(x: bigint, y: bigint): bigint { return x + y; }
+export function op_Subtraction(x: bigint, y: bigint): bigint { return x - y; }
+export function op_Multiply(x: bigint, y: bigint): bigint { return x * y; }
+export function op_Division(x: bigint, y: bigint): bigint { return x / y; }
+export function op_Modulus(x: bigint, y: bigint): bigint { return x % y; }
+export function op_UnaryNegation(x: bigint): bigint { return -x; }
+export function op_UnaryPlus(x: bigint): bigint { return x; }
+export function op_RightShift(x: bigint, n: int32): bigint { return x >> BigInt(n); }
+export function op_LeftShift(x: bigint, n: int32): bigint { return x << BigInt(n); }
+export function op_BitwiseAnd(x: bigint, y: bigint): bigint { return x & y; }
+export function op_BitwiseOr(x: bigint, y: bigint): bigint { return x | y; }
+export function op_ExclusiveOr(x: bigint, y: bigint): bigint { return x ^ y; }
+export function op_LessThan(x: bigint, y: bigint): boolean { return x < y; }
+export function op_LessThanOrEqual(x: bigint, y: bigint): boolean { return x <= y; }
+export function op_GreaterThan(x: bigint, y: bigint): boolean { return x > y; }
+export function op_GreaterThanOrEqual(x: bigint, y: bigint): boolean { return x >= y; }
+export function op_Equality(x: bigint, y: bigint): boolean { return x === y; }
+export function op_Inequality(x: bigint, y: bigint): boolean { return x !== y; }
+
+export function get_Zero(): bigint { return zero; }
+export function get_One(): bigint { return one; }
+export function get_MinusOne(): bigint { return minusOne; }
+export function get_IsZero(x: bigint): boolean { return x === zero; }
+export function get_IsOne(x: bigint): boolean { return x === one; }
+export function get_IsEven(x: bigint): boolean { return isEvenInteger(x); }
+export function get_IsPowerOfTwo(x: bigint): boolean { return isPow2(x); }
+export function get_Sign(x: bigint): int32 { return sign(x); }
+
+export function isNegative(x: bigint): boolean { return x < zero; }
+export function isPositive(x: bigint): boolean { return x > zero; }
+export function isEvenInteger(x: bigint): boolean { return (x % two) === zero; }
+export function isOddInteger(x: bigint): boolean { return (x % two) !== zero; }
+export function isPow2(x: bigint): boolean { return (x & (x - one)) === zero }
+
+export function fromZero(): bigint { return zero; }
+export function fromOne(): bigint { return one; }
+
+export function fromInt8(n: int8): bigint { return BigInt(n); }
+export function fromUInt8(n: uint8): bigint { return BigInt(n); }
+export function fromInt16(n: int16): bigint { return BigInt(n); }
+export function fromUInt16(n: uint16): bigint { return BigInt(n); }
+export function fromInt32(n: int32): bigint { return BigInt(n); }
+export function fromUInt32(n: uint32): bigint { return BigInt(n); }
+export function fromInt64(n: int64): bigint { return BigInt(n.toString()); }
+export function fromUInt64(n: uint64): bigint { return BigInt(n.toString()); }
+export function fromNativeInt(n: nativeint): bigint { return BigInt(n.toString()); }
+export function fromUNativeInt(n: unativeint): bigint { return BigInt(n.toString()); }
+
+export function fromFloat32(n: float32): bigint { return BigInt(n); }
+export function fromFloat64(n: float64): bigint { return BigInt(n); }
+
+export function fromDecimal(d: decimal): bigint {
+    const s = d.toString();
+    return BigInt(s.substring(0, s.indexOf(".")));
+}
+
+export function fromBigInt(x: bigint): bigint { return x }
+export function fromBoolean(b: boolean): bigint { return BigInt(b); }
+export function fromChar(c: string): bigint { return BigInt(c.charCodeAt(0)); }
+export function fromString(s: string): bigint { return BigInt(s); }
+
+export function fromByteArray(bytes: ArrayLike<uint8>): bigint {
+    return fromSignedBytes(bytes, isBigEndian);
+}
+
+export function toByteArray(value: bigint): number[] {
+    return toSignedBytes(value, isBigEndian) as any as number[];
+}
+
+export function toSByte(x: bigint): int8 { return Number(BigInt.asIntN(8, x)); }
+export function toByte(x: bigint): uint8 { return Number(BigInt.asUintN(8, x)); }
+export function toInt16(x: bigint): int16 { return Number(BigInt.asIntN(16, x)); }
+export function toUInt16(x: bigint): uint16 { return Number(BigInt.asUintN(16, x)); }
+export function toInt32(x: bigint): int32 { return Number(BigInt.asIntN(32, x)); }
+export function toUInt32(x: bigint): uint32 { return Number(BigInt.asUintN(32, x)); }
+
+export function toInt64(x: bigint): int64 {
+    const lowBits = Number(BigInt.asUintN(32, x))
+    const highBits = Number(BigInt.asUintN(32, x >> 32n))
+    return fromBits(lowBits, highBits, false);
+}
+
+export function toUInt64(x: bigint): uint64 {
+    const lowBits = Number(BigInt.asUintN(32, x))
+    const highBits = Number(BigInt.asUintN(32, x >> 32n))
+    return fromBits(lowBits, highBits, true);
+}
+
+export function toSingle(x: bigint): float32 { return Number(x); }
+export function toDouble(x: bigint): float64 { return Number(x); }
+
+export function toDecimal(x: bigint): decimal {
+    const low = Number(BigInt.asUintN(32, x))
+    const mid = Number(BigInt.asUintN(32, x >> 32n))
+    const high = Number(BigInt.asUintN(32, x >> 64n))
+    const isNegative = x < zero;
+    const scale = 0;
+    return fromParts(low, mid, high, isNegative, scale)
+}
+
+export function toBigInt(x: bigint): bigint { return x; }
+export function toBoolean(x: bigint): boolean { return x !== zero; }
+
+export function toChar(x: bigint): string {
+    return String.fromCharCode(toUInt16(x))
+}
+
+export function toString(x: bigint): string { return x.toString(); }
+
+export function tryParse(str: string, res: FSharpRef<bigint>): boolean {
+    try {
+        res.contents = BigInt(str);
+        return true;
+    }
+    catch (err: any) {
+        return false;
+    }
+}
+
+export function parse(arg: string): bigint {
+    return BigInt(arg);
+}
+
+export function pow(x: bigint, n: int32): bigint {
+    return x ** BigInt(n);
+}
+
+export function modPow(x: bigint, e: bigint, m: bigint): bigint {
+    return (x ** e) % m;
+}
+
+export function divRem(x: bigint, y: bigint): [bigint, bigint] {
+    return [x / y, x % y]
+}
+
+export function divRemOut(x: bigint, y: bigint, remainder: FSharpRef<bigint>): bigint {
+    remainder.contents = x % y;
+    return x / y;
+}
+
+export function greatestCommonDivisor(x: bigint, y: bigint): bigint {
+    while (y > zero) {
+        const q = x / y;
+        const r = x - q * y;
+        x = y;
+        y = r;
+    }
+    return x;
+}
+
+export function clamp(x: bigint, min: bigint, max: bigint): bigint {
+    return x < min ? min : x > max ? max : x;
+}
+
+export function getBitLength(x: bigint): int64 {
+    return fromNumber(x.toString(2).length);
+}
+
+// export function copySign
+// export function createChecked
+// export function createSaturating
+// export function createTruncating
+// export function getByteCount
+// export function leadingZeroCount
+// export function log
+// export function log10
+// export function log2
+// export function maxMagnitude
+// export function minMagnitude
+// export function popCount
+// export function rotateLeft
+// export function rotateRight
+// export function trailingZeroCount
+// export function tryFormat
+// export function tryWriteBytes
+
+// -------------------------------------------------
+// Binary serialization
+// -------------------------------------------------
+
+const hexCodes = new Uint8Array([48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 97, 98, 99, 100, 101, 102]);
+
+function fromHexCode(code: number): number {
+    if (48 <= code && code <= 57) return code - 48;
+    if (97 <= code && code <= 102) return code - 97 + 10;
+    if (65 <= code && code <= 70) return code - 65 + 10;
+    throw Error(`Invalid hex code: ${code}`);
+}
+
+function toSignedBytes(x: bigint, isBigEndian: boolean): Uint8Array {
+    const isNeg = x < 0n;
+    if (isNeg) {
+        const len = (-x).toString(16).length;
+        const bits = (len + len % 2) * 4;
+        const pow2 = (1n << BigInt(bits));
+        x = x + pow2; // two's complement
+    }
+    const hex = x.toString(16);
+    const len = hex.length;
+    const odd = len % 2;
+    const first = hex.charCodeAt(0);
+    const isLow = 48 <= first && first <= 55; // 0..7
+    const start = (isNeg && isLow) || (!isNeg && !isLow) ? 1 : 0;
+    const bytes = new Uint8Array(start + (len + odd) / 2);
+    const inc = isBigEndian ? 1 : -1;
+    let pos = isBigEndian ? 0 : bytes.length - 1;
+    if (start > 0) {
+        bytes[pos] = isNeg ? 255 : 0;
+        pos += inc;
+    }
+    if (odd > 0) {
+        bytes[pos] = fromHexCode(first);
+        pos += inc;
+    }
+    for (let i = odd; i < len; i += 2, pos += inc) {
+        const a = fromHexCode(hex.charCodeAt(i));
+        const b = fromHexCode(hex.charCodeAt(i + 1));
+        bytes[pos] = (a << 4) | b;
+    }
+    return bytes;
+}
+
+function fromSignedBytes(bytes: ArrayLike<uint8>, isBigEndian: boolean) {
+    if (bytes == null) {
+        throw new Error("bytes is null");
+    }
+    const len = bytes.length;
+    const first = isBigEndian ? 0 : len - 1;
+    const isNeg = bytes[first] > 127;
+    const codes = new Uint16Array(len * 2 + 2);
+    codes[0] = 48;  // 0
+    codes[1] = 120; // x
+    const inc = isBigEndian ? 1 : -1;
+    let pos = isBigEndian ? 0 : len - 1;
+    for (let i = 0; i < bytes.length; i++, pos += inc) {
+        const byte = bytes[pos];
+        codes[2 * i + 2] = hexCodes[byte >> 4];
+        codes[2 * i + 3] = hexCodes[byte & 15];
+    }
+    const str = String.fromCharCode.apply(null, codes as any as number[]);
+    let x = BigInt(str);
+    if (isNeg) {
+        const bits = len * 8;
+        const pow2 = (1n << BigInt(bits));
+        x = x - pow2; // two's complement
+    }
+    return x;
+}

--- a/src/fable-library/Decimal.ts
+++ b/src/fable-library/Decimal.ts
@@ -158,7 +158,7 @@ function getInt32Bits(hexDigits: Uint8Array, offset: number) {
   return bits;
 }
 
-export function fromIntArray(bits: number[]) {
+export function fromIntArray(bits: ArrayLike<number>) {
   return fromInts(bits[0], bits[1], bits[2], bits[3]);
 }
 

--- a/src/fable-library/FSharp.Core.fs
+++ b/src/fable-library/FSharp.Core.fs
@@ -29,7 +29,7 @@ module Operators =
     let nullArg x = raise(System.ArgumentNullException(x))
 
     [<CompiledName("Using")>]
-    let using (resource: System.IDisposable) action =
+    let using<'T, 'R when 'T :> System.IDisposable> (resource: 'T) (action: 'T -> 'R) =
         try action(resource)
         finally match (box resource) with null -> () | _ -> resource.Dispose()
 

--- a/src/fable-library/Fable.Library.fsproj
+++ b/src/fable-library/Fable.Library.fsproj
@@ -9,12 +9,12 @@
   <ItemGroup>
     <Compile Include="Global.fs" />
     <!-- <Compile Include="BigInt/n.fsi" /> -->
-    <Compile Include="BigInt/n.fs" />
+    <!-- <Compile Include="BigInt/n.fs" /> -->
     <!-- <Compile Include="BigInt/z.fsi" /> -->
-    <Compile Include="BigInt/z.fs" />
-    <Compile Include="BigInt.fs" />
-    <!-- <Compile Include="BigInt/q.fsi"/>
-    <Compile Include="BigInt/q.fs"/> -->
+    <!-- <Compile Include="BigInt/z.fs" /> -->
+    <!-- <Compile Include="BigInt.fs" /> -->
+    <!-- <Compile Include="BigInt/q.fsi"/> -->
+    <!-- <Compile Include="BigInt/q.fs"/> -->
     <Compile Include="SystemException.fs" />
     <Compile Include="System.Text.fs" />
     <Compile Include="System.Collections.Generic.fs" />

--- a/src/fable-library/Guid.ts
+++ b/src/fable-library/Guid.ts
@@ -90,7 +90,7 @@ function initConvertMaps() {
 
 /** Parse a UUID into it's component bytes */
 // Adapted from https://github.com/zefferus/uuid-parse
-export function guidToArray(s: string) {
+export function guidToArray(s: string): number[] {
   if (!_convertMapsInitialized) {
     initConvertMaps();
   }
@@ -119,7 +119,7 @@ export function guidToArray(s: string) {
   while (i < 16) {
     buf[i++] = 0;
   }
-  return buf;
+  return buf as any as number[];
 }
 
 /** Convert UUID byte array into a string */

--- a/src/fable-library/Long.ts
+++ b/src/fable-library/Long.ts
@@ -6,6 +6,8 @@ export default LongLib.Long;
 export type Long = LongLib.Long;
 export type int64 = Long;
 export type uint64 = Long;
+export type nativeint = Long;
+export type unativeint = Long;
 
 export const get_Zero = LongLib.ZERO;
 export const get_One = LongLib.ONE;

--- a/src/fable-library/String.ts
+++ b/src/fable-library/String.ts
@@ -82,10 +82,10 @@ export function indexOfAny(str: string, anyOf: string[], ...args: number[]) {
   if (length < 0) {
     throw new Error("Length cannot be negative");
   }
-  if (length > str.length - startIndex) {
+  if (startIndex + length > str.length) {
     throw new Error("Invalid startIndex and length");
   }
-  str = str.substr(startIndex, length);
+  str = str.substring(startIndex, startIndex + length);
   for (const c of anyOf) {
     const index = str.indexOf(c);
     if (index > -1) {
@@ -429,7 +429,7 @@ function notSupported(name: string): never {
   throw new Error("The environment doesn't support '" + name + "', please use a polyfill.");
 }
 
-export function toBase64String(inArray: number[]) {
+export function toBase64String(inArray: ArrayLike<number>) {
   let str = "";
   for (let i = 0; i < inArray.length; i++) {
     str += String.fromCharCode(inArray[i]);
@@ -437,13 +437,13 @@ export function toBase64String(inArray: number[]) {
   return typeof btoa === "function" ? btoa(str) : notSupported("btoa");
 }
 
-export function fromBase64String(b64Encoded: string) {
+export function fromBase64String(b64Encoded: string): number[] {
   const binary = typeof atob === "function" ? atob(b64Encoded) : notSupported("atob");
   const bytes = new Uint8Array(binary.length);
   for (let i = 0; i < binary.length; i++) {
     bytes[i] = binary.charCodeAt(i);
   }
-  return bytes;
+  return bytes as any as number[];
 }
 
 function pad(str: string, len: number, ch?: string, isRight?: boolean) {

--- a/src/fable-library/Util.ts
+++ b/src/fable-library/Util.ts
@@ -501,6 +501,10 @@ function equalObjects(x: { [k: string]: any }, y: { [k: string]: any }): boolean
   return true;
 }
 
+export function physicalEquality<T>(x: T, y: T): boolean {
+  return x === y;
+}
+
 export function equals<T>(x: T, y: T): boolean {
   if (x === y) {
     return true;
@@ -537,7 +541,7 @@ export function compareDates(x: Date | IDateTime | IDateTimeOffset, y: Date | ID
   return xtime === ytime ? 0 : (xtime < ytime ? -1 : 1);
 }
 
-export function comparePrimitives(x: any, y: any): number {
+export function comparePrimitives<T>(x: T, y: T): number {
   return x === y ? 0 : (x < y ? -1 : 1);
 }
 

--- a/src/fable-library/Util.ts
+++ b/src/fable-library/Util.ts
@@ -382,11 +382,14 @@ export function numberHash(x: number) {
 }
 
 // From https://stackoverflow.com/a/37449594
-export function combineHashCodes(hashes: number[]) {
-  if (hashes.length === 0) { return 0; }
-  return hashes.reduce((h1, h2) => {
-    return ((h1 << 5) + h1) ^ h2;
-  });
+export function combineHashCodes(hashes: ArrayLike<number>) {
+  let h1 = 0;
+  const len = hashes.length;
+  for (let i = 0; i < len; i++) {
+    const h2 = hashes[i];
+    h1 = ((h1 << 5) + h1) ^ h2;
+  }
+  return h1;
 }
 
 export function physicalHash<T>(x: T): number {

--- a/src/fable-library/tsconfig.json
+++ b/src/fable-library/tsconfig.json
@@ -3,8 +3,8 @@
     // "skipLibCheck": true,
     /* Basic Options */
     "outDir": "../../build/fable-library",    /* Redirect output structure to the directory. */
-    "target": "es2015",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
-    "module": "es2015",                       /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "target": "es2020",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "module": "es2020",                       /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "allowJs": true,                          /* Allow javascript files to be compiled. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "checkJs": true,                       /* Report errors in .js files. */

--- a/src/quicktest/tsconfig.json
+++ b/src/quicktest/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2015",
-    "module": "es2015",
+    "target": "es2020",
+    "module": "es2020",
     "sourceMap": false,
     "allowJs": true,
     "esModuleInterop": true,

--- a/tests/TypeScript/Fable.Tests.TypeScript.fsproj
+++ b/tests/TypeScript/Fable.Tests.TypeScript.fsproj
@@ -30,8 +30,8 @@
     <Compile Include="../Js/Main/ArrayTests.fs" />
     <Compile Include="../Js/Main/AsyncTests.fs" />
     <Compile Include="../Js/Main/CharTests.fs" />
-    <!-- <Compile Include="../Js/Main/ComparisonTests.fs" />
-    <Compile Include="../Js/Main/ConvertTests.fs" /> -->
+    <!-- <Compile Include="../Js/Main/ComparisonTests.fs" /> -->
+    <Compile Include="../Js/Main/ConvertTests.fs" />
     <Compile Include="../Js/Main/CustomOperatorsTests.fs" />
     <Compile Include="../Js/Main/DateTimeOffsetTests.fs" />
     <Compile Include="../Js/Main/DateTimeTests.fs" />
@@ -42,8 +42,8 @@
     <Compile Include="../Js/Main/EnumTests.fs" />
     <!-- <Compile Include="../Js/Main/EventTests.fs" /> -->
     <Compile Include="../Js/Main/HashSetTests.fs" />
-    <!-- <Compile Include="../Js/Main/ImportTests.fs" />
-    <Compile Include="../Js/Main/JsInteropTests.fs" /> -->
+    <!-- <Compile Include="../Js/Main/ImportTests.fs" /> -->
+    <!-- <Compile Include="../Js/Main/JsInteropTests.fs" /> -->
     <Compile Include="../Js/Main/ListTests.fs" />
     <Compile Include="../Js/Main/MapTests.fs" />
     <Compile Include="../Js/Main/MiscTestsHelper.fs" />

--- a/tests/TypeScript/Fable.Tests.TypeScript.fsproj
+++ b/tests/TypeScript/Fable.Tests.TypeScript.fsproj
@@ -30,7 +30,7 @@
     <Compile Include="../Js/Main/ArrayTests.fs" />
     <Compile Include="../Js/Main/AsyncTests.fs" />
     <Compile Include="../Js/Main/CharTests.fs" />
-    <!-- <Compile Include="../Js/Main/ComparisonTests.fs" /> -->
+    <Compile Include="../Js/Main/ComparisonTests.fs" />
     <Compile Include="../Js/Main/ConvertTests.fs" />
     <Compile Include="../Js/Main/CustomOperatorsTests.fs" />
     <Compile Include="../Js/Main/DateTimeOffsetTests.fs" />

--- a/tests/TypeScript/Main.fs
+++ b/tests/TypeScript/Main.fs
@@ -5,14 +5,14 @@ open Fable.Tests
 
 let allTests =
   [|
-    // UtilTests.tests
+    UtilTests.tests
     Applicative.tests
     Arithmetic.tests
     Arrays.tests
     Async.tests
     Chars.tests
     // Comparison.tests
-    // Convert.tests
+    Convert.tests
     CustomOperators.tests
     DateTimeOffset.tests
     DateTime.tests

--- a/tests/TypeScript/Main.fs
+++ b/tests/TypeScript/Main.fs
@@ -11,7 +11,7 @@ let allTests =
     Arrays.tests
     Async.tests
     Chars.tests
-    // Comparison.tests
+    Comparison.tests
     Convert.tests
     CustomOperators.tests
     DateTimeOffset.tests

--- a/tests/TypeScript/tsconfig.json
+++ b/tests/TypeScript/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
-      "target": "es2015",
-      "module": "es2015",
+      "target": "es2020",
+      "module": "es2020",
       "sourceMap": false,
       "allowJs": true,
       "esModuleInterop": true,


### PR DESCRIPTION
- Use native JS `bigint` type in `fable-library`.
- Enabled ConvertTests, UtilTests for TS.
- Enabled ComparisonTests for TS.

2190 tests passing for TS.

Note: `bigint` needs `es2020`, but perhaps that's ok, it's 2023 already.
