### PR TITLE
Improve switch optimization, TS string enums and JsDocs

### DIFF
--- a/src/Fable.AST/Common.fs
+++ b/src/Fable.AST/Common.fs
@@ -8,7 +8,8 @@ type Position =
 type SourceLocation =
     { start: Position
       ``end``: Position
-      /// We added the display name here because it seemed to be used by Babel source map generation
+      /// Used to pass the display name of the identifier, but also the name of the file
+      /// as a hack in order not to break the API
       identifierName: string option }
     static member (+)(r1, r2) =
         { start = r1.start

--- a/src/Fable.AST/Common.fs
+++ b/src/Fable.AST/Common.fs
@@ -8,17 +8,40 @@ type Position =
 type SourceLocation =
     { start: Position
       ``end``: Position
-      /// Used to pass the display name of the identifier, but also the name of the file
-      /// as a hack in order not to break the API
+      /// DO NOT USE, use DisplayName instead and Create for instantiation
       identifierName: string option }
+
+    member this.DisplayName =
+        this.identifierName
+        |> Option.bind (fun name ->
+            match name.IndexOf(";file:") with
+            | -1 -> Some name
+            | 0 -> None
+            | i -> name.Substring(0, i) |> Some)
+
+    member this.File =
+        this.identifierName
+        |> Option.bind (fun name ->
+            match name.IndexOf(";file:") with
+            | -1 -> None
+            | i -> name.Substring(";file:".Length) |> Some)
+
+    static member Create(start: Position, ``end``: Position, ?file: string, ?displayName: string) =
+        let identifierName =
+            match displayName, file with
+            | None, None -> None
+            | displayName, None -> displayName
+            | displayName, Some file -> (defaultArg displayName "") + ";file:" + file |> Some
+        { start = start
+          ``end`` = ``end``
+          identifierName = identifierName }
+
     static member (+)(r1, r2) =
-        { start = r1.start
-          ``end`` = r2.start
-          identifierName = None }
+        SourceLocation.Create(start=r1.start, ``end``=r2.``end``, ?file=r1.File)
+
     static member Empty =
-        { start = Position.Empty
-          ``end`` = Position.Empty
-          identifierName = None }
+        SourceLocation.Create(start=Position.Empty, ``end``=Position.Empty)
+
     override x.ToString() =
         sprintf $"(L%i{x.start.line},%i{x.start.column}-L%i{x.``end``.line},%i{x.``end``.column})"
 

--- a/src/Fable.AST/Fable.fs
+++ b/src/Fable.AST/Fable.fs
@@ -395,7 +395,7 @@ type Ident =
       Range: SourceLocation option }
     member x.DisplayName =
         x.Range
-        |> Option.bind (fun r -> r.identifierName)
+        |> Option.bind (fun r -> r.DisplayName)
         |> Option.defaultValue x.Name
 
 type NewArrayKind =

--- a/src/Fable.AST/Fable.fs
+++ b/src/Fable.AST/Fable.fs
@@ -121,6 +121,7 @@ type MemberFunctionOrValue =
     abstract DeclaringEntity: EntityRef option
     abstract ApparentEnclosingEntity: EntityRef option
     abstract ImplementedAbstractSignatures: AbstractSignature seq
+    abstract XmlDoc: string option
 
 type Entity =
     abstract Ref: EntityRef
@@ -321,6 +322,7 @@ type GeneratedMember =
         member _.Attributes = []
         member _.ApparentEnclosingEntity = None
         member _.ImplementedAbstractSignatures = []
+        member _.XmlDoc = None
 
 type ObjectExprMember = {
     Name: string

--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -107,10 +107,9 @@ module private Util =
                 | FSharpDiagnosticSeverity.Warning -> Severity.Warning
                 | FSharpDiagnosticSeverity.Error -> Severity.Error
 
-            let range =
-                { start={ line=er.StartLine; column=er.StartColumn+1}
-                  ``end``={ line=er.EndLine; column=er.EndColumn+1}
-                  identifierName = None }
+            let range = SourceLocation.Create(
+                start = { line=er.StartLine; column=er.StartColumn+1 },
+                ``end`` = { line=er.EndLine; column=er.EndColumn+1 })
 
             let msg = $"%s{er.Message} (code %i{er.ErrorNumber})"
 

--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -157,10 +157,11 @@ module private Util =
             Path.ChangeExtension(absPath, fileExt)
         | lang ->
             let changeExtension path fileExt =
-                if lang = JavaScript then
+                match lang with
+                | JavaScript | TypeScript ->
                     let isInFableModules = Naming.isInFableModules file
-                    File.changeExtensionButUseDefaultExtensionInFableModules JavaScript isInFableModules path fileExt
-                else
+                    File.changeExtensionButUseDefaultExtensionInFableModules lang isInFableModules path fileExt
+                | _ ->
                     Path.ChangeExtension(path, fileExt)
             let fileExt = cliArgs.CompilerOptions.FileExtension
             match cliArgs.OutDir with

--- a/src/Fable.Cli/Pipeline.fs
+++ b/src/Fable.Cli/Pipeline.fs
@@ -110,18 +110,13 @@ module Js =
                 else path
             member _.AddLog(msg, severity, ?range) =
                 com.AddLog(msg, severity, ?range=range, fileName=com.CurrentFile)
-            member _.AddSourceMapping((srcLine, srcCol, genLine, genCol, name)) =
+            member _.AddSourceMapping(srcLine, srcCol, genLine, genCol, file, displayName) =
                 if cliArgs.SourceMaps then
-                    let name, sourcePath =
-                        match name with
-                        | Some(Naming.SplitBy Naming.fileRangeSeparator (name, file)) ->
-                            (if name = "" then None else Some name), file
-                        | _ -> name, sourcePath
                     let generated: SourceMapSharp.Util.MappingIndex = { line = genLine; column = genCol }
                     let original: SourceMapSharp.Util.MappingIndex = { line = srcLine; column = srcCol }
                     let targetPath = Path.normalizeFullPath targetPath
-                    let sourcePath = Path.getRelativeFileOrDirPath false targetPath false sourcePath
-                    mapGenerator.Force().AddMapping(generated, original, source=sourcePath, ?name=name)
+                    let sourcePath = defaultArg file sourcePath |> Path.getRelativeFileOrDirPath false targetPath false
+                    mapGenerator.Force().AddMapping(generated, original, source=sourcePath, ?name=displayName)
 
     let compileFile (com: Compiler) (cliArgs: CliArgs) pathResolver isSilent (outPath: string) = async {
         let babel =
@@ -175,7 +170,7 @@ module Python =
 
             member _.Dispose() = stream.Dispose()
 
-            member _.AddSourceMapping _ = ()
+            member _.AddSourceMapping(_,_,_,_,_,_) = ()
 
             member _.AddLog(msg, severity, ?range) =
                 com.AddLog(msg, severity, ?range=range, fileName=com.CurrentFile)
@@ -274,7 +269,7 @@ module Php =
                 let projDir = IO.Path.GetDirectoryName(cliArgs.ProjectFile)
                 let path = Imports.getImportPath pathResolver sourcePath targetPath projDir cliArgs.OutDir path
                 if path.EndsWith(".fs") then Path.ChangeExtension(path, fileExt) else path
-            member _.AddSourceMapping _ = ()
+            member _.AddSourceMapping(_,_,_,_,_,_) = ()
             member _.AddLog(msg, severity, ?range) =
                 com.AddLog(msg, severity, ?range=range, fileName=com.CurrentFile)
             member _.Dispose() = stream.Dispose()
@@ -302,7 +297,7 @@ module Dart =
             member _.MakeImportPath(path) =
                 let path = Imports.getImportPath pathResolver sourcePath targetPath projDir cliArgs.OutDir path
                 if path.EndsWith(".fs") then Path.ChangeExtension(path, fileExt) else path
-            member _.AddSourceMapping _ = ()
+            member _.AddSourceMapping(_,_,_,_,_,_) = ()
             member _.AddLog(msg, severity, ?range) =
                 com.AddLog(msg, severity, ?range=range, fileName=com.CurrentFile)
             member _.Dispose() = stream.Dispose()
@@ -332,7 +327,7 @@ module Rust =
                 let projDir = IO.Path.GetDirectoryName(cliArgs.ProjectFile)
                 let path = Imports.getImportPath pathResolver sourcePath targetPath projDir cliArgs.OutDir path
                 if path.EndsWith(".fs") then Path.ChangeExtension(path, fileExt) else path
-            member _.AddSourceMapping _ = ()
+            member _.AddSourceMapping(_,_,_,_,_,_) = ()
             member _.AddLog(msg, severity, ?range) =
                 com.AddLog(msg, severity, ?range=range, fileName=com.CurrentFile)
             member _.Dispose() = stream.Dispose()

--- a/src/Fable.Transforms/BabelPrinter.fs
+++ b/src/Fable.Transforms/BabelPrinter.fs
@@ -815,8 +815,8 @@ module PrinterExtensions =
                 let canConflict = declarations.Length > 1
 
                 for i = 0 to declarations.Length - 1 do
-                    let (VariableDeclarator(name, annotation, typeParams, init)) = declarations[i]
-                    printer.Print(name)
+                    let (VariableDeclarator(name, annotation, typeParams, init, loc)) = declarations[i]
+                    printer.Print(name, ?loc = loc)
                     // In some situations when inlining functions it may happen that a unit argument is assigned a value
                     // (see "Unit expression arguments are not removed" in ApplicativeTests). To prevent the TypeScript
                     // compiler from complaining we replace `void` type with `any`.

--- a/src/Fable.Transforms/BabelPrinter.fs
+++ b/src/Fable.Transforms/BabelPrinter.fs
@@ -804,40 +804,40 @@ module PrinterExtensions =
 
 // Declarations
 
-        member printer.Print(node: VariableDeclaration) =
-            let (VariableDeclaration(declarations, kind, loc)) = node
-            let kind =
-                match kind with
-                | Var -> "var"
-                | Let -> "let"
-                | Const -> "const"
-            printer.Print(kind + " ", ?loc = loc)
-            let canConflict = declarations.Length > 1
+        member printer.Print(VariableDeclaration(declarations, kind, loc)) =
+            if declarations.Length > 0 then
+                let kind =
+                    match kind with
+                    | Var -> "var"
+                    | Let -> "let"
+                    | Const -> "const"
+                printer.Print(kind + " ", ?loc = loc)
+                let canConflict = declarations.Length > 1
 
-            for i = 0 to declarations.Length - 1 do
-                let (VariableDeclarator(name, annotation, typeParams, init)) = declarations[i]
-                printer.Print(name)
-                // In some situations when inlining functions it may happen that a unit argument is assigned a value
-                // (see "Unit expression arguments are not removed" in ApplicativeTests). To prevent the TypeScript
-                // compiler from complaining we replace `void` type with `any`.
-                let annotation = annotation |> Option.map (function VoidTypeAnnotation -> AnyTypeAnnotation | t -> t)
-                printer.PrintOptional(annotation, (fun p a ->
-                    match a with
-                    | FunctionTypeAnnotation(parameters, returnType, spread) ->
-                        p.PrintFunctionTypeAnnotation(parameters, returnType, typeParams, ?spread=spread)
-                    | _ ->
-                        p.Print(typeParams)
-                        p.Print(a)
-                ), ": ")
+                for i = 0 to declarations.Length - 1 do
+                    let (VariableDeclarator(name, annotation, typeParams, init)) = declarations[i]
+                    printer.Print(name)
+                    // In some situations when inlining functions it may happen that a unit argument is assigned a value
+                    // (see "Unit expression arguments are not removed" in ApplicativeTests). To prevent the TypeScript
+                    // compiler from complaining we replace `void` type with `any`.
+                    let annotation = annotation |> Option.map (function VoidTypeAnnotation -> AnyTypeAnnotation | t -> t)
+                    printer.PrintOptional(annotation, (fun p a ->
+                        match a with
+                        | FunctionTypeAnnotation(parameters, returnType, spread) ->
+                            p.PrintFunctionTypeAnnotation(parameters, returnType, typeParams, ?spread=spread)
+                        | _ ->
+                            p.Print(typeParams)
+                            p.Print(a)
+                    ), ": ")
 
-                match init with
-                | None -> ()
-                | Some e ->
-                    printer.Print(" = ")
-                    if canConflict then printer.ComplexExpressionWithParens(e)
-                    else printer.Print(e)
-                if i < declarations.Length - 1 then
-                    printer.Print(", ")
+                    match init with
+                    | None -> ()
+                    | Some e ->
+                        printer.Print(" = ")
+                        if canConflict then printer.ComplexExpressionWithParens(e)
+                        else printer.Print(e)
+                    if i < declarations.Length - 1 then
+                        printer.Print(", ")
 
         member printer.PrintWhileStatement(test, body, loc) =
             printer.Print("while (", ?loc = loc)

--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -255,6 +255,7 @@ type FsMemberFunctionOrValue(m: FSharpMemberOrFunctionOrValue) =
         member _.ImplementedAbstractSignatures = m.ImplementedAbstractSignatures |> Seq.map (fun s -> FsAbstractSignature(s))
         member _.ApparentEnclosingEntity = FsEnt.Ref m.ApparentEnclosingEntity |> Some
         member _.DeclaringEntity = m.DeclaringEntity |> Option.map FsEnt.Ref
+        member _.XmlDoc = TypeHelpers.tryGetXmlDoc m.XmlDoc
 
 type FsEnt(maybeAbbrevEnt: FSharpEntity) =
     let ent = Helpers.nonAbbreviatedDefinition maybeAbbrevEnt
@@ -1199,7 +1200,7 @@ module TypeHelpers =
                 | Choice1Of2 t -> t
                 | Choice2Of2 fullName -> makeRuntimeTypeWithMeasure genArgs fullName
             | fullName when tdef.IsMeasure -> Fable.Measure fullName
-            | _ when hasAttribute Atts.stringEnum tdef.Attributes -> Fable.String
+            | _ when hasAttribute Atts.stringEnum tdef.Attributes && Compiler.Language <> TypeScript -> Fable.String
             | _ ->
                 let genArgs = makeTypeGenArgsWithConstraints withConstraints ctxTypeArgs genArgs
                 Fable.DeclaredType(FsEnt.Ref tdef, genArgs)

--- a/src/Fable.Transforms/FSharp2Fable.fs
+++ b/src/Fable.Transforms/FSharp2Fable.fs
@@ -1520,7 +1520,8 @@ let rec private transformDeclarations (com: FableCompiler) ctx fsDecls =
             | [] ->
                 let entRef = FsEnt.Ref fsEnt
                 let ent = (com :> Compiler).GetEntity(entRef)
-                if isErasedOrStringEnumEntity ent || isGlobalOrImportedEntity ent then
+                if (isErasedOrStringEnumEntity ent && Compiler.Language <> TypeScript)
+                    || isGlobalOrImportedEntity ent then
                     []
                 else
                     // If the file is empty F# creates a class for the module, but Fable clears the name

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -83,7 +83,7 @@ module Lib =
     let tryJsConstructorFor purpose (com: IBabelCompiler) ctx (ent: Fable.Entity) =
         let isErased =
             match purpose with
-            | Annotation -> ent.IsMeasure
+            | Annotation -> ent.IsMeasure || (FSharp2Fable.Util.isErasedOrStringEnumEntity ent && not ent.IsFSharpUnion)
             // Historically we have used interfaces to represent JS classes in bindings,
             // so it may happen that an F# interface corresponds to an actual type in JS.
             // But just in case we avoid referencing interfaces for reflection.
@@ -2837,7 +2837,10 @@ module Util =
             ent.MembersFunctionsAndValues
             // It's not usual to have getters/setters in TS interfaces, so let's ignore setters
             // and compile getters as fields
-            |> Seq.filter (fun info -> not(info.IsProperty || info.IsSetter))
+            |> Seq.filter (fun info ->
+                not(info.IsProperty || info.IsSetter)
+                // TODO: Deal with other emit attributes like EmitMethod or EmitConstructor
+                && not(hasAttribute Atts.emitAttr info.Attributes))
             |> Seq.toArray
             |> Array.partition (fun info -> info.IsGetter)
 

--- a/src/Fable.Transforms/Global/Babel.fs
+++ b/src/Fable.Transforms/Global/Babel.fs
@@ -36,7 +36,7 @@ type Expression =
         typeParameters: TypeParameter array *
         loc: SourceLocation option
     | Super of loc: SourceLocation option
-    | Undefined of Loc: SourceLocation option
+    | Undefined of loc: SourceLocation option
     | ThisExpression of loc: SourceLocation option
     | SpreadElement of argument: Expression * loc: SourceLocation option
     | ArrayExpression of elements: Expression array * loc: SourceLocation option
@@ -66,6 +66,29 @@ type Expression =
         typeParameters: TypeParameter array *
         loc: SourceLocation option
     | AsExpression of expression: Expression * typeAnnotation: TypeAnnotation
+    member this.Location =
+        match this with
+        | ClassExpression(loc=loc) -> loc
+        | Super(loc=loc) -> loc
+        | Undefined(loc=loc) -> loc
+        | ThisExpression(loc=loc) -> loc
+        | SpreadElement(loc=loc) -> loc
+        | ArrayExpression(loc=loc) -> loc
+        | ObjectExpression(loc=loc) -> loc
+        | SequenceExpression(loc=loc) -> loc
+        | EmitExpression(loc=loc) -> loc
+        | CallExpression(loc=loc) -> loc
+        | UnaryExpression(loc=loc) -> loc
+        | UpdateExpression(loc=loc) -> loc
+        | BinaryExpression(loc=loc) -> loc
+        | LogicalExpression(loc=loc) -> loc
+        | AssignmentExpression(loc=loc) -> loc
+        | ConditionalExpression(loc=loc) -> loc
+        | MemberExpression(loc=loc) -> loc
+        | NewExpression(loc=loc) -> loc
+        | FunctionExpression(loc=loc) -> loc
+        | ArrowFunctionExpression(loc=loc) -> loc
+        | _ -> None
 
 type ParameterFlags(?defVal: Expression, ?isOptional, ?isSpread, ?isNamed) =
     member _.DefVal = defVal
@@ -236,7 +259,7 @@ type CatchClause =
 
 // Declarations
 type VariableDeclarator =
-    | VariableDeclarator of name: string * annotation: TypeAnnotation option * typeParameters: TypeParameter array * init: Expression option
+    | VariableDeclarator of name: string * annotation: TypeAnnotation option * typeParameters: TypeParameter array * init: Expression option * loc: SourceLocation option
 
 type VariableDeclarationKind =
     | Var
@@ -651,8 +674,8 @@ module Helpers =
             )
 
     type VariableDeclarator with
-        static member variableDeclarator(id, ?annotation, ?typeParameters, ?init) =
-            VariableDeclarator(id, annotation, defaultArg typeParameters [||], init)
+        static member variableDeclarator(id, ?annotation, ?typeParameters, ?init, ?loc) =
+            VariableDeclarator(id, annotation, defaultArg typeParameters [||], init, loc)
 
     type FunctionTypeParam with
         static member functionTypeParam(name, typeInfo, ?isOptional) =

--- a/src/Fable.Transforms/Global/Naming.fs
+++ b/src/Fable.Transforms/Global/Naming.fs
@@ -18,11 +18,6 @@ module Naming =
         then txt.Substring(0, txt.Length - pattern.Length) |> Some
         else None
 
-    let (|SplitBy|_|) (pattern: string) (txt: string) =
-        match txt.IndexOf(pattern) with
-        | -1 -> None
-        | i -> Some(txt.Substring(0, i), txt.Substring(i + pattern.Length))
-
     let (|Regex|_|) (reg: Regex) (str: string) =
         let m = reg.Match(str)
         if m.Success then
@@ -33,7 +28,6 @@ module Naming =
             |> Some
         else None
 
-    let [<Literal>] fileRangeSeparator = ";file:"
     let [<Literal>] fableCompilerConstant = "FABLE_COMPILER"
     let [<Literal>] placeholder = "__PLACE-HOLDER__"
     let [<Literal>] fableModules = "fable_modules"

--- a/src/Fable.Transforms/Global/Naming.fs
+++ b/src/Fable.Transforms/Global/Naming.fs
@@ -18,6 +18,11 @@ module Naming =
         then txt.Substring(0, txt.Length - pattern.Length) |> Some
         else None
 
+    let (|SplitBy|_|) (pattern: string) (txt: string) =
+        match txt.IndexOf(pattern) with
+        | -1 -> None
+        | i -> Some(txt.Substring(0, i), txt.Substring(i + pattern.Length))
+
     let (|Regex|_|) (reg: Regex) (str: string) =
         let m = reg.Match(str)
         if m.Success then
@@ -28,6 +33,7 @@ module Naming =
             |> Some
         else None
 
+    let [<Literal>] fileRangeSeparator = ";file:"
     let [<Literal>] fableCompilerConstant = "FABLE_COMPILER"
     let [<Literal>] placeholder = "__PLACE-HOLDER__"
     let [<Literal>] fableModules = "fable_modules"

--- a/src/Fable.Transforms/Printer.fs
+++ b/src/Fable.Transforms/Printer.fs
@@ -5,12 +5,9 @@ open System
 open Fable
 open Fable.AST
 
-type SourceMapping =
-    int * int * int * int * string option
-
 type Writer =
     inherit IDisposable
-    abstract AddSourceMapping: SourceMapping -> unit
+    abstract AddSourceMapping: srcLine: int * srcCol: int * genLine: int * genCol: int * file: string option * displayName: string option -> unit
     abstract MakeImportPath: string -> string
     abstract Write: string -> Async<unit>
     abstract AddLog: msg:string * severity: Fable.Severity * ?range: SourceLocation -> unit
@@ -39,11 +36,12 @@ type PrinterImpl(writer: Writer, ?indent: string) =
         | None -> ()
         | Some loc ->
             writer.AddSourceMapping(
-                loc.start.line,
-                loc.start.column,
-                line,
-                column,
-                loc.identifierName)
+                srcLine=loc.start.line,
+                srcCol=loc.start.column,
+                genLine=line,
+                genCol=column,
+                file=loc.File,
+                displayName=loc.DisplayName)
 
     member _.Flush(): Async<unit> =
         async {

--- a/src/Fable.Transforms/Python/PythonPrinter.fs
+++ b/src/Fable.Transforms/Python/PythonPrinter.fs
@@ -295,13 +295,7 @@ module PrinterExtensions =
 
         member printer.Print(node: UnaryOp) =
             printer.AddLocation(node.Loc)
-
-            match node.Op with
-            | USub
-            | UAdd
-            | Not
-            | Invert -> printer.Print(node.Op)
-
+            printer.Print(node.Op)
             printer.ComplexExpressionWithParens(node.Operand)
 
         member printer.Print(node: FormattedValue) = printer.Print("(FormattedValue)")

--- a/src/Fable.Transforms/Replacements.Util.fs
+++ b/src/Fable.Transforms/Replacements.Util.fs
@@ -252,6 +252,9 @@ let getElementType = function
 let genericTypeInfoError (name: string) =
     $"Cannot get type info of generic parameter {name}. Fable erases generics at runtime, try inlining the functions so generics can be resolved at compile time."
 
+let fixInlineRange (inlinePath: InlinePath list) (range: SourceLocation option) =
+    List.tryLast inlinePath |> Option.bind (fun i -> i.FromRange) |> Option.orElse range
+
 let splitFullName (fullname: string) =
     let fullname =
         match fullname.IndexOf("[") with

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -1203,8 +1203,8 @@ let operators (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr o
     | Patterns.SetContains Operators.standardSet, _ ->
         applyOp com ctx r t i.CompiledName args |> Some
     // Type info
-    | "TypeOf", _ -> (genArg com ctx r 0 i.GenericArgs) |> makeTypeInfo (fixInlineRange ctx.InlinePath r) |> Some
-    | "TypeDefOf", _ -> (genArg com ctx r 0 i.GenericArgs) |> makeTypeDefinitionInfo (fixInlineRange ctx.InlinePath r) |> Some
+    | "TypeOf", _ -> (genArg com ctx r 0 i.GenericArgs) |> makeTypeInfo (changeRangeToCallSite ctx.InlinePath r) |> Some
+    | "TypeDefOf", _ -> (genArg com ctx r 0 i.GenericArgs) |> makeTypeDefinitionInfo (changeRangeToCallSite ctx.InlinePath r) |> Some
     | _ -> None
 
 let chars (com: ICompiler) (ctx: Context) r t (i: CallInfo) (_: Expr option) (args: Expr list) =
@@ -2147,7 +2147,7 @@ let objects (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr opt
         if arg.Type = Any then
             "Types can only be resolved at compile time. At runtime this will be same as `typeof<obj>`"
             |> addWarning com ctx.InlinePath r
-        makeTypeInfo (fixInlineRange ctx.InlinePath r) arg.Type |> Some
+        makeTypeInfo (changeRangeToCallSite ctx.InlinePath r) arg.Type |> Some
     | _ -> None
 
 let valueTypes (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr option) (args: Expr list) =
@@ -2758,7 +2758,7 @@ let types (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr optio
                             Some(ifc.Entity, genArgs)
                         else None)
                     |> function
-                        | Some(ifcEnt, genArgs) -> DeclaredType(ifcEnt, genArgs) |> makeTypeInfo (fixInlineRange ctx.InlinePath r)
+                        | Some(ifcEnt, genArgs) -> DeclaredType(ifcEnt, genArgs) |> makeTypeInfo (changeRangeToCallSite ctx.InlinePath r)
                         | None -> Value(Null t, r))
             | "get_FullName" -> getTypeFullName false exprType |> returnString r
             | "get_Namespace" -> getTypeFullName false exprType |> splitFullName |> fst |> returnString r
@@ -2771,12 +2771,12 @@ let types (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr optio
                 |> BoolConstant |> makeValue r |> Some
             | "GetElementType" ->
                 match exprType with
-                | Array(t,_) -> makeTypeInfo (fixInlineRange ctx.InlinePath r) t |> Some
+                | Array(t,_) -> makeTypeInfo (changeRangeToCallSite ctx.InlinePath r) t |> Some
                 | _ -> Null t |> makeValue r |> Some
             | "get_IsGenericType" ->
                 List.isEmpty exprType.Generics |> not |> BoolConstant |> makeValue r |> Some
             | "get_GenericTypeArguments" | "GetGenericArguments" ->
-                let arVals = exprType.Generics |> List.map (makeTypeInfo (fixInlineRange ctx.InlinePath r))
+                let arVals = exprType.Generics |> List.map (makeTypeInfo (changeRangeToCallSite ctx.InlinePath r))
                 NewArray(ArrayValues arVals, Any, MutableArray) |> makeValue r |> Some
             | "GetGenericTypeDefinition" ->
                 let newGen = exprType.Generics |> List.map (fun _ -> Any)
@@ -2794,7 +2794,7 @@ let types (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr optio
                     | Tuple (_, isStruct) -> Tuple(newGen, isStruct)
                     | DeclaredType (ent, _) -> DeclaredType(ent, newGen)
                     | t -> t
-                makeTypeInfo (fixInlineRange ctx.InlinePath exprRange) exprType |> Some
+                makeTypeInfo (changeRangeToCallSite ctx.InlinePath exprRange) exprType |> Some
             | _ -> None
         |  _ -> None
     match resolved, thisArg with

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -1114,9 +1114,9 @@ module AST =
         extractGenericArgs Map.empty maybeGenericExpr.Type concreteType
 
     let rec resolveInlineType (genArgs: Map<string, Type>) = function
-        | Fable.GenericParam(name, isMeasure, _constraints) as t ->
+        | GenericParam(name, isMeasure, _constraints) as t ->
             match Map.tryFind name genArgs with
-            | Some v when isMeasure && v = Fable.Any -> t // avoids resolving measures to Fable.Any
+            | Some v when isMeasure && v = Any -> t // avoids resolving measures to Fable.Any
             | Some v -> v
             | None -> t
         | t -> t.MapGenerics(resolveInlineType genArgs)

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -238,14 +238,15 @@ module Log =
             | Some r -> $"%s{path}(%i{r.start.line},%i{r.start.column})"
             | None -> path
         let actualFile, msg =
-            match inlinePath with
-            | [] -> com.CurrentFile, msg
-            | { ToFile = file }::_ ->
+            match inlinePath, range with
+            | { ToFile = file }::_, _ ->
                 let inlinePath =
                     inlinePath
                     |> List.map (printInlineSource file)
                     |> String.concat " < "
                 file, msg + " - Inline call from " + inlinePath
+            | [], Some { identifierName = Some(Naming.SplitBy Naming.fileRangeSeparator (_,file)) } -> file, msg
+            | [], _ -> com.CurrentFile, msg
         com.AddLog(msg, severity, ?range=range, fileName=actualFile)
 
     let addWarning (com: Compiler) inlinePath range warning =

--- a/src/fable-standalone/src/Main.fs
+++ b/src/fable-standalone/src/Main.fs
@@ -327,7 +327,8 @@ let makeWriter (writer: IWriter) =
         member _.Dispose() = writer.Dispose()
         member _.MakeImportPath(path) = writer.MakeImportPath(path)
         member _.AddLog(msg, severity, ?range) = ()
-        member _.AddSourceMapping(mapping) = writer.AddSourceMapping(mapping)
+        member _.AddSourceMapping(srcLine, srcCol, genLine, genCol, _file, displayName) =
+            writer.AddSourceMapping(srcLine, srcCol, genLine, genCol, displayName)
         member _.Write(str) = writer.Write(str) }
 
 let getLanguage (language: string) =


### PR DESCRIPTION
### Enable annotations for `StringEnum` and `TypeScriptTaggedUnion` unions

~~For now I'm just inlining the annotation everywhere and not emitting the declaration, although this may make the code quite verbose sometimes.~~

### Transform XmlDocs as JsDocs

This is activated also for JS (better only for TS?). For now it's the **summary** of classes, dettached members and interface members. I am not adding the docs to attached members because that requires telling interface implementations apart to prevent comment duplication.

### Improve nested ifs to switch optimization

Cleanup of the code for decision trees and unification of switch optimization with general IfThenElse compilation (sometimes there are also ifs nested in a decision tree that were missed before) 