### PR TITLE
Support (un)curry up to 20 arguments

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -8,9 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+#### JavaScript
+
+* Support (un)curry up to 20 arguments (by @MangelMaxime)
+
 #### Python
 
 * Remove support for Python 3.9. Add GH testing for Python 3.12 (by @dbrattli)
+* Support (un)curry up to 20 arguments (by @MangelMaxime)
+
+#### Dart
+
+* Support (un)curry up to 20 arguments (by @MangelMaxime)
 
 ## 4.3.0 - 2023-10-14
 

--- a/src/fable-library-dart/Util.dart
+++ b/src/fable-library-dart/Util.dart
@@ -235,6 +235,692 @@ TResult Function(T10) Function(T9) Function(T8) Function(T7) Function(T6)
   }
 }
 
+TResult Function(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+    uncurry11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(
+        TResult Function(T11) Function(T10) Function(T9) Function(T8) Function(
+                                        T7)
+                                    Function(T6)
+                                Function(T5)
+                            Function(T4)
+                        Function(T3)
+                    Function(T2)
+                Function(T1)
+            f) {
+  f2(T1 a1, T2 a2, T3 a3, T4 a4, T5 a5, T6 a6, T7 a7, T8 a8, T9 a9, T10 a10,
+          T11 a11) =>
+      f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11);
+  _curried[f2] = f;
+  return f2;
+}
+
+TResult Function(T11) Function(T10) Function(T9) Function(T8) Function(T7)
+                            Function(T6)
+                        Function(T5)
+                    Function(T4)
+                Function(T3)
+            Function(T2)
+        Function(T1)
+    curry11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(
+        TResult Function(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) f) {
+  var c = _curried[f];
+  if (c == null) {
+    return (T1 a1) => (T2 a2) => (T3 a3) => (T4 a4) => (T5 a5) => (T6 a6) =>
+        (T7 a7) => (T8 a8) => (T9 a9) => (T10 a10) =>
+            (T11 a11) => f(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11);
+  } else {
+    return c as TResult Function(T11) Function(T10) Function(T9) Function(T8)
+                                Function(T7)
+                            Function(T6)
+                        Function(T5)
+                    Function(T4)
+                Function(T3)
+            Function(T2)
+        Function(T1);
+  }
+}
+
+TResult Function(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+    uncurry12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(
+        TResult Function(T12) Function(T11) Function(T10) Function(T9) Function(
+                                            T8)
+                                        Function(T7)
+                                    Function(T6)
+                                Function(T5)
+                            Function(T4)
+                        Function(T3)
+                    Function(T2)
+                Function(T1)
+            f) {
+  f2(T1 a1, T2 a2, T3 a3, T4 a4, T5 a5, T6 a6, T7 a7, T8 a8, T9 a9, T10 a10,
+          T11 a11, T12 a12) =>
+      f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12);
+  _curried[f2] = f;
+  return f2;
+}
+
+TResult Function(T12) Function(T11) Function(T10) Function(T9) Function(T8)
+                                Function(T7)
+                            Function(T6)
+                        Function(T5)
+                    Function(T4)
+                Function(T3)
+            Function(T2)
+        Function(T1)
+    curry12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(
+        TResult Function(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) f) {
+  var c = _curried[f];
+  if (c == null) {
+    return (T1 a1) => (T2 a2) => (T3 a3) => (T4 a4) => (T5 a5) => (T6 a6) =>
+        (T7 a7) => (T8 a8) => (T9 a9) => (T10 a10) => (T11 a11) =>
+            (T12 a12) => f(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12);
+  } else {
+    return c as TResult Function(T12) Function(T11) Function(T10) Function(T9)
+                                    Function(T8)
+                                Function(T7)
+                            Function(T6)
+                        Function(T5)
+                    Function(T4)
+                Function(T3)
+            Function(T2)
+        Function(T1);
+  }
+}
+
+TResult Function(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+    uncurry13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(
+        TResult Function(T13) Function(T12) Function(T11) Function(T10)
+                                                Function(T9)
+                                            Function(T8)
+                                        Function(T7)
+                                    Function(T6)
+                                Function(T5)
+                            Function(T4)
+                        Function(T3)
+                    Function(T2)
+                Function(T1)
+            f) {
+  f2(T1 a1, T2 a2, T3 a3, T4 a4, T5 a5, T6 a6, T7 a7, T8 a8, T9 a9, T10 a10,
+          T11 a11, T12 a12, T13 a13) =>
+      f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13);
+  _curried[f2] = f;
+  return f2;
+}
+
+TResult Function(T13) Function(T12) Function(T11) Function(T10) Function(T9)
+                                    Function(T8)
+                                Function(T7)
+                            Function(T6)
+                        Function(T5)
+                    Function(T4)
+                Function(T3)
+            Function(T2)
+        Function(T1)
+    curry13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(
+        TResult Function(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+            f) {
+  var c = _curried[f];
+  if (c == null) {
+    return (T1 a1) => (T2 a2) => (T3 a3) => (T4 a4) => (T5 a5) => (T6 a6) =>
+        (T7 a7) => (T8 a8) => (T9 a9) => (T10 a10) => (T11 a11) => (T12 a12) =>
+            (T13 a13) =>
+                f(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13);
+  } else {
+    return c as TResult Function(T13) Function(T12) Function(T11) Function(T10)
+                                        Function(T9)
+                                    Function(T8)
+                                Function(T7)
+                            Function(T6)
+                        Function(T5)
+                    Function(T4)
+                Function(T3)
+            Function(T2)
+        Function(T1);
+  }
+}
+
+TResult Function(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+    uncurry14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14,
+            TResult>(
+        TResult Function(T14) Function(T13) Function(T12) Function(T11)
+                                                    Function(T10)
+                                                Function(T9)
+                                            Function(T8)
+                                        Function(T7)
+                                    Function(T6)
+                                Function(T5)
+                            Function(T4)
+                        Function(T3)
+                    Function(T2)
+                Function(T1)
+            f) {
+  f2(T1 a1, T2 a2, T3 a3, T4 a4, T5 a5, T6 a6, T7 a7, T8 a8, T9 a9, T10 a10,
+          T11 a11, T12 a12, T13 a13, T14 a14) =>
+      f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14);
+  _curried[f2] = f;
+  return f2;
+}
+
+TResult Function(T14) Function(T13) Function(T12) Function(T11) Function(T10)
+                                    Function(T9)
+                                Function(T8)
+                            Function(T7)
+                        Function(T6)
+                    Function(T5)
+                Function(T4)
+            Function(T3)
+        Function(T2)
+    Function(T1) curry14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
+        T14, TResult>(
+    TResult Function(
+            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+        f) {
+  var c = _curried[f];
+  if (c == null) {
+    return (T1 a1) => (T2 a2) => (T3 a3) => (T4 a4) => (T5 a5) => (T6 a6) =>
+        (T7 a7) => (T8 a8) => (T9 a9) => (T10 a10) => (T11 a11) => (T12 a12) =>
+            (T13 a13) => (T14 a14) =>
+                f(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14);
+  } else {
+    return c as TResult Function(T14) Function(T13) Function(T12) Function(T11)
+                                            Function(T10)
+                                        Function(T9)
+                                    Function(T8)
+                                Function(T7)
+                            Function(T6)
+                        Function(T5)
+                    Function(T4)
+                Function(T3)
+            Function(T2)
+        Function(T1);
+  }
+}
+
+TResult Function(
+    T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) uncurry15<
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
+        T9,
+        T10,
+        T11,
+        T12,
+        T13,
+        T14,
+        T15,
+        TResult>(
+    TResult Function(T15) Function(T14) Function(T13) Function(T12) Function(
+                                                    T11)
+                                                Function(T10)
+                                            Function(T9)
+                                        Function(T8)
+                                    Function(T7)
+                                Function(T6)
+                            Function(T5)
+                        Function(T4)
+                    Function(T3)
+                Function(T2)
+            Function(T1)
+        f) {
+  f2(T1 a1, T2 a2, T3 a3, T4 a4, T5 a5, T6 a6, T7 a7, T8 a8, T9 a9, T10 a10,
+          T11 a11, T12 a12, T13 a13, T14 a14, T15 a15) =>
+      f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)(a15);
+  _curried[f2] = f;
+  return f2;
+}
+
+TResult Function(T15) Function(T14) Function(T13) Function(T12) Function(T11)
+                                        Function(T10)
+                                    Function(T9)
+                                Function(T8)
+                            Function(T7)
+                        Function(T6)
+                    Function(T5)
+                Function(T4)
+            Function(T3)
+        Function(T2)
+    Function(T1) curry15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
+        T14, T15, TResult>(
+    TResult Function(
+            T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+        f) {
+  var c = _curried[f];
+  if (c == null) {
+    return (T1 a1) => (T2 a2) => (T3 a3) => (T4 a4) => (T5 a5) => (T6 a6) =>
+        (T7 a7) => (T8 a8) => (T9 a9) => (T10 a10) => (T11 a11) => (T12 a12) =>
+            (T13 a13) => (T14 a14) => (T15 a15) => f(a1, a2, a3, a4, a5, a6, a7,
+                a8, a9, a10, a11, a12, a13, a14, a15);
+  } else {
+    return c as TResult Function(T15) Function(T14) Function(T13) Function(T12)
+                                                Function(T11)
+                                            Function(T10)
+                                        Function(T9)
+                                    Function(T8)
+                                Function(T7)
+                            Function(T6)
+                        Function(T5)
+                    Function(T4)
+                Function(T3)
+            Function(T2)
+        Function(T1);
+  }
+}
+
+TResult Function(
+        T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+    uncurry16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(
+        TResult Function(T16) Function(T15) Function(T14) Function(T13)
+                                                            Function(T12)
+                                                        Function(T11)
+                                                    Function(T10)
+                                                Function(T9)
+                                            Function(T8)
+                                        Function(T7)
+                                    Function(T6)
+                                Function(T5)
+                            Function(T4)
+                        Function(T3)
+                    Function(T2)
+                Function(T1)
+            f) {
+  f2(T1 a1, T2 a2, T3 a3, T4 a4, T5 a5, T6 a6, T7 a7, T8 a8, T9 a9, T10 a10,
+          T11 a11, T12 a12, T13 a13, T14 a14, T15 a15, T16 a16) =>
+      f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)(a15)(a16);
+  _curried[f2] = f;
+  return f2;
+}
+
+TResult Function(T16) Function(T15) Function(T14) Function(T13) Function(T12)
+                                            Function(T11)
+                                        Function(T10)
+                                    Function(T9)
+                                Function(T8)
+                            Function(T7)
+                        Function(T6)
+                    Function(T5)
+                Function(T4)
+            Function(T3)
+        Function(T2)
+    Function(T1) curry16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
+        T14, T15, T16, TResult>(
+    TResult Function(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+        f) {
+  var c = _curried[f];
+  if (c == null) {
+    return (T1 a1) => (T2 a2) => (T3 a3) => (T4 a4) => (T5 a5) => (T6 a6) =>
+        (T7 a7) => (T8 a8) => (T9 a9) => (T10 a10) => (T11 a11) => (T12 a12) =>
+            (T13 a13) => (T14 a14) => (T15 a15) => (T16 a16) => f(a1, a2, a3,
+                a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16);
+  } else {
+    return c as TResult Function(T16) Function(T15) Function(T14) Function(T13)
+                                                    Function(T12)
+                                                Function(T11)
+                                            Function(T10)
+                                        Function(T9)
+                                    Function(T8)
+                                Function(T7)
+                            Function(T6)
+                        Function(T5)
+                    Function(T4)
+                Function(T3)
+            Function(T2)
+        Function(T1);
+  }
+}
+
+TResult Function(
+        T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+    uncurry17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TResult>(
+        TResult Function(T17) Function(T16) Function(T15) Function(T14) Function(T13)
+                                                            Function(T12)
+                                                        Function(T11)
+                                                    Function(T10)
+                                                Function(T9)
+                                            Function(T8)
+                                        Function(T7)
+                                    Function(T6)
+                                Function(T5)
+                            Function(T4)
+                        Function(T3)
+                    Function(T2)
+                Function(T1)
+            f) {
+  f2(T1 a1, T2 a2, T3 a3, T4 a4, T5 a5, T6 a6, T7 a7, T8 a8, T9 a9, T10 a10,
+          T11 a11, T12 a12, T13 a13, T14 a14, T15 a15, T16 a16, T17 a17) =>
+      f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)(a15)(a16)(
+          a17);
+  _curried[f2] = f;
+  return f2;
+}
+
+TResult Function(T17) Function(T16) Function(T15) Function(T14) Function(T13)
+                                                Function(T12)
+                                            Function(T11)
+                                        Function(T10)
+                                    Function(T9)
+                                Function(T8)
+                            Function(T7)
+                        Function(T6)
+                    Function(T5)
+                Function(T4)
+            Function(T3)
+        Function(T2)
+    Function(T1) curry17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
+        T14, T15, T16, T17, TResult>(
+    TResult Function(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17) f) {
+  var c = _curried[f];
+  if (c == null) {
+    return (T1 a1) => (T2 a2) => (T3 a3) => (T4 a4) => (T5 a5) => (T6 a6) =>
+        (T7 a7) => (T8 a8) => (T9 a9) => (T10 a10) => (T11 a11) => (T12 a12) =>
+            (T13 a13) => (T14 a14) => (T15 a15) => (T16 a16) => (T17 a17) => f(
+                a1,
+                a2,
+                a3,
+                a4,
+                a5,
+                a6,
+                a7,
+                a8,
+                a9,
+                a10,
+                a11,
+                a12,
+                a13,
+                a14,
+                a15,
+                a16,
+                a17);
+  } else {
+    return c as TResult Function(T17) Function(T16) Function(T15) Function(T14)
+                                                        Function(T13)
+                                                    Function(T12)
+                                                Function(T11)
+                                            Function(T10)
+                                        Function(T9)
+                                    Function(T8)
+                                Function(T7)
+                            Function(T6)
+                        Function(T5)
+                    Function(T4)
+                Function(T3)
+            Function(T2)
+        Function(T1);
+  }
+}
+
+TResult Function(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+    uncurry18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TResult>(
+        TResult Function(T18) Function(T17) Function(T16) Function(T15) Function(T14) Function(T13)
+                                                            Function(T12)
+                                                        Function(T11)
+                                                    Function(T10)
+                                                Function(T9)
+                                            Function(T8)
+                                        Function(T7)
+                                    Function(T6)
+                                Function(T5)
+                            Function(T4)
+                        Function(T3)
+                    Function(T2)
+                Function(T1)
+            f) {
+  f2(
+          T1 a1,
+          T2 a2,
+          T3 a3,
+          T4 a4,
+          T5 a5,
+          T6 a6,
+          T7 a7,
+          T8 a8,
+          T9 a9,
+          T10 a10,
+          T11 a11,
+          T12 a12,
+          T13 a13,
+          T14 a14,
+          T15 a15,
+          T16 a16,
+          T17 a17,
+          T18 a18) =>
+      f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)(a15)(a16)(
+          a17)(a18);
+  _curried[f2] = f;
+  return f2;
+}
+
+TResult Function(T18) Function(T17) Function(T16) Function(T15) Function(T14) Function(T13)
+                                                Function(T12)
+                                            Function(T11)
+                                        Function(T10)
+                                    Function(T9)
+                                Function(T8)
+                            Function(T7)
+                        Function(T6)
+                    Function(T5)
+                Function(T4)
+            Function(T3)
+        Function(T2)
+    Function(T1) curry18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
+        T14, T15, T16, T17, T18, TResult>(
+    TResult Function(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18) f) {
+  var c = _curried[f];
+  if (c == null) {
+    return (T1 a1) => (T2 a2) => (T3 a3) => (T4 a4) => (T5 a5) => (T6 a6) =>
+        (T7 a7) => (T8 a8) => (T9 a9) => (T10 a10) => (T11 a11) => (T12 a12) =>
+            (T13 a13) => (T14 a14) => (T15 a15) => (T16 a16) => (T17 a17) =>
+                (T18 a18) => f(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11,
+                    a12, a13, a14, a15, a16, a17, a18);
+  } else {
+    return c as TResult Function(T18) Function(T17) Function(T16) Function(T15)
+                                                            Function(T14)
+                                                        Function(T13)
+                                                    Function(T12)
+                                                Function(T11)
+                                            Function(T10)
+                                        Function(T9)
+                                    Function(T8)
+                                Function(T7)
+                            Function(T6)
+                        Function(T5)
+                    Function(T4)
+                Function(T3)
+            Function(T2)
+        Function(T1);
+  }
+}
+
+TResult Function(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+    uncurry19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TResult>(
+        TResult Function(T19) Function(T18) Function(T17) Function(T16) Function(T15) Function(T14) Function(T13) Function(T12)
+                                                        Function(T11)
+                                                    Function(T10)
+                                                Function(T9)
+                                            Function(T8)
+                                        Function(T7)
+                                    Function(T6)
+                                Function(T5)
+                            Function(T4)
+                        Function(T3)
+                    Function(T2)
+                Function(T1)
+            f) {
+  f2(
+          T1 a1,
+          T2 a2,
+          T3 a3,
+          T4 a4,
+          T5 a5,
+          T6 a6,
+          T7 a7,
+          T8 a8,
+          T9 a9,
+          T10 a10,
+          T11 a11,
+          T12 a12,
+          T13 a13,
+          T14 a14,
+          T15 a15,
+          T16 a16,
+          T17 a17,
+          T18 a18,
+          T19 a19) =>
+      f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)(a15)(a16)(
+          a17)(a18)(a19);
+  _curried[f2] = f;
+  return f2;
+}
+
+TResult Function(T19) Function(T18) Function(T17) Function(T16) Function(T15) Function(T14) Function(T13)
+                                                Function(T12)
+                                            Function(T11)
+                                        Function(T10)
+                                    Function(T9)
+                                Function(T8)
+                            Function(T7)
+                        Function(T6)
+                    Function(T5)
+                Function(T4)
+            Function(T3)
+        Function(T2)
+    Function(T1) curry19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
+        T14, T15, T16, T17, T18, T19, TResult>(
+    TResult Function(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19) f) {
+  var c = _curried[f];
+  if (c == null) {
+    return (T1 a1) => (T2 a2) => (T3 a3) => (T4 a4) => (T5 a5) => (T6 a6) => (T7 a7) =>
+        (T8 a8) => (T9 a9) => (T10 a10) => (T11 a11) => (T12 a12) => (T13 a13) =>
+            (T14 a14) => (T15 a15) => (T16 a16) => (T17 a17) => (T18 a18) => (T19 a19) => f(
+                a1,
+                a2,
+                a3,
+                a4,
+                a5,
+                a6,
+                a7,
+                a8,
+                a9,
+                a10,
+                a11,
+                a12,
+                a13,
+                a14,
+                a15,
+                a16,
+                a17,
+                a18,
+                a19);
+  } else {
+    return c as TResult Function(T19) Function(T18) Function(T17) Function(T16)
+                                                                Function(T15)
+                                                            Function(T14)
+                                                        Function(T13)
+                                                    Function(T12)
+                                                Function(T11)
+                                            Function(T10)
+                                        Function(T9)
+                                    Function(T8)
+                                Function(T7)
+                            Function(T6)
+                        Function(T5)
+                    Function(T4)
+                Function(T3)
+            Function(T2)
+        Function(T1);
+  }
+}
+
+TResult Function(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+    uncurry20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TResult>(
+        TResult Function(T20) Function(T19) Function(T18) Function(T17) Function(T16) Function(T15) Function(T14) Function(T13) Function(T12) Function(T11)
+                                                    Function(T10)
+                                                Function(T9)
+                                            Function(T8)
+                                        Function(T7)
+                                    Function(T6)
+                                Function(T5)
+                            Function(T4)
+                        Function(T3)
+                    Function(T2)
+                Function(T1)
+            f) {
+  f2(
+          T1 a1,
+          T2 a2,
+          T3 a3,
+          T4 a4,
+          T5 a5,
+          T6 a6,
+          T7 a7,
+          T8 a8,
+          T9 a9,
+          T10 a10,
+          T11 a11,
+          T12 a12,
+          T13 a13,
+          T14 a14,
+          T15 a15,
+          T16 a16,
+          T17 a17,
+          T18 a18,
+          T19 a19,
+          T20 a20) =>
+      f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)(a15)(a16)(
+          a17)(a18)(a19)(a20);
+  _curried[f2] = f;
+  return f2;
+}
+
+TResult Function(T20) Function(T19) Function(T18) Function(T17) Function(T16)
+                                                                Function(T15)
+                                                            Function(T14)
+                                                        Function(T13)
+                                                    Function(T12)
+                                                Function(T11)
+                                            Function(T10)
+                                        Function(T9)
+                                    Function(T8)
+                                Function(T7)
+                            Function(T6)
+                        Function(T5)
+                    Function(T4)
+                Function(T3)
+            Function(T2)
+        Function(T1)
+    curry20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TResult>(
+        TResult Function(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20) f) {
+  var c = _curried[f];
+  if (c == null) {
+    return (T1 a1) => (T2 a2) => (T3 a3) => (T4 a4) => (T5 a5) => (T6 a6) =>
+        (T7 a7) => (T8 a8) => (T9 a9) => (T10 a10) => (T11 a11) => (T12 a12) =>
+            (T13 a13) => (T14 a14) => (T15 a15) => (T16 a16) => (T17 a17) =>
+                (T18 a18) => (T19 a19) => (T20 a20) => f(
+                    a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20);
+  } else {
+    return c as TResult Function(T20) Function(T19) Function(T18) Function(T17)
+                                                                    Function(T16)
+                                                                Function(T15)
+                                                            Function(T14)
+                                                        Function(T13)
+                                                    Function(T12)
+                                                Function(T11)
+                                            Function(T10)
+                                        Function(T9)
+                                    Function(T8)
+                                Function(T7)
+                            Function(T6)
+                        Function(T5)
+                    Function(T4)
+                Function(T3)
+            Function(T2)
+        Function(T1);
+  }
+}
+
 void ignore([dynamic _]) {}
 
 T value<T>(T? value) => value!;

--- a/src/fable-library-py/fable_library/util.py
+++ b/src/fable-library-py/fable_library/util.py
@@ -1041,8 +1041,8 @@ def uncurry11(
     ]
 ) -> Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11], _TResult]:
     def f2(
-        a1: _T1, a2: _T2, a3: _T3, a4: _T4, a5: _T5, a6: _T6, a7: _T7, a8: _T8, a9: _T9, a10: _T10, a11: _T11
-    ) -> _TResult:
+        a1: Any, a2: Any, a3: Any, a4: Any, a5: Any, a6: Any, a7: Any, a8: Any, a9: Any, a10: Any, a11: Any
+    ) -> Any:
         return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)
 
     _curried[f2] = f
@@ -1118,19 +1118,8 @@ def uncurry12(
     ]
 ) -> Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12], _TResult]:
     def f2(
-        a1: _T1,
-        a2: _T2,
-        a3: _T3,
-        a4: _T4,
-        a5: _T5,
-        a6: _T6,
-        a7: _T7,
-        a8: _T8,
-        a9: _T9,
-        a10: _T10,
-        a11: _T11,
-        a12: _T12,
-    ) -> _TResult:
+        a1: Any, a2: Any, a3: Any, a4: Any, a5: Any, a6: Any, a7: Any, a8: Any, a9: Any, a10: Any, a11: Any, a12: Any,
+    ) -> Any:
         return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)
 
     _curried[f2] = f
@@ -1221,20 +1210,8 @@ def uncurry13(
     [_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12, _T13], _TResult
 ]:
     def f2(
-        a1: _T1,
-        a2: _T2,
-        a3: _T3,
-        a4: _T4,
-        a5: _T5,
-        a6: _T6,
-        a7: _T7,
-        a8: _T8,
-        a9: _T9,
-        a10: _T10,
-        a11: _T11,
-        a12: _T12,
-        a13: _T13,
-    ) -> _TResult:
+        a1: Any, a2: Any, a3: Any, a4: Any, a5: Any, a6: Any, a7: Any, a8: Any, a9: Any, a10: Any, a11: Any, a12: Any, a13: Any,
+    ) -> Any:
         return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)
 
     _curried[f2] = f
@@ -1329,21 +1306,8 @@ def uncurry14(
 ) -> Callable[
     [ _T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12, _T13, _T14, ], _TResult, ]:
     def f2(
-        a1: _T1,
-        a2: _T2,
-        a3: _T3,
-        a4: _T4,
-        a5: _T5,
-        a6: _T6,
-        a7: _T7,
-        a8: _T8,
-        a9: _T9,
-        a10: _T10,
-        a11: _T11,
-        a12: _T12,
-        a13: _T13,
-        a14: _T14,
-    ) -> _TResult:
+        a1: Any, a2: Any, a3: Any, a4: Any, a5: Any, a6: Any, a7: Any, a8: Any, a9: Any, a10: Any, a11: Any, a12: Any, a13: Any, a14: Any,
+    ) -> Any:
         return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)
 
     _curried[f2] = f
@@ -1445,22 +1409,8 @@ def uncurry15(
     [ _T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12, _T13, _T14, _T15] ,_TResult,
 ]:
     def f2(
-        a1: _T1,
-        a2: _T2,
-        a3: _T3,
-        a4: _T4,
-        a5: _T5,
-        a6: _T6,
-        a7: _T7,
-        a8: _T8,
-        a9: _T9,
-        a10: _T10,
-        a11: _T11,
-        a12: _T12,
-        a13: _T13,
-        a14: _T14,
-        a15: _T15,
-    ) -> _TResult:
+        a1: Any, a2: Any, a3: Any, a4: Any, a5: Any, a6: Any, a7: Any, a8: Any, a9: Any, a10: Any, a11: Any, a12: Any, a13: Any, a14: Any, a15: Any,
+    ) -> Any:
         return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)(a15)
 
     _curried[f2] = f
@@ -1568,23 +1518,8 @@ def uncurry16(
     [ _T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12, _T13, _T14, _T15, _T16] ,_TResult,
 ]:
     def f2(
-        a1: _T1,
-        a2: _T2,
-        a3: _T3,
-        a4: _T4,
-        a5: _T5,
-        a6: _T6,
-        a7: _T7,
-        a8: _T8,
-        a9: _T9,
-        a10: _T10,
-        a11: _T11,
-        a12: _T12,
-        a13: _T13,
-        a14: _T14,
-        a15: _T15,
-        a16: _T16,
-    ) -> _TResult:
+        a1: Any, a2: Any, a3: Any, a4: Any, a5: Any, a6: Any, a7: Any, a8: Any, a9: Any, a10: Any, a11: Any, a12: Any, a13: Any, a14: Any, a15: Any, a16: Any,
+    ) -> Any:
         return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)(a15)(a16)
 
     _curried[f2] = f
@@ -1694,24 +1629,8 @@ def uncurry17(
     [ _T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12, _T13, _T14, _T15, _T16, _T17] ,_TResult,
 ]:
     def f2(
-        a1: _T1,
-        a2: _T2,
-        a3: _T3,
-        a4: _T4,
-        a5: _T5,
-        a6: _T6,
-        a7: _T7,
-        a8: _T8,
-        a9: _T9,
-        a10: _T10,
-        a11: _T11,
-        a12: _T12,
-        a13: _T13,
-        a14: _T14,
-        a15: _T15,
-        a16: _T16,
-        a17: _T17,
-    ) -> _TResult:
+        a1: Any, a2: Any, a3: Any, a4: Any, a5: Any, a6: Any, a7: Any, a8: Any, a9: Any, a10: Any, a11: Any, a12: Any, a13: Any, a14: Any, a15: Any, a16: Any, a17: Any,
+    ) -> Any:
         return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)(a15)(a16)(a17)
 
     _curried[f2] = f
@@ -1830,25 +1749,8 @@ def uncurry18(
     [ _T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12, _T13, _T14, _T15, _T16, _T17, _T18] ,_TResult,
 ]:
     def f2(
-        a1: _T1,
-        a2: _T2,
-        a3: _T3,
-        a4: _T4,
-        a5: _T5,
-        a6: _T6,
-        a7: _T7,
-        a8: _T8,
-        a9: _T9,
-        a10: _T10,
-        a11: _T11,
-        a12: _T12,
-        a13: _T13,
-        a14: _T14,
-        a15: _T15,
-        a16: _T16,
-        a17: _T17,
-        a18: _T18,
-    ) -> _TResult:
+        a1: Any, a2: Any, a3: Any, a4: Any, a5: Any, a6: Any, a7: Any, a8: Any, a9: Any, a10: Any, a11: Any, a12: Any, a13: Any, a14: Any, a15: Any, a16: Any, a17: Any, a18: Any,
+    ) -> Any:
         return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)(a15)(a16)(a17)(a18)
 
     _curried[f2] = f
@@ -1977,26 +1879,8 @@ def uncurry19(
     [ _T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12, _T13, _T14, _T15, _T16, _T17, _T18, _T19] ,_TResult,
 ]:
     def f2(
-        a1: _T1,
-        a2: _T2,
-        a3: _T3,
-        a4: _T4,
-        a5: _T5,
-        a6: _T6,
-        a7: _T7,
-        a8: _T8,
-        a9: _T9,
-        a10: _T10,
-        a11: _T11,
-        a12: _T12,
-        a13: _T13,
-        a14: _T14,
-        a15: _T15,
-        a16: _T16,
-        a17: _T17,
-        a18: _T18,
-        a19: _T19,
-    ) -> _TResult:
+        a1: Any, a2: Any, a3: Any, a4: Any, a5: Any, a6: Any, a7: Any, a8: Any, a9: Any, a10: Any, a11: Any, a12: Any, a13: Any, a14: Any, a15: Any, a16: Any, a17: Any, a18: Any, a19: Any,
+    ) -> Any:
         return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)(a15)(a16)(a17)(a18)(a19)
 
     _curried[f2] = f
@@ -2129,27 +2013,8 @@ def uncurry20(
     [ _T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12, _T13, _T14, _T15, _T16, _T17, _T18, _T19, _T20] ,_TResult,
 ]:
     def f2(
-        a1: _T1,
-        a2: _T2,
-        a3: _T3,
-        a4: _T4,
-        a5: _T5,
-        a6: _T6,
-        a7: _T7,
-        a8: _T8,
-        a9: _T9,
-        a10: _T10,
-        a11: _T11,
-        a12: _T12,
-        a13: _T13,
-        a14: _T14,
-        a15: _T15,
-        a16: _T16,
-        a17: _T17,
-        a18: _T18,
-        a19: _T19,
-        a20: _T20,
-    ) -> _TResult:
+        a1: Any, a2: Any, a3: Any, a4: Any, a5: Any, a6: Any, a7: Any, a8: Any, a9: Any, a10: Any, a11: Any, a12: Any, a13: Any, a14: Any, a15: Any, a16: Any, a17: Any, a18: Any, a19: Any, a20: Any,
+    ) -> Any:
         return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)(a15)(a16)(a17)(a18)(a19)(a20)
 
     _curried[f2] = f

--- a/src/fable-library-py/fable_library/util.py
+++ b/src/fable-library-py/fable_library/util.py
@@ -640,10 +640,294 @@ _T7 = TypeVar("_T7")
 _T8 = TypeVar("_T8")
 _T9 = TypeVar("_T9")
 _T10 = TypeVar("_T10")
+_T11 = TypeVar("_T11")
+_T12 = TypeVar("_T12")
+_T13 = TypeVar("_T13")
+_T14 = TypeVar("_T14")
+_T15 = TypeVar("_T15")
+_T16 = TypeVar("_T16")
+_T17 = TypeVar("_T17")
+_T18 = TypeVar("_T18")
+_T19 = TypeVar("_T19")
+_T20 = TypeVar("_T20")
 _TResult = TypeVar("_TResult")
 
 _curried = weakref.WeakKeyDictionary[Any, Any]()
 
+
+def uncurry2(
+    f: Callable[[_T1], Callable[[_T2], _TResult]]
+) -> Callable[[_T1, _T2], _TResult]:
+    def f2(a1: _T1, a2: _T2) -> _TResult:
+        return f(a1)(a2)
+
+    _curried[f2] = f
+    return f2
+
+
+def curry2(
+    f: Callable[[_T1, _T2], _TResult]
+) -> Callable[[_T1], Callable[[_T2], _TResult]]:
+    f2 = _curried.get(f)
+    if f2 is None:
+        return lambda a1: lambda a2: f(a1, a2)
+    else:
+        return f2
+
+def uncurry3(
+    f: Callable[[_T1], Callable[[_T2], Callable[[_T3], _TResult]]]
+) -> Callable[[_T1, _T2, _T3], _TResult]:
+    def f2(a1: _T1, a2: _T2, a3: _T3) -> _TResult:
+        return f(a1)(a2)(a3)
+
+    _curried[f2] = f
+    return f2
+
+
+def curry3(
+    f: Callable[[_T1, _T2, _T3], _TResult]
+) -> Callable[[_T1], Callable[[_T2], Callable[[_T3], _TResult]]]:
+    f2 = _curried.get(f)
+    if f2 is None:
+        return lambda a1: lambda a2: lambda a3: f(a1, a2, a3)
+    else:
+        return f2
+
+
+def uncurry4(
+    f: Callable[[_T1], Callable[[_T2], Callable[[_T3], Callable[[_T4], _TResult]]]]
+) -> Callable[[_T1, _T2, _T3, _T4], _TResult]:
+    def f2(a1: _T1, a2: _T2, a3: _T3, a4: _T4) -> _TResult:
+        return f(a1)(a2)(a3)(a4)
+
+    _curried[f2] = f
+    return f2
+
+
+def curry4(
+    f: Callable[[_T1, _T2, _T3, _T4], _TResult]
+) -> Callable[[_T1], Callable[[_T2], Callable[[_T3], Callable[[_T4], _TResult]]]]:
+    f2 = _curried.get(f)
+    if f2 is None:
+        return lambda a1: lambda a2: lambda a3: lambda a4: f(a1, a2, a3, a4)
+    else:
+        return f2
+
+def uncurry5(
+    f: Callable[
+        [_T1],
+        Callable[[_T2], Callable[[_T3], Callable[[_T4], Callable[[_T5], _TResult]]]],
+    ]
+) -> Callable[[_T1, _T2, _T3, _T4, _T5], _TResult]:
+    def f2(a1: _T1, a2: _T2, a3: _T3, a4: _T4, a5: _T5) -> _TResult:
+        return f(a1)(a2)(a3)(a4)(a5)
+
+    _curried[f2] = f
+    return f2
+
+
+def curry5(
+    f: Callable[[_T1, _T2, _T3, _T4, _T5], _TResult]
+) -> Callable[
+    [_T1], Callable[[_T2], Callable[[_T3], Callable[[_T4], Callable[[_T5], _TResult]]]]
+]:
+    f2 = _curried.get(f)
+    if f2 is None:
+        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: f(
+            a1, a2, a3, a4, a5
+        )
+    else:
+        return f2
+
+
+def uncurry6(
+    f: Callable[
+        [_T1],
+        Callable[
+            [_T2],
+            Callable[
+                [_T3], Callable[[_T4], Callable[[_T5], Callable[[_T6], _TResult]]]
+            ],
+        ],
+    ]
+) -> Callable[[_T1, _T2, _T3, _T4, _T5, _T6], _TResult]:
+    def f2(a1: _T1, a2: _T2, a3: _T3, a4: _T4, a5: _T5, a6: _T6) -> _TResult:
+        return f(a1)(a2)(a3)(a4)(a5)(a6)
+
+    _curried[f2] = f
+    return f2
+
+
+def curry6(
+    f: Callable[[_T1, _T2, _T3, _T4, _T5, _T6], _TResult]
+) -> Callable[
+    [_T1],
+    Callable[
+        [_T2],
+        Callable[[_T3], Callable[[_T4], Callable[[_T5], Callable[[_T6], _TResult]]]],
+    ],
+]:
+    f2 = _curried.get(f)
+    if f2 is None:
+        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: f(
+            a1, a2, a3, a4, a5, a6
+        )
+    else:
+        return f2
+
+def uncurry7(
+    f: Callable[
+        [_T1],
+        Callable[
+            [_T2],
+            Callable[
+                [_T3],
+                Callable[
+                    [_T4], Callable[[_T5], Callable[[_T6], Callable[[_T7], _TResult]]]
+                ],
+            ],
+        ],
+    ]
+) -> Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7], _TResult]:
+    def f2(a1: _T1, a2: _T2, a3: _T3, a4: _T4, a5: _T5, a6: _T6, a7: _T7) -> _TResult:
+        return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)
+
+    _curried[f2] = f
+    return f2
+
+
+def curry7(
+    f: Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7], _TResult]
+) -> Callable[
+    [_T1],
+    Callable[
+        [_T2],
+        Callable[
+            [_T3],
+            Callable[
+                [_T4], Callable[[_T5], Callable[[_T6], Callable[[_T7], _TResult]]]
+            ],
+        ],
+    ],
+]:
+    f2 = _curried.get(f)
+    if f2 is None:
+        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: f(
+            a1, a2, a3, a4, a5, a6, a7
+        )
+    else:
+        return f2
+
+def uncurry8(
+    f: Callable[
+        [_T1],
+        Callable[
+            [_T2],
+            Callable[
+                [_T3],
+                Callable[
+                    [_T4],
+                    Callable[
+                        [_T5],
+                        Callable[[_T6], Callable[[_T7], Callable[[_T8], _TResult]]],
+                    ],
+                ],
+            ],
+        ],
+    ]
+) -> Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8], _TResult]:
+    def f2(
+        a1: _T1, a2: _T2, a3: _T3, a4: _T4, a5: _T5, a6: _T6, a7: _T7, a8: _T8
+    ) -> _TResult:
+        return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)
+
+    _curried[f2] = f
+    return f2
+
+
+def curry8(
+    f: Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8], _TResult]
+) -> Callable[
+    [_T1],
+    Callable[
+        [_T2],
+        Callable[
+            [_T3],
+            Callable[
+                [_T4],
+                Callable[
+                    [_T5], Callable[[_T6], Callable[[_T7], Callable[[_T8], _TResult]]]
+                ],
+            ],
+        ],
+    ],
+]:
+    f2 = _curried.get(f)
+    if f2 is None:
+        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: f(
+            a1, a2, a3, a4, a5, a6, a7, a8
+        )
+    else:
+        return f2
+
+def uncurry9(
+    f: Callable[
+        [_T1],
+        Callable[
+            [_T2],
+            Callable[
+                [_T3],
+                Callable[
+                    [_T4],
+                    Callable[
+                        [_T5],
+                        Callable[
+                            [_T6],
+                            Callable[[_T7], Callable[[_T8], Callable[[_T9], _TResult]]],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ]
+) -> Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9], _TResult]:
+    def f2(
+        a1: _T1, a2: _T2, a3: _T3, a4: _T4, a5: _T5, a6: _T6, a7: _T7, a8: _T8, a9: _T9
+    ) -> _TResult:
+        return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)
+
+    _curried[f2] = f
+    return f2
+
+
+def curry9(
+    f: Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9], _TResult]
+) -> Callable[
+    [_T1],
+    Callable[
+        [_T2],
+        Callable[
+            [_T3],
+            Callable[
+                [_T4],
+                Callable[
+                    [_T5],
+                    Callable[
+                        [_T6],
+                        Callable[[_T7], Callable[[_T8], Callable[[_T9], _TResult]]],
+                    ],
+                ],
+            ],
+        ],
+    ],
+]:
+    f2 = _curried.get(f)
+    if f2 is None:
+        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: f(
+            a1, a2, a3, a4, a5, a6, a7, a8, a9
+        )
+    else:
+        return f2
 
 def uncurry10(
     f: Callable[
@@ -723,8 +1007,7 @@ def curry10(
     else:
         return f2
 
-
-def uncurry9(
+def uncurry11(
     f: Callable[
         [_T1],
         Callable[
@@ -737,25 +1020,37 @@ def uncurry9(
                         [_T5],
                         Callable[
                             [_T6],
-                            Callable[[_T7], Callable[[_T8], Callable[[_T9], _TResult]]],
+                            Callable[
+                                [_T7],
+                                Callable[
+                                    [_T8],
+                                    Callable[
+                                        [_T9],
+                                        Callable[
+                                            [_T10],
+                                            Callable[[_T11], _TResult]
+                                        ]
+                                    ]
+                                ],
+                            ],
                         ],
                     ],
                 ],
             ],
         ],
     ]
-) -> Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9], _TResult]:
+) -> Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11], _TResult]:
     def f2(
-        a1: _T1, a2: _T2, a3: _T3, a4: _T4, a5: _T5, a6: _T6, a7: _T7, a8: _T8, a9: _T9
+        a1: _T1, a2: _T2, a3: _T3, a4: _T4, a5: _T5, a6: _T6, a7: _T7, a8: _T8, a9: _T9, a10: _T10, a11: _T11
     ) -> _TResult:
-        return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)
+        return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)
 
     _curried[f2] = f
     return f2
 
 
-def curry9(
-    f: Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9], _TResult]
+def curry11(
+    f: Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11], _TResult]
 ) -> Callable[
     [_T1],
     Callable[
@@ -768,7 +1063,12 @@ def curry9(
                     [_T5],
                     Callable[
                         [_T6],
-                        Callable[[_T7], Callable[[_T8], Callable[[_T9], _TResult]]],
+                        Callable[
+                            [_T7],
+                            Callable[
+                                [_T8], Callable[[_T9], Callable[[_T10], Callable[[_T11], _TResult]]]
+                            ],
+                        ],
                     ],
                 ],
             ],
@@ -777,14 +1077,14 @@ def curry9(
 ]:
     f2 = _curried.get(f)
     if f2 is None:
-        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: f(
-            a1, a2, a3, a4, a5, a6, a7, a8, a9
+        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: lambda a10: lambda a11: f(
+            a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11
         )
     else:
         return f2
 
 
-def uncurry8(
+def uncurry12(
     f: Callable[
         [_T1],
         Callable[
@@ -795,24 +1095,50 @@ def uncurry8(
                     [_T4],
                     Callable[
                         [_T5],
-                        Callable[[_T6], Callable[[_T7], Callable[[_T8], _TResult]]],
+                        Callable[
+                            [_T6],
+                            Callable[
+                                [_T7],
+                                Callable[
+                                    [_T8],
+                                    Callable[
+                                        [_T9],
+                                        Callable[
+                                            [_T10],
+                                            Callable[[_T11], Callable[[_T12], _TResult]]
+                                        ]
+                                    ]
+                                ],
+                            ],
+                        ],
                     ],
                 ],
             ],
         ],
     ]
-) -> Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8], _TResult]:
+) -> Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12], _TResult]:
     def f2(
-        a1: _T1, a2: _T2, a3: _T3, a4: _T4, a5: _T5, a6: _T6, a7: _T7, a8: _T8
+        a1: _T1,
+        a2: _T2,
+        a3: _T3,
+        a4: _T4,
+        a5: _T5,
+        a6: _T6,
+        a7: _T7,
+        a8: _T8,
+        a9: _T9,
+        a10: _T10,
+        a11: _T11,
+        a12: _T12,
     ) -> _TResult:
-        return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)
+        return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)
 
     _curried[f2] = f
     return f2
 
 
-def curry8(
-    f: Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8], _TResult]
+def curry12(
+    f: Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12], _TResult]
 ) -> Callable[
     [_T1],
     Callable[
@@ -822,7 +1148,26 @@ def curry8(
             Callable[
                 [_T4],
                 Callable[
-                    [_T5], Callable[[_T6], Callable[[_T7], Callable[[_T8], _TResult]]]
+                    [_T5],
+                    Callable[
+                        [_T6],
+                        Callable[
+                            [_T7],
+                            Callable[
+                                [_T8],
+                                Callable[
+                                    [_T9],
+                                    Callable[
+                                        [_T10],
+                                        Callable[
+                                            [_T11],
+                                            Callable[[_T12], _TResult]
+                                        ]
+                                    ]
+                                ]
+                            ],
+                        ],
+                    ],
                 ],
             ],
         ],
@@ -830,14 +1175,14 @@ def curry8(
 ]:
     f2 = _curried.get(f)
     if f2 is None:
-        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: f(
-            a1, a2, a3, a4, a5, a6, a7, a8
+        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: lambda a10: lambda a11: lambda a12: f(
+            a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12
         )
     else:
         return f2
 
 
-def uncurry7(
+def uncurry13(
     f: Callable[
         [_T1],
         Callable[
@@ -845,21 +1190,58 @@ def uncurry7(
             Callable[
                 [_T3],
                 Callable[
-                    [_T4], Callable[[_T5], Callable[[_T6], Callable[[_T7], _TResult]]]
+                    [_T4],
+                    Callable[
+                        [_T5],
+                        Callable[
+                            [_T6],
+                            Callable[
+                                [_T7],
+                                Callable[
+                                    [_T8],
+                                    Callable[
+                                        [_T9],
+                                        Callable[
+                                            [_T10],
+                                            Callable[
+                                                [_T11],
+                                                Callable[[_T12], Callable[[_T13], _TResult]]
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ],
+                        ],
+                    ],
                 ],
             ],
         ],
     ]
-) -> Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7], _TResult]:
-    def f2(a1: _T1, a2: _T2, a3: _T3, a4: _T4, a5: _T5, a6: _T6, a7: _T7) -> _TResult:
-        return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)
+) -> Callable[
+    [_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12, _T13], _TResult
+]:
+    def f2(
+        a1: _T1,
+        a2: _T2,
+        a3: _T3,
+        a4: _T4,
+        a5: _T5,
+        a6: _T6,
+        a7: _T7,
+        a8: _T8,
+        a9: _T9,
+        a10: _T10,
+        a11: _T11,
+        a12: _T12,
+        a13: _T13,
+    ) -> _TResult:
+        return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)
 
     _curried[f2] = f
     return f2
 
-
-def curry7(
-    f: Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7], _TResult]
+def curry13(
+    f: Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12, _T13], _TResult]
 ) -> Callable[
     [_T1],
     Callable[
@@ -867,139 +1249,979 @@ def curry7(
         Callable[
             [_T3],
             Callable[
-                [_T4], Callable[[_T5], Callable[[_T6], Callable[[_T7], _TResult]]]
+                [_T4],
+                Callable[
+                    [_T5],
+                    Callable[
+                        [_T6],
+                        Callable[
+                            [_T7],
+                            Callable[
+                                [_T8],
+                                Callable[
+                                    [_T9],
+                                    Callable[
+                                        [_T10],
+                                        Callable[
+                                            [_T11],
+                                            Callable[
+                                                [_T12],
+                                                Callable[[_T13], _TResult]
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ],
+                        ],
+                    ],
+                ],
             ],
         ],
     ],
 ]:
     f2 = _curried.get(f)
     if f2 is None:
-        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: f(
-            a1, a2, a3, a4, a5, a6, a7
+        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: lambda a10: lambda a11: lambda a12: lambda a13: f(
+            a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13
         )
     else:
         return f2
 
 
-def uncurry6(
+def uncurry14(
     f: Callable[
         [_T1],
         Callable[
             [_T2],
             Callable[
-                [_T3], Callable[[_T4], Callable[[_T5], Callable[[_T6], _TResult]]]
+                [_T3],
+                Callable[
+                    [_T4],
+                    Callable[
+                        [_T5],
+                        Callable[
+                            [_T6],
+                            Callable[
+                                [_T7],
+                                Callable[
+                                    [_T8],
+                                    Callable[
+                                        [_T9],
+                                        Callable[
+                                            [_T10],
+                                            Callable[
+                                                [_T11],
+                                                Callable[
+                                                    [_T12],
+                                                    Callable[[_T13], Callable[[_T14], _TResult]]
+                                                ]
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ],
+                        ],
+                    ],
+                ],
             ],
         ],
     ]
-) -> Callable[[_T1, _T2, _T3, _T4, _T5, _T6], _TResult]:
-    def f2(a1: _T1, a2: _T2, a3: _T3, a4: _T4, a5: _T5, a6: _T6) -> _TResult:
-        return f(a1)(a2)(a3)(a4)(a5)(a6)
+) -> Callable[
+    [ _T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12, _T13, _T14, ], _TResult, ]:
+    def f2(
+        a1: _T1,
+        a2: _T2,
+        a3: _T3,
+        a4: _T4,
+        a5: _T5,
+        a6: _T6,
+        a7: _T7,
+        a8: _T8,
+        a9: _T9,
+        a10: _T10,
+        a11: _T11,
+        a12: _T12,
+        a13: _T13,
+        a14: _T14,
+    ) -> _TResult:
+        return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)
 
     _curried[f2] = f
     return f2
 
 
-def curry6(
-    f: Callable[[_T1, _T2, _T3, _T4, _T5, _T6], _TResult]
+def curry14(
+    f: Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12, _T13, _T14], _TResult]
 ) -> Callable[
     [_T1],
     Callable[
         [_T2],
-        Callable[[_T3], Callable[[_T4], Callable[[_T5], Callable[[_T6], _TResult]]]],
+        Callable[
+            [_T3],
+            Callable[
+                [_T4],
+                Callable[
+                    [_T5],
+                    Callable[
+                        [_T6],
+                        Callable[
+                            [_T7],
+                            Callable[
+                                [_T8],
+                                Callable[
+                                    [_T9],
+                                    Callable[
+                                        [_T10],
+                                        Callable[
+                                            [_T11],
+                                            Callable[
+                                                [_T12],
+                                                Callable[
+                                                    [_T13],
+                                                    Callable[[_T14], _TResult]
+                                                ]
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
     ],
 ]:
     f2 = _curried.get(f)
     if f2 is None:
-        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: f(
-            a1, a2, a3, a4, a5, a6
+        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: lambda a10: lambda a11: lambda a12: lambda a13: lambda a14: f(
+            a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14
         )
     else:
         return f2
 
-
-def uncurry5(
+def uncurry15(
     f: Callable[
         [_T1],
-        Callable[[_T2], Callable[[_T3], Callable[[_T4], Callable[[_T5], _TResult]]]],
+        Callable[
+            [_T2],
+            Callable[
+                [_T3],
+                Callable[
+                    [_T4],
+                    Callable[
+                        [_T5],
+                        Callable[
+                            [_T6],
+                            Callable[
+                                [_T7],
+                                Callable[
+                                    [_T8],
+                                    Callable[
+                                        [_T9],
+                                        Callable[
+                                            [_T10],
+                                            Callable[
+                                                [_T11],
+                                                Callable[
+                                                    [_T12],
+                                                    Callable[
+                                                        [_T13],
+                                                        Callable[[_T14], Callable[[_T15], _TResult]]
+                                                    ]
+                                                ]
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
     ]
-) -> Callable[[_T1, _T2, _T3, _T4, _T5], _TResult]:
-    def f2(a1: _T1, a2: _T2, a3: _T3, a4: _T4, a5: _T5) -> _TResult:
-        return f(a1)(a2)(a3)(a4)(a5)
+) -> Callable[
+    [ _T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12, _T13, _T14, _T15] ,_TResult,
+]:
+    def f2(
+        a1: _T1,
+        a2: _T2,
+        a3: _T3,
+        a4: _T4,
+        a5: _T5,
+        a6: _T6,
+        a7: _T7,
+        a8: _T8,
+        a9: _T9,
+        a10: _T10,
+        a11: _T11,
+        a12: _T12,
+        a13: _T13,
+        a14: _T14,
+        a15: _T15,
+    ) -> _TResult:
+        return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)(a15)
 
     _curried[f2] = f
     return f2
 
 
-def curry5(
-    f: Callable[[_T1, _T2, _T3, _T4, _T5], _TResult]
+def curry15(
+    f: Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12, _T13, _T14, _T15], _TResult]
 ) -> Callable[
-    [_T1], Callable[[_T2], Callable[[_T3], Callable[[_T4], Callable[[_T5], _TResult]]]]
+    [_T1],
+    Callable[
+        [_T2],
+        Callable[
+            [_T3],
+            Callable[
+                [_T4],
+                Callable[
+                    [_T5],
+                    Callable[
+                        [_T6],
+                        Callable[
+                            [_T7],
+                            Callable[
+                                [_T8],
+                                Callable[
+                                    [_T9],
+                                    Callable[
+                                        [_T10],
+                                        Callable[
+                                            [_T11],
+                                            Callable[
+                                                [_T12],
+                                                Callable[
+                                                    [_T13],
+                                                    Callable[
+                                                        [_T14],
+                                                        Callable[[_T15], _TResult]
+                                                    ]
+                                                ]
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ],
 ]:
     f2 = _curried.get(f)
     if f2 is None:
-        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: f(
-            a1, a2, a3, a4, a5
+        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: lambda a10: lambda a11: lambda a12: lambda a13: lambda a14: lambda a15: f(
+            a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15
+        )
+    else:
+        return f2
+
+def uncurry16(
+    f: Callable[
+        [_T1],
+        Callable[
+            [_T2],
+            Callable[
+                [_T3],
+                Callable[
+                    [_T4],
+                    Callable[
+                        [_T5],
+                        Callable[
+                            [_T6],
+                            Callable[
+                                [_T7],
+                                Callable[
+                                    [_T8],
+                                    Callable[
+                                        [_T9],
+                                        Callable[
+                                            [_T10],
+                                            Callable[
+                                                [_T11],
+                                                Callable[
+                                                    [_T12],
+                                                    Callable[
+                                                        [_T13],
+                                                        Callable[
+                                                            [_T14],
+                                                            Callable[[_T15], Callable[[_T16], _TResult]]
+                                                        ]
+                                                    ]
+                                                ]
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ]
+) -> Callable[
+    [ _T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12, _T13, _T14, _T15, _T16] ,_TResult,
+]:
+    def f2(
+        a1: _T1,
+        a2: _T2,
+        a3: _T3,
+        a4: _T4,
+        a5: _T5,
+        a6: _T6,
+        a7: _T7,
+        a8: _T8,
+        a9: _T9,
+        a10: _T10,
+        a11: _T11,
+        a12: _T12,
+        a13: _T13,
+        a14: _T14,
+        a15: _T15,
+        a16: _T16,
+    ) -> _TResult:
+        return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)(a15)(a16)
+
+    _curried[f2] = f
+    return f2
+
+def curry16(
+    f: Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12, _T13, _T14, _T15, _T16], _TResult]
+) -> Callable[
+    [_T1],
+    Callable[
+        [_T2],
+        Callable[
+            [_T3],
+            Callable[
+                [_T4],
+                Callable[
+                    [_T5],
+                    Callable[
+                        [_T6],
+                        Callable[
+                            [_T7],
+                            Callable[
+                                [_T8],
+                                Callable[
+                                    [_T9],
+                                    Callable[
+                                        [_T10],
+                                        Callable[
+                                            [_T11],
+                                            Callable[
+                                                [_T12],
+                                                Callable[
+                                                    [_T13],
+                                                    Callable[
+                                                        [_T14],
+                                                        Callable[
+                                                            [_T15],
+                                                            Callable[[_T16], _TResult]
+                                                        ]
+                                                    ]
+                                                ]
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ],
+]:
+    f2 = _curried.get(f)
+    if f2 is None:
+        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: lambda a10: lambda a11: lambda a12: lambda a13: lambda a14: lambda a15: lambda a16: f(
+            a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16
+        )
+    else:
+        return f2
+
+def uncurry17(
+    f: Callable[
+        [_T1],
+        Callable[
+            [_T2],
+            Callable[
+                [_T3],
+                Callable[
+                    [_T4],
+                    Callable[
+                        [_T5],
+                        Callable[
+                            [_T6],
+                            Callable[
+                                [_T7],
+                                Callable[
+                                    [_T8],
+                                    Callable[
+                                        [_T9],
+                                        Callable[
+                                            [_T10],
+                                            Callable[
+                                                [_T11],
+                                                Callable[
+                                                    [_T12],
+                                                    Callable[
+                                                        [_T13],
+                                                        Callable[
+                                                            [_T14],
+                                                            Callable[[_T15], Callable[[_T16], Callable[[_T17], _TResult]]]
+                                                        ]
+                                                    ]
+                                                ]
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ]
+) -> Callable[
+    [ _T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12, _T13, _T14, _T15, _T16, _T17] ,_TResult,
+]:
+    def f2(
+        a1: _T1,
+        a2: _T2,
+        a3: _T3,
+        a4: _T4,
+        a5: _T5,
+        a6: _T6,
+        a7: _T7,
+        a8: _T8,
+        a9: _T9,
+        a10: _T10,
+        a11: _T11,
+        a12: _T12,
+        a13: _T13,
+        a14: _T14,
+        a15: _T15,
+        a16: _T16,
+        a17: _T17,
+    ) -> _TResult:
+        return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)(a15)(a16)(a17)
+
+    _curried[f2] = f
+    return f2
+
+def curry17(
+    f: Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12, _T13, _T14, _T15, _T16, _T17], _TResult]
+) -> Callable[
+    [_T1],
+    Callable[
+        [_T2],
+        Callable[
+            [_T3],
+            Callable[
+                [_T4],
+                Callable[
+                    [_T5],
+                    Callable[
+                        [_T6],
+                        Callable[
+                            [_T7],
+                            Callable[
+                                [_T8],
+                                Callable[
+                                    [_T9],
+                                    Callable[
+                                        [_T10],
+                                        Callable[
+                                            [_T11],
+                                            Callable[
+                                                [_T12],
+                                                Callable[
+                                                    [_T13],
+                                                    Callable[
+                                                        [_T14],
+                                                        Callable[
+                                                            [_T15],
+                                                            Callable[
+                                                                [_T16],
+                                                                Callable[[_T17], _TResult]
+                                                            ]
+                                                        ]
+                                                    ]
+                                                ]
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ],
+]:
+    f2 = _curried.get(f)
+    if f2 is None:
+        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: lambda a10: lambda a11: lambda a12: lambda a13: lambda a14: lambda a15: lambda a16: lambda a17: f(
+            a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17
+        )
+    else:
+        return f2
+
+def uncurry18(
+    f: Callable[
+        [_T1],
+        Callable[
+            [_T2],
+            Callable[
+                [_T3],
+                Callable[
+                    [_T4],
+                    Callable[
+                        [_T5],
+                        Callable[
+                            [_T6],
+                            Callable[
+                                [_T7],
+                                Callable[
+                                    [_T8],
+                                    Callable[
+                                        [_T9],
+                                        Callable[
+                                            [_T10],
+                                            Callable[
+                                                [_T11],
+                                                Callable[
+                                                    [_T12],
+                                                    Callable[
+                                                        [_T13],
+                                                        Callable[
+                                                            [_T14],
+                                                            Callable[
+                                                                [_T15],
+                                                                Callable[
+                                                                    [_T16],
+                                                                    Callable[[_T17], Callable[[_T18], _TResult]]
+                                                                ]
+                                                            ]
+                                                        ]
+                                                    ]
+                                                ]
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ]
+) -> Callable[
+    [ _T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12, _T13, _T14, _T15, _T16, _T17, _T18] ,_TResult,
+]:
+    def f2(
+        a1: _T1,
+        a2: _T2,
+        a3: _T3,
+        a4: _T4,
+        a5: _T5,
+        a6: _T6,
+        a7: _T7,
+        a8: _T8,
+        a9: _T9,
+        a10: _T10,
+        a11: _T11,
+        a12: _T12,
+        a13: _T13,
+        a14: _T14,
+        a15: _T15,
+        a16: _T16,
+        a17: _T17,
+        a18: _T18,
+    ) -> _TResult:
+        return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)(a15)(a16)(a17)(a18)
+
+    _curried[f2] = f
+    return f2
+
+
+def curry18(
+    f: Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12, _T13, _T14, _T15, _T16, _T17, _T18], _TResult]
+) -> Callable[
+    [_T1],
+    Callable[
+        [_T2],
+        Callable[
+            [_T3],
+            Callable[
+                [_T4],
+                Callable[
+                    [_T5],
+                    Callable[
+                        [_T6],
+                        Callable[
+                            [_T7],
+                            Callable[
+                                [_T8],
+                                Callable[
+                                    [_T9],
+                                    Callable[
+                                        [_T10],
+                                        Callable[
+                                            [_T11],
+                                            Callable[
+                                                [_T12],
+                                                Callable[
+                                                    [_T13],
+                                                    Callable[
+                                                        [_T14],
+                                                        Callable[
+                                                            [_T15],
+                                                            Callable[
+                                                                [_T16],
+                                                                Callable[
+                                                                    [_T17],
+                                                                    Callable[[_T18], _TResult]
+                                                                ]
+                                                            ]
+                                                        ]
+                                                    ]
+                                                ]
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ],
+]:
+    f2 = _curried.get(f)
+    if f2 is None:
+        return (
+            lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: lambda a10: lambda a11: lambda a12: lambda a13: lambda a14: lambda a15: lambda a16: lambda a17: lambda a18: f(
+                a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18
+            )
         )
     else:
         return f2
 
 
-def uncurry4(
-    f: Callable[[_T1], Callable[[_T2], Callable[[_T3], Callable[[_T4], _TResult]]]]
-) -> Callable[[_T1, _T2, _T3, _T4], _TResult]:
-    def f2(a1: _T1, a2: _T2, a3: _T3, a4: _T4) -> _TResult:
-        return f(a1)(a2)(a3)(a4)
+def uncurry19(
+    f: Callable[
+        [_T1],
+        Callable[
+            [_T2],
+            Callable[
+                [_T3],
+                Callable[
+                    [_T4],
+                    Callable[
+                        [_T5],
+                        Callable[
+                            [_T6],
+                            Callable[
+                                [_T7],
+                                Callable[
+                                    [_T8],
+                                    Callable[
+                                        [_T9],
+                                        Callable[
+                                            [_T10],
+                                            Callable[
+                                                [_T11],
+                                                Callable[
+                                                    [_T12],
+                                                    Callable[
+                                                        [_T13],
+                                                        Callable[
+                                                            [_T14],
+                                                            Callable[
+                                                                [_T15],
+                                                                Callable[
+                                                                    [_T16],
+                                                                    Callable[
+                                                                        [_T17],
+                                                                        Callable[[_T18], Callable[[_T19], _TResult]]
+                                                                    ]
+                                                                ]
+                                                            ]
+                                                        ]
+                                                    ]
+                                                ]
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ]
+) -> Callable[
+    [ _T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12, _T13, _T14, _T15, _T16, _T17, _T18, _T19] ,_TResult,
+]:
+    def f2(
+        a1: _T1,
+        a2: _T2,
+        a3: _T3,
+        a4: _T4,
+        a5: _T5,
+        a6: _T6,
+        a7: _T7,
+        a8: _T8,
+        a9: _T9,
+        a10: _T10,
+        a11: _T11,
+        a12: _T12,
+        a13: _T13,
+        a14: _T14,
+        a15: _T15,
+        a16: _T16,
+        a17: _T17,
+        a18: _T18,
+        a19: _T19,
+    ) -> _TResult:
+        return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)(a15)(a16)(a17)(a18)(a19)
 
     _curried[f2] = f
     return f2
 
-
-def curry4(
-    f: Callable[[_T1, _T2, _T3, _T4], _TResult]
-) -> Callable[[_T1], Callable[[_T2], Callable[[_T3], Callable[[_T4], _TResult]]]]:
+def curry19(
+    f: Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12, _T13, _T14, _T15, _T16, _T17, _T18, _T19], _TResult]
+) -> Callable[
+    [_T1],
+    Callable[
+        [_T2],
+        Callable[
+            [_T3],
+            Callable[
+                [_T4],
+                Callable[
+                    [_T5],
+                    Callable[
+                        [_T6],
+                        Callable[
+                            [_T7],
+                            Callable[
+                                [_T8],
+                                Callable[
+                                    [_T9],
+                                    Callable[
+                                        [_T10],
+                                        Callable[
+                                            [_T11],
+                                            Callable[
+                                                [_T12],
+                                                Callable[
+                                                    [_T13],
+                                                    Callable[
+                                                        [_T14],
+                                                        Callable[
+                                                            [_T15],
+                                                            Callable[
+                                                                [_T16],
+                                                                Callable[
+                                                                    [_T17],
+                                                                    Callable[
+                                                                        [_T18],
+                                                                        Callable[[_T19], _TResult]
+                                                                    ]
+                                                                ]
+                                                            ]
+                                                        ]
+                                                    ]
+                                                ]
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ],
+]:
     f2 = _curried.get(f)
     if f2 is None:
-        return lambda a1: lambda a2: lambda a3: lambda a4: f(a1, a2, a3, a4)
+        return (
+            lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: lambda a10: lambda a11: lambda a12: lambda a13: lambda a14: lambda a15: lambda a16: lambda a17: lambda a18: lambda a19: f(
+                a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19
+            )
+        )
     else:
         return f2
 
-
-def uncurry3(
-    f: Callable[[_T1], Callable[[_T2], Callable[[_T3], _TResult]]]
-) -> Callable[[_T1, _T2, _T3], _TResult]:
-    def f2(a1: _T1, a2: _T2, a3: _T3) -> _TResult:
-        return f(a1)(a2)(a3)
+def uncurry20(
+    f: Callable[
+        [_T1],
+        Callable[
+            [_T2],
+            Callable[
+                [_T3],
+                Callable[
+                    [_T4],
+                    Callable[
+                        [_T5],
+                        Callable[
+                            [_T6],
+                            Callable[
+                                [_T7],
+                                Callable[
+                                    [_T8],
+                                    Callable[
+                                        [_T9],
+                                        Callable[
+                                            [_T10],
+                                            Callable[
+                                                [_T11],
+                                                Callable[
+                                                    [_T12],
+                                                    Callable[
+                                                        [_T13],
+                                                        Callable[
+                                                            [_T14],
+                                                            Callable[
+                                                                [_T15],
+                                                                Callable[
+                                                                    [_T16],
+                                                                    Callable[
+                                                                        [_T17],
+                                                                        Callable[
+                                                                            [_T18],
+                                                                            Callable[[_T19], Callable[[_T20], _TResult]]
+                                                                        ]
+                                                                    ]
+                                                                ]
+                                                            ]
+                                                        ]
+                                                    ]
+                                                ]
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ]
+) -> Callable[
+    [ _T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12, _T13, _T14, _T15, _T16, _T17, _T18, _T19, _T20] ,_TResult,
+]:
+    def f2(
+        a1: _T1,
+        a2: _T2,
+        a3: _T3,
+        a4: _T4,
+        a5: _T5,
+        a6: _T6,
+        a7: _T7,
+        a8: _T8,
+        a9: _T9,
+        a10: _T10,
+        a11: _T11,
+        a12: _T12,
+        a13: _T13,
+        a14: _T14,
+        a15: _T15,
+        a16: _T16,
+        a17: _T17,
+        a18: _T18,
+        a19: _T19,
+        a20: _T20,
+    ) -> _TResult:
+        return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)(a15)(a16)(a17)(a18)(a19)(a20)
 
     _curried[f2] = f
     return f2
 
-
-def curry3(
-    f: Callable[[_T1, _T2, _T3], _TResult]
-) -> Callable[[_T1], Callable[[_T2], Callable[[_T3], _TResult]]]:
+def curry20(
+    f: Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12, _T13, _T14, _T15, _T16, _T17, _T18, _T19, _T20], _TResult]
+) -> Callable[
+    [_T1],
+    Callable[
+        [_T2],
+        Callable[
+            [_T3],
+            Callable[
+                [_T4],
+                Callable[
+                    [_T5],
+                    Callable[
+                        [_T6],
+                        Callable[
+                            [_T7],
+                            Callable[
+                                [_T8],
+                                Callable[
+                                    [_T9],
+                                    Callable[
+                                        [_T10],
+                                        Callable[
+                                            [_T11],
+                                            Callable[
+                                                [_T12],
+                                                Callable[
+                                                    [_T13],
+                                                    Callable[
+                                                        [_T14],
+                                                        Callable[
+                                                            [_T15],
+                                                            Callable[
+                                                                [_T16],
+                                                                Callable[
+                                                                    [_T17],
+                                                                    Callable[
+                                                                        [_T18],
+                                                                        Callable[
+                                                                            [_T19],
+                                                                            Callable[[_T20], _TResult]
+                                                                        ]
+                                                                    ]
+                                                                ]
+                                                            ]
+                                                        ]
+                                                    ]
+                                                ]
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ],
+]:
     f2 = _curried.get(f)
     if f2 is None:
-        return lambda a1: lambda a2: lambda a3: f(a1, a2, a3)
-    else:
-        return f2
-
-
-def uncurry2(
-    f: Callable[[_T1], Callable[[_T2], _TResult]]
-) -> Callable[[_T1, _T2], _TResult]:
-    def f2(a1: _T1, a2: _T2) -> _TResult:
-        return f(a1)(a2)
-
-    _curried[f2] = f
-    return f2
-
-
-def curry2(
-    f: Callable[[_T1, _T2], _TResult]
-) -> Callable[[_T1], Callable[[_T2], _TResult]]:
-    f2 = _curried.get(f)
-    if f2 is None:
-        return lambda a1: lambda a2: f(a1, a2)
+        return (
+            lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: lambda a10: lambda a11: lambda a12: lambda a13: lambda a14: lambda a15: lambda a16: lambda a17: lambda a18: lambda a19: lambda a20: f(
+                a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20
+            )
+        )
     else:
         return f2
 

--- a/src/fable-library/Util.ts
+++ b/src/fable-library/Util.ts
@@ -776,6 +776,146 @@ export function curry10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(f: (a1
     ?? ((a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => f(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10));
 }
 
+export function uncurry11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(
+  f: (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => (a11: T11) => TResult
+) {
+  if (f == null) { return null as unknown as (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10, a11: T11) => TResult }
+  const f2 = (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10, a11: T11) => f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11);
+  curried.set(f2, f);
+  return f2;
+}
+
+export function curry11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(f: (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10, a11: T11) => TResult) {
+  return curried.get(f) as (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => (a11: T11) => TResult
+    ?? ((a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => (a11: T11) => f(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11));
+}
+
+export function uncurry12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(
+  f: (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => (a11: T11) => (a12: T12) => TResult
+) {
+  if (f == null) { return null as unknown as (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10, a11: T11, a12: T12) => TResult }
+  const f2 = (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10, a11: T11, a12: T12) => f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12);
+  curried.set(f2, f);
+  return f2;
+}
+
+export function curry12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(f: (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10, a11: T11, a12: T12) => TResult) {
+  return curried.get(f) as (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => (a11: T11) => (a12: T12) => TResult
+    ?? ((a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => (a11: T11) => (a12: T12) => f(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12));
+}
+
+export function uncurry13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(
+  f: (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => (a11: T11) => (a12: T12) => (a13: T13) => TResult
+) {
+  if (f == null) { return null as unknown as (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10, a11: T11, a12: T12, a13: T13) => TResult }
+  const f2 = (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10, a11: T11, a12: T12, a13: T13) => f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13);
+  curried.set(f2, f);
+  return f2;
+}
+
+export function curry13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(f: (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10, a11: T11, a12: T12, a13: T13) => TResult) {
+  return curried.get(f) as (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => (a11: T11) => (a12: T12) => (a13: T13) => TResult
+    ?? ((a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => (a11: T11) => (a12: T12) => (a13: T13) => f(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13));
+}
+
+export function uncurry14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(
+  f: (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => (a11: T11) => (a12: T12) => (a13: T13) => (a14: T14) => TResult
+) {
+  if (f == null) { return null as unknown as (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10, a11: T11, a12: T12, a13: T13, a14: T14) => TResult }
+  const f2 = (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10, a11: T11, a12: T12, a13: T13, a14: T14) => f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14);
+  curried.set(f2, f);
+  return f2;
+}
+
+export function curry14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(f: (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10, a11: T11, a12: T12, a13: T13, a14: T14) => TResult) {
+  return curried.get(f) as (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => (a11: T11) => (a12: T12) => (a13: T13) => (a14: T14) => TResult
+    ?? ((a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => (a11: T11) => (a12: T12) => (a13: T13) => (a14: T14) => f(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14));
+}
+
+export function uncurry15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(
+  f: (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => (a11: T11) => (a12: T12) => (a13: T13) => (a14: T14) => (a15: T15) => TResult
+) {
+  if (f == null) { return null as unknown as (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10, a11: T11, a12: T12, a13: T13, a14: T14, a15: T15) => TResult }
+  const f2 = (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10, a11: T11, a12: T12, a13: T13, a14: T14, a15: T15) => f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)(a15);
+  curried.set(f2, f);
+  return f2;
+}
+
+export function curry15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(f: (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10, a11: T11, a12: T12, a13: T13, a14: T14, a15: T15) => TResult) {
+  return curried.get(f) as (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => (a11: T11) => (a12: T12) => (a13: T13) => (a14: T14) => (a15: T15) => TResult
+    ?? ((a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => (a11: T11) => (a12: T12) => (a13: T13) => (a14: T14) => (a15: T15) => f(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15));
+}
+
+export function uncurry16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(
+  f: (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => (a11: T11) => (a12: T12) => (a13: T13) => (a14: T14) => (a15: T15) => (a16: T16) => TResult
+) {
+  if (f == null) { return null as unknown as (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10, a11: T11, a12: T12, a13: T13, a14: T14, a15: T15, a16: T16) => TResult }
+  const f2 = (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10, a11: T11, a12: T12, a13: T13, a14: T14, a15: T15, a16: T16) => f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)(a15)(a16);
+  curried.set(f2, f);
+  return f2;
+}
+
+export function curry16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(f: (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10, a11: T11, a12: T12, a13: T13, a14: T14, a15: T15, a16: T16) => TResult) {
+  return curried.get(f) as (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => (a11: T11) => (a12: T12) => (a13: T13) => (a14: T14) => (a15: T15) => (a16: T16) => TResult
+    ?? ((a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => (a11: T11) => (a12: T12) => (a13: T13) => (a14: T14) => (a15: T15) => (a16: T16) => f(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16));
+}
+
+export function uncurry17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TResult>(
+  f: (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => (a11: T11) => (a12: T12) => (a13: T13) => (a14: T14) => (a15: T15) => (a16: T16) => (a17: T17) => TResult
+) {
+  if (f == null) { return null as unknown as (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10, a11: T11, a12: T12, a13: T13, a14: T14, a15: T15, a16: T16, a17: T17) => TResult }
+  const f2 = (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10, a11: T11, a12: T12, a13: T13, a14: T14, a15: T15, a16: T16, a17: T17) => f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)(a15)(a16)(a17);
+  curried.set(f2, f);
+  return f2;
+}
+
+export function curry17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TResult>(f: (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10, a11: T11, a12: T12, a13: T13, a14: T14, a15: T15, a16: T16, a17: T17) => TResult) {
+  return curried.get(f) as (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => (a11: T11) => (a12: T12) => (a13: T13) => (a14: T14) => (a15: T15) => (a16: T16) => (a17: T17) => TResult
+    ?? ((a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => (a11: T11) => (a12: T12) => (a13: T13) => (a14: T14) => (a15: T15) => (a16: T16) => (a17: T17) => f(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17));
+}
+
+export function uncurry18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TResult>(
+  f: (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => (a11: T11) => (a12: T12) => (a13: T13) => (a14: T14) => (a15: T15) => (a16: T16) => (a17: T17) => (a18: T18) => TResult
+) {
+  if (f == null) { return null as unknown as (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10, a11: T11, a12: T12, a13: T13, a14: T14, a15: T15, a16: T16, a17: T17, a18: T18) => TResult }
+  const f2 = (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10, a11: T11, a12: T12, a13: T13, a14: T14, a15: T15, a16: T16, a17: T17, a18: T18) => f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)(a15)(a16)(a17)(a18);
+  curried.set(f2, f);
+  return f2;
+}
+
+export function curry18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TResult>(f: (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10, a11: T11, a12: T12, a13: T13, a14: T14, a15: T15, a16: T16, a17: T17, a18: T18) => TResult) {
+  return curried.get(f) as (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => (a11: T11) => (a12: T12) => (a13: T13) => (a14: T14) => (a15: T15) => (a16: T16) => (a17: T17) => (a18: T18) => TResult
+    ?? ((a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => (a11: T11) => (a12: T12) => (a13: T13) => (a14: T14) => (a15: T15) => (a16: T16) => (a17: T17) => (a18: T18) => f(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18));
+}
+
+export function uncurry19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TResult>(
+  f: (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => (a11: T11) => (a12: T12) => (a13: T13) => (a14: T14) => (a15: T15) => (a16: T16) => (a17: T17) => (a18: T18) => (a19: T19) => TResult
+) {
+  if (f == null) { return null as unknown as (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10, a11: T11, a12: T12, a13: T13, a14: T14, a15: T15, a16: T16, a17: T17, a18: T18, a19: T19) => TResult }
+  const f2 = (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10, a11: T11, a12: T12, a13: T13, a14: T14, a15: T15, a16: T16, a17: T17, a18: T18, a19: T19) => f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)(a15)(a16)(a17)(a18)(a19);
+  curried.set(f2, f);
+  return f2;
+}
+
+export function curry19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TResult>(f: (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10, a11: T11, a12: T12, a13: T13, a14: T14, a15: T15, a16: T16, a17: T17, a18: T18, a19: T19) => TResult) {
+  return curried.get(f) as (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => (a11: T11) => (a12: T12) => (a13: T13) => (a14: T14) => (a15: T15) => (a16: T16) => (a17: T17) => (a18: T18) => (a19: T19) => TResult
+    ?? ((a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => (a11: T11) => (a12: T12) => (a13: T13) => (a14: T14) => (a15: T15) => (a16: T16) => (a17: T17) => (a18: T18) => (a19: T19) => f(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19));
+}
+
+export function uncurry20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TResult>(
+  f: (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => (a11: T11) => (a12: T12) => (a13: T13) => (a14: T14) => (a15: T15) => (a16: T16) => (a17: T17) => (a18: T18) => (a19: T19) => (a20: T20) => TResult
+) {
+  if (f == null) { return null as unknown as (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10, a11: T11, a12: T12, a13: T13, a14: T14, a15: T15, a16: T16, a17: T17, a18: T18, a19: T19, a20: T20) => TResult }
+  const f2 = (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10, a11: T11, a12: T12, a13: T13, a14: T14, a15: T15, a16: T16, a17: T17, a18: T18, a19: T19, a20: T20) => f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)(a15)(a16)(a17)(a18)(a19)(a20);
+  curried.set(f2, f);
+  return f2;
+}
+
+export function curry20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TResult>(f: (a1: T1, a2: T2, a3: T3, a4: T4, a5: T5, a6: T6, a7: T7, a8: T8, a9: T9, a10: T10, a11: T11, a12: T12, a13: T13, a14: T14, a15: T15, a16: T16, a17: T17, a18: T18, a19: T19, a20: T20) => TResult) {
+  return curried.get(f) as (a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => (a11: T11) => (a12: T12) => (a13: T13) => (a14: T14) => (a15: T15) => (a16: T16) => (a17: T17) => (a18: T18) => (a19: T19) => (a20: T20) => TResult
+    ?? ((a1: T1) => (a2: T2) => (a3: T3) => (a4: T4) => (a5: T5) => (a6: T6) => (a7: T7) => (a8: T8) => (a9: T9) => (a10: T10) => (a11: T11) => (a12: T12) => (a13: T13) => (a14: T14) => (a15: T15) => (a16: T16) => (a17: T17) => (a18: T18) => (a19: T19) => (a20: T20) => f(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20));
+}
+
 // More performant method to copy arrays, see #2352
 export function copyToArray<T>(source: T[], sourceIndex: number, target: T[], targetIndex: number, count: number): void {
   if (ArrayBuffer.isView(source) && ArrayBuffer.isView(target)) {


### PR DESCRIPTION
#3514

@dbrattli Can you please have a look at the `fable-library-py/Util.py`.

I don't understand why Pylance generates errors when the function as more that 10 arguments.

![CleanShot 2023-10-19 at 22 15 42@2x](https://github.com/fable-compiler/Fable/assets/4760796/99755e43-a831-4649-bea0-d8aa768568d1)

I tried to check for syntax errors, but could not find any.