### PR TITLE
[Python[ Change python requirement to >= 3.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, "3.10", 3.11]
+        python-version: ["3.10", 3.11, 3.12]
 
     steps:
       - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "Fable"
-version = "4.0.0"
+version = "4.3.0"
 description = "Fable"
 authors = ["Alfonso Garcia-Caro <@alfonsogcnunez>", "Dag Brattli <dag@brattli.net>"]
 license = "MIT License"

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -727,7 +727,7 @@ module Annotation =
             stdlibModuleTypeHint com ctx "typing" "Callable" (argTypes @ [ returnType ])
         | Fable.DelegateType (argTypes, returnType) -> stdlibModuleTypeHint com ctx "typing" "Callable" (argTypes @ [ returnType ])
         | Fable.Option (genArg, _) -> stdlibModuleTypeHint com ctx "typing" "Optional" [ genArg ]
-        | Fable.Tuple (genArgs, _) -> stdlibModuleTypeHint com ctx "typing" "Tuple" genArgs
+        | Fable.Tuple (genArgs, _) -> makeGenericTypeAnnotation com ctx "tuple" genArgs None, []
         | Fable.Array (genArg, _) ->
             match genArg with
             | Fable.Type.Number (UInt8, _) -> Expression.name "bytearray", []

--- a/src/fable-library-py/fable_library/bit_converter.py
+++ b/src/fable-library-py/fable_library/bit_converter.py
@@ -5,43 +5,43 @@ from typing import Optional
 
 
 def get_bytes_char(value: str) -> bytes:
-    return bytearray(bytes(value, "UTF-8"))
+    return bytes(value, "UTF-8")
 
 
 def get_bytes_int16(value: int) -> bytes:
-    return bytearray(value.to_bytes(length=2, byteorder=sys.byteorder))
+    return value.to_bytes(length=2, byteorder=sys.byteorder)
 
 
 def get_bytes_uint16(value: int) -> bytes:
-    return bytearray(value.to_bytes(length=2, byteorder=sys.byteorder))
+    return value.to_bytes(length=2, byteorder=sys.byteorder)
 
 
 def get_bytes_int32(value: int) -> bytes:
-    return bytearray(value.to_bytes(length=4, byteorder=sys.byteorder))
+    return value.to_bytes(length=4, byteorder=sys.byteorder)
 
 
 def get_bytes_uint32(value: int) -> bytes:
-    return bytearray(value.to_bytes(length=4, byteorder=sys.byteorder))
+    return value.to_bytes(length=4, byteorder=sys.byteorder)
 
 
 def get_bytes_int64(value: int) -> bytes:
-    return bytearray(value.to_bytes(length=8, byteorder=sys.byteorder))
+    return value.to_bytes(length=8, byteorder=sys.byteorder)
 
 
 def get_bytes_uint64(value: int) -> bytes:
-    return bytearray(value.to_bytes(length=8, byteorder=sys.byteorder))
+    return value.to_bytes(length=8, byteorder=sys.byteorder)
 
 
 def get_bytes_boolean(value: bool) -> bytes:
-    return bytearray(value.to_bytes(length=1, byteorder=sys.byteorder))
+    return value.to_bytes(length=1, byteorder=sys.byteorder)
 
 
 def get_bytes_single(value: float) -> bytes:
-    return bytearray(struct.pack("f", value))
+    return struct.pack("f", value)
 
 
 def get_bytes_double(value: float) -> bytes:
-    return bytearray(struct.pack("d", value))
+    return struct.pack("d", value)
 
 
 def int64bits_to_double(value: int) -> float:

--- a/src/fable-library-py/fable_library/char.py
+++ b/src/fable-library-py/fable_library/char.py
@@ -1,7 +1,7 @@
-import unicodedata
+from __future__ import annotations
 
+import unicodedata
 from enum import IntEnum
-from typing import Dict, Union
 
 
 class UnicodeCategory(IntEnum):
@@ -42,7 +42,7 @@ class UnicodeCategory(IntEnum):
     OtherNotAssigned = 29
 
 
-unicode_category_2_python: Dict[str, UnicodeCategory] = {
+unicode_category_2_python: dict[str, UnicodeCategory] = {
     "Ll": UnicodeCategory.LowercaseLetter,
     "Lu": UnicodeCategory.UppercaseLetter,
     "Nd": UnicodeCategory.DecimalDigitNumber,
@@ -203,7 +203,7 @@ def is_surrogate(s: str, index: int = 0) -> bool:
     return 0xD800 <= cp <= 0xDFFF
 
 
-def is_surrogate_pair(s: str, index: Union[str, int]) -> bool:
+def is_surrogate_pair(s: str, index: str | int) -> bool:
     if isinstance(index, int):
         return is_high_surrogate(s, index) and is_low_surrogate(s, index + 1)
 

--- a/src/fable-library-py/fable_library/date_offset.py
+++ b/src/fable-library-py/fable_library/date_offset.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta, timezone
-from typing import Optional, Union
 
 from .types import FSharpRef
 
@@ -31,8 +32,8 @@ def create(
     h: int,
     m: int,
     s: int,
-    ms: Union[int, timedelta],
-    offset: Optional[timedelta] = None,
+    ms: int | timedelta,
+    offset: timedelta | None = None,
 ) -> datetime:
     if isinstance(ms, timedelta):
         offset = ms
@@ -57,9 +58,7 @@ def op_addition(x: datetime, y: timedelta) -> datetime:
     return x + y
 
 
-def op_subtraction(
-    x: datetime, y: Union[datetime, timedelta]
-) -> Union[datetime, timedelta]:
+def op_subtraction(x: datetime, y: datetime | timedelta) -> datetime | timedelta:
     if isinstance(y, timedelta):
         return x - y
 

--- a/src/fable-library-py/fable_library/diagnostics.py
+++ b/src/fable-library-py/fable_library/diagnostics.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import time
-from typing import Optional
 
 
 class TimerError(Exception):
@@ -8,8 +9,8 @@ class TimerError(Exception):
 
 class StopWatch:
     def __init__(self) -> None:
-        self._start_time: Optional[float] = None
-        self._elapsed_time: Optional[float] = None
+        self._start_time: float | None = None
+        self._elapsed_time: float | None = None
 
     def is_running(self) -> bool:
         """Return True if timer is running"""
@@ -18,14 +19,14 @@ class StopWatch:
     def start(self) -> None:
         """Start a new timer"""
         if self._start_time is not None:
-            raise TimerError(f"Timer is running. Use .stop() to stop it")
+            raise TimerError("Timer is running. Use .stop() to stop it")
 
         self._start_time = time.perf_counter()
 
     def stop(self) -> None:
         """Stop the timer, and report the elapsed time"""
         if self._start_time is None:
-            raise TimerError(f"Timer is not running. Use .start() to start it")
+            raise TimerError("Timer is not running. Use .start() to start it")
 
         self._elapsed_time = time.perf_counter() - self._start_time
         self._start_time = None
@@ -33,16 +34,17 @@ class StopWatch:
     def elapsed_milliseconds(self) -> int:
         """Return the elapsed time in milliseconds"""
         if self._elapsed_time is None:
-            raise TimerError(f"Timer is not running. Use .start() to start it")
+            raise TimerError("Timer is not running. Use .start() to start it")
 
         return int(self._elapsed_time * 1000)
 
     def elapsed_ticks(self) -> int:
         """Return the elapsed time in ticks"""
         if self._elapsed_time is None:
-            raise TimerError(f"Timer is not running. Use .start() to start it")
+            raise TimerError("Timer is not running. Use .start() to start it")
 
         return int(self._elapsed_time * 10000000)
+
 
 def frequency() -> int:
     return 1000000000

--- a/src/fable-library-py/fable_library/mailbox_processor.py
+++ b/src/fable-library-py/fable_library/mailbox_processor.py
@@ -2,10 +2,15 @@ from __future__ import annotations
 
 from queue import SimpleQueue
 from threading import RLock
-from typing import Any, Callable, Generic, List, Optional, TypeVar
+from typing import Any, Callable, Generic, Optional, TypeVar
 
 from .async_ import from_continuations, start_immediate
-from .async_builder import Async, CancellationToken, OperationCanceledError
+from .async_builder import (
+    Async,
+    CancellationToken,
+    Continuations,
+    OperationCanceledError,
+)
 
 
 _Msg = TypeVar("_Msg")
@@ -32,7 +37,7 @@ class MailboxProcessor(Generic[_Msg]):
         self.body = body
 
         # Holds the continuation i.e the `done` callback of Async.from_continuations returned by `receive`.
-        self.continuation: List[Callable[[Any], None]] = []
+        self.continuation: Continuations[Any] | None = None
 
     def post(self, msg: _Msg) -> None:
         """Post a message synchronously to the mailbox processor.
@@ -67,9 +72,9 @@ class MailboxProcessor(Generic[_Msg]):
         """
 
         result: Optional[_Reply] = None
-        continuation: List[
-            Callable[[Any], None]
-        ] = None  # This is the continuation for the `done` callback of the awaiting poster.
+        continuation: Continuations[
+            Any
+        ] | None = None  # This is the continuation for the `done` callback of the awaiting poster.
 
         def check_completion() -> None:
             if result is not None and continuation is not None:
@@ -84,7 +89,7 @@ class MailboxProcessor(Generic[_Msg]):
         self.messages.put(build_message(reply_channel))
         self.__process_events()
 
-        def callback(conts: List[Callable[[Any], None]]) -> None:
+        def callback(conts: Continuations[Any]) -> None:
             nonlocal continuation
             continuation = conts
             check_completion()
@@ -101,7 +106,7 @@ class MailboxProcessor(Generic[_Msg]):
             the timeout is exceeded.
         """
 
-        def callback(conts: List[Callable[[Any], None]]):
+        def callback(conts: Continuations[Any]):
             if self.continuation:
                 raise Exception("Receive can only be called once!")
 
@@ -118,7 +123,7 @@ class MailboxProcessor(Generic[_Msg]):
         # Cancellation of async workflows is more tricky in Python than
         # with F# so we check the cancellation token for each process.
         if self.token.is_cancellation_requested:
-            self.continuation, cont = [], self.continuation
+            self.continuation, cont = None, self.continuation
             if cont:
                 cont[2](OperationCanceledError("Mailbox was cancelled"))
             return
@@ -127,7 +132,7 @@ class MailboxProcessor(Generic[_Msg]):
             if self.messages.empty():
                 return
             msg = self.messages.get()
-            self.continuation, cont = [], self.continuation
+            self.continuation, cont = None, self.continuation
 
         if cont:
             cont[0](msg)

--- a/src/fable-library-py/fable_library/numeric.py
+++ b/src/fable-library-py/fable_library/numeric.py
@@ -1,34 +1,34 @@
-from typing import Optional
+from __future__ import annotations
 
 from .types import int64
 
 
-def to_fixed(x: float, dp: Optional[int] = None) -> str:
+def to_fixed(x: float, dp: int | None = None) -> str:
     x = int(x) if int(x) == x else x
 
     if dp is not None:
         fmt = "{:.%sf}" % dp
         return fmt.format(x)
 
-    return "{}".format(x)
+    return f"{x}"
 
 
-def to_precision(x: float, sd: Optional[int] = None) -> str:
+def to_precision(x: float, sd: int | None = None) -> str:
     x = int(x) if int(x) == x else x
 
     if sd is not None:
         fmt = "{:.%se}" % sd
         return fmt.format(x)
 
-    return "{}".format(x)
+    return f"{x}"
 
 
-def to_exponential(x: float, dp: Optional[int] = None) -> str:
+def to_exponential(x: float, dp: int | None = None) -> str:
     if dp is not None:
         fmt = "{:.%se}" % dp
         return fmt.format(x)
 
-    return "{}".format(x)
+    return f"{x}"
 
 
 def to_hex(x: int) -> str:
@@ -36,7 +36,7 @@ def to_hex(x: int) -> str:
         sign = 0x10000000000000000 if isinstance(val, int64) else 0x100000000
         return val >> n if val >= 0 else (val + sign) >> n
 
-    return "{0:x}".format(rshift(x, 0))
+    return f"{rshift(x, 0):x}"
 
 
 def multiply(x: float, y: float) -> float:

--- a/src/fable-library-py/fable_library/option.py
+++ b/src/fable-library-py/fable_library/option.py
@@ -1,4 +1,7 @@
-from typing import Any, Callable, Generic, List, Optional, TypeVar, cast
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, Generic, TypeVar, cast
 
 
 _T = TypeVar("_T")
@@ -32,27 +35,27 @@ class Some(Generic[_T]):
         return str(self)
 
 
-def default_arg(opt: Optional[_T], default_value: _T) -> _T:
+def default_arg(opt: _T | None, default_value: _T) -> _T:
     return value(opt) if opt is not None else default_value
 
 
-def default_arg_with(opt: Optional[_T], def_thunk: Callable[[], _T]) -> _T:
+def default_arg_with(opt: _T | None, def_thunk: Callable[[], _T]) -> _T:
     return value(opt) if opt is not None else def_thunk()
 
 
-def filter(predicate: Callable[[_T], bool], opt: Optional[_T]) -> Optional[_T]:
+def filter(predicate: Callable[[_T], bool], opt: _T | None) -> _T | None:
     if opt is not None:
         return opt if predicate(value(opt)) else None
     return opt
 
 
-def map(mapping: Callable[[_T], _U], opt: Optional[_T]) -> Optional[_U]:
+def map(mapping: Callable[[_T], _U], opt: _T | None) -> _U | None:
     return some(mapping(value(opt))) if opt is not None else None
 
 
 def map2(
-    mapping: Callable[[_T, _U], _V], opt1: Optional[_T], opt2: Optional[_U]
-) -> Optional[_V]:
+    mapping: Callable[[_T, _U], _V], opt1: _T | None, opt2: _U | None
+) -> _V | None:
     return (
         mapping(value(opt1), value(opt2))
         if (opt1 is not None and opt2 is not None)
@@ -62,10 +65,10 @@ def map2(
 
 def map3(
     mapping: Callable[[_T, _U, _V], _W],
-    opt1: Optional[_T],
-    opt2: Optional[_U],
-    opt3: Optional[_V],
-) -> Optional[_W]:
+    opt1: _T | None,
+    opt2: _U | None,
+    opt3: _V | None,
+) -> _W | None:
     return (
         mapping(value(opt1), value(opt2), value(opt3))
         if (opt1 is not None and opt2 is not None and opt3 is not None)
@@ -73,11 +76,11 @@ def map3(
     )
 
 
-def some(x: Any) -> Optional[Any]:
+def some(x: Any) -> Any | None:
     return Some[Any](x) if x is None or isinstance(x, Some) else x
 
 
-def value(x: Optional[_T]) -> _T:
+def value(x: _T | None) -> _T:
     if x is None:
         raise Exception("Option has no value")
     elif isinstance(x, Some):
@@ -86,33 +89,31 @@ def value(x: Optional[_T]) -> _T:
     return x
 
 
-def of_nullable(x: Optional[_T]) -> Optional[_T]:
+def of_nullable(x: _T | None) -> _T | None:
     return x
 
 
-def to_nullable(x: Optional[_T]) -> Optional[_T]:
+def to_nullable(x: _T | None) -> _T | None:
     return None if x is None else value(x)
 
 
-def flatten(x: Optional[Optional[_T]]) -> Optional[_T]:
+def flatten(x: _T | None | None) -> _T | None:
     return x if x is None else value(x)
 
 
-def to_array(opt: Optional[_T]) -> List[_T]:
+def to_array(opt: _T | None) -> list[_T]:
     return [] if opt is None else [value(opt)]
 
 
-def bind(binder: Callable[[_T], Optional[_U]], opt: Optional[_T]) -> Optional[_U]:
+def bind(binder: Callable[[_T], _U | None], opt: _T | None) -> _U | None:
     return binder(value(opt)) if opt is not None else None
 
 
-def or_else(opt: Optional[_T], if_none: Optional[_T]) -> Optional[_T]:
+def or_else(opt: _T | None, if_none: _T | None) -> _T | None:
     return if_none if opt is None else opt
 
 
-def or_else_with(
-    opt: Optional[_T], if_none_thunk: Callable[[], Optional[_T]]
-) -> Optional[_T]:
+def or_else_with(opt: _T | None, if_none_thunk: Callable[[], _T | None]) -> _T | None:
     return if_none_thunk() if opt is None else opt
 
 

--- a/src/fable-library-py/fable_library/path.py
+++ b/src/fable-library-py/fable_library/path.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import os
 import tempfile
-from typing import Optional
 
 
 def get_temp_file_name() -> str:
@@ -35,7 +36,7 @@ def get_file_name_without_extension(path: str) -> str:
     return os.path.splitext(os.path.basename(path))[0]
 
 
-def get_full_path(path: str, base_path: Optional[str]=None) -> str:
+def get_full_path(path: str, base_path: str | None = None) -> str:
     return os.path.join(base_path or "", path)
 
 

--- a/src/fable-library-py/fable_library/reflection.py
+++ b/src/fable-library-py/fable_library/reflection.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import functools
-
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union, cast
+from typing import Any, cast
 
 from .types import FSharpRef, Record
 from .types import Union as FsUnion
@@ -12,8 +12,8 @@ from .util import Array, combine_hash_codes, equal_arrays_with
 
 Constructor = Callable[..., Any]
 
-EnumCase = Tuple[str, int]
-FieldInfo = Tuple[str, "TypeInfo"]
+EnumCase = tuple[str, int]
+FieldInfo = tuple[str, "TypeInfo"]
 PropertyInfo = FieldInfo
 ParameterInfo = FieldInfo
 
@@ -23,25 +23,25 @@ class CaseInfo:
     declaringType: TypeInfo
     tag: int
     name: str
-    fields: List[FieldInfo]
+    fields: list[FieldInfo]
 
 
 @dataclass
 class MethodInfo:
     name: str
-    parameters: List[ParameterInfo]
+    parameters: list[ParameterInfo]
     returnType: TypeInfo
 
 
 @dataclass
 class TypeInfo:
     fullname: str
-    generics: Optional[List[TypeInfo]] = None
-    construct: Optional[Constructor] = None
-    parent: Optional[TypeInfo] = None
-    fields: Optional[Callable[[], List[FieldInfo]]] = None
-    cases: Optional[Callable[[], List[CaseInfo]]] = None
-    enum_cases: Optional[List[EnumCase]] = None
+    generics: list[TypeInfo] | None = None
+    construct: Constructor | None = None
+    parent: TypeInfo | None = None
+    fields: Callable[[], list[FieldInfo]] | None = None
+    cases: Callable[[], list[CaseInfo]] | None = None
+    enum_cases: list[EnumCase] | None = None
 
     def __str__(self) -> str:
         return full_name(self)
@@ -57,23 +57,23 @@ class TypeInfo:
 
 def class_type(
     fullname: str,
-    generics: Optional[List[TypeInfo]] = None,
-    construct: Optional[Constructor] = None,
-    parent: Optional[TypeInfo] = None,
+    generics: list[TypeInfo] | None = None,
+    construct: Constructor | None = None,
+    parent: TypeInfo | None = None,
 ) -> TypeInfo:
     return TypeInfo(fullname, generics, construct, parent)
 
 
 def union_type(
     fullname: str,
-    generics: List[TypeInfo],
-    construct: Type[FsUnion],
-    cases: Callable[[], List[List[FieldInfo]]],
+    generics: list[TypeInfo],
+    construct: type[FsUnion],
+    cases: Callable[[], list[list[FieldInfo]]],
 ) -> TypeInfo:
-    def fn() -> List[CaseInfo]:
-        caseNames: List[str] = construct.cases()
+    def fn() -> list[CaseInfo]:
+        caseNames: list[str] = construct.cases()
 
-        def mapper(i: int, fields: List[FieldInfo]) -> CaseInfo:
+        def mapper(i: int, fields: list[FieldInfo]) -> CaseInfo:
             return CaseInfo(t, i, caseNames[i], fields)
 
         return [mapper(i, x) for i, x in enumerate(cases())]
@@ -92,9 +92,9 @@ def delegate_type(*generics: TypeInfo) -> TypeInfo:
 
 def record_type(
     fullname: str,
-    generics: List[TypeInfo],
+    generics: list[TypeInfo],
     construct: Constructor,
-    fields: Callable[[], List[FieldInfo]],
+    fields: Callable[[], list[FieldInfo]],
 ) -> TypeInfo:
     return TypeInfo(fullname, generics, construct, fields=fields)
 
@@ -116,7 +116,7 @@ def array_type(generic: TypeInfo) -> TypeInfo:
 
 
 def enum_type(
-    fullname: str, underlyingType: TypeInfo, enumCases: List[EnumCase]
+    fullname: str, underlyingType: TypeInfo, enumCases: list[EnumCase]
 ) -> TypeInfo:
     return TypeInfo(fullname, [underlyingType], None, None, None, None, enumCases)
 
@@ -171,15 +171,15 @@ def get_generic_type_definition(t: TypeInfo):
     )
 
 
-def get_generics(t: TypeInfo) -> List[TypeInfo]:
+def get_generics(t: TypeInfo) -> list[TypeInfo]:
     return t.generics if t.generics else []
 
 
-def make_generic_type(t: TypeInfo, generics: List[TypeInfo]) -> TypeInfo:
+def make_generic_type(t: TypeInfo, generics: list[TypeInfo]) -> TypeInfo:
     return TypeInfo(t.fullname, generics, t.construct, t.parent, t.fields, t.cases)
 
 
-def create_instance(t: TypeInfo, consArgs: List[Any]) -> Any:
+def create_instance(t: TypeInfo, consArgs: list[Any]) -> Any:
     # TODO: Check if consArgs length is same as t.construct?
     # (Arg types can still be different)
     if callable(t.construct):
@@ -192,9 +192,9 @@ def get_value(propertyInfo: PropertyInfo, v: Any) -> Any:
     return getattr(v, str(propertyInfo[0]))
 
 
-def name(info: Union[FieldInfo, TypeInfo, CaseInfo]) -> str:
-    if isinstance(info, Tuple):
-        return cast(FieldInfo, info)[0]
+def name(info: FieldInfo | (TypeInfo | CaseInfo)) -> str:
+    if isinstance(info, tuple):
+        return info[0]
 
     elif isinstance(info, TypeInfo):
         i = info.fullname.rfind(".")
@@ -255,7 +255,7 @@ def is_instance_of_type(t: TypeInfo, o: Any) -> bool:
     if isinstance(o, str):
         return t.fullname == string_type.fullname
 
-    if isinstance(o, (int, float)):
+    if isinstance(o, int | float):
         return is_erased_to_number(t)
 
     if callable(o):
@@ -284,7 +284,7 @@ def is_function(t: TypeInfo) -> bool:
     return t.fullname == "Microsoft.FSharp.Core.FSharpFunc`2"
 
 
-def get_element_type(t: TypeInfo) -> Optional[TypeInfo]:
+def get_element_type(t: TypeInfo) -> TypeInfo | None:
     return (t.generics[0] if t.generics else None) if is_array(t) else None
 
 
@@ -292,21 +292,21 @@ def get_enum_underlying_type(t: TypeInfo):
     return t.generics[0] if t.generics else None
 
 
-def get_enum_values(t: TypeInfo) -> List[int]:
+def get_enum_values(t: TypeInfo) -> list[int]:
     if is_enum(t) and t.enum_cases is not None:
         return [int(kv[1]) for kv in t.enum_cases]
     else:
         raise ValueError(f"{t.fullname} is not an enum type")
 
 
-def get_enum_names(t: TypeInfo) -> List[str]:
+def get_enum_names(t: TypeInfo) -> list[str]:
     if is_enum(t) and t.enum_cases is not None:
         return [str(kv[0]) for kv in t.enum_cases]
     else:
         raise ValueError(f"{t.fullname} is not an enum type")
 
 
-def get_enum_case(t: TypeInfo, v: Union[int, str]) -> EnumCase:
+def get_enum_case(t: TypeInfo, v: int | str) -> EnumCase:
     if t.enum_cases is None:
         raise ValueError(f"{t.fullname} is not an enum type")
 
@@ -325,14 +325,14 @@ def get_enum_case(t: TypeInfo, v: Union[int, str]) -> EnumCase:
     return ("", v)
 
 
-def get_tuple_elements(t: TypeInfo) -> List[TypeInfo]:
+def get_tuple_elements(t: TypeInfo) -> list[TypeInfo]:
     if is_tuple(t) and t.generics is not None:
         return t.generics
     else:
         raise ValueError(f"{t.fullname} is not a tuple type")
 
 
-def get_function_elements(t: TypeInfo) -> List[TypeInfo]:
+def get_function_elements(t: TypeInfo) -> list[TypeInfo]:
     if is_function(t) and t.generics is not None:
         gen = t.generics
         return [gen[0], gen[1]]
@@ -341,7 +341,7 @@ def get_function_elements(t: TypeInfo) -> List[TypeInfo]:
 
 
 def parse_enum(t: TypeInfo, string: str) -> int:
-    value: Optional[int]
+    value: int | None
     try:
         value = int(string)
     except Exception:
@@ -362,7 +362,7 @@ def get_enum_name(t: TypeInfo, v: int) -> str:
     return str(get_enum_case(t, v)[0])
 
 
-def is_enum_defined(t: TypeInfo, v: Union[str, int]) -> bool:
+def is_enum_defined(t: TypeInfo, v: str | int) -> bool:
     try:
         kv = get_enum_case(t, v)
         return kv[0] is not None and kv[0] != ""
@@ -373,16 +373,16 @@ def is_enum_defined(t: TypeInfo, v: Union[str, int]) -> bool:
     return False
 
 
-def get_record_elements(t: TypeInfo) -> List[FieldInfo]:
+def get_record_elements(t: TypeInfo) -> list[FieldInfo]:
     if t.fields is not None:
         return t.fields()
     else:
         raise ValueError(f"{t.fullname} is not an F# record type")
 
 
-def get_record_fields(v: Any) -> List[str]:
-    if isinstance(v, Dict):
-        return list(cast(Dict[str, Any], v).values())
+def get_record_fields(v: Any) -> list[str]:
+    if isinstance(v, dict):
+        return list(cast(dict[str, Any], v).values())
 
     return [getattr(v, k) for k in v.__dict__.keys()]
 
@@ -396,15 +396,15 @@ def get_record_field(v: Any, field: FieldInfo) -> Any:
     return getattr(v, field[0])
 
 
-def get_tuple_fields(v: Tuple[Any, ...]) -> Array[Any]:
+def get_tuple_fields(v: tuple[Any, ...]) -> Array[Any]:
     return list(v)
 
 
-def get_tuple_field(v: Tuple[Any, ...], i: int) -> Any:
+def get_tuple_field(v: tuple[Any, ...], i: int) -> Any:
     return v[i]
 
 
-def make_record(t: TypeInfo, values: List[Any]) -> Dict[str, Any]:
+def make_record(t: TypeInfo, values: list[Any]) -> dict[str, Any]:
     fields = get_record_elements(t)
     if len(fields) != len(values):
         raise ValueError(
@@ -414,20 +414,20 @@ def make_record(t: TypeInfo, values: List[Any]) -> Dict[str, Any]:
     if t.construct is not None:
         return t.construct(*values)
 
-    def reducer(obj: Dict[str, Any], ifield: Tuple[int, FieldInfo]):
+    def reducer(obj: dict[str, Any], ifield: tuple[int, FieldInfo]):
         i, field = ifield
         obj[field[0]] = values[i]
         return obj
 
-    initial: Dict[str, Any] = {}
+    initial: dict[str, Any] = {}
     return functools.reduce(reducer, enumerate(fields), initial)
 
 
-def make_tuple(values: List[Any], _t: TypeInfo) -> Tuple[Any, ...]:
+def make_tuple(values: list[Any], _t: TypeInfo) -> tuple[Any, ...]:
     return tuple(values)
 
 
-def make_union(uci: CaseInfo, values: List[Any]) -> Any:
+def make_union(uci: CaseInfo, values: list[Any]) -> Any:
     expectedLength = len(uci.fields or [])
     if len(values) != expectedLength:
         raise ValueError(
@@ -441,14 +441,14 @@ def make_union(uci: CaseInfo, values: List[Any]) -> Any:
     )
 
 
-def get_union_cases(t: TypeInfo) -> List[CaseInfo]:
+def get_union_cases(t: TypeInfo) -> list[CaseInfo]:
     if t.cases and callable(t.cases):
         return t.cases()
     else:
         raise ValueError(f"{t.fullname} is not an F# union type")
 
 
-def get_union_fields(v: Any, t: TypeInfo) -> List[Any]:
+def get_union_fields(v: Any, t: TypeInfo) -> list[Any]:
     cases = get_union_cases(t)
     case_ = cases[v.tag]
     if not case_:
@@ -457,7 +457,7 @@ def get_union_fields(v: Any, t: TypeInfo) -> List[Any]:
     return [case_, list(v.fields)]
 
 
-def get_union_case_fields(uci: CaseInfo) -> List[FieldInfo]:
+def get_union_case_fields(uci: CaseInfo) -> list[FieldInfo]:
     return uci.fields if uci.fields else []
 
 
@@ -476,6 +476,6 @@ def get_case_name(x: Any) -> str:
     return x.cases()[x.tag]
 
 
-def get_case_fields(x: Any) -> List[Any]:
+def get_case_fields(x: Any) -> list[Any]:
     assert_union(x)
     return x.fields

--- a/src/fable-library-py/fable_library/reg_exp.py
+++ b/src/fable-library-py/fable_library/reg_exp.py
@@ -1,32 +1,25 @@
-import re
+from __future__ import annotations
 
-from typing import (
-    Callable,
-    Iterator,
-    List,
-    Match,
-    Optional,
-    Pattern,
-    Union,
-    Dict,
-)
+import re
+from collections.abc import Callable, Iterator
+from re import Match, Pattern
 
 
 MatchEvaluator = Callable[[Match[str]], str]
 
 
 class GroupCollection:
-    def __init__(self, groups: List[str], named_groups: Dict[str, str]) -> None:
+    def __init__(self, groups: list[str], named_groups: dict[str, str]) -> None:
         self.named_groups = named_groups
         self.groups = groups
 
-    def values(self) -> List[str]:
+    def values(self) -> list[str]:
         return list(self.groups)
 
     def __len__(self) -> int:
         return len(self.groups)
 
-    def __getitem__(self, key: Union[int, str]) -> Optional[str]:
+    def __getitem__(self, key: int | str) -> str | None:
         if isinstance(key, int):
             return self.groups[key]
         else:
@@ -63,16 +56,14 @@ def unescape(string: str) -> str:
     return re.sub(r"\\(.)", r"\1", string)
 
 
-def match(
-    reg: Union[Pattern[str], str], input: str, start_at: int = 0
-) -> Optional[Match[str]]:
+def match(reg: Pattern[str] | str, input: str, start_at: int = 0) -> Match[str] | None:
     if isinstance(reg, str):
         flags = _options_to_flags(start_at)
         return re.search(input, reg, flags)
     return reg.search(input, pos=start_at)
 
 
-def matches(reg: Pattern[str], input: str, start_at: int = 0) -> List[Match[str]]:
+def matches(reg: Pattern[str], input: str, start_at: int = 0) -> list[Match[str]]:
     if isinstance(reg, str):
         flags = _options_to_flags(start_at)
         input = input.replace("?<", "?P<")
@@ -81,7 +72,7 @@ def matches(reg: Pattern[str], input: str, start_at: int = 0) -> List[Match[str]
     return list(reg.finditer(input, pos=start_at))
 
 
-def is_match(reg: Union[Pattern[str], str], input: str, start_at: int = 0) -> bool:
+def is_match(reg: Pattern[str] | str, input: str, start_at: int = 0) -> bool:
     if isinstance(reg, str):
         # Note: input is the pattern here
         flags = _options_to_flags(start_at)
@@ -91,7 +82,7 @@ def is_match(reg: Union[Pattern[str], str], input: str, start_at: int = 0) -> bo
 
 
 def groups(m: Match[str]) -> GroupCollection:
-    named_groups: Dict[str, str] = m.groupdict()
+    named_groups: dict[str, str] = m.groupdict()
 
     # .NET adds the whole capture as group 0
     groups_ = [m.group(0), *m.groups()]
@@ -111,10 +102,10 @@ def options(reg: Pattern[str]) -> int:
 
 
 def replace(
-    reg: Union[str, Pattern[str]],
+    reg: str | Pattern[str],
     input: str,
-    replacement: Union[str, MatchEvaluator],
-    limit: Optional[int] = None,
+    replacement: str | MatchEvaluator,
+    limit: int | None = None,
     offset: int = 0,
 ) -> str:
     if isinstance(replacement, str):
@@ -128,11 +119,11 @@ def replace(
 
 
 def split(
-    reg: Union[str, Pattern[str]],
+    reg: str | Pattern[str],
     input: str,
-    limit: Optional[int] = None,
+    limit: int | None = None,
     offset: int = 0,
-) -> List[str]:
+) -> list[str]:
     if isinstance(reg, str):
         return re.split(input, reg, maxsplit=limit or 0)
 
@@ -140,7 +131,7 @@ def split(
     return reg.split(input, maxsplit=limit or 0)[:limit]
 
 
-def get_item(groups: GroupCollection, index: Union[str, int]) -> Optional[str]:
+def get_item(groups: GroupCollection, index: str | int) -> str | None:
     return groups[index]
 
 

--- a/src/fable-library-py/fable_library/resize_array.py
+++ b/src/fable-library-py/fable_library/resize_array.py
@@ -1,10 +1,13 @@
-from typing import Any, Callable, List, TypeVar
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, TypeVar
 
 
 _T = TypeVar("_T")
 
 
-def exists(predicate: Callable[[_T], bool], xs: List[_T]) -> bool:
+def exists(predicate: Callable[[_T], bool], xs: list[_T]) -> bool:
     """Test if a predicate is true for at least one element in a list."""
 
     for x in xs:
@@ -13,7 +16,7 @@ def exists(predicate: Callable[[_T], bool], xs: List[_T]) -> bool:
     return False
 
 
-def find_index(predicate: Callable[[_T], bool], xs: List[_T]) -> int:
+def find_index(predicate: Callable[[_T], bool], xs: list[_T]) -> int:
     """Find the index of the first element in a list that satisfies a predicate."""
 
     for i, x in enumerate(xs):
@@ -22,7 +25,7 @@ def find_index(predicate: Callable[[_T], bool], xs: List[_T]) -> int:
     return -1
 
 
-def remove_range(start: int, count: int, xs: List[Any]) -> None:
+def remove_range(start: int, count: int, xs: list[Any]) -> None:
     """Remove a range of elements from a list in-place."""
 
     del xs[start : start + count]

--- a/src/fable-library-py/fable_library/task.py
+++ b/src/fable-library-py/fable_library/task.py
@@ -7,9 +7,9 @@ using Python async / await.
 from __future__ import annotations
 
 import asyncio
-
 from asyncio import AbstractEventLoop, Future
-from typing import Any, Awaitable, Generic, TypeVar
+from collections.abc import Awaitable
+from typing import Any, Generic, TypeVar
 
 
 _T = TypeVar("_T")

--- a/src/fable-library-py/fable_library/task_builder.py
+++ b/src/fable-library-py/fable_library/task_builder.py
@@ -1,9 +1,8 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Iterable
 from typing import (
     Any,
-    Awaitable,
-    Callable,
-    Iterable,
-    Optional,
     Protocol,
     TypeVar,
     overload,
@@ -20,7 +19,7 @@ _U = TypeVar("_U")
 
 
 class Delayed(Protocol[_T_co]):
-    def __call__(self, __unit: Optional[None] = None) -> Awaitable[_T_co]:
+    def __call__(self, __unit: None | None = None) -> Awaitable[_T_co]:
         ...
 
 

--- a/src/fable-library-py/fable_library/time_span.py
+++ b/src/fable-library-py/fable_library/time_span.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from datetime import timedelta
-from typing import Any, Optional
+from typing import Any
 
 from .util import pad_left_and_right_with_zeros, pad_with_zeros
 
@@ -101,10 +103,10 @@ def divide(ts: timedelta, divisor: int) -> timedelta:
 
 def create(
     d: int = 0,
-    h: Optional[int] = None,
-    m: Optional[int] = None,
-    s: Optional[int] = None,
-    ms: Optional[int] = None,
+    h: int | None = None,
+    m: int | None = None,
+    s: int | None = None,
+    ms: int | None = None,
 ) -> timedelta:
     if h is None and m is None and s is None and ms is None:
         return from_ticks(d)
@@ -117,7 +119,7 @@ def create(
     )
 
 
-def to_string(ts: timedelta, format: str = "c", _provider: Optional[Any] = None) -> str:
+def to_string(ts: timedelta, format: str = "c", _provider: Any | None = None) -> str:
     if format not in ["c", "g", "G"]:
         raise ValueError("Custom formats are not supported")
 

--- a/src/fable-library-py/fable_library/types.py
+++ b/src/fable-library-py/fable_library/types.py
@@ -1,20 +1,14 @@
 from __future__ import annotations
 
 import array
-
 from abc import abstractmethod
+from collections.abc import Callable, Iterable, MutableSequence
 from typing import (
     Any,
-    Callable,
     Generic,
-    Iterable,
-    List,
-    MutableSequence,
-    Optional,
     TypeVar,
+    cast,
 )
-from typing import Union as Union_
-from typing import cast
 
 from .util import Array, IComparable, compare
 
@@ -27,8 +21,8 @@ class FSharpRef(Generic[_T]):
 
     def __init__(
         self,
-        contents_or_getter: Union_[None, _T, Callable[[], _T]],
-        setter: Optional[Callable[[_T], None]] = None,
+        contents_or_getter: None | (_T | Callable[[], _T]),
+        setter: Callable[[_T], None] | None = None,
     ) -> None:
         contents = cast(_T, contents_or_getter)
 
@@ -61,7 +55,7 @@ class Union(IComparable):
 
     @staticmethod
     @abstractmethod
-    def cases() -> List[str]:
+    def cases() -> list[str]:
         ...
 
     @property
@@ -186,7 +180,7 @@ def record_get_hashcode(self: Record) -> int:
 
 
 class Record(IComparable):
-    __slots__: List[str]
+    __slots__: list[str]
 
     def GetHashCode(self) -> int:
         return record_get_hashcode(self)
@@ -234,7 +228,7 @@ def seq_to_string(self: Iterable[Any]) -> str:
     return str + "]"
 
 
-def to_string(x: Union_[Iterable[Any], Any], call_stack: int = 0) -> str:
+def to_string(x: Iterable[Any] | Any, call_stack: int = 0) -> str:
     if x is not None:
         if isinstance(x, float) and int(x) == x:
             return str(int(x))
@@ -341,35 +335,35 @@ class float32(float):
 float = float  # use native float for float64
 
 
-def Int8Array(lst: List[int]) -> MutableSequence[int]:
+def Int8Array(lst: list[int]) -> MutableSequence[int]:
     return array.array("b", lst)
 
 
-def Uint8Array(lst: List[int]) -> MutableSequence[int]:
+def Uint8Array(lst: list[int]) -> MutableSequence[int]:
     return bytearray(lst)
 
 
-def Int16Array(lst: List[int]) -> MutableSequence[int]:
+def Int16Array(lst: list[int]) -> MutableSequence[int]:
     return array.array("h", lst)
 
 
-def Uint16Array(lst: List[int]) -> MutableSequence[int]:
+def Uint16Array(lst: list[int]) -> MutableSequence[int]:
     return array.array("H", lst)
 
 
-def Int32Array(lst: List[int]) -> MutableSequence[int]:
+def Int32Array(lst: list[int]) -> MutableSequence[int]:
     return array.array("i", lst)
 
 
-def Uint32Array(lst: List[int]) -> MutableSequence[int]:
+def Uint32Array(lst: list[int]) -> MutableSequence[int]:
     return array.array("I", lst)
 
 
-def Float32Array(lst: List[float]) -> MutableSequence[float]:
+def Float32Array(lst: list[float]) -> MutableSequence[float]:
     return array.array("f", lst)
 
 
-def Float64Array(lst: List[float]) -> MutableSequence[float]:
+def Float64Array(lst: list[float]) -> MutableSequence[float]:
     return array.array("d", lst)
 
 

--- a/src/fable-library-py/fable_library/uri.py
+++ b/src/fable-library-py/fable_library/uri.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 from enum import IntEnum
-from typing import Union
-from urllib.parse import ParseResult, urlparse, urljoin, unquote
-
+from urllib.parse import ParseResult, unquote, urljoin, urlparse
 
 from .types import FSharpRef
 
@@ -19,8 +17,8 @@ class Uri:
 
     def __init__(
         self,
-        base_uri: Union[Uri, str],
-        kind_or_uri: Union[int, str, Uri, None] = UriKind.Absolute,
+        base_uri: Uri | str,
+        kind_or_uri: int | (str | (Uri | None)) = UriKind.Absolute,
     ) -> None:
         self.res: ParseResult
 
@@ -104,13 +102,13 @@ class Uri:
 
     @staticmethod
     def create(
-        uri: Union[str, Uri], kind_or_uri: Union[UriKind, str, Uri] = UriKind.Absolute
+        uri: str | Uri, kind_or_uri: UriKind | (str | Uri) = UriKind.Absolute
     ) -> Uri:
         return Uri(uri, kind_or_uri)
 
     @staticmethod
     def try_create(
-        uri: Union[str, Uri], kind_or_uri: Union[UriKind, str, Uri], out: FSharpRef[Uri]
+        uri: str | Uri, kind_or_uri: UriKind | (str | Uri), out: FSharpRef[Uri]
     ) -> bool:
         try:
             out.contents = Uri.create(uri, kind_or_uri)


### PR DESCRIPTION
We will not support more than 3 versions of Python. 

- Remove support for 3.9
- Add support for 3.12
- Cleanup code mostly `A | B` instead of `Union[A, B]`, `A | None` instead of `Optional[A]`.
- Use `tuple` instead of `Tuple`. Use `list` instead of `List`. Use `dict` instead of `Dict`.