### PR TITLE
[Python] Generic typing fixes

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- [Python] Use `Any` type for all non-repeated generic types (by @dbrattli)
+- [Python] Don't generate unnecessary type type-vars if generic type is replaced by `Any` (by @dbrattli)
+
 ### Fixed
 
 #### JavaScript

--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Python] Use `Any` type for all non-repeated generic arguments (by @dbrattli)
 - [Python] Don't generate unnecessary type type-vars if generic type is replaced by `Any` (by @dbrattli)
+- [Python] Generate new style `_T | None` instead of `Optional[_T]` (by @dbrattli)
 
 ### Fixed
 

--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- [Python] Use `Any` type for all non-repeated generic types (by @dbrattli)
+- [Python] Use `Any` type for all non-repeated generic arguments (by @dbrattli)
 - [Python] Don't generate unnecessary type type-vars if generic type is replaced by `Any` (by @dbrattli)
 
 ### Fixed

--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -6,9 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- [Python] Use `Any` type for all non-repeated generic arguments (by @dbrattli)
-- [Python] Don't generate unnecessary type type-vars if generic type is replaced by `Any` (by @dbrattli)
-- [Python] Generate new style `_T | None` instead of `Optional[_T]` (by @dbrattli)
+#### Python
+
+* Use `Any` type for all non-repeated generic arguments (by @dbrattli)
+* Don't generate unnecessary type type-vars if generic type is replaced by `Any` (by @dbrattli)
+* Generate new style `_T | None` instead of `Optional[_T]` (by @dbrattli)
 
 ### Fixed
 

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -1039,9 +1039,8 @@ module Util =
             discardUnitArg args
             |> List.map (fun arg ->
                 let name = getUniqueNameInDeclarationScope ctx (arg.Name + "_mut")
-                // Use empty repeated generics to avoid creating unnecssary typevars
-                let ta, _ = typeAnnotation com ctx (Some Set.empty) arg.Type
-                Arg.arg (name, ta))
+                // Ignore type annotation here as it generates unnecessary typevars
+                Arg.arg name)
 
         interface ITailCallOpportunity with
             member _.Label = name

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -1039,8 +1039,7 @@ module Util =
             discardUnitArg args
             |> List.map (fun arg ->
                 let name = getUniqueNameInDeclarationScope ctx (arg.Name + "_mut")
-
-                let ta, _ = typeAnnotation com ctx (Some (set [])) arg.Type
+                let ta, _ = typeAnnotation com ctx (Some Set.empty) arg.Type
                 Arg.arg (name, ta))
 
         interface ITailCallOpportunity with

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -1039,6 +1039,7 @@ module Util =
             discardUnitArg args
             |> List.map (fun arg ->
                 let name = getUniqueNameInDeclarationScope ctx (arg.Name + "_mut")
+                // Use empty repeated generics to avoid creating unnecssary typevars
                 let ta, _ = typeAnnotation com ctx (Some Set.empty) arg.Type
                 Arg.arg (name, ta))
 


### PR DESCRIPTION
- Use `Any` type for all non-repeated generic parameters
- Don't generate unnecessary type type-vars if generic type is replaced by `Any`
- Generate new style `_T | None` instead of `Optional[_T]`

