### PR TITLE
Print message about library version

### DIFF
--- a/src/Fable.Cli/Entry.fs
+++ b/src/Fable.Cli/Entry.fs
@@ -366,6 +366,14 @@ let getStatus = function
     | Dart -> "beta"
     | Php -> "experimental"
 
+let getLibPkgVersion = function
+    | JavaScript
+    | TypeScript -> Some("npm", "fable-library", Literals.JS_LIBRARY_VERSION)
+    | Python
+    | Rust
+    | Dart
+    | Php -> None
+
 [<EntryPoint>]
 let main argv =
     result {
@@ -411,8 +419,14 @@ let main argv =
                     match getStatus language with
                     | "stable" | "" -> ""
                     | status -> $" (status: {status})"
-                Log.always($"Fable: F# to {language} compiler {Literals.VERSION}{status}")
-                Log.always("Thanks to the contributor! @" + Contributors.getRandom())
+                Log.always($"Fable {Literals.VERSION}: F# to {language} compiler{status}")
+
+                match getLibPkgVersion language with
+                | Some(repository, pkgName, version) ->
+                    Log.always($"Minimum {pkgName} version (when installed from {repository}): {version}")
+                | None -> ()
+
+                Log.always("\nThanks to the contributor! @" + Contributors.getRandom())
                 Log.always("Stand with Ukraine! https://standwithukraine.com.ua/" + "\n")
 
         match commands with

--- a/src/Fable.PublishUtils/PublishUtils.fs
+++ b/src/Fable.PublishUtils/PublishUtils.fs
@@ -487,6 +487,23 @@ module Publish =
                 printfn "Please revert the version change in .fsproj"
                 reraise()
 
+    let pushNpmWithoutReleaseNotesCheck projDir (tag: string option) =
+        let _npmToken =
+            match envVarOrNone "NPM_TOKEN" with
+            | Some npmToken -> npmToken
+            | None -> failwith "The npm token key must be set in a NPM_TOKEN environmental variable"
+        runInDir projDir @"npm config set '//registry.npmjs.org/:_authToken' ""${NPM_TOKEN}"""
+        try
+            let publishCmd =
+                match tag with
+                | Some tag -> $"npm publish --tag {tag}"
+                | None -> "npm publish"
+            runInDir projDir publishCmd
+        with _ ->
+            printfn "There's been an error when pushing project: %s" projDir
+            printfn "Please revert the version change in package.json"
+            reraise()
+
     let pushNpm (projDir: string) buildAction =
         let checkPkgVersion json: string option =
             Json.Parse(json)
@@ -494,23 +511,13 @@ module Publish =
             |> Option.map Json.GetString
         let releaseVersion = loadReleaseVersion projDir
         if needsPublishing checkPkgVersion releaseVersion (projDir </> "package.json") then
-            let _npmToken =
-                match envVarOrNone "NPM_TOKEN" with
-                | Some npmToken -> npmToken
-                | None -> failwith "The npm token key must be set in a NPM_TOKEN environmental variable"
-            runInDir projDir @"npm config set '//registry.npmjs.org/:_authToken' ""${NPM_TOKEN}"""
             buildAction()
             bumpNpmVersion projDir releaseVersion
-            try
-                let publishCmd =
-                    match splitPrerelease releaseVersion with
-                    | _, Some _ -> "npm publish --tag next"
-                    | _, None -> "npm publish"
-                runInDir projDir publishCmd
-            with _ ->
-                printfn "There's been an error when pushing project: %s" projDir
-                printfn "Please revert the version change in package.json"
-                reraise()
+            let tag =
+                match splitPrerelease releaseVersion with
+                | _, Some _ -> Some "next"
+                | _, None -> None
+            pushNpmWithoutReleaseNotesCheck projDir tag
 
 let doNothing () = ()
 
@@ -550,12 +557,26 @@ let pushFableNuget projFile props buildAction =
 let pushNpm projDir buildAction =
     Publish.pushNpm projDir buildAction
 
+let pushNpmWithoutReleaseNotesCheck projDir =
+    Publish.pushNpmWithoutReleaseNotesCheck projDir None
+
 let getDotNetSDKVersionFromGlobalJson(): string =
     readFile "global.json"
     |> Json.Parse
     |> Json.TryGetProperty "sdk"
     |> Option.bind (Json.TryGetProperty "version")
     |> Option.map (Json.GetString)
+    |> Option.defaultWith (fun _ -> failwith "Cannot parse version")
+
+let getNpmVersion (projDir: string) =
+    let pkgJsonPath =
+        if projDir.EndsWith("package.json")
+        then projDir
+        else projDir </> "package.json"
+    readFile pkgJsonPath
+    |> Json.Parse
+    |> Json.TryGetProperty "version"
+    |> Option.map Json.GetString
     |> Option.defaultWith (fun _ -> failwith "Cannot parse version")
 
 (*

--- a/src/Fable.Transforms/Global/Compiler.fs
+++ b/src/Fable.Transforms/Global/Compiler.fs
@@ -2,6 +2,7 @@ namespace Fable
 
 module Literals =
     let [<Literal>] VERSION = "4.1.1"
+    let [<Literal>] JS_LIBRARY_VERSION = "1.0.0"
 
 type CompilerOptionsHelper =
     static member Make(?language,

--- a/src/fable-library/package.json
+++ b/src/fable-library/package.json
@@ -2,7 +2,7 @@
   "sideEffects": false,
   "type": "module",
   "name": "fable-library",
-  "version": "4.1.1",
+  "version": "1.0.0",
   "description": "Core library used by F# projects compiled with fable.io",
   "author": "Fable Contributors",
   "license": "MIT",

--- a/src/quicktest/QuickTest.fs
+++ b/src/quicktest/QuickTest.fs
@@ -78,9 +78,3 @@ let measureTime (f: unit -> unit): unit = emitJsStatement () """
 // to Fable.Tests project. For example:
 // testCase "Addition works" <| fun () ->
 //     2 + 2 |> equal 4
-
-
-[<Literal>]
-let foo = "FOO%f"
-
-let x = sprintf foo 1.5


### PR DESCRIPTION
@dbrattli This can be interesting to you. Now that we are also distributing fable-library through npm, Fable will print the minimum version compatible with the current compiler version. You can add Python too, check [this](https://github.com/fable-compiler/Fable/blob/2b8d24ce32a161945551862f5370cd91583b1fb4/build.fsx#L754-L762) and [this](https://github.com/fable-compiler/Fable/blob/2b8d24ce32a161945551862f5370cd91583b1fb4/src/Fable.Cli/Entry.fs#L369-L372).