### PR TITLE
Python DU refinements: provide access to DU case constructors to python code

### DIFF
--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -3759,7 +3759,8 @@ module Util =
                 Arguments.arguments
                   [
                     for field in case.UnionCaseFields do
-                      Arg.arg(com.GetIdentifier(ctx, field.Name))
+                      let ta, _ = typeAnnotation com ctx None field.FieldType
+                      Arg.arg(com.GetIdentifier(ctx, field.Name), ta)
                   ]
               let decorators = [Expression.name "staticmethod"]
 

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -3688,6 +3688,16 @@ module Util =
     let transformUnion (com: IPythonCompiler) ctx (ent: Fable.Entity) (entName: string) classMembers =
         let fieldIds = getUnionFieldsAsIdents com ctx ent
 
+        let genTypeArgument =
+          let gen =
+            getGenericTypeParams [ fieldIds[1].Type ]
+            |> Set.toList
+            |> List.tryHead
+
+          let ta = Expression.name (gen |> Option.defaultValue "Any")
+          let id = ident com ctx fieldIds[1]
+          Arg.arg (id, annotation = ta)
+
         let args, isOptional =
             let args =
                 fieldIds[0]
@@ -3697,20 +3707,8 @@ module Util =
                     Arg.arg (id, annotation = ta))
                 |> List.singleton
 
-            let varargs =
-                fieldIds[1]
-                |> ident com ctx
-                |> (fun id ->
-                    let gen =
-                        getGenericTypeParams [ fieldIds[1].Type ]
-                        |> Set.toList
-                        |> List.tryHead
-
-                    let ta = Expression.name (gen |> Option.defaultValue "Any")
-                    Arg.arg (id, annotation = ta))
-
             let isOptional = Helpers.isOptional fieldIds
-            Arguments.arguments (args = args, vararg = varargs), isOptional
+            Arguments.arguments (args = args, vararg = genTypeArgument), isOptional
 
         let body =
             [ yield callSuperAsStatement []
@@ -3751,8 +3749,34 @@ module Util =
 
             Statement.functionDef (name, Arguments.arguments (), body = body, returns = returnType, decoratorList = decorators)
 
+        let constructors =
+          [
+            for case in ent.UnionCases do
+              let name = Identifier case.Name
+              let args =
+                Arguments.arguments
+                  [
+                    for field in case.UnionCaseFields do
+                      Arg.arg(com.GetIdentifier(ctx, field.Name))
+                  ]
+              let decorators = [Expression.name "staticmethod"]
+              let body =
+                // todo
+                [Statement.return' (Expression.constant 1)]
+
+              let returnType =
+                match args.VarArg with
+                | None -> Expression.name entName
+                | Some _ ->
+                  Expression.subscript(Expression.name entName, Expression.name genTypeArgument.Arg)
+              Statement.functionDef(name, args, body = body, returns = returnType, decoratorList = decorators)
+          ]
         let baseExpr = libValue com ctx "types" "Union" |> Some
-        let classMembers = List.append [ cases ] classMembers
+        let classMembers = [
+          cases
+          yield! constructors
+          yield! classMembers
+        ]
         declareType com ctx ent entName args isOptional body baseExpr classMembers
 
     let transformClassWithCompilerGeneratedConstructor (com: IPythonCompiler) ctx (ent: Fable.Entity) (entName: string) classMembers =

--- a/tests/Python/TestUnionType.fs
+++ b/tests/Python/TestUnionType.fs
@@ -1,5 +1,6 @@
 module Fable.Tests.UnionTypes
 
+open Fable.Core
 open Util.Testing
 
 type Gender = Male | Female
@@ -205,3 +206,17 @@ let ``test Equality works in filter`` () =
     |> Array.filter (fun r -> r.Case = MyUnion3.Case1)
     |> Array.length
     |> equal 2
+
+#if FABLE_COMPILER
+[<Fact>]
+let ``test constructor exposed to python code`` () =
+  let u0 = MyUnion.Case0
+  let u1 = MyUnion.Case1 "a"
+  let u2 = MyUnion.Case2 ("a","b")
+  let u3 = MyUnion.Case3 ("a","b","c")
+  let v0 : MyUnion = PyInterop.emitPyExpr () "MyUnion.Case0()"
+  let v1 : MyUnion = PyInterop.emitPyExpr "a" "MyUnion.Case1($0)"
+  let v2 : MyUnion = PyInterop.emitPyExpr ("a","b") "MyUnion.Case2($0,$1)"
+  let v3 : MyUnion = PyInterop.emitPyExpr ("a","b","c") "MyUnion.Case3($0,$1,$2)"
+  equal [u0;u1;u2;u3] [v0;v1;v2;v3]
+#endif


### PR DESCRIPTION
I'd like to provide DU case constructors to the python code that interops with code generated by Fable.

This suggested PR seems to do what I want, albeit there is edge case of generic type annotation not being carried in the case constructor of union with generic type argument, it doesn't seem to cause an issue to the python interpreter (and I'm not clear those would be required either).

Short quick test:
```fsharp

type U = Z of value: int | Y of name: string

let u1 = Z 1
let u2 = Y "abc"

let a : U = Fable.Core.PyInterop.emitPyExpr 1 "U.Z($0)"
let b : U = Fable.Core.PyInterop.emitPyExpr "abc" "U.Y($0)"
Fable.Core.Testing.Assert.AreEqual(a, u1)
Fable.Core.Testing.Assert.AreEqual(b, u2)
```

Turned by Fable into:
```python
from __future__ import annotations
from typing import (Any, List)
from fable_modules.fable_library.reflection import (TypeInfo, int32_type, string_type, union_type)
from fable_modules.fable_library.types import (Array, Union)
from fable_modules.fable_library.util import assert_equal

def _expr0() -> TypeInfo:
    return union_type("QuickTest.U", [], U, lambda: [[("value", int32_type)], [("name", string_type)]])


class U(Union):
    def __init__(self, tag: int, *fields: Any) -> None:
        super().__init__()
        self.tag: int = tag or 0
        self.fields: Array[Any] = list(fields)

    @staticmethod
    def cases() -> List[str]:
        return ["Z", "Y"]

    @staticmethod
    def Z(value: int) -> U:
        return U(0, value)

    @staticmethod
    def Y(name: str) -> U:
        return U(1, name)


U_reflection = _expr0

u1: U = U(0, 1)

u2: U = U(1, "abc")

a: U = U.Z(1)

b: U = U.Y("abc")

assert_equal(a, u1)

assert_equal(b, u2)
```

cc: @dbrattli