### PR TITLE
Use library-ts also for JS compilation

### DIFF
--- a/src/Fable.Transforms/FableTransforms.fs
+++ b/src/Fable.Transforms/FableTransforms.fs
@@ -508,7 +508,7 @@ module private Transforms =
                                                                           && not ident.IsMutable ->
             let fnBody = curryIdentInBody ident.Name args fnBody
             let letBody = curryIdentInBody ident.Name args letBody
-            Let(ident, Delegate(args, fnBody, None, Tags.empty), letBody)
+            Let({ ident with Type = uncurryType ident.Type }, Delegate(args, fnBody, None, Tags.empty), letBody)
         // Anonymous lambda immediately applied
         | CurriedApply(NestedLambdaWithSameArity(args, fnBody, Some name), argExprs, t, r)
                         when List.isMultiple args && List.sameLength args argExprs ->

--- a/src/Fable.Transforms/Global/Babel.fs
+++ b/src/Fable.Transforms/Global/Babel.fs
@@ -23,6 +23,7 @@ type AssignmentOperator =
 
 /// Since the left-hand side of an assignment may be any expression in general, an expression can also be a pattern.
 type Expression =
+    | CommentedExpression of comment: string * expr: Expression
     | JsxElement of componentOrTag: Expression * props: (string * Expression) list * children: Expression list
     | JsxTemplate of parts: string[] * values: Expression[]
     | Literal of Literal

--- a/src/Fable.Transforms/Global/Naming.fs
+++ b/src/Fable.Transforms/Global/Naming.fs
@@ -325,7 +325,7 @@ module Naming =
             | StaticMemberPart(_,o) -> o
             | NoMemberPart -> ""
 
-    let reflectionSuffix = "$reflection"
+    let reflectionSuffix = "_$reflection"
 
     let private printPart sanitize separator part overloadSuffix =
         (if part = "" then "" else separator + (sanitize part)) +

--- a/src/fable-library/Async.ts
+++ b/src/fable-library/Async.ts
@@ -6,7 +6,7 @@ import { IAsyncContext } from "./AsyncBuilder.js";
 import { protectedCont } from "./AsyncBuilder.js";
 import { protectedBind } from "./AsyncBuilder.js";
 import { protectedReturn } from "./AsyncBuilder.js";
-import { FSharpChoice$2, Choice_makeChoice1Of2, Choice_makeChoice2Of2 } from "./Choice.js";
+import { FSharpChoice$2_$union, Choice_makeChoice1Of2, Choice_makeChoice2Of2 } from "./Choice.js";
 import { TimeoutException } from "./SystemException.js";
 
 // Implemented just for type references
@@ -111,7 +111,7 @@ export function cancellationToken() {
 export const defaultCancellationToken = new CancellationToken();
 
 export function catchAsync<T>(work: IAsync<T>) {
-  return protectedCont((ctx: IAsyncContext<FSharpChoice$2<T, Error>>) => {
+  return protectedCont((ctx: IAsyncContext<FSharpChoice$2_$union<T, Error>>) => {
     work({
       onSuccess: (x) => ctx.onSuccess(Choice_makeChoice1Of2(x)),
       onError: (ex) => ctx.onSuccess(Choice_makeChoice2Of2(ex)),

--- a/src/fable-library/Choice.d.ts
+++ b/src/fable-library/Choice.d.ts
@@ -1,17 +1,8 @@
-import { int32 } from "./Int32.js";
 import { Option } from "./Option.js";
-import { Union } from "./Types.js";
-import { TypeInfo } from "./Reflection.js";
 
-declare class FSharpChoice$2<T1, T2> extends Union {
-    tag: int32;
-    fields: Array<any>;
-    constructor(tag: int32, ...fields: Array<any>);
-    cases(): string[];
-}
+declare type FSharpChoice$2_$union<T1, T2> = never;
 
-declare function FSharpChoice$2$reflection(gen0: TypeInfo, gen1: TypeInfo): TypeInfo;
-declare function Choice_makeChoice1Of2<T1, a$>(x: T1): FSharpChoice$2<T1, a$>;
-declare function Choice_makeChoice2Of2<T2, a$>(x: T2): FSharpChoice$2<a$, T2>;
-declare function Choice_tryValueIfChoice1Of2<T1, T2>(x: FSharpChoice$2<T1, T2>): Option<T1>;
-declare function Choice_tryValueIfChoice2Of2<T1, T2>(x: FSharpChoice$2<T1, T2>): Option<T2>;
+declare function Choice_makeChoice1Of2<T1, a$>(x: T1): FSharpChoice$2_$union<T1, a$>;
+declare function Choice_makeChoice2Of2<T2, a$>(x: T2): FSharpChoice$2_$union<a$, T2>;
+declare function Choice_tryValueIfChoice1Of2<T1, T2>(x: FSharpChoice$2_$union<T1, T2>): Option<T1>;
+declare function Choice_tryValueIfChoice2Of2<T1, T2>(x: FSharpChoice$2_$union<T1, T2>): Option<T2>;

--- a/src/fable-library/Event.ts
+++ b/src/fable-library/Event.ts
@@ -1,6 +1,6 @@
 import { IObservable, subscribe } from "./Observable.js";
 import { Option, some, value } from "./Option.js";
-import { FSharpChoice$2, Choice_tryValueIfChoice1Of2, Choice_tryValueIfChoice2Of2 } from "./Choice.js";
+import { FSharpChoice$2_$union, Choice_tryValueIfChoice1Of2, Choice_tryValueIfChoice2Of2 } from "./Choice.js";
 
 export type Handler<T> = (sender: any, x: T) => void;
 
@@ -97,7 +97,7 @@ export function scan<Del extends Function, U, T>(collector: (u: U, t: T) => U, s
   return map((t) => state = collector(state, t), sourceEvent);
 }
 
-export function split<Del extends Function, T, U1, U2>(splitter: (x: T) => FSharpChoice$2<U1, U2>, sourceEvent: IEvent$2<Del, T>): [IEvent<U1>, IEvent<U2>] {
+export function split<Del extends Function, T, U1, U2>(splitter: (x: T) => FSharpChoice$2_$union<U1, U2>, sourceEvent: IEvent$2<Del, T>): [IEvent<U1>, IEvent<U2>] {
   return [
     choose((v) => Choice_tryValueIfChoice1Of2(splitter(v)), sourceEvent),
     choose((v) => Choice_tryValueIfChoice2Of2(splitter(v)), sourceEvent),

--- a/src/fable-library/Observable.ts
+++ b/src/fable-library/Observable.ts
@@ -1,5 +1,5 @@
 
-import { FSharpChoice$2, Choice_tryValueIfChoice1Of2, Choice_tryValueIfChoice2Of2 } from "./Choice.js";
+import { FSharpChoice$2_$union, Choice_tryValueIfChoice1Of2, Choice_tryValueIfChoice2Of2 } from "./Choice.js";
 import { Option, value } from "./Option.js";
 import { IDisposable } from "./Util.js";
 
@@ -144,7 +144,7 @@ export function scan<U, T>(collector: (u: U, t: T) => U, state: U, source: IObse
   });
 }
 
-export function split<T, U1, U2>(splitter: (x: T) => FSharpChoice$2<U1, U2>, source: IObservable<T>): [Observable<U1>, Observable<U2>] {
+export function split<T, U1, U2>(splitter: (x: T) => FSharpChoice$2_$union<U1, U2>, source: IObservable<T>): [Observable<U1>, Observable<U2>] {
   return [
     choose((v) => Choice_tryValueIfChoice1Of2(splitter(v)), source),
     choose((v) => Choice_tryValueIfChoice2Of2(splitter(v)), source)

--- a/src/fable-library/Reflection.ts
+++ b/src/fable-library/Reflection.ts
@@ -445,9 +445,17 @@ export function makeUnion(uci: CaseInfo, values: any[]): any {
   if (values.length !== expectedLength) {
     throw new Error(`Expected an array of length ${expectedLength} but got ${values.length}`);
   }
-  return uci.declaringType.construct != null
-    ? new uci.declaringType.construct(uci.tag, values)
-    : {};
+  const construct = uci.declaringType.construct;
+  if (construct == null) {
+    return {};
+  }
+  const isSingleCase = uci.declaringType.cases ? uci.declaringType.cases().length == 1 : false;
+  if (isSingleCase) {
+    return new construct(...values);
+  }
+  else {
+    return new construct(uci.tag, values);
+  }
 }
 
 export function makeRecord(t: TypeInfo, values: any[]): any {

--- a/src/fable-library/Types.ts
+++ b/src/fable-library/Types.ts
@@ -54,13 +54,13 @@ export function unionToString(name: string, fields: any[]) {
   }
 }
 
-export abstract class Union implements IEquatable<Union>, IComparable<Union> {
-  public tag!: any;
-  public fields!: any;
+export abstract class Union<Tag extends number, Name extends string> implements IEquatable<Union<Tag, Name>>, IComparable<Union<Tag, Name>> {
+  abstract readonly tag: Tag;
+  abstract readonly fields: any[];
   abstract cases(): string[];
 
-  public get name() {
-    return this.cases()[this.tag];
+  public get name(): Name {
+    return this.cases()[this.tag] as Name;
   }
 
   public toJSON() {
@@ -77,7 +77,7 @@ export abstract class Union implements IEquatable<Union>, IComparable<Union> {
     return combineHashCodes(hashes);
   }
 
-  public Equals(other: Union) {
+  public Equals(other: Union<Tag, Name>) {
     if (this === other) {
       return true;
     } else if (!sameConstructor(this, other)) {
@@ -89,7 +89,7 @@ export abstract class Union implements IEquatable<Union>, IComparable<Union> {
     }
   }
 
-  public CompareTo(other: Union) {
+  public CompareTo(other: Union<Tag, Name>) {
     if (this === other) {
       return 0;
     } else if (!sameConstructor(this, other)) {

--- a/src/fable-library/lib/big.js
+++ b/src/fable-library/lib/big.js
@@ -1045,6 +1045,9 @@ P.valueOf = function () {
 // Export
 
 
+/**
+ * @type object
+ */
 export var Big = _Big_();
 
 /// <reference types="https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/master/types/big.js/index.d.ts" />

--- a/src/fable-library/ts/tsconfig.json
+++ b/src/fable-library/ts/tsconfig.json
@@ -44,7 +44,7 @@
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
 
     /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */

--- a/tests/Js/Main/ApplicativeTests.fs
+++ b/tests/Js/Main/ApplicativeTests.fs
@@ -1056,6 +1056,23 @@ let tests7 = [
         r1.result |> equal 16
         r2.result |> equal 19
 
+    testCase "Ident of uncurried inner lambdas is uncurried too" <| fun () -> // See #3415
+        let copy1 xs =
+            let copySnd x y = x + y
+            ignore copySnd // just to prevent inlining
+            copySnd 3 xs |> id
+
+        // copySnd is hoisted in release mode
+        let copy2 xs =
+            let copy x =
+                let copySnd x y = x + y
+                ignore copySnd // just to prevent inlining
+                copySnd 3 x
+            copy xs |> id
+
+        copy1 5 |> equal 8
+        copy2 5 |> equal 8
+
     testCase "SRTP with ActivePattern works" <| fun () ->
         (lengthWrapper []) |> equal 0
         (lengthWrapper [1;2;3;4]) |> equal 4

--- a/tests/Js/Main/ComparisonTests.fs
+++ b/tests/Js/Main/ComparisonTests.fs
@@ -159,17 +159,20 @@ let tests =
         equal true (xs1 = xs4)
 
     testCase "Union equality works" <| fun () ->
+        // Prevents Fable from inlining so TypeScript doesn't complain
+        let mutable run = fun u1 u2 u3 u4 ->
+            equal true (u1 = u2)
+            equal false (u1 = u3)
+            equal true (u1 <> u3)
+            equal false (u1 <> u2)
+            equal false (u1 = u4)
+            Object.ReferenceEquals(u1, u1) |> equal true
+            Object.ReferenceEquals(u1, u2) |> equal false
         let u1 = A 2
         let u2 = A 2
         let u3 = A 4
         let u4 = B 2
-        equal true (u1 = u2)
-        equal false (u1 = u3)
-        equal true (u1 <> u3)
-        equal false (u1 <> u2)
-        equal false (u1 = u4)
-        Object.ReferenceEquals(u1, u1) |> equal true
-        Object.ReferenceEquals(u1, u2) |> equal false
+        run u1 u2 u3 u4
 
     testCase "Union custom equality works" <| fun () ->
         let u1 = String "A"
@@ -320,17 +323,19 @@ let tests =
         equal false (xs1 > xs6)
 
     testCase "Union comparison works" <| fun () ->
+        let mutable run = fun u1 u2 u3 u4 u5 ->
+            equal 0 (compare u1 u2)
+            equal -1 (compare u1 u3)
+            equal true (u1 < u3)
+            equal 1 (compare u1 u4)
+            equal false (u1 < u4)
+            (compare u1 u5) = 0 |> equal false
         let u1 = A 2
         let u2 = A 2
         let u3 = A 4
         let u4 = A 1
         let u5 = B 2
-        equal 0 (compare u1 u2)
-        equal -1 (compare u1 u3)
-        equal true (u1 < u3)
-        equal 1 (compare u1 u4)
-        equal false (u1 < u4)
-        (compare u1 u5) = 0 |> equal false
+        run u1 u2 u3 u4 u5
 
     testCase "Union custom comparison works" <| fun () ->
         let u1 = String "A"
@@ -592,10 +597,10 @@ let tests =
     testCase "DU comparison works" <| fun () ->
         let hasStatusReached expectedStatus status =
             status >= expectedStatus
-        Status.CreateNewMeterReadingPicture >= Status.SelectingNewDevice
-        |> equal true
-        hasStatusReached Status.SelectingNewDevice Status.CreateNewMeterReadingPicture
-        |> equal true
+        let mutable run = fun x y ->
+            x >= y |> equal true
+            hasStatusReached y x |> equal true
+        run Status.CreateNewMeterReadingPicture Status.SelectingNewDevice
 
     testCase "LanguagePrimitives.GenericHash with primitives works" <| fun () ->
         (LanguagePrimitives.GenericHash 111, LanguagePrimitives.GenericHash 111) ||> equal

--- a/tests/Js/Main/Fable.Tests.fsproj
+++ b/tests/Js/Main/Fable.Tests.fsproj
@@ -56,6 +56,7 @@
     <Compile Include="MapTests.fs" />
     <Compile Include="MiscTestsHelper.fs" />
     <Compile Include="MiscTests.fs" />
+    <Compile Include="NestedAndRecursivePatternTests.fs" />
     <Compile Include="ObservableTests.fs" />
     <Compile Include="OptionTests.fs" />
     <Compile Include="QueueTests.fs" />

--- a/tests/Js/Main/Main.fs
+++ b/tests/Js/Main/Main.fs
@@ -28,6 +28,7 @@ let allTests =
     Lists.tests
     Maps.tests
     Misc.tests
+    NestedAndRecursivePatternTests.tests
     Observable.tests
     Option.tests
     Queue.tests

--- a/tests/Js/Main/NestedAndRecursivePatternTests.fs
+++ b/tests/Js/Main/NestedAndRecursivePatternTests.fs
@@ -1,0 +1,137 @@
+module NestedAndRecursivePatternTests
+
+type Position (line: int32, col: int32) =
+    member p.Line = line
+    member p.Column = col
+
+
+let relaxWhitespace2 = false
+
+type token =
+| SIG | CLASS | STRUCT | INTERFACE | LBRACK_LESS | INTERP_STRING_BEGIN_PART | INTERP_STRING_PART
+| BEGIN | LPAREN | LBRACE | LBRACE_BAR | LBRACK | LBRACK_BAR | LQUOTE | LESS
+
+type Context =
+    | CtxtLetDecl of bool * Position
+    | CtxtIf of Position
+    | CtxtTry of Position
+    | CtxtFun of Position
+    | CtxtFunction of Position
+    | CtxtWithAsLet of Position
+    | CtxtWithAsAugment of Position
+    | CtxtMatch of Position
+    | CtxtFor of Position
+    | CtxtWhile of Position
+    | CtxtWhen of Position
+    | CtxtVanilla of Position * bool
+    | CtxtThen of Position
+    | CtxtElse of Position
+    | CtxtDo of Position
+    | CtxtInterfaceHead of Position
+    | CtxtTypeDefns of Position
+
+    | CtxtNamespaceHead of Position * token
+    | CtxtMemberHead of Position
+    | CtxtMemberBody of Position
+    | CtxtModuleBody of Position * bool
+    | CtxtNamespaceBody of Position
+    | CtxtException of Position
+    | CtxtParen of token * Position
+    | CtxtSeqBlock of FirstInSequence * Position * AddBlockEnd
+    | CtxtMatchClauses of bool * Position
+
+    member c.StartPos =
+        match c with
+        | CtxtNamespaceHead (p, _)
+        | CtxtException p | CtxtModuleBody (p, _) | CtxtNamespaceBody p
+        | CtxtLetDecl (_, p) | CtxtDo p | CtxtInterfaceHead p | CtxtTypeDefns p | CtxtParen (_, p) | CtxtMemberHead p | CtxtMemberBody p
+        | CtxtWithAsLet p
+        | CtxtWithAsAugment p
+        | CtxtMatchClauses (_, p) | CtxtIf p | CtxtMatch p | CtxtFor p | CtxtWhile p | CtxtWhen p | CtxtFunction p | CtxtFun p | CtxtTry p | CtxtThen p | CtxtElse p | CtxtVanilla (p, _)
+        | CtxtSeqBlock (_, p, _) -> p
+
+    member c.StartCol = c.StartPos.Column
+
+and AddBlockEnd = AddBlockEnd | NoAddBlockEnd | AddOneSidedBlockEnd
+and FirstInSequence = FirstInSeqBlock | NotFirstInSeqBlock
+and LexingModuleAttributes = LexingModuleAttributes | NotLexingModuleAttributes
+
+[<Struct>]
+type PositionWithColumn =
+    val Position: Position
+    val Column: int
+    new (position: Position, column: int) = { Position = position; Column = column }
+    override this.ToString() = $"L{this.Position.Line}-C1{this.Position.Column}-C2{this.Column}"
+
+let rec undentationLimit strict stack =
+    match stack with
+    | CtxtVanilla _ :: rest -> undentationLimit strict rest
+
+    | CtxtSeqBlock _ :: rest when not strict -> undentationLimit strict rest
+    | CtxtParen _ :: rest when not strict -> undentationLimit strict rest
+    | (CtxtMatch _ as ctxt1) :: CtxtSeqBlock _ :: (CtxtParen ((BEGIN | LPAREN), _) as ctxt2) :: _
+                -> if ctxt1.StartCol <= ctxt2.StartCol
+                    then PositionWithColumn(ctxt1.StartPos, ctxt1.StartCol)
+                    else PositionWithColumn(ctxt2.StartPos, ctxt2.StartCol)
+    | (CtxtMatchClauses _ as ctxt1) :: (CtxtMatch _) :: CtxtSeqBlock _ :: (CtxtParen ((BEGIN | LPAREN), _) as ctxt2) :: _ when relaxWhitespace2
+                -> if ctxt1.StartCol <= ctxt2.StartCol
+                    then PositionWithColumn(ctxt1.StartPos, ctxt1.StartCol)
+                    else PositionWithColumn(ctxt2.StartPos, ctxt2.StartCol)
+    | CtxtFunction _ :: CtxtSeqBlock _ :: (CtxtLetDecl _ as limitCtxt) :: _rest
+                -> PositionWithColumn(limitCtxt.StartPos, limitCtxt.StartCol)
+    | CtxtFunction _ :: rest
+                -> undentationLimit false rest
+    | (CtxtMatchClauses _ :: (CtxtTry _ as limitCtxt) :: _rest)
+                -> PositionWithColumn(limitCtxt.StartPos, limitCtxt.StartCol)
+    | (CtxtMatchClauses _ :: (CtxtMatch _ as limitCtxt) :: _rest) when relaxWhitespace2
+                -> PositionWithColumn(limitCtxt.StartPos, limitCtxt.StartCol)
+    | CtxtFun _ :: rest
+                -> undentationLimit false rest
+    | CtxtParen ((LBRACE _ | LBRACK | LBRACK_BAR), _) :: CtxtSeqBlock _ :: rest
+    | CtxtParen ((LBRACE _ | LBRACK | LBRACK_BAR), _) :: CtxtVanilla _ :: CtxtSeqBlock _ :: rest
+    | CtxtSeqBlock _ :: CtxtParen((LBRACE _ | LBRACK | LBRACK_BAR), _) :: CtxtVanilla _ :: CtxtSeqBlock _ :: rest
+                -> undentationLimit false rest
+    | CtxtElse _ :: (CtxtIf _ as limitCtxt) :: _rest
+                -> PositionWithColumn(limitCtxt.StartPos, limitCtxt.StartCol)
+    | (CtxtInterfaceHead _ | CtxtMemberHead _ | CtxtException _ | CtxtTypeDefns _ as limitCtxt :: _rest)
+                -> PositionWithColumn(limitCtxt.StartPos, limitCtxt.StartCol)
+
+    | (CtxtWithAsAugment _ | CtxtThen _ | CtxtElse _ | CtxtDo _ ) :: rest
+                -> undentationLimit false rest
+    // | CtxtFunction _ :: rest
+    //             -> undentationLimit false rest
+    | CtxtParen ((SIG | STRUCT | BEGIN), _) :: CtxtSeqBlock _ :: (CtxtModuleBody (_, false) as limitCtxt) :: _
+    | CtxtParen ((BEGIN | LPAREN | LBRACK | LBRACE | LBRACE_BAR | LBRACK_BAR), _) :: CtxtSeqBlock _ :: CtxtThen _ :: (CtxtIf _ as limitCtxt) :: _
+    | CtxtParen ((BEGIN | LPAREN | LBRACK | LBRACE | LBRACE_BAR | LBRACK_BAR | LBRACK_LESS), _) :: CtxtSeqBlock _ :: CtxtElse _ :: (CtxtIf _ as limitCtxt) :: _
+    | CtxtParen ((BEGIN | LPAREN | LESS | LBRACK | LBRACK_BAR), _) :: CtxtVanilla _ :: (CtxtSeqBlock _ as limitCtxt) :: _
+    | CtxtParen ((CLASS | STRUCT | INTERFACE), _) :: CtxtSeqBlock _ :: (CtxtTypeDefns _ as limitCtxt) ::  _
+        -> PositionWithColumn(limitCtxt.StartPos, limitCtxt.StartCol + 1)
+    | CtxtSeqBlock _ :: CtxtParen(LPAREN, _) :: (CtxtTypeDefns _ as limitCtxt) :: _
+    | CtxtSeqBlock _ :: CtxtParen(LPAREN, _) :: (CtxtMemberHead _ as limitCtxt) :: _
+    | CtxtWithAsLet _ :: (CtxtMemberHead _ as limitCtxt) :: _
+            when relaxWhitespace2
+            -> PositionWithColumn(limitCtxt.StartPos, limitCtxt.StartCol + 1)
+    | CtxtSeqBlock _ :: CtxtParen((BEGIN | LPAREN | LBRACK | LBRACK_BAR), _) :: CtxtVanilla _ :: (CtxtSeqBlock _ as limitCtxt) :: _
+    | CtxtParen ((BEGIN | LPAREN | LBRACE _ | LBRACE_BAR | LBRACK | LBRACK_BAR), _) :: CtxtSeqBlock _ :: (CtxtTypeDefns _ | CtxtLetDecl _ | CtxtMemberBody _ | CtxtWithAsLet _ as limitCtxt) :: _
+                -> PositionWithColumn(limitCtxt.StartPos, limitCtxt.StartCol + 1)
+    | (CtxtIf _ as limitCtxt) :: _rest
+                -> PositionWithColumn(limitCtxt.StartPos, limitCtxt.StartCol)
+    | (CtxtFor _ | CtxtWhile _ as limitCtxt) :: _rest
+                -> PositionWithColumn(limitCtxt.StartPos, limitCtxt.StartCol)
+    | (CtxtInterfaceHead _ | CtxtNamespaceHead _
+    | CtxtException _ | CtxtModuleBody (_, false) | CtxtIf _ | CtxtWithAsLet _ | CtxtLetDecl _ | CtxtMemberHead _ | CtxtMemberBody _ as limitCtxt :: _)
+                -> PositionWithColumn(limitCtxt.StartPos, limitCtxt.StartCol + 1)
+    | (CtxtParen _ | CtxtFor _ | CtxtWhen _ | CtxtWhile _ | CtxtTypeDefns _ | CtxtMatch _ | CtxtModuleBody (_, true) | CtxtNamespaceBody _ | CtxtTry _ | CtxtMatchClauses _ | CtxtSeqBlock _ as limitCtxt :: _)
+                -> PositionWithColumn(limitCtxt.StartPos, limitCtxt.StartCol)
+
+    | _ -> PositionWithColumn(Position(0, 0), 0)
+
+open Util.Testing
+
+let tests =
+  testList "Nested and Recursive Patterns" [
+    testCase "Nested and Recursive Patterns works" <| fun () ->
+        let ctx1 = Position (5, 8) |> CtxtWhile
+        let ctx2 = Position (78, 2) |> CtxtWhile
+        undentationLimit true [ctx1; ctx2] |> string |> equal "L5-C18-C28"
+  ]

--- a/tests/TypeScript/Fable.Tests.TypeScript.fsproj
+++ b/tests/TypeScript/Fable.Tests.TypeScript.fsproj
@@ -48,6 +48,7 @@
     <Compile Include="../Js/Main/MapTests.fs" />
     <Compile Include="../Js/Main/MiscTestsHelper.fs" />
     <Compile Include="../Js/Main/MiscTests.fs" />
+    <Compile Include="../Js/Main/NestedAndRecursivePatternTests.fs" />
     <Compile Include="../Js/Main/ObservableTests.fs" />
     <Compile Include="../Js/Main/OptionTests.fs" />
     <Compile Include="../Js/Main/QueueTests.fs" />

--- a/tests/TypeScript/Fable.Tests.TypeScript.fsproj
+++ b/tests/TypeScript/Fable.Tests.TypeScript.fsproj
@@ -53,7 +53,7 @@
     <Compile Include="../Js/Main/OptionTests.fs" />
     <Compile Include="../Js/Main/QueueTests.fs" />
     <Compile Include="../Js/Main/RecordTypeTests.fs" />
-    <!-- <Compile Include="../Js/Main/ReflectionTests.fs" /> -->
+    <Compile Include="../Js/Main/ReflectionTests.fs" />
     <Compile Include="../Js/Main/RegexTests.fs" />
     <Compile Include="../Js/Main/ResizeArrayTests.fs" />
     <Compile Include="../Js/Main/ResultTests.fs" />

--- a/tests/TypeScript/Main.fs
+++ b/tests/TypeScript/Main.fs
@@ -30,6 +30,7 @@ let allTests =
     Lists.tests
     Maps.tests
     Misc.tests
+    NestedAndRecursivePatternTests.tests
     Observable.tests
     Option.tests
     Queue.tests

--- a/tests/TypeScript/Main.fs
+++ b/tests/TypeScript/Main.fs
@@ -35,7 +35,7 @@ let allTests =
     Option.tests
     Queue.tests
     RecordTypes.tests
-    // Reflection.tests
+    Reflection.tests
     Regex.tests
     ResizeArrays.tests
     Result.tests


### PR DESCRIPTION
This unifies fable-library(-js) and fable-library-ts. The idea is to publish fable-library as JS but with .d.ts declarations to make sure F# code compiled both as JS and TS is compatible.

I ama having some trouble with the const enums for the union tags, so we may need to drop them and use plain ints again.