### PR TITLE
add test case for issue with bigint to decimal conversion

### DIFF
--- a/tests/Js/Main/ConvertTests.fs
+++ b/tests/Js/Main/ConvertTests.fs
@@ -1076,6 +1076,14 @@ let tests =
         let value = 1.0m
         decimal (bigint value) |> equal value
 
+    testCase "BigInt ToDecimal of Decimal.MinValue works" <| fun () ->
+        let value = Decimal.MinValue
+        decimal (bigint value) |> equal value
+
+    testCase "BigInt ToDecimal of Decimal.MaxValue works" <| fun () ->
+        let value = Decimal.MaxValue
+        decimal (bigint value) |> equal value
+
     testCase "BigInt ToString works" <| fun () ->
         let value = 1234567890
         string (bigint value) |> equal "1234567890"


### PR DESCRIPTION
Converting `Decimal.MinValue` to `bigint` and back to decimal returns -1 instead of `Decimal.MinValue`
