### PR TITLE
Issue fixes

### DIFF
--- a/src/Fable.AST/Common.fs
+++ b/src/Fable.AST/Common.fs
@@ -24,7 +24,7 @@ type SourceLocation =
         |> Option.bind (fun name ->
             match name.IndexOf(";file:") with
             | -1 -> None
-            | i -> name.Substring(";file:".Length) |> Some)
+            | i -> name.Substring(i + ";file:".Length) |> Some)
 
     static member Create(start: Position, ``end``: Position, ?file: string, ?displayName: string) =
         let identifierName =

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -85,9 +85,11 @@ module Lib =
             match purpose with
             | Annotation -> ent.IsMeasure || (FSharp2Fable.Util.isErasedOrStringEnumEntity ent && not ent.IsFSharpUnion)
             // Historically we have used interfaces to represent JS classes in bindings,
-            // so it may happen that an F# interface corresponds to an actual type in JS.
-            // But just in case we avoid referencing interfaces for reflection.
-            | ActualConsRef -> ent.IsMeasure || FSharp2Fable.Util.isErasedOrStringEnumEntity ent
+            // so we allow explicit type references (e.g. for type testing) when the interface is global or imported.
+            // But just in case we avoid referencing interfaces for reflection (as the type may not exist in actual code)
+            | ActualConsRef ->
+                if ent.IsInterface then not(FSharp2Fable.Util.isGlobalOrImportedEntity ent)
+                else ent.IsMeasure || FSharp2Fable.Util.isErasedOrStringEnumEntity ent
             | Reflection -> ent.IsInterface || ent.IsMeasure || FSharp2Fable.Util.isErasedOrStringEnumEntity ent
 
         if isErased then None

--- a/src/Fable.Transforms/Replacements.Api.fs
+++ b/src/Fable.Transforms/Replacements.Api.fs
@@ -6,7 +6,6 @@ open Fable
 open Fable.AST
 open Fable.AST.Fable
 open Fable.Transforms
-open Replacements.Util
 
 type ICompiler = FSharp2Fable.IFableCompiler
 
@@ -14,13 +13,13 @@ let curryExprAtRuntime (com: Compiler) arity (expr: Expr) =
     match com.Options.Language with
     // | Rust -> Rust.Replacements.curryExprAtRuntime com arity expr
     // | Python -> Helper.LibCall(com, "Util", "curry", expr.Type, [makeIntConst arity; expr])
-    | _ -> Replacements.Util.curryExprAtRuntime com arity expr
+    | _ -> Util.curryExprAtRuntime com arity expr
 
 let uncurryExprAtRuntime (com: Compiler) arity (expr: Expr) =
     match com.Options.Language with
     //| Rust -> Rust.Replacements.uncurryExprAtRuntime com expr.Type arity expr
     // | Python -> Helper.LibCall(com, "Util", "uncurry", expr.Type, [makeIntConst arity; expr])
-    | _ -> Replacements.Util.uncurryExprAtRuntime com arity expr
+    | _ -> Util.uncurryExprAtRuntime com arity expr
 
 let partialApplyAtRuntime (com: Compiler) t arity (fn: Expr) (args: Expr list) =
     match com.Options.Language with
@@ -28,7 +27,7 @@ let partialApplyAtRuntime (com: Compiler) t arity (fn: Expr) (args: Expr list) =
     // | Python ->
     //     let args = NewArray(ArrayValues args, Any, MutableArray) |> makeValue None
     //     Helper.LibCall(com, "Util", "partialApply", t, [makeIntConst arity; fn; args])
-    | _ -> Replacements.Util.partialApplyAtRuntime com t arity fn args
+    | _ -> Util.partialApplyAtRuntime com t arity fn args
 
 let tryField (com: ICompiler) returnTyp ownerTyp fieldName =
     match com.Options.Language with

--- a/src/Fable.Transforms/Replacements.Util.fs
+++ b/src/Fable.Transforms/Replacements.Util.fs
@@ -379,12 +379,14 @@ let compose (com: ICompiler) ctx r t (f1: Expr) (f2: Expr) =
 let partialApplyAtRuntime (com: Compiler) t arity (expr: Expr) (partialArgs: Expr list) =
     match com.Options.Language with
     | JavaScript | TypeScript | Dart | Python ->
-        let argTypes, returnType = uncurryLambdaType -1 [] expr.Type
-        let curriedType = makeLambdaType argTypes returnType
-        let curried = Helper.LibCall(com, "Util", $"curry{argTypes.Length}", curriedType, [expr])
-        match partialArgs with
-        | [] -> curried
-        | partialArgs -> curriedApply None t curried partialArgs
+        match uncurryLambdaType -1 [] expr.Type with
+        | ([]|[_]), _ -> expr
+        | argTypes, returnType ->
+            let curriedType = makeLambdaType argTypes returnType
+            let curried = Helper.LibCall(com, "Util", $"curry{argTypes.Length}", curriedType, [expr])
+            match partialArgs with
+            | [] -> curried
+            | partialArgs -> curriedApply None t curried partialArgs
     | _ ->
         // Check if argTypes.Length < arity?
         let argTypes, returnType = uncurryLambdaType arity [] t

--- a/src/fable-library/DateOffset.ts
+++ b/src/fable-library/DateOffset.ts
@@ -14,7 +14,7 @@
  */
 
 import { int64, fromFloat64, toFloat64 } from "./BigInt.js";
-import { create as createDate, dateOffsetToString, daysInMonth, parseRaw, ticksToUnixEpochMilliseconds, unixEpochMillisecondsToTicks } from "./Date.js";
+import DateTime, { create as createDate, dateOffsetToString, daysInMonth, parseRaw, ticksToUnixEpochMilliseconds, unixEpochMillisecondsToTicks } from "./Date.js";
 import { FSharpRef } from "./Types.js";
 import { compareDates, DateKind, IDateTime, IDateTimeOffset, padWithZeros } from "./Util.js";
 
@@ -161,12 +161,12 @@ export function utcNow() {
   return DateTimeOffset(date.getTime(), 0);
 }
 
-export function toUniversalTime(date: IDateTimeOffset) {
-  return DateTimeOffset(date.getTime(), 0);
+export function toUniversalTime(date: IDateTimeOffset): Date {
+  return DateTime(date.getTime(), DateKind.UTC);
 }
 
-export function toLocalTime(date: Date) {
-  return DateTimeOffset(date.getTime(), date.getTimezoneOffset() * -60000);
+export function toLocalTime(date: IDateTimeOffset): Date {
+  return DateTime(date.getTime(), DateKind.Local);
 }
 
 export function timeOfDay(d: IDateTimeOffset) {

--- a/tests/Js/Main/DateTimeTests.fs
+++ b/tests/Js/Main/DateTimeTests.fs
@@ -103,6 +103,25 @@ let tests =
         // dto.ToString() |> equal "2014-10-09 13:23:30 +00:00"
         dto.ToString("HH:mm:ss", CultureInfo.InvariantCulture) |> equal "13:23:30"
 
+    testCase "DateTimeOffset.UtcDateTime works" <| fun () ->
+        let timeStr = "2016-07-07T01:00:00.000Z"
+        let dtOffset = System.DateTimeOffset.Parse timeStr
+        let dt = dtOffset.UtcDateTime
+        equal 7 dt.Day
+        equal 1 dt.Hour
+        equal 0 dt.Minute
+        equal DateTimeKind.Utc dt.Kind
+
+    testCase "DateTimeOffset.LocalDateTime works" <| fun () ->
+        let timeStr = "2016-07-07T01:00:00.000Z"
+        let dtOffset = System.DateTimeOffset.Parse timeStr
+        let dt = dtOffset.LocalDateTime
+        equal DateTimeKind.Local dt.Kind
+        let dt2 = DateTime.Parse(timeStr, CultureInfo.InvariantCulture).ToLocalTime()
+        equal dt2.Day dt.Day
+        equal dt2.Hour dt.Hour
+        equal dt2.Minute dt.Minute
+
     testCase "DateTime.Hour works" <| fun () ->
         let d = DateTime(2014, 10, 9, 13, 23, 30, DateTimeKind.Local)
         d.Hour |> equal 13


### PR DESCRIPTION
- Fix #3438: Source maps
- Fix #3440: Don't curry arity-1 functions
- Fix #3452: DateTimeOffset conversion to DateTime
- Fix [regression](https://github.com/fable-compiler/Fable/issues/3443#issuecomment-1537548685): Don't type test interfaces declared in F# code