### PR TITLE
[Python] Fix mainloop async warnings

### DIFF
--- a/src/fable-library-py/fable_library/async_builder.py
+++ b/src/fable-library-py/fable_library/async_builder.py
@@ -256,7 +256,7 @@ def protected_bind(
     computation: Callable[[IAsyncContext[_T]], None],
     binder: Callable[[_T], Async[_U]],
 ) -> Async[_U]:
-    def cont(ctx: IAsyncContext[_T]):
+    def cont(ctx: IAsyncContext[_U]) -> None:
         def on_success(x: _T) -> None:
             try:
                 binder(x)(ctx)


### PR DESCRIPTION
Fixes for async mainloop warnings in Python. Use `get_running_loop` instead of `get_event_loop` to check if there is a current mainloop or not.

No changelog needed and it fixes the previous fix