### PR TITLE
WIP fix for #3496

### DIFF
--- a/tests/Python/Fable.Tests.Python.fsproj
+++ b/tests/Python/Fable.Tests.Python.fsproj
@@ -75,6 +75,7 @@
     <Compile Include="TestUri.fs" />
     <Compile Include="TestPyInterop.fs" />
 
+    <Compile Include="TestNonRegression.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
 </Project>

--- a/tests/Python/TestNonRegression.fs
+++ b/tests/Python/TestNonRegression.fs
@@ -1,0 +1,17 @@
+module Fable.Tests.NonRegression
+
+open Util.Testing
+
+module Issue3496 =
+  type Class(length: int) =
+    member x.Length = length
+    static member StaticLength (length: int) = length
+  let returnLength (length: int) = length
+  
+  
+  [<Fact>]
+  let testLengthPassedToCtorIsOk() =
+    let c = Class(1)
+    equal 1 c.Length
+    equal 1 (returnLength 1)
+    equal 1 (Class.StaticLength 1)


### PR DESCRIPTION
Not to be merged as it fails ``test Can type test interfaces decorated with Global`` in TestPyInterop.

I'm not sure how to deal with this, it would be needed to resolve the `[<Global("Array")>]` attribute adorned to `PyArray` or some other approach.

cc: @dbrattli 