### PR TITLE
[Rust] Fixed deprecated DateTimeOffset parsing

### DIFF
--- a/src/Fable.Cli/ProjectCracker.fs
+++ b/src/Fable.Cli/ProjectCracker.fs
@@ -655,7 +655,7 @@ let copyFableLibraryAndPackageSourcesPy (opts: CrackerOptions) (pkgs: FablePacka
     getFableLibraryPath opts, pkgRefs
 
 // See #1455: F# compiler generates *.AssemblyInfo.fs in obj folder, but we don't need it
-let removeFilesInObjFolder sourceFiles =
+let removeFilesInObjFolder (sourceFiles: string[]) =
     let reg = Regex(@"[\\\/]obj[\\\/]")
     sourceFiles |> Array.filter (reg.IsMatch >> not)
 
@@ -717,7 +717,7 @@ let getFullProjectOpts (opts: CrackerOptions) =
     let cacheInfo =
         opts.CacheInfo |> Option.filter (fun cacheInfo ->
             let cacheTimestamp = cacheInfo.GetTimestamp()
-            let isOlderThanCache filePath =
+            let isOlderThanCache (filePath: string) =
                 let fileTimestamp = IO.File.GetLastWriteTime(filePath)
                 let isOlder = fileTimestamp < cacheTimestamp
                 if not isOlder then

--- a/src/Fable.Transforms/Rust/Fable2Rust.fs
+++ b/src/Fable.Transforms/Rust/Fable2Rust.fs
@@ -48,7 +48,7 @@ type Context = {
     ScopedEntityGenArgs: Set<string>
     ScopedMemberGenArgs: Set<string>
     ScopedSymbols: FSharp.Collections.Map<string, ScopedVarAttrs>
-    HasMultipleUses: bool //this could be a closure in a map, or a for loop. The point is anything leaving the scope cannot be assumed to be the only reference
+    // HasMultipleUses: bool //this could be a closure in a map, or a for loop. The point is anything leaving the scope cannot be assumed to be the only reference
     InferAnyType: bool
     IsAssocMember: bool
     IsLambda: bool
@@ -2513,7 +2513,7 @@ module Util =
     let transformForLoop (com: IRustCompiler) ctx range isUp (var: Fable.Ident) start limit body =
         let startExpr = transformExpr com ctx start
         let limitExpr = transformExpr com ctx limit
-        let ctx = { ctx with HasMultipleUses = true }
+        // let ctx = { ctx with HasMultipleUses = true }
         let bodyExpr = com.TransformExpr(ctx, body)
         let varPat = makeFullNameIdentPat var.Name
         let rangeExpr =
@@ -3254,7 +3254,7 @@ module Util =
         // remove captured names from scoped symbols, as they will be cloned
         let closedOverCloneableIdents = getCapturedIdents com ctx name args body
         let scopedSymbols = ctx.ScopedSymbols |> Helpers.Map.except closedOverCloneableIdents
-        let ctx = { ctx with ScopedSymbols = scopedSymbols; HasMultipleUses = true }
+        let ctx = { ctx with ScopedSymbols = scopedSymbols } //; HasMultipleUses = true }
         let argCount = args |> List.length |> string
         let fnBody = transformFunctionBody com ctx args body
         let fnBody =
@@ -4330,7 +4330,7 @@ module Compiler =
             ScopedEntityGenArgs = Set.empty
             ScopedMemberGenArgs = Set.empty
             ScopedSymbols = Map.empty
-            HasMultipleUses = false
+            // HasMultipleUses = false
             InferAnyType = false
             IsAssocMember = false
             IsLambda = false

--- a/src/fable-library-rust/Cargo.toml
+++ b/src/fable-library-rust/Cargo.toml
@@ -20,15 +20,15 @@ default = ["bigint", "datetime", "decimal", "enum_func", "enum_string", "guid", 
 
 [dependencies]
 startup = { version = "0.1", path = "vendored/startup", optional = true }
-hashbrown = { version = "0.13", optional = true }
+hashbrown = { version = "0.14", optional = true }
 num-bigint = { version = "0.4", optional = true }
 num-integer = { version = "0.1", optional = true }
 num-traits = { version = "0.2", optional = true }
-rust_decimal = { version = "1.29", features = ["maths"], default-features = false, optional = true }
+rust_decimal = { version = "1.32", features = ["maths"], default-features = false, optional = true }
 futures = { version = "0.3", features = ["executor", "thread-pool"], optional = true }
-uuid = { version = "1.3", features = ["v4"], default-features = false, optional = true }
+uuid = { version = "1.4", features = ["v4"], default-features = false, optional = true }
 chrono = { version = "0.4", optional = true }
-regex = { version = "1.8", optional = true }
+regex = { version = "1.9", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/src/fable-library-rust/src/DateTimeOffset.rs
+++ b/src/fable-library-rust/src/DateTimeOffset.rs
@@ -408,13 +408,19 @@ pub mod DateTimeOffset_ {
             fromString(df.to_string())
         }
 
-        pub(crate) fn try_parse_str(s: &str) -> ParseResult<CDateTime<FixedOffset>> {
+        fn local_time_from_str(s: &str, fmt: &str) -> ParseResult<CDateTime<FixedOffset>> {
             let now = Local::now();
             let localTz = now.offset();
+            let ndt = NaiveDateTime::parse_from_str(s, fmt)?;
+            let loc = localTz.from_local_datetime(&ndt).unwrap();
+            Ok(loc)
+        }
+
+        pub(crate) fn try_parse_str(s: &str) -> ParseResult<CDateTime<FixedOffset>> {
             s.parse::<CDateTime<FixedOffset>>()
                 .or(CDateTime::parse_from_str(s, "%m/%d/%Y %H:%M:%S%.f %#z"))
-                .or(localTz.datetime_from_str(s, "%m/%d/%Y %H:%M:%S%.f"))
-                .or(localTz.datetime_from_str(s, "%m/%d/%Y %I:%M:%S %P"))
+                .or(Self::local_time_from_str(s, "%m/%d/%Y %H:%M:%S%.f"))
+                .or(Self::local_time_from_str(s, "%m/%d/%Y %I:%M:%S %P"))
         }
 
         pub fn tryParse(s: string, res: &MutCell<DateTimeOffset>) -> bool {

--- a/tests/Rust/tests/src/MiscTests2.fs
+++ b/tests/Rust/tests/src/MiscTests2.fs
@@ -76,10 +76,10 @@ module MiscTestsHelper =
         member        this.Method  ()       = { this with a = this.a * 10 }
         member inline this.MethodI ()       = { this with a = this.a * 10 }
 
-    type Vector2<[<Measure>] 'u> = Vector2 of x: float<'u> * y: float<'u> with
-
-    static member inline ( + ) (Vector2(ax, ay), Vector2(bx, by)) = Vector2(ax + bx, ay + by)
-    static member inline ( * ) (scalar, Vector2(x, y)) = Vector2(scalar * x, scalar * y)
+    type Vector2<[<Measure>] 'u> = Vector2 of x: float<'u> * y: float<'u>
+    with
+        static member inline ( + ) (Vector2(ax, ay), Vector2(bx, by)) = Vector2(ax + bx, ay + by)
+        static member inline ( * ) (scalar, Vector2(x, y)) = Vector2(scalar * x, scalar * y)
 
 // We can have aliases with same name in same file #1662
 module One =


### PR DESCRIPTION
- Fixed deprecated DateTimeOffset parsing (`TimeZone::datetime_from_str`).
- Updated `fable-library-rust` dependencies.