### PR TITLE
[Python] Implemented many missing bigint functions

### DIFF
--- a/src/fable-library-py/fable_library/big_int.py
+++ b/src/fable-library-py/fable_library/big_int.py
@@ -288,6 +288,7 @@ __all__ = [
     "op_left_shift",
     "op_bitwise_and",
     "op_bitwise_or",
+    "op_exclusive_or",
     "op_less_than",
     "op_less_than_or_equal",
     "op_greater_than",

--- a/src/fable-library-py/fable_library/big_int.py
+++ b/src/fable-library-py/fable_library/big_int.py
@@ -4,6 +4,182 @@ from typing import Any
 from .types import FSharpRef
 
 
+def compare(x: int, y: int) -> int:
+    return -1 if x < y else 1 if x > y else 0
+
+
+def equals(a: int, b: int) -> bool:
+    return a == b
+
+
+def abs(x: int) -> int:
+    return -x if x < 0 else x
+
+
+def sign(x: int) -> int:
+    return -1 if x < 0 else 1 if x > 0 else 0
+
+
+def max(x: int, y: int) -> int:
+    return x if x > y else y
+
+
+def min(x: int, y: int) -> int:
+    return x if x < y else y
+
+
+def add(x: int, y: int) -> int:
+    return x + y
+
+
+def subtract(x: int, y: int) -> int:
+    return x - y
+
+
+def multiply(x: int, y: int) -> int:
+    return x * y
+
+
+def divide(x: int, y: int) -> int:
+    return x // y
+
+
+def remainder(x: int, y: int) -> int:
+    return x % y
+
+
+def negate(x: int) -> int:
+    return -x
+
+
+def op_unary_negation(x: int) -> int:
+    return -x
+
+
+def op_logical_not(x: int) -> int:
+    return ~x
+
+
+def op_unary_plus(x: int) -> int:
+    return x
+
+
+def op_addition(a: int, b: int) -> int:
+    return a + b
+
+
+def op_subtraction(a: int, b: int) -> int:
+    return a - b
+
+
+def op_multiply(a: int, b: int) -> int:
+    return a * b
+
+
+def op_division(a: int, b: int) -> int:
+    return a // b
+
+
+def op_modulus(a: int, b: int) -> int:
+    return a % b
+
+
+def op_right_shift(a: int, num_bits: int) -> int:
+    return a >> num_bits
+
+
+def op_left_shift(a: int, num_bits: int) -> int:
+    return a << num_bits
+
+
+def op_bitwise_and(x: int, y: int) -> int:
+    return x & y
+
+
+def op_bitwise_or(x: int, y: int) -> int:
+    return x | y
+
+
+def op_exclusive_or(x: int, y: int) -> int:
+    return x ^ y
+
+
+def op_less_than(x: int, y: int) -> bool:
+    return x < y
+
+
+def op_less_than_or_equal(x: int, y: int) -> bool:
+    return x <= y
+
+
+def op_greater_than(x: int, y: int) -> bool:
+    return x > y
+
+
+def op_greater_than_or_equal(x: int, y: int) -> bool:
+    return x >= y
+
+
+def op_equality(x: int, y: int) -> bool:
+    return x == y
+
+
+def op_inequality(x: int, y: int) -> bool:
+    return x != y
+
+
+def get_zero() -> int:
+    return 0
+
+
+def get_one() -> int:
+    return 1
+
+
+def get_minus_one() -> int:
+    return -1
+
+
+def get_is_zero(x: int) -> bool:
+    return x == 0
+
+
+def get_is_one(x: int) -> bool:
+    return x == 1
+
+
+def get_is_even(x: int) -> bool:
+    return is_even_integer(x)
+
+
+def get_is_power_of_two(x: int) -> bool:
+    return is_pow2(x)
+
+
+def get_sign(x: int) -> int:
+    return sign(x)
+
+
+def is_negative(x: int) -> bool:
+    return x < 0
+
+
+def is_positive(x: int) -> bool:
+    return x > 0
+
+
+def is_even_integer(x: int) -> bool:
+    return x % 2 == 0
+
+
+def is_odd_integer(x: int) -> bool:
+    return x % 2 != 0
+
+
+def is_pow2(x: int) -> bool:
+    return (x & (x - 1)) == 0
+
+
 def from_zero() -> int:
     return 0
 
@@ -22,10 +198,6 @@ def from_int64(x: int) -> int:
 
 def from_string(x: str) -> int:
     return int(x)
-
-
-def op_addition(a: int, b: int) -> int:
-    return a + b
 
 
 def parse(value: Any) -> int:
@@ -80,10 +252,6 @@ def to_decimal(value: int) -> Decimal:
     return Decimal(value)
 
 
-def equals(a: int, b: int) -> bool:
-    return a == b
-
-
 def try_parse(string: str, def_value: FSharpRef[int]) -> bool:
     try:
         def_value.contents = parse(string)
@@ -92,19 +260,53 @@ def try_parse(string: str, def_value: FSharpRef[int]) -> bool:
         return False
 
 
-def op_right_shift(a: int, num_bits: int) -> int:
-    return a >> num_bits
-
-
-def of_left_shift(a: int, num_bits: int) -> int:
-    return a << num_bits
-
-
 BigInteger = int
 
 __all__ = [
     "BigInteger",
+    "compare",
     "equals",
+    "abs",
+    "sign",
+    "max",
+    "min",
+    "add",
+    "subtract",
+    "multiply",
+    "divide",
+    "remainder",
+    "negate",
+    "op_unary_negation",
+    "op_logical_not",
+    "op_unary_plus",
+    "op_addition",
+    "op_subtraction",
+    "op_multiply",
+    "op_division",
+    "op_modulus",
+    "op_right_shift",
+    "op_left_shift",
+    "op_bitwise_and",
+    "op_bitwise_or",
+    "op_less_than",
+    "op_less_than_or_equal",
+    "op_greater_than",
+    "op_greater_than_or_equal",
+    "op_equality",
+    "op_inequality",
+    "get_zero",
+    "get_one",
+    "get_minus_one",
+    "get_is_zero",
+    "get_is_one",
+    "get_is_even",
+    "get_is_power_of_two",
+    "get_sign",
+    "is_negative",
+    "is_positive",
+    "is_even_integer",
+    "is_odd_integer",
+    "is_pow2",
     "from_zero",
     "from_one",
     "from_int32",
@@ -122,7 +324,6 @@ __all__ = [
     "to_byte",
     "to_sbyte",
     "to_string",
-    "op_addition",
     "parse",
     "try_parse",
 ]


### PR DESCRIPTION
First of all thank you for this amazing package.

I'm porting my F# code into TS and Python, and am using bigint's in a few places. I saw that much better support was recently added in #3400. For the Python version though, many basic functions are still missing, like multiplication or comparing.

I added most functions from the TS implementation, but didn't bother with the conversions. Getting those basic functions likely cover most use cases of bigint.

I also didn't spend time writing or running tests, so be warned that it may contain errors. I followed the Python naming pattern, and could see from my own project that it generates the references to e.g. `op_multiply`, but the implementation is missing.

Hope this helps kickstart better bigint support for Python! :)