### PR TITLE
[Python] Revert removal of Fable.Core.Py.python

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Fix #3482: Revert removal of `Py.python` (by @dbrattli)
+
 ### Fixed
 
 #### JavaScript

--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -6,8 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-* Fix #3482: Revert removal of `Py.python` (by @dbrattli)
-
 ### Fixed
 
 #### JavaScript
@@ -38,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Python
 
 * Added `Async.StartChild` (by @dbrattli)
+* Fix #3482: Revert removal of `Py.python` and `Py.expr_python` (by @dbrattli)
 
 ## 4.2.2 - 2023-10-14
 

--- a/src/Fable.Core/CHANGELOG.md
+++ b/src/Fable.Core/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+#### Python
+
+* Fix #3482: Revert removal of `Py.python` and `Py.expr_python` (by @dbrattli)
+
 ## 4.1.0
 
 * Fix #3482: Remove `Py.python` and `Py.expr_python`

--- a/src/Fable.Core/Fable.Core.Py.fs
+++ b/src/Fable.Core/Fable.Core.Py.fs
@@ -43,3 +43,7 @@ module Py =
     /// https://code.visualstudio.com/docs/python/jupyter-support-py
     [<Emit("# %%", isStatement=true)>]
     let NEW_CELL: unit = nativeOnly
+
+     /// Embeds literal Python code into F#. Code will be printed as statements,
+    /// if you want to return a value use Python `return` keyword within a function.
+    let python (template: string): 'T = nativeOnly

--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -867,6 +867,12 @@ let fableCoreLib (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Exp
         | "typedArrays" -> makeBoolConst com.Options.TypedArrays |> Some
         | "extension" -> makeStrConst com.Options.FileExtension |> Some
         | _ -> None
+    | "Fable.Core.Py", ("python" | "expr_python" as meth) ->
+        let isStatement = meth <> "expr_python"
+        match args with
+        | RequireStringConstOrTemplate com ctx r template::_ ->
+            emitTemplate r t [] isStatement template  |> Some
+        | _ -> None
     | "Fable.Core.PyInterop", _ ->
         match i.CompiledName, args with
         | Naming.StartsWith "import" suffix, _ ->


### PR DESCRIPTION
Fixes #3482

- Also does some fixing of async handling with the addition of `throw_after` that was missing in the previous PR.