### PR TITLE
[Python] Format generated files using ruff

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,10 +109,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install dependencies
+      - name: Install poetry
         run: |
           pip install poetry
-        # poetry install
 
       - name: Fable Library - Python (linux)
         if: matrix.platform == 'ubuntu-latest'

--- a/poetry.lock
+++ b/poetry.lock
@@ -29,54 +29,6 @@ tests = ["attrs[tests-no-zope]", "zope-interface"]
 tests-no-zope = ["cloudpickle", "hypothesis", "mypy (>=1.1.1)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
 
 [[package]]
-name = "black"
-version = "22.12.0"
-description = "The uncompromising code formatter."
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "black-22.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9eedd20838bd5d75b80c9f5487dbcb06836a43833a37846cf1d8c1cc01cef59d"},
-    {file = "black-22.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:159a46a4947f73387b4d83e87ea006dbb2337eab6c879620a3ba52699b1f4351"},
-    {file = "black-22.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d30b212bffeb1e252b31dd269dfae69dd17e06d92b87ad26e23890f3efea366f"},
-    {file = "black-22.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:7412e75863aa5c5411886804678b7d083c7c28421210180d67dfd8cf1221e1f4"},
-    {file = "black-22.12.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c116eed0efb9ff870ded8b62fe9f28dd61ef6e9ddd28d83d7d264a38417dcee2"},
-    {file = "black-22.12.0-cp37-cp37m-win_amd64.whl", hash = "sha256:1f58cbe16dfe8c12b7434e50ff889fa479072096d79f0a7f25e4ab8e94cd8350"},
-    {file = "black-22.12.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77d86c9f3db9b1bf6761244bc0b3572a546f5fe37917a044e02f3166d5aafa7d"},
-    {file = "black-22.12.0-cp38-cp38-win_amd64.whl", hash = "sha256:82d9fe8fee3401e02e79767016b4907820a7dc28d70d137eb397b92ef3cc5bfc"},
-    {file = "black-22.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:101c69b23df9b44247bd88e1d7e90154336ac4992502d4197bdac35dd7ee3320"},
-    {file = "black-22.12.0-cp39-cp39-win_amd64.whl", hash = "sha256:559c7a1ba9a006226f09e4916060982fd27334ae1998e7a38b3f33a37f7a2148"},
-    {file = "black-22.12.0-py3-none-any.whl", hash = "sha256:436cc9167dd28040ad90d3b404aec22cedf24a6e4d7de221bec2730ec0c97bcf"},
-    {file = "black-22.12.0.tar.gz", hash = "sha256:229351e5a18ca30f447bf724d007f890f97e13af070bb6ad4c0a441cd7596a2f"},
-]
-
-[package.dependencies]
-click = ">=8.0.0"
-mypy-extensions = ">=0.4.3"
-pathspec = ">=0.9.0"
-platformdirs = ">=2"
-tomli = {version = ">=1.1.0", markers = "python_full_version < \"3.11.0a7\""}
-
-[package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.7.4)"]
-jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-uvloop = ["uvloop (>=0.15.2)"]
-
-[[package]]
-name = "click"
-version = "8.1.7"
-description = "Composable command line interface toolkit"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"},
-    {file = "click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"},
-]
-
-[package.dependencies]
-colorama = {version = "*", markers = "platform_system == \"Windows\""}
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -115,34 +67,6 @@ files = [
 ]
 
 [[package]]
-name = "isort"
-version = "5.12.0"
-description = "A Python utility / library to sort Python imports."
-optional = false
-python-versions = ">=3.8.0"
-files = [
-    {file = "isort-5.12.0-py3-none-any.whl", hash = "sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"},
-    {file = "isort-5.12.0.tar.gz", hash = "sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504"},
-]
-
-[package.extras]
-colors = ["colorama (>=0.4.3)"]
-pipfile-deprecated-finder = ["pip-shims (>=0.5.2)", "pipreqs", "requirementslib"]
-plugins = ["setuptools"]
-requirements-deprecated-finder = ["pip-api", "pipreqs"]
-
-[[package]]
-name = "mypy-extensions"
-version = "1.0.0"
-description = "Type system extensions for programs checked with the mypy type checker."
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
-    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
-]
-
-[[package]]
 name = "packaging"
 version = "23.2"
 description = "Core utilities for Python packages"
@@ -152,32 +76,6 @@ files = [
     {file = "packaging-23.2-py3-none-any.whl", hash = "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"},
     {file = "packaging-23.2.tar.gz", hash = "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5"},
 ]
-
-[[package]]
-name = "pathspec"
-version = "0.11.2"
-description = "Utility library for gitignore style pattern matching of file paths."
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "pathspec-0.11.2-py3-none-any.whl", hash = "sha256:1d6ed233af05e679efb96b1851550ea95bbb64b7c490b0f5aa52996c11e92a20"},
-    {file = "pathspec-0.11.2.tar.gz", hash = "sha256:e0d8d0ac2f12da61956eb2306b69f9469b42f4deb0f3cb6ed47b9cce9996ced3"},
-]
-
-[[package]]
-name = "platformdirs"
-version = "3.11.0"
-description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "platformdirs-3.11.0-py3-none-any.whl", hash = "sha256:e9d171d00af68be50e9202731309c4e658fd8bc76f55c11c7dd760d023bda68e"},
-    {file = "platformdirs-3.11.0.tar.gz", hash = "sha256:cf8ee52a3afdb965072dcc652433e0c7e3e40cf5ea1477cd4b3b1d2eb75495b3"},
-]
-
-[package.extras]
-docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.1)", "sphinx-autodoc-typehints (>=1.24)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4)", "pytest-cov (>=4.1)", "pytest-mock (>=3.11.1)"]
 
 [[package]]
 name = "pluggy"
@@ -244,6 +142,32 @@ files = [
 six = ">=1.5"
 
 [[package]]
+name = "ruff"
+version = "0.1.3"
+description = "An extremely fast Python linter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.1.3-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:b46d43d51f7061652eeadb426a9e3caa1e0002470229ab2fc19de8a7b0766901"},
+    {file = "ruff-0.1.3-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:b8afeb9abd26b4029c72adc9921b8363374f4e7edb78385ffaa80278313a15f9"},
+    {file = "ruff-0.1.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca3cf365bf32e9ba7e6db3f48a4d3e2c446cd19ebee04f05338bc3910114528b"},
+    {file = "ruff-0.1.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4874c165f96c14a00590dcc727a04dca0cfd110334c24b039458c06cf78a672e"},
+    {file = "ruff-0.1.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eec2dd31eed114e48ea42dbffc443e9b7221976554a504767ceaee3dd38edeb8"},
+    {file = "ruff-0.1.3-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:dc3ec4edb3b73f21b4aa51337e16674c752f1d76a4a543af56d7d04e97769613"},
+    {file = "ruff-0.1.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2e3de9ed2e39160800281848ff4670e1698037ca039bda7b9274f849258d26ce"},
+    {file = "ruff-0.1.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1c595193881922cc0556a90f3af99b1c5681f0c552e7a2a189956141d8666fe8"},
+    {file = "ruff-0.1.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f75e670d529aa2288cd00fc0e9b9287603d95e1536d7a7e0cafe00f75e0dd9d"},
+    {file = "ruff-0.1.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:76dd49f6cd945d82d9d4a9a6622c54a994689d8d7b22fa1322983389b4892e20"},
+    {file = "ruff-0.1.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:918b454bc4f8874a616f0d725590277c42949431ceb303950e87fef7a7d94cb3"},
+    {file = "ruff-0.1.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d8859605e729cd5e53aa38275568dbbdb4fe882d2ea2714c5453b678dca83784"},
+    {file = "ruff-0.1.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:0b6c55f5ef8d9dd05b230bb6ab80bc4381ecb60ae56db0330f660ea240cb0d4a"},
+    {file = "ruff-0.1.3-py3-none-win32.whl", hash = "sha256:3e7afcbdcfbe3399c34e0f6370c30f6e529193c731b885316c5a09c9e4317eef"},
+    {file = "ruff-0.1.3-py3-none-win_amd64.whl", hash = "sha256:7a18df6638cec4a5bd75350639b2bb2a2366e01222825562c7346674bdceb7ea"},
+    {file = "ruff-0.1.3-py3-none-win_arm64.whl", hash = "sha256:12fd53696c83a194a2db7f9a46337ce06445fb9aa7d25ea6f293cf75b21aca9f"},
+    {file = "ruff-0.1.3.tar.gz", hash = "sha256:3ba6145369a151401d5db79f0a47d50e470384d0d89d0d6f7fab0b589ad07c34"},
+]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -265,18 +189,7 @@ files = [
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 
-[[package]]
-name = "tomli"
-version = "2.0.1"
-description = "A lil' TOML parser"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
-    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
-]
-
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.10, < 4.0"
-content-hash = "2c698c39cc59d24313e61757f40dbdaaec386795315a7629691f8662977b5d0c"
+content-hash = "4f2b7eff58e9829e844883c28ab72c2c89782fc2d89befe3eef35099fb10258b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,7 @@ python-dateutil = "^2.8.2"
 [tool.poetry.dev-dependencies]
 fable-library = {path = "./temp/fable-library-py", develop = true}
 pytest = "^6.2.4"
-black = {version = "^22.6.0", allow-prereleases = true}
-isort = "^5.10.1"
+ruff = "^0.1.3"
 
 [tool.pyright]
 reportMissingTypeStubs = false
@@ -37,15 +36,12 @@ reportImplicitStringConcatenation = true
 pythonVersion = "3.10"
 typeCheckingMode = "strict"
 
-[tool.isort]
-
 [tool.ruff]
 # Keep in sync with .pre-commit-config.yaml
 line-length = 120
 ignore = []
 target-version = "py310"
 select = ["E", "W",  "F", "I", "T", "RUF", "TID", "UP"]
-exclude = ["tests", "build", "temp", "src/fable_library", "src/fable_library_rust", "src/fable_library_php"]
 include =["*.py"]
 
 [tool.ruff.pydocstyle]
@@ -53,7 +49,6 @@ convention = "google"
 
 [tool.ruff.isort]
 lines-after-imports = 2
-
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/src/Fable.Build/FableLibrary/Python.fs
+++ b/src/Fable.Build/FableLibrary/Python.fs
@@ -43,7 +43,7 @@ type BuildFableLibraryPython() =
             "poetry",
             $"run ruff --select I --fix {this.BuildDir}"
         )
-        // Run Ruff formatter using poetry on all generated files
+        // Run Ruff formatter on all generated files
         Command.Run(
             "poetry",
             $"run ruff format {this.BuildDir}"

--- a/src/Fable.Build/FableLibrary/Python.fs
+++ b/src/Fable.Build/FableLibrary/Python.fs
@@ -3,6 +3,7 @@ namespace Build.FableLibrary
 open System.IO
 open Fake.IO
 open Build.Utils
+open SimpleExec
 
 type BuildFableLibraryPython() =
     inherit
@@ -30,3 +31,10 @@ type BuildFableLibraryPython() =
         Directory.GetFiles(linkedFileFolder, "*") |> Shell.copyFiles this.OutDir
 
         Shell.deleteDir (this.BuildDir </> "fable_library/fable-library")
+
+        // Run Ruff formatter using poetry on all generated files
+        Command.Run(
+            "poetry",
+            "run ruff format .",
+            this.OutDir
+        )

--- a/src/Fable.Build/FableLibrary/Python.fs
+++ b/src/Fable.Build/FableLibrary/Python.fs
@@ -32,6 +32,13 @@ type BuildFableLibraryPython() =
 
         Shell.deleteDir (this.BuildDir </> "fable_library/fable-library")
 
+        // Run Ruff linter checking import sorting and fix any issues
+        Command.Run(
+            "poetry",
+            "run ruff --select I --fix .",
+            this.OutDir
+        )
+
         // Run Ruff formatter using poetry on all generated files
         Command.Run(
             "poetry",

--- a/src/Fable.Build/FableLibrary/Python.fs
+++ b/src/Fable.Build/FableLibrary/Python.fs
@@ -41,8 +41,7 @@ type BuildFableLibraryPython() =
         // Run Ruff linter checking import sorting and fix any issues
         Command.Run(
             "poetry",
-            "run ruff --select I --fix .",
-            this.OutDir
+            $"run ruff --select I --fix {this.BuildDir}"
         )
         // Run Ruff formatter using poetry on all generated files
         Command.Run(

--- a/src/fable-library-py/fable_library/async_.py
+++ b/src/fable-library-py/fable_library/async_.py
@@ -137,9 +137,7 @@ def sequential(computations: Iterable[Async[_T]]) -> Async[list[_T | None]]:
         def _arrow21(__unit: Literal[None] = None) -> Async[list[_T]]:
             return singleton.Return(results)
 
-        return singleton.Combine(
-            singleton.For(computations, _arrow20), singleton.Delay(_arrow21)
-        )
+        return singleton.Combine(singleton.For(computations, _arrow20), singleton.Delay(_arrow21))
 
     return delay(delayed)
 
@@ -152,9 +150,7 @@ def catch_async(work: Async[_T]) -> Async[_T]:
         def on_error(err: Exception):
             ctx.on_success(Choice_makeChoice2Of2(err))  # type: ignore
 
-        ctx_ = IAsyncContext.create(
-            on_success, on_error, ctx.on_cancel, ctx.trampoline, ctx.cancel_token
-        )
+        ctx_ = IAsyncContext.create(on_success, on_error, ctx.on_cancel, ctx.trampoline, ctx.cancel_token)
         work(ctx_)
 
     return protected_cont(cont)
@@ -164,7 +160,7 @@ def from_continuations(
     f: Callable[
         [Continuations[_T]],
         None,
-    ]
+    ],
 ) -> Callable[[IAsyncContext[_T]], None]:
     def cont(ctx: IAsyncContext[_T]) -> None:
         f((ctx.on_success, ctx.on_error, ctx.on_cancel))
@@ -247,9 +243,7 @@ def start_with_continuations(
     run_in_loop(runner)
 
 
-def start_as_task(
-    computation: Async[_T], cancellation_token: CancellationToken | None = None
-) -> Awaitable[_T]:
+def start_as_task(computation: Async[_T], cancellation_token: CancellationToken | None = None) -> Awaitable[_T]:
     """Executes a computation in the thread pool.
 
     If no cancellation token is provided then the default cancellation

--- a/src/fable-library-py/fable_library/async_builder.py
+++ b/src/fable-library-py/fable_library/async_builder.py
@@ -132,9 +132,7 @@ class IAsyncContext(Generic[_T]):
         trampoline: Trampoline | None,
         cancel_token: CancellationToken | None,
     ) -> IAsyncContext[_T]:
-        return AnonymousAsyncContext(
-            on_success, on_error, on_cancel, trampoline, cancel_token
-        )
+        return AnonymousAsyncContext(on_success, on_error, on_cancel, trampoline, cancel_token)
 
 
 """ FSharpAsync"""
@@ -158,9 +156,7 @@ class AnonymousAsyncContext(IAsyncContext[_T]):
     ):
         self._on_success: Callable[[_T], None] = on_success or empty_continuation
         self._on_error: Callable[[Exception], None] = on_error or empty_continuation
-        self._on_cancel: Callable[[OperationCanceledError], None] = (
-            on_cancel or empty_continuation
-        )
+        self._on_cancel: Callable[[OperationCanceledError], None] = on_cancel or empty_continuation
 
         self._cancel_token = cancel_token
         self._trampoline = trampoline
@@ -264,9 +260,7 @@ def protected_bind(
                 # print("Exception: ", err)
                 ctx.on_error(err)
 
-        ctx_ = IAsyncContext.create(
-            on_success, ctx.on_error, ctx.on_cancel, ctx.trampoline, ctx.cancel_token
-        )
+        ctx_ = IAsyncContext.create(on_success, ctx.on_error, ctx.on_cancel, ctx.trampoline, ctx.cancel_token)
         return computation(ctx_)
 
     return protected_cont(cont)
@@ -282,9 +276,7 @@ def protected_return(value: _T) -> Async[_T]:
 class AsyncBuilder:
     __slots__ = ()
 
-    def Bind(
-        self, computation: Async[_T], binder: Callable[[_T], Async[_U]]
-    ) -> Async[_U]:
+    def Bind(self, computation: Async[_T], binder: Callable[[_T], Async[_U]]) -> Async[_U]:
         return protected_bind(computation, binder)
 
     def Combine(self, computation1: Async[Any], computation2: Async[_T]) -> Async[_T]:
@@ -329,9 +321,7 @@ class AsyncBuilder:
     def ReturnFrom(self, computation: Async[_T]) -> Async[_T]:
         return computation
 
-    def TryFinally(
-        self, computation: Async[_T], compensation: Callable[[], None]
-    ) -> Async[_T]:
+    def TryFinally(self, computation: Async[_T], compensation: Callable[[], None]) -> Async[_T]:
         def cont(ctx: IAsyncContext[_T]) -> None:
             def on_success(x: _T) -> None:
                 compensation()
@@ -345,16 +335,12 @@ class AsyncBuilder:
                 compensation()
                 ctx.on_cancel(x)
 
-            ctx_ = IAsyncContext.create(
-                on_success, on_error, on_cancel, ctx.trampoline, ctx.cancel_token
-            )
+            ctx_ = IAsyncContext.create(on_success, on_error, on_cancel, ctx.trampoline, ctx.cancel_token)
             computation(ctx_)
 
         return protected_cont(cont)
 
-    def TryWith(
-        self, computation: Async[_T], catch_handler: Callable[[Exception], Async[_T]]
-    ) -> Async[_T]:
+    def TryWith(self, computation: Async[_T], catch_handler: Callable[[Exception], Async[_T]]) -> Async[_T]:
         def fn(ctx: IAsyncContext[_T]):
             def on_error(err: Exception) -> None:
                 try:
@@ -381,9 +367,7 @@ class AsyncBuilder:
         return self.TryFinally(binder(resource), compensation)
 
     @overload
-    def While(
-        self, guard: Callable[[], bool], computation: Async[Literal[None]]
-    ) -> Async[None]:
+    def While(self, guard: Callable[[], bool], computation: Async[Literal[None]]) -> Async[None]:
         ...
 
     @overload

--- a/src/fable-library-py/fable_library/bit_converter.py
+++ b/src/fable-library-py/fable_library/bit_converter.py
@@ -63,39 +63,27 @@ def to_char(bytes: bytearray, offset: int) -> str:
 
 
 def to_int16(bytes: bytearray, offset: int) -> int:
-    return int.from_bytes(
-        bytes[offset : offset + 2], byteorder=sys.byteorder, signed=True
-    )
+    return int.from_bytes(bytes[offset : offset + 2], byteorder=sys.byteorder, signed=True)
 
 
 def to_uint16(bytes: bytearray, offset: int) -> int:
-    return int.from_bytes(
-        bytes[offset : offset + 2], byteorder=sys.byteorder, signed=False
-    )
+    return int.from_bytes(bytes[offset : offset + 2], byteorder=sys.byteorder, signed=False)
 
 
 def to_int32(bytes: bytearray, offset: int) -> int:
-    return int.from_bytes(
-        bytes[offset : offset + 4], byteorder=sys.byteorder, signed=True
-    )
+    return int.from_bytes(bytes[offset : offset + 4], byteorder=sys.byteorder, signed=True)
 
 
 def to_uint32(bytes: bytearray, offset: int) -> int:
-    return int.from_bytes(
-        bytes[offset : offset + 4], byteorder=sys.byteorder, signed=False
-    )
+    return int.from_bytes(bytes[offset : offset + 4], byteorder=sys.byteorder, signed=False)
 
 
 def to_int64(bytes: bytes, offset: int) -> int:
-    return int.from_bytes(
-        bytes[offset : offset + 8], byteorder=sys.byteorder, signed=True
-    )
+    return int.from_bytes(bytes[offset : offset + 8], byteorder=sys.byteorder, signed=True)
 
 
 def to_uint64(bytes: bytearray, offset: int) -> int:
-    return int.from_bytes(
-        bytes[offset : offset + 8], byteorder=sys.byteorder, signed=False
-    )
+    return int.from_bytes(bytes[offset : offset + 8], byteorder=sys.byteorder, signed=False)
 
 
 def to_single(bytes: bytearray, offset: int) -> float:

--- a/src/fable-library-py/fable_library/char.py
+++ b/src/fable-library-py/fable_library/char.py
@@ -105,10 +105,7 @@ IS_SEPARATOR_MASK = (
     | 1 << UnicodeCategory.ParagraphSeparator
 )
 IS_NUMBER_MASK = (
-    0
-    | 1 << UnicodeCategory.DecimalDigitNumber
-    | 1 << UnicodeCategory.LetterNumber
-    | 1 << UnicodeCategory.OtherNumber
+    0 | 1 << UnicodeCategory.DecimalDigitNumber | 1 << UnicodeCategory.LetterNumber | 1 << UnicodeCategory.OtherNumber
 )
 IS_SYMBOL_MASK = (
     0

--- a/src/fable-library-py/fable_library/date.py
+++ b/src/fable-library-py/fable_library/date.py
@@ -1,7 +1,9 @@
-import re
+from __future__ import annotations
 
+import re
 from datetime import datetime, timedelta, timezone
-from typing import Any, Match, Optional
+from re import Match
+from typing import Any
 
 from .types import FSharpRef
 from .util import DateKind
@@ -22,7 +24,7 @@ def create(
     m: int = 0,
     s: int = 0,
     ms: int = 0,
-    kind: Optional[DateKind] = None,
+    kind: DateKind | None = None,
 ) -> datetime:
     if kind == DateKind.UTC:
         date = datetime(
@@ -132,14 +134,14 @@ def date_to_string_with_custom_format(date: datetime, format: str, utc: bool) ->
 #         return dateToStringWithCustomFormat(d, format, True)
 
 
-def date_to_string_with_offset(date: datetime, format: Optional[str] = None) -> str:
+def date_to_string_with_offset(date: datetime, format: str | None = None) -> str:
     if format and len(format) == 1:
         return date_to_string_with_custom_format(date, format, True)
 
     raise NotImplementedError("date_to_string_with_offset")
 
 
-def date_to_string_with_kind(date: datetime, format: Optional[str] = None) -> str:
+def date_to_string_with_kind(date: datetime, format: str | None = None) -> str:
     utc = date.tzinfo == timezone.utc
     if not format:
         return date.isoformat() if utc else str(date)
@@ -158,9 +160,7 @@ def date_to_string_with_kind(date: datetime, format: Optional[str] = None) -> st
         return date_to_string_with_custom_format(date, format, utc)
 
 
-def to_string(
-    date: datetime, format: Optional[str] = None, provider: Optional[Any] = None
-) -> str:
+def to_string(date: datetime, format: str | None = None, provider: Any | None = None) -> str:
     if date.tzinfo:
         return date_to_string_with_offset(date, format)
 
@@ -211,9 +211,7 @@ def parse(string: str, detectUTC: bool = False) -> datetime:
     return parser.parse(string)
 
 
-def try_parse(
-    string: str, style: int, unsigned: bool, bitsize: int, defValue: FSharpRef[datetime]
-) -> bool:
+def try_parse(string: str, style: int, unsigned: bool, bitsize: int, defValue: FSharpRef[datetime]) -> bool:
     try:
         defValue.contents = parse(string)
         return True

--- a/src/fable-library-py/fable_library/date_offset.py
+++ b/src/fable-library-py/fable_library/date_offset.py
@@ -15,9 +15,7 @@ def parse(string: str, detectUTC: bool = False) -> datetime:
     return parser.parse(string)
 
 
-def try_parse(
-    string: str, style: int, unsigned: bool, bitsize: int, defValue: FSharpRef[datetime]
-) -> bool:
+def try_parse(string: str, style: int, unsigned: bool, bitsize: int, defValue: FSharpRef[datetime]) -> bool:
     try:
         defValue.contents = parse(string)
         return True

--- a/src/fable-library-py/fable_library/decimal_.py
+++ b/src/fable-library-py/fable_library/decimal_.py
@@ -37,28 +37,80 @@ def min(x: Decimal, y: Decimal) -> Decimal:
     return x if x < y else y
 
 
-def add(a: Decimal, b: Decimal) -> Decimal: return a + b
-def subtract(a: Decimal, b: Decimal) -> Decimal: return a - b
-def multiply(a: Decimal, b: Decimal) -> Decimal: return a * b
-def divide(a: Decimal, b: Decimal) -> Decimal: return a / b
-def remainder(a: Decimal, b: Decimal) -> Decimal: return a % b
-def negate(a: Decimal) -> Decimal: return -a
+def add(a: Decimal, b: Decimal) -> Decimal:
+    return a + b
 
-def op_unary_negation(a: Decimal) -> Decimal: return -a
-def op_unary_plus(a: Decimal) -> Decimal: return +a
 
-def op_addition(a: Decimal, b: Decimal) -> Decimal: return a + b
-def op_subtraction(a: Decimal, b: Decimal) -> Decimal: return a - b
-def op_multiply(a: Decimal, b: Decimal) -> Decimal: return a * b
-def op_division(a: Decimal, b: Decimal) -> Decimal: return a / b
-def op_modulus(a: Decimal, b: Decimal) -> Decimal: return a % b
+def subtract(a: Decimal, b: Decimal) -> Decimal:
+    return a - b
 
-def op_less_than(a: Decimal, b: Decimal) -> bool: return a < b
-def op_less_than_or_equal(a: Decimal, b: Decimal) -> bool: return a <= b
-def op_greater_than(a: Decimal, b: Decimal) -> bool: return a > b
-def op_greater_than_or_equal(a: Decimal, b: Decimal) -> bool: return a >= b
-def op_equality(a: Decimal, b: Decimal) -> bool: return a == b
-def op_inequality(a: Decimal, b: Decimal) -> bool: return a != b
+
+def multiply(a: Decimal, b: Decimal) -> Decimal:
+    return a * b
+
+
+def divide(a: Decimal, b: Decimal) -> Decimal:
+    return a / b
+
+
+def remainder(a: Decimal, b: Decimal) -> Decimal:
+    return a % b
+
+
+def negate(a: Decimal) -> Decimal:
+    return -a
+
+
+def op_unary_negation(a: Decimal) -> Decimal:
+    return -a
+
+
+def op_unary_plus(a: Decimal) -> Decimal:
+    return +a
+
+
+def op_addition(a: Decimal, b: Decimal) -> Decimal:
+    return a + b
+
+
+def op_subtraction(a: Decimal, b: Decimal) -> Decimal:
+    return a - b
+
+
+def op_multiply(a: Decimal, b: Decimal) -> Decimal:
+    return a * b
+
+
+def op_division(a: Decimal, b: Decimal) -> Decimal:
+    return a / b
+
+
+def op_modulus(a: Decimal, b: Decimal) -> Decimal:
+    return a % b
+
+
+def op_less_than(a: Decimal, b: Decimal) -> bool:
+    return a < b
+
+
+def op_less_than_or_equal(a: Decimal, b: Decimal) -> bool:
+    return a <= b
+
+
+def op_greater_than(a: Decimal, b: Decimal) -> bool:
+    return a > b
+
+
+def op_greater_than_or_equal(a: Decimal, b: Decimal) -> bool:
+    return a >= b
+
+
+def op_equality(a: Decimal, b: Decimal) -> bool:
+    return a == b
+
+
+def op_inequality(a: Decimal, b: Decimal) -> bool:
+    return a != b
 
 
 def from_parts(low: int, mid: int, high: int, isNegative: bool, scale: int) -> Decimal:
@@ -107,35 +159,29 @@ def try_parse(string: str, def_value: FSharpRef[Decimal]) -> bool:
 __all__ = [
     "compare",
     "equals",
-
     "abs",
     "sign",
     "max",
     "min",
-
     "add",
     "subtract",
     "multiply",
     "divide",
     "remainder",
     "negate",
-
     "op_unary_negation",
     "op_unary_plus",
-
     "op_addition",
     "op_subtraction",
     "op_multiply",
     "op_division",
     "op_modulus",
-
     "op_less_than",
     "op_less_than_or_equal",
     "op_greater_than",
     "op_greater_than_or_equal",
     "op_equality",
     "op_inequality",
-
     "from_parts",
     "to_string",
     "to_number",

--- a/src/fable-library-py/fable_library/double.py
+++ b/src/fable-library-py/fable_library/double.py
@@ -1,5 +1,4 @@
 import math
-
 from math import copysign
 from typing import Any
 
@@ -69,16 +68,4 @@ def try_parse(string: str, def_value: FSharpRef[float]) -> bool:
         return False
 
 
-__all__ = [
-    "abs",
-    "sign",
-    "max",
-    "min",
-
-    "parse",
-    "try_parse",
-    "divide",
-    "log",
-    "sqrt",
-    "is_negative_inf"
-]
+__all__ = ["abs", "sign", "max", "min", "parse", "try_parse", "divide", "log", "sqrt", "is_negative_inf"]

--- a/src/fable-library-py/fable_library/encoding.py
+++ b/src/fable-library-py/fable_library/encoding.py
@@ -1,15 +1,11 @@
-from typing import Optional
+from __future__ import annotations
 
 
 class UTF16LE:
-    def get_bytes(
-        self, string: str, index: Optional[int] = None, count: Optional[int] = None
-    ) -> bytes:
+    def get_bytes(self, string: str, index: int | None = None, count: int | None = None) -> bytes:
         return string.encode("utf-16le")
 
-    def get_string(
-        self, bytes: bytes, index: Optional[int] = None, count: Optional[int] = None
-    ) -> str:
+    def get_string(self, bytes: bytes, index: int | None = None, count: int | None = None) -> str:
         if index is None:
             return bytes.decode("utf-8")
         else:
@@ -17,17 +13,13 @@ class UTF16LE:
 
 
 class UTF8:
-    def get_bytes(
-        self, string: str, index: Optional[int] = None, count: Optional[int] = None
-    ) -> bytes:
+    def get_bytes(self, string: str, index: int | None = None, count: int | None = None) -> bytes:
         if index is None:
             return string.encode("utf-8")
         else:
             return string.encode("utf-8")[index:count]
 
-    def get_string(
-        self, bytes: bytes, index: Optional[int] = None, count: Optional[int] = None
-    ) -> str:
+    def get_string(self, bytes: bytes, index: int | None = None, count: int | None = None) -> str:
         if index is None:
             return bytes.decode("utf-8")
         else:

--- a/src/fable-library-py/fable_library/file.py
+++ b/src/fable-library-py/fable_library/file.py
@@ -56,13 +56,13 @@ def write_all_text_async(file_name: str, text: str) -> Awaitable[None]:
 
 def write_all_lines(file_name: str, lines: list[str]) -> None:
     with open(file_name, "w") as f:
-        f.write('\n'.join(lines))
+        f.write("\n".join(lines))
 
 
 def write_all_lines_async(file_name: str, lines: list[str]) -> Awaitable[None]:
     async def write_all_lines_async():
         with open(file_name, "w") as f:
-            f.write('\n'.join(lines))
+            f.write("\n".join(lines))
 
     return write_all_lines_async()
 
@@ -99,9 +99,7 @@ def exists(path: str) -> bool:
     return os.path.exists(path)
 
 
-def replace(
-    source_file_name: str, destination_file_name: str, destination_backup_file_name: str
-) -> None:
+def replace(source_file_name: str, destination_file_name: str, destination_backup_file_name: str) -> None:
     with open(destination_file_name, "rb") as f:
         data = f.read()
     with open(destination_backup_file_name, "wb") as f:

--- a/src/fable-library-py/fable_library/int32.py
+++ b/src/fable-library-py/fable_library/int32.py
@@ -16,9 +16,7 @@ def get_range(unsigned: bool, bitsize: int) -> Tuple[int, int]:
 AllowHexSpecifier = 0x00000200
 
 
-def parse(
-    string: str, style: int, unsigned: bool, bitsize: int, radix: int = 10
-) -> int:
+def parse(string: str, style: int, unsigned: bool, bitsize: int, radix: int = 10) -> int:
     # const res = isValid(str, style, radix);
     if style & AllowHexSpecifier or string.startswith("0x"):
         radix = 16
@@ -45,9 +43,7 @@ def parse(
     raise ValueError(f"The input string {string} was not in a correct format.")
 
 
-def try_parse(
-    string: str, style: int, unsigned: bool, bitsize: int, defValue: FSharpRef[int]
-) -> bool:
+def try_parse(string: str, style: int, unsigned: bool, bitsize: int, defValue: FSharpRef[int]) -> bool:
     try:
         defValue.contents = parse(string, style, unsigned, bitsize)
         return True

--- a/src/fable-library-py/fable_library/long.py
+++ b/src/fable-library-py/fable_library/long.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Tuple
+from typing import Any
 
 from .types import FSharpRef
 
@@ -31,28 +31,78 @@ def op_unary_negation(value: int) -> int:
     # Note that we cannot negate the smallest negative number
     return -value if value != -0x8000000000000000 else -0x8000000000000000
 
+
 # def op_unary_negation(a: int) -> int: return -a
-def op_unary_plus(a: int) -> int: return +a
-def op_logical_not(a: int) -> int: return ~a
+def op_unary_plus(a: int) -> int:
+    return +a
 
-def op_addition(a: int, b: int) -> int: return a + b
-def op_subtraction(a: int, b: int) -> int: return a - b
-def op_multiply(a: int, b: int) -> int: return a * b
-def op_division(a: int, b: int) -> int: return a // b
-def op_modulus(a: int, b: int) -> int: return a % b
 
-def op_right_shift(a: int, b: int) -> int: return a >> b
-def op_left_shift(a: int, b: int) -> int: return a << b
-def op_bitwise_and(a: int, b: int) -> int: return a & b
-def op_bitwise_or(a: int, b: int) -> int: return a | b
-def op_exclusive_or(a: int, b: int) -> int: return a ^ b
+def op_logical_not(a: int) -> int:
+    return ~a
 
-def op_less_than(a: int, b: int) -> bool: return a < b
-def op_less_than_or_equal(a: int, b: int) -> bool: return a <= b
-def op_greater_than(a: int, b: int) -> bool: return a > b
-def op_greater_than_or_equal(a: int, b: int) -> bool: return a >= b
-def op_equality(a: int, b: int) -> bool: return a == b
-def op_inequality(a: int, b: int) -> bool: return a != b
+
+def op_addition(a: int, b: int) -> int:
+    return a + b
+
+
+def op_subtraction(a: int, b: int) -> int:
+    return a - b
+
+
+def op_multiply(a: int, b: int) -> int:
+    return a * b
+
+
+def op_division(a: int, b: int) -> int:
+    return a // b
+
+
+def op_modulus(a: int, b: int) -> int:
+    return a % b
+
+
+def op_right_shift(a: int, b: int) -> int:
+    return a >> b
+
+
+def op_left_shift(a: int, b: int) -> int:
+    return a << b
+
+
+def op_bitwise_and(a: int, b: int) -> int:
+    return a & b
+
+
+def op_bitwise_or(a: int, b: int) -> int:
+    return a | b
+
+
+def op_exclusive_or(a: int, b: int) -> int:
+    return a ^ b
+
+
+def op_less_than(a: int, b: int) -> bool:
+    return a < b
+
+
+def op_less_than_or_equal(a: int, b: int) -> bool:
+    return a <= b
+
+
+def op_greater_than(a: int, b: int) -> bool:
+    return a > b
+
+
+def op_greater_than_or_equal(a: int, b: int) -> bool:
+    return a >= b
+
+
+def op_equality(a: int, b: int) -> bool:
+    return a == b
+
+
+def op_inequality(a: int, b: int) -> bool:
+    return a != b
 
 
 def from_bits(lowBits: int, highBits: int, unsigned: bool) -> int:
@@ -87,9 +137,7 @@ def to_number(value: int) -> float:
     return float(value)
 
 
-def from_integer(
-    value: int, unsigned: Optional[bool] = None, kind: Optional[int] = None
-) -> int:
+def from_integer(value: int, unsigned: bool | None = None, kind: int | None = None) -> int:
     if unsigned and value < 0:
         return value + 0x10000000000000000
     elif not unsigned and value > 9223372036854775807:
@@ -97,20 +145,14 @@ def from_integer(
     return value
 
 
-def get_range(unsigned: bool) -> Tuple[int, int]:
-    return (
-        (0, 18446744073709551615)
-        if unsigned
-        else (-9223372036854775808, 9223372036854775807)
-    )
+def get_range(unsigned: bool) -> tuple[int, int]:
+    return (0, 18446744073709551615) if unsigned else (-9223372036854775808, 9223372036854775807)
 
 
 AllowHexSpecifier = 0x00000200
 
 
-def parse(
-    string: str, style: int, unsigned: bool, bitsize: int, radix: int = 10
-) -> int:
+def parse(string: str, style: int, unsigned: bool, bitsize: int, radix: int = 10) -> int:
     # const res = isValid(str, style, radix);
     if style & AllowHexSpecifier or string.startswith("0x"):
         radix = 16
@@ -137,9 +179,7 @@ def parse(
     raise ValueError(f"The input string {string} was not in a correct format.")
 
 
-def try_parse(
-    string: str, style: int, unsigned: bool, bitsize: int, defValue: FSharpRef[int]
-) -> bool:
+def try_parse(string: str, style: int, unsigned: bool, bitsize: int, defValue: FSharpRef[int]) -> bool:
     try:
         defValue.contents = parse(string, style, unsigned, bitsize)
         return True
@@ -162,47 +202,39 @@ long = int
 __all__ = [
     "compare",
     "equals",
-
     "abs",
     "sign",
     "max",
     "min",
-
     "op_unary_negation",
     "op_unary_plus",
     "op_logical_not",
-
     "op_addition",
     "op_subtraction",
     "op_multiply",
     "op_division",
     "op_modulus",
-
     "op_right_shift",
     "op_left_shift",
     "op_bitwise_and",
     "op_bitwise_or",
     "op_exclusive_or",
-
     "op_less_than",
     "op_less_than_or_equal",
     "op_greater_than",
     "op_greater_than_or_equal",
     "op_equality",
     "op_inequality",
-
     "from_bits",
     "from_int",
     "from_value",
     "from_number",
     "to_number",
     "from_integer",
-
     "get_range",
     "parse",
     "try_parse",
     "to_string",
     "to_int",
-
     "long",
 ]

--- a/src/fable-library-py/fable_library/mailbox_processor.py
+++ b/src/fable-library-py/fable_library/mailbox_processor.py
@@ -56,9 +56,7 @@ class MailboxProcessor(Generic[_Msg]):
         self.messages.put(msg)
         self.__process_events()
 
-    def post_and_async_reply(
-        self, build_message: Callable[[AsyncReplyChannel[_Reply]], _Msg]
-    ) -> Async[_Reply]:
+    def post_and_async_reply(self, build_message: Callable[[AsyncReplyChannel[_Reply]], _Msg]) -> Async[_Reply]:
         """Post a message asynchronously to the mailbox processor and
         wait for the reply.
 

--- a/src/fable-library-py/fable_library/map_util.py
+++ b/src/fable-library-py/fable_library/map_util.py
@@ -70,9 +70,7 @@ def add_to_set(v: _V, st: set[_V]) -> bool:
 
 def add_to_dict(di: dict[_K, _V], k: _K, v: _V) -> None:
     if k in di:
-        raise Exception(
-            "An item with the same key has already been added. Key: " + str(k)
-        )
+        raise Exception("An item with the same key has already been added. Key: " + str(k))
 
     di[k] = v
 
@@ -85,9 +83,7 @@ def remove_from_dict(di: dict[_K, Any], k: _K) -> bool:
     return False
 
 
-def try_get_value(
-    map: FSharpMap[_K, _V], key: _K, default_value: FSharpRef[_V]
-) -> bool:
+def try_get_value(map: FSharpMap[_K, _V], key: _K, default_value: FSharpRef[_V]) -> bool:
     if key in map.keys():
         default_value.contents = map[key]
         return True

--- a/src/fable-library-py/fable_library/observable.py
+++ b/src/fable-library-py/fable_library/observable.py
@@ -99,9 +99,7 @@ def protect(
         fail(e)
 
 
-def choose(
-    chooser: Callable[[_T], _U | None], source: IObservable[_T]
-) -> IObservable[_U]:
+def choose(chooser: Callable[[_T], _U | None], source: IObservable[_T]) -> IObservable[_U]:
     def subscribe(observer: IObserver[_U]):
         def on_next(t: _T) -> None:
             def success(u: _U | None) -> None:
@@ -201,15 +199,11 @@ def pairwise(source: IObservable[_T]) -> IObservable[tuple[_T, _T]]:
     return Observable(subscribe)
 
 
-def partition(
-    predicate: Callable[[_T], bool], source: IObservable[_T]
-) -> tuple[IObservable[_T], IObservable[_T]]:
+def partition(predicate: Callable[[_T], bool], source: IObservable[_T]) -> tuple[IObservable[_T], IObservable[_T]]:
     return (filter(predicate, source), filter(lambda x: not predicate(x), source))
 
 
-def scan(
-    collector: Callable[[_U, _T], _U], state: _U, source: IObservable[_T]
-) -> IObservable[_U]:
+def scan(collector: Callable[[_U, _T], _U], state: _U, source: IObservable[_T]) -> IObservable[_U]:
     def subscribe(observer: IObserver[_U]) -> IDisposable:
         def on_next(t: _T) -> None:
             def success(u: _U) -> None:
@@ -225,9 +219,7 @@ def scan(
     return Observable(subscribe)
 
 
-def split(
-    splitter: Callable[[_T], FSharpChoice_2], source: IObservable[_T]
-) -> tuple[IObservable[_T], IObservable[_T]]:
+def split(splitter: Callable[[_T], FSharpChoice_2], source: IObservable[_T]) -> tuple[IObservable[_T], IObservable[_T]]:
     return (
         choose(lambda v: Choice_tryValueIfChoice1Of2(splitter(v)), source),
         choose(lambda v: Choice_tryValueIfChoice2Of2(splitter(v)), source),

--- a/src/fable-library-py/fable_library/option.py
+++ b/src/fable-library-py/fable_library/option.py
@@ -53,14 +53,8 @@ def map(mapping: Callable[[_T], _U], opt: _T | None) -> _U | None:
     return some(mapping(value(opt))) if opt is not None else None
 
 
-def map2(
-    mapping: Callable[[_T, _U], _V], opt1: _T | None, opt2: _U | None
-) -> _V | None:
-    return (
-        mapping(value(opt1), value(opt2))
-        if (opt1 is not None and opt2 is not None)
-        else None
-    )
+def map2(mapping: Callable[[_T, _U], _V], opt1: _T | None, opt2: _U | None) -> _V | None:
+    return mapping(value(opt1), value(opt2)) if (opt1 is not None and opt2 is not None) else None
 
 
 def map3(

--- a/src/fable-library-py/fable_library/reflection.py
+++ b/src/fable-library-py/fable_library/reflection.py
@@ -115,9 +115,7 @@ def array_type(generic: TypeInfo) -> TypeInfo:
     return TypeInfo(generic.fullname + "[]", [generic])
 
 
-def enum_type(
-    fullname: str, underlyingType: TypeInfo, enumCases: list[EnumCase]
-) -> TypeInfo:
+def enum_type(fullname: str, underlyingType: TypeInfo, enumCases: list[EnumCase]) -> TypeInfo:
     return TypeInfo(fullname, [underlyingType], None, None, None, None, enumCases)
 
 
@@ -154,9 +152,7 @@ def equals(t1: TypeInfo, t2: TypeInfo) -> bool:
             lambda kv1, kv2: kv1[0] == kv2[0] and equals(kv1[1], kv2[1]),
         )
 
-    return t1.fullname == t2.fullname and equal_arrays_with(
-        t1.generics, t2.generics, equals
-    )
+    return t1.fullname == t2.fullname and equal_arrays_with(t1.generics, t2.generics, equals)
 
 
 def is_generic_type(t: TypeInfo) -> bool:
@@ -164,11 +160,7 @@ def is_generic_type(t: TypeInfo) -> bool:
 
 
 def get_generic_type_definition(t: TypeInfo):
-    return (
-        t
-        if t.generics is None
-        else TypeInfo(t.fullname, list(map(lambda _: obj_type, t.generics)))
-    )
+    return t if t.generics is None else TypeInfo(t.fullname, list(map(lambda _: obj_type, t.generics)))
 
 
 def get_generics(t: TypeInfo) -> list[TypeInfo]:
@@ -227,9 +219,7 @@ def is_enum(t: TypeInfo) -> bool:
 
 
 def is_subclass_of(t1: TypeInfo, t2: TypeInfo) -> bool:
-    return t1.parent is not None and (
-        (t1.parent == t2) or is_subclass_of(t1.parent, t2)
-    )
+    return t1.parent is not None and ((t1.parent == t2) or is_subclass_of(t1.parent, t2))
 
 
 def is_erased_to_number(t: TypeInfo) -> bool:
@@ -407,9 +397,7 @@ def get_tuple_field(v: tuple[Any, ...], i: int) -> Any:
 def make_record(t: TypeInfo, values: list[Any]) -> dict[str, Any]:
     fields = get_record_elements(t)
     if len(fields) != len(values):
-        raise ValueError(
-            f"Expected an array of length {len(fields)} but got {len(values)}"
-        )
+        raise ValueError(f"Expected an array of length {len(fields)} but got {len(values)}")
 
     if t.construct is not None:
         return t.construct(*values)
@@ -430,15 +418,9 @@ def make_tuple(values: list[Any], _t: TypeInfo) -> tuple[Any, ...]:
 def make_union(uci: CaseInfo, values: list[Any]) -> Any:
     expectedLength = len(uci.fields or [])
     if len(values) != expectedLength:
-        raise ValueError(
-            f"Expected an array of length {expectedLength} but got {len(values)}"
-        )
+        raise ValueError(f"Expected an array of length {expectedLength} but got {len(values)}")
 
-    return (
-        uci.declaringType.construct(uci.tag, *values)
-        if uci.declaringType.construct
-        else {}
-    )
+    return uci.declaringType.construct(uci.tag, *values) if uci.declaringType.construct else {}
 
 
 def get_union_cases(t: TypeInfo) -> list[CaseInfo]:

--- a/src/fable-library-py/fable_library/string_.py
+++ b/src/fable-library-py/fable_library/string_.py
@@ -25,15 +25,9 @@ from .types import to_string
 T = TypeVar("T")
 
 
-_fs_format_regexp: Pattern[str] = re.compile(
-    r"(^|[^%])%([0+\- ]*)(\d+)?(?:\.(\d+))?(\w)"
-)
-_interpolate_regexp: Pattern[str] = re.compile(
-    r"(?:(^|[^%])%([0+\- ]*)(\d+)?(?:\.(\d+))?(\w))?%P\(\)"
-)
-_format_regexp: Pattern[str] = re.compile(
-    r"\{(\d+)(,-?\d+)?(?:\:([a-zA-Z])(\d{0,2})|\:(.+?))?\}"
-)
+_fs_format_regexp: Pattern[str] = re.compile(r"(^|[^%])%([0+\- ]*)(\d+)?(?:\.(\d+))?(\w)")
+_interpolate_regexp: Pattern[str] = re.compile(r"(?:(^|[^%])%([0+\- ]*)(\d+)?(?:\.(\d+))?(\w))?%P\(\)")
+_format_regexp: Pattern[str] = re.compile(r"\{(\d+)(,-?\d+)?(?:\:([a-zA-Z])(\d{0,2})|\:(.+?))?\}")
 
 
 IPrintfFormatContinuation = Callable[[Callable[[str], Any]], Callable[[str], Any]]
@@ -82,9 +76,7 @@ def to_fail(arg: IPrintfFormat | str):
     return continue_print(fail, arg)
 
 
-def format_replacement(
-    rep: Any, flags: Any, padLength: Any, precision: Any, format: Any
-):
+def format_replacement(rep: Any, flags: Any, padLength: Any, precision: Any, format: Any):
     sign = ""
     flags = flags or ""
     format = format or ""
@@ -108,17 +100,9 @@ def format_replacement(
             precision = int(precision) if precision is not None else 6
             rep = to_fixed(rep, precision)
         elif format in ("g", "G"):
-            rep = (
-                to_precision(rep, precision)
-                if precision is not None
-                else to_precision(rep)
-            )
+            rep = to_precision(rep, precision) if precision is not None else to_precision(rep)
         elif format in ("e", "E"):
-            rep = (
-                to_exponential(rep, precision)
-                if precision is not None
-                else to_exponential(rep)
-            )
+            rep = to_exponential(rep, precision) if precision is not None else to_exponential(rep)
         else:  # AOid
             rep = to_string(rep)
 
@@ -155,9 +139,7 @@ def interpolate(string: str, values: list[Any]) -> str:
         matchIndex = match.start() + len(match[1] or "")
         result += string[strIdx:matchIndex].replace("%%", "%")
         [_, flags, padLength, precision, format] = match.groups()
-        result += format_replacement(
-            values[valIdx], flags, padLength, precision, format
-        )
+        result += format_replacement(values[valIdx], flags, padLength, precision, format)
         valIdx += 1
 
         strIdx = match.end()
@@ -219,36 +201,20 @@ def format(string: str, *args: Any) -> str:
                 rep = to_fixed(rep, precision)
 
             elif format in ["g", "G"]:
-                rep = (
-                    to_precision(rep, precision)
-                    if precision is not None
-                    else to_precision(rep)
-                )
+                rep = to_precision(rep, precision) if precision is not None else to_precision(rep)
 
             elif format in ["e", "E"]:
-                rep = (
-                    to_exponential(rep, precision)
-                    if precision is not None
-                    else to_exponential(rep)
-                )
+                rep = to_exponential(rep, precision) if precision is not None else to_exponential(rep)
 
             elif format in ["p", "P"]:
                 precision = precision if precision is not None else 2
                 rep = to_fixed(multiply(rep, 100), precision) + " %"
 
             elif format in ["d", "D"]:
-                rep = (
-                    pad_left(str(rep), precision, "0")
-                    if precision is not None
-                    else str(rep)
-                )
+                rep = pad_left(str(rep), precision, "0") if precision is not None else str(rep)
 
             elif format in ["x", "X"] and isinstance(rep, int):
-                rep = (
-                    pad_left(to_hex(rep), precision, "0")
-                    if precision is not None
-                    else to_hex(rep)
-                )
+                rep = pad_left(to_hex(rep), precision, "0") if precision is not None else to_hex(rep)
                 if format == "X":
                     rep = rep.upper()
             elif pattern:
@@ -265,9 +231,7 @@ def format(string: str, *args: Any) -> str:
                     rep = to_fixed(rep, len(decimalPart) - 1 if decimalPart else 0)
                     return pad_left(
                         rep,
-                        len(intPart or "")
-                        - len(sign)
-                        + (len(decimalPart) if decimalPart else 0),
+                        len(intPart or "") - len(sign) + (len(decimalPart) if decimalPart else 0),
                         "0",
                     )
 
@@ -299,9 +263,7 @@ def initialize(n: int, f: Callable[[int], str]) -> str:
 
 def insert(string: str, startIndex: int, value: str):
     if startIndex < 0 or startIndex > len(string):
-        raise ValueError(
-            "startIndex is negative or greater than the length of this instance."
-        )
+        raise ValueError("startIndex is negative or greater than the length of this instance.")
 
     return string[:startIndex] + value + string[startIndex:]
 
@@ -331,9 +293,7 @@ def join_with_indices(delimiter: str, xs: list[str], startIndex: int, count: int
 
 
 def not_supported(name: str) -> NoReturn:
-    raise Exception(
-        "The environment doesn't support '" + name + "', please use a polyfill."
-    )
+    raise Exception("The environment doesn't support '" + name + "', please use a polyfill.")
 
 
 def to_base64string(in_array: bytes) -> str:
@@ -344,9 +304,7 @@ def from_base64string(b64encoded: str) -> bytes:
     return b64decode(b64encoded)
 
 
-def pad_left(
-    string: str, length: int, ch: str | None = None, isRight: bool | None = False
-) -> str:
+def pad_left(string: str, length: int, ch: str | None = None, isRight: bool | None = False) -> str:
     ch = ch or " "
     length = length - len(string)
     for _ in range(length):
@@ -366,9 +324,7 @@ def remove(string: str, startIndex: int, count: int | None = None):
     if count and (startIndex + count) > len(string):
         raise ValueError("Index and count must refer to a location within the string.")
 
-    return string[:startIndex] + (
-        string[startIndex + count :] if count is not None else ""
-    )
+    return string[:startIndex] + (string[startIndex + count :] if count is not None else "")
 
 
 def replace(string: str, search: str, replace: str):
@@ -518,9 +474,7 @@ def compare(string1: str, string2: str, /) -> int:
 
 
 @overload
-def compare(
-    string1: str, string2: str, ignore_case: bool, culture: StringComparison, /
-) -> int:
+def compare(string1: str, string2: str, ignore_case: bool, culture: StringComparison, /) -> int:
     ...
 
 
@@ -551,17 +505,11 @@ def compare(*args: Any) -> int:
     if length == 4:
         return cmp(args[0], args[1], args[2])
     if length == 5:
-        return cmp(
-            args[0][args[1] : args[4] + 1], args[2][args[3] : args[4] + 1], False
-        )
+        return cmp(args[0][args[1] : args[4] + 1], args[2][args[3] : args[4] + 1], False)
     if length == 6:
-        return cmp(
-            args[0][args[1] : args[4] + 1], args[2][args[3] : args[4] + 1], args[5]
-        )
+        return cmp(args[0][args[1] : args[4] + 1], args[2][args[3] : args[4] + 1], args[5])
     if length == 7:
-        return cmp(
-            args[0][args[1] : args[4] + 1], args[2][args[3] : args[4] + 1], args[5]
-        )
+        return cmp(args[0][args[1] : args[4] + 1], args[2][args[3] : args[4] + 1], args[5])
     raise Exception("String.compare: Unsupported number of parameters")
 
 

--- a/src/fable-library-py/fable_library/task.py
+++ b/src/fable-library-py/fable_library/task.py
@@ -71,7 +71,6 @@ async def from_result(value: _T) -> _T:
 
 
 def get_awaiter(value: Awaitable[_T]) -> Awaitable[_T]:
-
     # Wrap awaitable in coroutine (so we can run it using create_task)
     async def get_value() -> _T:
         return await asyncio.ensure_future(value)

--- a/src/fable-library-py/fable_library/task_builder.py
+++ b/src/fable-library-py/fable_library/task_builder.py
@@ -24,18 +24,14 @@ class Delayed(Protocol[_T_co]):
 
 
 class TaskBuilder:
-    def Bind(
-        self, computation: Awaitable[_T], binder: Callable[[_T], Awaitable[_U]]
-    ) -> Awaitable[_U]:
+    def Bind(self, computation: Awaitable[_T], binder: Callable[[_T], Awaitable[_U]]) -> Awaitable[_U]:
         async def bind() -> _U:
             value = await computation
             return await binder(value)
 
         return bind()
 
-    def Combine(
-        self, computation1: Awaitable[None], computation2: Delayed[_T]
-    ) -> Awaitable[_T]:
+    def Combine(self, computation1: Awaitable[None], computation2: Delayed[_T]) -> Awaitable[_T]:
         return self.Bind(computation1, computation2)
 
     def Delay(self, generator: Callable[[], Awaitable[_T]]) -> Delayed[_T]:
@@ -45,9 +41,7 @@ class TaskBuilder:
 
         return deferred
 
-    def For(
-        self, sequence: Iterable[_T], body: Callable[[_T], Awaitable[_U]]
-    ) -> Awaitable[_U]:
+    def For(self, sequence: Iterable[_T], body: Callable[[_T], Awaitable[_U]]) -> Awaitable[_U]:
         done = False
         it = iter(sequence)
         try:
@@ -80,9 +74,7 @@ class TaskBuilder:
     def ReturnFrom(self, computation: Awaitable[_T]) -> Awaitable[_T]:
         return computation
 
-    def TryFinally(
-        self, computation: Delayed[_T], compensation: Callable[[], None]
-    ) -> Awaitable[_T]:
+    def TryFinally(self, computation: Delayed[_T], compensation: Callable[[], None]) -> Awaitable[_T]:
         async def try_finally() -> _T:
             try:
                 t = await computation()
@@ -92,9 +84,7 @@ class TaskBuilder:
 
         return try_finally()
 
-    def TryWith(
-        self, computation: Delayed[_T], catchHandler: Callable[[Any], Awaitable[_T]]
-    ) -> Awaitable[_T]:
+    def TryWith(self, computation: Delayed[_T], catchHandler: Callable[[Any], Awaitable[_T]]) -> Awaitable[_T]:
         async def try_with() -> _T:
             try:
                 t = await computation()
@@ -104,28 +94,18 @@ class TaskBuilder:
 
         return try_with()
 
-    def Using(
-        self, resource: _TD, binder: Callable[[_TD], Awaitable[_U]]
-    ) -> Awaitable[_U]:
-        return self.TryFinally(
-            self.Delay(lambda: binder(resource)), lambda: resource.Dispose()
-        )
+    def Using(self, resource: _TD, binder: Callable[[_TD], Awaitable[_U]]) -> Awaitable[_U]:
+        return self.TryFinally(self.Delay(lambda: binder(resource)), lambda: resource.Dispose())
 
     @overload
-    def While(
-        self, guard: Callable[[], bool], computation: Delayed[None]
-    ) -> Awaitable[None]:
+    def While(self, guard: Callable[[], bool], computation: Delayed[None]) -> Awaitable[None]:
         ...
 
     @overload
-    def While(
-        self, guard: Callable[[], bool], computation: Delayed[_T]
-    ) -> Awaitable[_T]:
+    def While(self, guard: Callable[[], bool], computation: Delayed[_T]) -> Awaitable[_T]:
         ...
 
-    def While(
-        self, guard: Callable[[], bool], computation: Delayed[Any]
-    ) -> Awaitable[Any]:
+    def While(self, guard: Callable[[], bool], computation: Delayed[Any]) -> Awaitable[Any]:
         if guard():
             return self.Bind(computation(), lambda _: self.While(guard, computation))
         else:

--- a/src/fable-library-py/fable_library/time_span.py
+++ b/src/fable-library-py/fable_library/time_span.py
@@ -114,9 +114,7 @@ def create(
     elif s is None and ms is None:
         return timedelta(hours=d or 0, minutes=h or 0, seconds=m or 0)
 
-    return timedelta(
-        days=d, hours=h or 0, minutes=m or 0, seconds=s or 0, milliseconds=ms or 0
-    )
+    return timedelta(days=d, hours=h or 0, minutes=m or 0, seconds=s or 0, milliseconds=ms or 0)
 
 
 def to_string(ts: timedelta, format: str = "c", _provider: Any | None = None) -> str:

--- a/src/fable-library-py/fable_library/types.py
+++ b/src/fable-library-py/fable_library/types.py
@@ -75,12 +75,7 @@ class Union(IComparable):
         else:
             fields = ", ".join(map(str, self.fields))
 
-        return (
-            self.name
-            + (" (" if with_parens else " ")
-            + fields
-            + (")" if with_parens else "")
-        )
+        return self.name + (" (" if with_parens else " ") + fields + (")" if with_parens else "")
 
     def __repr__(self) -> str:
         return str(self)
@@ -155,23 +150,9 @@ def record_equals(self: _T, other: _T) -> bool:
 
 def record_to_string(self: Record) -> str:
     if hasattr(self, "__slots__"):
-        return (
-            "{ "
-            + "\n  ".join(
-                map(
-                    lambda slot: slot + " = " + str(getattr(self, slot)), self.__slots__
-                )
-            )
-            + " }"
-        )
+        return "{ " + "\n  ".join(map(lambda slot: slot + " = " + str(getattr(self, slot)), self.__slots__)) + " }"
     else:
-        return (
-            "{ "
-            + "\n  ".join(
-                map(lambda kv: kv[0] + " = " + str(kv[1]), self.__dict__.items())
-            )
-            + " }"
-        )
+        return "{ " + "\n  ".join(map(lambda kv: kv[0] + " = " + str(kv[1]), self.__dict__.items())) + " }"
 
 
 def record_get_hashcode(self: Record) -> int:

--- a/src/fable-library-py/fable_library/uri.py
+++ b/src/fable-library-py/fable_library/uri.py
@@ -34,15 +34,11 @@ class Uri:
 
         # Absolute base URI must be absolute
         if kind == UriKind.Absolute and not uri.netloc:
-            raise ValueError(
-                "Invalid URI: The format of the URI could not be determined."
-            )
+            raise ValueError("Invalid URI: The format of the URI could not be determined.")
 
         # Relative base URI must be relative
         if kind == UriKind.Relative and uri.netloc:
-            raise ValueError(
-                "Invalid URI: The format of the URI could not be determined."
-            )
+            raise ValueError("Invalid URI: The format of the URI could not be determined.")
 
         if relative_uri:
             self.res = urlparse(urljoin(uri.geturl(), relative_uri.geturl()))
@@ -101,15 +97,11 @@ class Uri:
         return unquote(res.geturl())
 
     @staticmethod
-    def create(
-        uri: str | Uri, kind_or_uri: UriKind | str | Uri = UriKind.Absolute
-    ) -> Uri:
+    def create(uri: str | Uri, kind_or_uri: UriKind | str | Uri = UriKind.Absolute) -> Uri:
         return Uri(uri, kind_or_uri)
 
     @staticmethod
-    def try_create(
-        uri: str | Uri, kind_or_uri: UriKind | str | Uri, out: FSharpRef[Uri]
-    ) -> bool:
+    def try_create(uri: str | Uri, kind_or_uri: UriKind | str | Uri, out: FSharpRef[Uri]) -> bool:
         try:
             out.contents = Uri.create(uri, kind_or_uri)
             return True

--- a/src/fable-library-py/fable_library/util.py
+++ b/src/fable-library-py/fable_library/util.py
@@ -178,15 +178,11 @@ class IEqualityComparer(Protocol):
         return self.System_Collections_IEqualityComparer_GetHashCode4E60E31B()
 
     @abstractmethod
-    def System_Collections_IEqualityComparer_Equals541DA560(
-        self, x: Any = None, y: Any = None
-    ) -> bool:
+    def System_Collections_IEqualityComparer_Equals541DA560(self, x: Any = None, y: Any = None) -> bool:
         raise NotImplementedError
 
     @abstractmethod
-    def System_Collections_IEqualityComparer_GetHashCode4E60E31B(
-        self, x_1: Any = None
-    ) -> int:
+    def System_Collections_IEqualityComparer_GetHashCode4E60E31B(self, x_1: Any = None) -> int:
         raise NotImplementedError
 
 
@@ -315,9 +311,7 @@ def compare(a: Any, b: Any) -> int:
     return 1
 
 
-def equal_arrays_with(
-    xs: Sequence[_T] | None, ys: Sequence[_T] | None, eq: Callable[[_T, _T], bool]
-) -> bool:
+def equal_arrays_with(xs: Sequence[_T] | None, ys: Sequence[_T] | None, eq: Callable[[_T, _T], bool]) -> bool:
     if xs is None:
         return ys is None
 
@@ -351,13 +345,7 @@ def max(comparer: Callable[[_T, _T], int], x: _T, y: _T) -> _T:
 
 
 def clamp(comparer: Callable[[_T, _T], int], value: _T, min: _T, max: _T):
-    return (
-        min
-        if (comparer(value, min) < 0)
-        else max
-        if comparer(value, max) > 0
-        else value
-    )
+    return min if (comparer(value, min) < 0) else max if comparer(value, max) > 0 else value
 
 
 def assert_equal(actual: Any, expected: Any, msg: str | None = None) -> None:
@@ -654,9 +642,7 @@ _TResult = TypeVar("_TResult")
 _curried = weakref.WeakKeyDictionary[Any, Any]()
 
 
-def uncurry2(
-    f: Callable[[_T1], Callable[[_T2], _TResult]]
-) -> Callable[[_T1, _T2], _TResult]:
+def uncurry2(f: Callable[[_T1], Callable[[_T2], _TResult]]) -> Callable[[_T1, _T2], _TResult]:
     def f2(a1: _T1, a2: _T2) -> _TResult:
         return f(a1)(a2)
 
@@ -664,9 +650,7 @@ def uncurry2(
     return f2
 
 
-def curry2(
-    f: Callable[[_T1, _T2], _TResult]
-) -> Callable[[_T1], Callable[[_T2], _TResult]]:
+def curry2(f: Callable[[_T1, _T2], _TResult]) -> Callable[[_T1], Callable[[_T2], _TResult]]:
     f2 = _curried.get(f)
     if f2 is None:
         return lambda a1: lambda a2: f(a1, a2)
@@ -674,9 +658,7 @@ def curry2(
         return f2
 
 
-def uncurry3(
-    f: Callable[[_T1], Callable[[_T2], Callable[[_T3], _TResult]]]
-) -> Callable[[_T1, _T2, _T3], _TResult]:
+def uncurry3(f: Callable[[_T1], Callable[[_T2], Callable[[_T3], _TResult]]]) -> Callable[[_T1, _T2, _T3], _TResult]:
     def f2(a1: _T1, a2: _T2, a3: _T3) -> _TResult:
         return f(a1)(a2)(a3)
 
@@ -684,9 +666,7 @@ def uncurry3(
     return f2
 
 
-def curry3(
-    f: Callable[[_T1, _T2, _T3], _TResult]
-) -> Callable[[_T1], Callable[[_T2], Callable[[_T3], _TResult]]]:
+def curry3(f: Callable[[_T1, _T2, _T3], _TResult]) -> Callable[[_T1], Callable[[_T2], Callable[[_T3], _TResult]]]:
     f2 = _curried.get(f)
     if f2 is None:
         return lambda a1: lambda a2: lambda a3: f(a1, a2, a3)
@@ -718,7 +698,7 @@ def uncurry5(
     f: Callable[
         [_T1],
         Callable[[_T2], Callable[[_T3], Callable[[_T4], Callable[[_T5], _TResult]]]],
-    ]
+    ],
 ) -> Callable[[_T1, _T2, _T3, _T4, _T5], _TResult]:
     def f2(a1: _T1, a2: _T2, a3: _T3, a4: _T4, a5: _T5) -> _TResult:
         return f(a1)(a2)(a3)(a4)(a5)
@@ -729,14 +709,10 @@ def uncurry5(
 
 def curry5(
     f: Callable[[_T1, _T2, _T3, _T4, _T5], _TResult]
-) -> Callable[
-    [_T1], Callable[[_T2], Callable[[_T3], Callable[[_T4], Callable[[_T5], _TResult]]]]
-]:
+) -> Callable[[_T1], Callable[[_T2], Callable[[_T3], Callable[[_T4], Callable[[_T5], _TResult]]]]]:
     f2 = _curried.get(f)
     if f2 is None:
-        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: f(
-            a1, a2, a3, a4, a5
-        )
+        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: f(a1, a2, a3, a4, a5)
     else:
         return f2
 
@@ -746,11 +722,9 @@ def uncurry6(
         [_T1],
         Callable[
             [_T2],
-            Callable[
-                [_T3], Callable[[_T4], Callable[[_T5], Callable[[_T6], _TResult]]]
-            ],
+            Callable[[_T3], Callable[[_T4], Callable[[_T5], Callable[[_T6], _TResult]]]],
         ],
-    ]
+    ],
 ) -> Callable[[_T1, _T2, _T3, _T4, _T5, _T6], _TResult]:
     def f2(a1: _T1, a2: _T2, a3: _T3, a4: _T4, a5: _T5, a6: _T6) -> _TResult:
         return f(a1)(a2)(a3)(a4)(a5)(a6)
@@ -770,9 +744,7 @@ def curry6(
 ]:
     f2 = _curried.get(f)
     if f2 is None:
-        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: f(
-            a1, a2, a3, a4, a5, a6
-        )
+        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: f(a1, a2, a3, a4, a5, a6)
     else:
         return f2
 
@@ -784,12 +756,10 @@ def uncurry7(
             [_T2],
             Callable[
                 [_T3],
-                Callable[
-                    [_T4], Callable[[_T5], Callable[[_T6], Callable[[_T7], _TResult]]]
-                ],
+                Callable[[_T4], Callable[[_T5], Callable[[_T6], Callable[[_T7], _TResult]]]],
             ],
         ],
-    ]
+    ],
 ) -> Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7], _TResult]:
     def f2(a1: _T1, a2: _T2, a3: _T3, a4: _T4, a5: _T5, a6: _T6, a7: _T7) -> _TResult:
         return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)
@@ -806,9 +776,7 @@ def curry7(
         [_T2],
         Callable[
             [_T3],
-            Callable[
-                [_T4], Callable[[_T5], Callable[[_T6], Callable[[_T7], _TResult]]]
-            ],
+            Callable[[_T4], Callable[[_T5], Callable[[_T6], Callable[[_T7], _TResult]]]],
         ],
     ],
 ]:
@@ -837,11 +805,9 @@ def uncurry8(
                 ],
             ],
         ],
-    ]
+    ],
 ) -> Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8], _TResult]:
-    def f2(
-        a1: _T1, a2: _T2, a3: _T3, a4: _T4, a5: _T5, a6: _T6, a7: _T7, a8: _T8
-    ) -> _TResult:
+    def f2(a1: _T1, a2: _T2, a3: _T3, a4: _T4, a5: _T5, a6: _T6, a7: _T7, a8: _T8) -> _TResult:
         return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)
 
     _curried[f2] = f
@@ -858,9 +824,7 @@ def curry8(
             [_T3],
             Callable[
                 [_T4],
-                Callable[
-                    [_T5], Callable[[_T6], Callable[[_T7], Callable[[_T8], _TResult]]]
-                ],
+                Callable[[_T5], Callable[[_T6], Callable[[_T7], Callable[[_T8], _TResult]]]],
             ],
         ],
     ],
@@ -893,11 +857,9 @@ def uncurry9(
                 ],
             ],
         ],
-    ]
+    ],
 ) -> Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9], _TResult]:
-    def f2(
-        a1: _T1, a2: _T2, a3: _T3, a4: _T4, a5: _T5, a6: _T6, a7: _T7, a8: _T8, a9: _T9
-    ) -> _TResult:
+    def f2(a1: _T1, a2: _T2, a3: _T3, a4: _T4, a5: _T5, a6: _T6, a7: _T7, a8: _T8, a9: _T9) -> _TResult:
         return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)
 
     _curried[f2] = f
@@ -949,16 +911,14 @@ def uncurry10(
                             [_T6],
                             Callable[
                                 [_T7],
-                                Callable[
-                                    [_T8], Callable[[_T9], Callable[[_T10], _TResult]]
-                                ],
+                                Callable[[_T8], Callable[[_T9], Callable[[_T10], _TResult]]],
                             ],
                         ],
                     ],
                 ],
             ],
         ],
-    ]
+    ],
 ) -> Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10], _TResult]:
     def f2(
         a1: _T1,
@@ -994,9 +954,7 @@ def curry10(
                         [_T6],
                         Callable[
                             [_T7],
-                            Callable[
-                                [_T8], Callable[[_T9], Callable[[_T10], _TResult]]
-                            ],
+                            Callable[[_T8], Callable[[_T9], Callable[[_T10], _TResult]]],
                         ],
                     ],
                 ],
@@ -1006,8 +964,10 @@ def curry10(
 ]:
     f2 = _curried.get(f)
     if f2 is None:
-        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: lambda a10: f(
-            a1, a2, a3, a4, a5, a6, a7, a8, a9, a10
+        return (
+            lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: lambda a10: f(
+                a1, a2, a3, a4, a5, a6, a7, a8, a9, a10
+            )
         )
     else:
         return f2
@@ -1041,7 +1001,7 @@ def uncurry11(
                 ],
             ],
         ],
-    ]
+    ],
 ) -> Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11], _TResult]:
     def f2(
         a1: Any,
@@ -1080,9 +1040,7 @@ def curry11(
                             [_T7],
                             Callable[
                                 [_T8],
-                                Callable[
-                                    [_T9], Callable[[_T10], Callable[[_T11], _TResult]]
-                                ],
+                                Callable[[_T9], Callable[[_T10], Callable[[_T11], _TResult]]],
                             ],
                         ],
                     ],
@@ -1093,8 +1051,10 @@ def curry11(
 ]:
     f2 = _curried.get(f)
     if f2 is None:
-        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: lambda a10: lambda a11: f(
-            a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11
+        return (
+            lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: lambda a10: lambda a11: f(
+                a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11
+            )
         )
     else:
         return f2
@@ -1121,9 +1081,7 @@ def uncurry12(
                                         [_T9],
                                         Callable[
                                             [_T10],
-                                            Callable[
-                                                [_T11], Callable[[_T12], _TResult]
-                                            ],
+                                            Callable[[_T11], Callable[[_T12], _TResult]],
                                         ],
                                     ],
                                 ],
@@ -1133,10 +1091,8 @@ def uncurry12(
                 ],
             ],
         ],
-    ]
-) -> Callable[
-    [_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12], _TResult
-]:
+    ],
+) -> Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12], _TResult]:
     def f2(
         a1: Any,
         a2: Any,
@@ -1158,9 +1114,7 @@ def uncurry12(
 
 
 def curry12(
-    f: Callable[
-        [_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12], _TResult
-    ]
+    f: Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12], _TResult]
 ) -> Callable[
     [_T1],
     Callable[
@@ -1194,8 +1148,10 @@ def curry12(
 ]:
     f2 = _curried.get(f)
     if f2 is None:
-        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: lambda a10: lambda a11: lambda a12: f(
-            a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12
+        return (
+            lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: lambda a10: lambda a11: lambda a12: f(
+                a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12
+            )
         )
     else:
         return f2
@@ -1224,9 +1180,7 @@ def uncurry13(
                                             [_T10],
                                             Callable[
                                                 [_T11],
-                                                Callable[
-                                                    [_T12], Callable[[_T13], _TResult]
-                                                ],
+                                                Callable[[_T12], Callable[[_T13], _TResult]],
                                             ],
                                         ],
                                     ],
@@ -1237,10 +1191,8 @@ def uncurry13(
                 ],
             ],
         ],
-    ]
-) -> Callable[
-    [_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12, _T13], _TResult
-]:
+    ],
+) -> Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12, _T13], _TResult]:
     def f2(
         a1: Any,
         a2: Any,
@@ -1263,9 +1215,7 @@ def uncurry13(
 
 
 def curry13(
-    f: Callable[
-        [_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12, _T13], _TResult
-    ]
+    f: Callable[[_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12, _T13], _TResult]
 ) -> Callable[
     [_T1],
     Callable[
@@ -1288,9 +1238,7 @@ def curry13(
                                         [_T10],
                                         Callable[
                                             [_T11],
-                                            Callable[
-                                                [_T12], Callable[[_T13], _TResult]
-                                            ],
+                                            Callable[[_T12], Callable[[_T13], _TResult]],
                                         ],
                                     ],
                                 ],
@@ -1304,8 +1252,10 @@ def curry13(
 ]:
     f2 = _curried.get(f)
     if f2 is None:
-        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: lambda a10: lambda a11: lambda a12: lambda a13: f(
-            a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13
+        return (
+            lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: lambda a10: lambda a11: lambda a12: lambda a13: f(
+                a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13
+            )
         )
     else:
         return f2
@@ -1351,7 +1301,7 @@ def uncurry14(
                 ],
             ],
         ],
-    ]
+    ],
 ) -> Callable[
     [
         _T1,
@@ -1397,7 +1347,7 @@ def curry14(
     f: Callable[
         [_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12, _T13, _T14],
         _TResult,
-    ]
+    ],
 ) -> Callable[
     [_T1],
     Callable[
@@ -1422,9 +1372,7 @@ def curry14(
                                             [_T11],
                                             Callable[
                                                 [_T12],
-                                                Callable[
-                                                    [_T13], Callable[[_T14], _TResult]
-                                                ],
+                                                Callable[[_T13], Callable[[_T14], _TResult]],
                                             ],
                                         ],
                                     ],
@@ -1439,8 +1387,10 @@ def curry14(
 ]:
     f2 = _curried.get(f)
     if f2 is None:
-        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: lambda a10: lambda a11: lambda a12: lambda a13: lambda a14: f(
-            a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14
+        return (
+            lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: lambda a10: lambda a11: lambda a12: lambda a13: lambda a14: f(
+                a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14
+            )
         )
     else:
         return f2
@@ -1489,7 +1439,7 @@ def uncurry15(
                 ],
             ],
         ],
-    ]
+    ],
 ) -> Callable[
     [_T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, _T10, _T11, _T12, _T13, _T14, _T15],
     _TResult,
@@ -1537,7 +1487,7 @@ def curry15(
             _T15,
         ],
         _TResult,
-    ]
+    ],
 ) -> Callable[
     [_T1],
     Callable[
@@ -1583,8 +1533,10 @@ def curry15(
 ]:
     f2 = _curried.get(f)
     if f2 is None:
-        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: lambda a10: lambda a11: lambda a12: lambda a13: lambda a14: lambda a15: f(
-            a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15
+        return (
+            lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: lambda a10: lambda a11: lambda a12: lambda a13: lambda a14: lambda a15: f(
+                a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15
+            )
         )
     else:
         return f2
@@ -1621,9 +1573,7 @@ def uncurry16(
                                                             [_T14],
                                                             Callable[
                                                                 [_T15],
-                                                                Callable[
-                                                                    [_T16], _TResult
-                                                                ],
+                                                                Callable[[_T16], _TResult],
                                                             ],
                                                         ],
                                                     ],
@@ -1638,7 +1588,7 @@ def uncurry16(
                 ],
             ],
         ],
-    ]
+    ],
 ) -> Callable[
     [
         _T1,
@@ -1705,7 +1655,7 @@ def curry16(
             _T16,
         ],
         _TResult,
-    ]
+    ],
 ) -> Callable[
     [_T1],
     Callable[
@@ -1754,8 +1704,10 @@ def curry16(
 ]:
     f2 = _curried.get(f)
     if f2 is None:
-        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: lambda a10: lambda a11: lambda a12: lambda a13: lambda a14: lambda a15: lambda a16: f(
-            a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16
+        return (
+            lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: lambda a10: lambda a11: lambda a12: lambda a13: lambda a14: lambda a15: lambda a16: f(
+                a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16
+            )
         )
     else:
         return f2
@@ -1794,9 +1746,7 @@ def uncurry17(
                                                                 [_T15],
                                                                 Callable[
                                                                     [_T16],
-                                                                    Callable[
-                                                                        [_T17], _TResult
-                                                                    ],
+                                                                    Callable[[_T17], _TResult],
                                                                 ],
                                                             ],
                                                         ],
@@ -1812,7 +1762,7 @@ def uncurry17(
                 ],
             ],
         ],
-    ]
+    ],
 ) -> Callable[
     [
         _T1,
@@ -1854,9 +1804,7 @@ def uncurry17(
         a16: Any,
         a17: Any,
     ) -> Any:
-        return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)(a15)(a16)(
-            a17
-        )
+        return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)(a15)(a16)(a17)
 
     _curried[f2] = f
     return f2
@@ -1884,7 +1832,7 @@ def curry17(
             _T17,
         ],
         _TResult,
-    ]
+    ],
 ) -> Callable[
     [_T1],
     Callable[
@@ -1917,9 +1865,7 @@ def curry17(
                                                             [_T15],
                                                             Callable[
                                                                 [_T16],
-                                                                Callable[
-                                                                    [_T17], _TResult
-                                                                ],
+                                                                Callable[[_T17], _TResult],
                                                             ],
                                                         ],
                                                     ],
@@ -1938,8 +1884,10 @@ def curry17(
 ]:
     f2 = _curried.get(f)
     if f2 is None:
-        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: lambda a10: lambda a11: lambda a12: lambda a13: lambda a14: lambda a15: lambda a16: lambda a17: f(
-            a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17
+        return (
+            lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: lambda a10: lambda a11: lambda a12: lambda a13: lambda a14: lambda a15: lambda a16: lambda a17: f(
+                a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17
+            )
         )
     else:
         return f2
@@ -2000,7 +1948,7 @@ def uncurry18(
                 ],
             ],
         ],
-    ]
+    ],
 ) -> Callable[
     [
         _T1,
@@ -2044,9 +1992,7 @@ def uncurry18(
         a17: Any,
         a18: Any,
     ) -> Any:
-        return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)(a15)(a16)(
-            a17
-        )(a18)
+        return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)(a15)(a16)(a17)(a18)
 
     _curried[f2] = f
     return f2
@@ -2075,7 +2021,7 @@ def curry18(
             _T18,
         ],
         _TResult,
-    ]
+    ],
 ) -> Callable[
     [_T1],
     Callable[
@@ -2110,9 +2056,7 @@ def curry18(
                                                                 [_T16],
                                                                 Callable[
                                                                     [_T17],
-                                                                    Callable[
-                                                                        [_T18], _TResult
-                                                                    ],
+                                                                    Callable[[_T18], _TResult],
                                                                 ],
                                                             ],
                                                         ],
@@ -2132,25 +2076,27 @@ def curry18(
 ]:
     f2 = _curried.get(f)
     if f2 is None:
-        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: lambda a10: lambda a11: lambda a12: lambda a13: lambda a14: lambda a15: lambda a16: lambda a17: lambda a18: f(
-            a1,
-            a2,
-            a3,
-            a4,
-            a5,
-            a6,
-            a7,
-            a8,
-            a9,
-            a10,
-            a11,
-            a12,
-            a13,
-            a14,
-            a15,
-            a16,
-            a17,
-            a18,
+        return (
+            lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: lambda a10: lambda a11: lambda a12: lambda a13: lambda a14: lambda a15: lambda a16: lambda a17: lambda a18: f(
+                a1,
+                a2,
+                a3,
+                a4,
+                a5,
+                a6,
+                a7,
+                a8,
+                a9,
+                a10,
+                a11,
+                a12,
+                a13,
+                a14,
+                a15,
+                a16,
+                a17,
+                a18,
+            )
         )
     else:
         return f2
@@ -2214,7 +2160,7 @@ def uncurry19(
                 ],
             ],
         ],
-    ]
+    ],
 ) -> Callable[
     [
         _T1,
@@ -2260,9 +2206,7 @@ def uncurry19(
         a18: Any,
         a19: Any,
     ) -> Any:
-        return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)(a15)(a16)(
-            a17
-        )(a18)(a19)
+        return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)(a15)(a16)(a17)(a18)(a19)
 
     _curried[f2] = f
     return f2
@@ -2292,7 +2236,7 @@ def curry19(
             _T19,
         ],
         _TResult,
-    ]
+    ],
 ) -> Callable[
     [_T1],
     Callable[
@@ -2353,26 +2297,28 @@ def curry19(
 ]:
     f2 = _curried.get(f)
     if f2 is None:
-        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: lambda a10: lambda a11: lambda a12: lambda a13: lambda a14: lambda a15: lambda a16: lambda a17: lambda a18: lambda a19: f(
-            a1,
-            a2,
-            a3,
-            a4,
-            a5,
-            a6,
-            a7,
-            a8,
-            a9,
-            a10,
-            a11,
-            a12,
-            a13,
-            a14,
-            a15,
-            a16,
-            a17,
-            a18,
-            a19,
+        return (
+            lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: lambda a10: lambda a11: lambda a12: lambda a13: lambda a14: lambda a15: lambda a16: lambda a17: lambda a18: lambda a19: f(
+                a1,
+                a2,
+                a3,
+                a4,
+                a5,
+                a6,
+                a7,
+                a8,
+                a9,
+                a10,
+                a11,
+                a12,
+                a13,
+                a14,
+                a15,
+                a16,
+                a17,
+                a18,
+                a19,
+            )
         )
     else:
         return f2
@@ -2418,9 +2364,7 @@ def uncurry20(
                                                                             Callable[
                                                                                 [_T19],
                                                                                 Callable[
-                                                                                    [
-                                                                                        _T20
-                                                                                    ],
+                                                                                    [_T20],
                                                                                     _TResult,
                                                                                 ],
                                                                             ],
@@ -2441,7 +2385,7 @@ def uncurry20(
                 ],
             ],
         ],
-    ]
+    ],
 ) -> Callable[
     [
         _T1,
@@ -2489,9 +2433,7 @@ def uncurry20(
         a19: Any,
         a20: Any,
     ) -> Any:
-        return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)(a15)(a16)(
-            a17
-        )(a18)(a19)(a20)
+        return f(a1)(a2)(a3)(a4)(a5)(a6)(a7)(a8)(a9)(a10)(a11)(a12)(a13)(a14)(a15)(a16)(a17)(a18)(a19)(a20)
 
     _curried[f2] = f
     return f2
@@ -2522,7 +2464,7 @@ def curry20(
             _T20,
         ],
         _TResult,
-    ]
+    ],
 ) -> Callable[
     [_T1],
     Callable[
@@ -2586,27 +2528,29 @@ def curry20(
 ]:
     f2 = _curried.get(f)
     if f2 is None:
-        return lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: lambda a10: lambda a11: lambda a12: lambda a13: lambda a14: lambda a15: lambda a16: lambda a17: lambda a18: lambda a19: lambda a20: f(
-            a1,
-            a2,
-            a3,
-            a4,
-            a5,
-            a6,
-            a7,
-            a8,
-            a9,
-            a10,
-            a11,
-            a12,
-            a13,
-            a14,
-            a15,
-            a16,
-            a17,
-            a18,
-            a19,
-            a20,
+        return (
+            lambda a1: lambda a2: lambda a3: lambda a4: lambda a5: lambda a6: lambda a7: lambda a8: lambda a9: lambda a10: lambda a11: lambda a12: lambda a13: lambda a14: lambda a15: lambda a16: lambda a17: lambda a18: lambda a19: lambda a20: f(
+                a1,
+                a2,
+                a3,
+                a4,
+                a5,
+                a6,
+                a7,
+                a8,
+                a9,
+                a10,
+                a11,
+                a12,
+                a13,
+                a14,
+                a15,
+                a16,
+                a17,
+                a18,
+                a19,
+                a20,
+            )
         )
     else:
         return f2
@@ -2672,13 +2616,7 @@ class ObjectRef:
 
 
 def safe_hash(x: Any) -> int:
-    return (
-        0
-        if x is None
-        else x.GetHashCode()
-        if is_hashable(x)
-        else number_hash(ObjectRef.id(x))
-    )
+    return 0 if x is None else x.GetHashCode() if is_hashable(x) else number_hash(ObjectRef.id(x))
 
 
 def string_hash(s: str) -> int:
@@ -2738,11 +2676,7 @@ def round(value: float, digits: int = 0):
     i = math.floor(n)
     f = n - i
     e = 1e-8
-    r = (
-        (i if (i % 2 == 0) else i + 1)
-        if (f > 0.5 - e and f < 0.5 + e)
-        else builtins.round(n)
-    )
+    r = (i if (i % 2 == 0) else i + 1) if (f > 0.5 - e and f < 0.5 + e) else builtins.round(n)
     return r / m if digits else r
 
 
@@ -2768,9 +2702,7 @@ def ignore(a: Any = None) -> None:
     return
 
 
-def copy_to_array(
-    src: Array[_T], srci: int, trg: Array[_T], trgi: int, cnt: int
-) -> None:
+def copy_to_array(src: Array[_T], srci: int, trg: Array[_T], trgi: int, cnt: int) -> None:
     for i in range(0, cnt, 1):
         trg[trgi + i] = src[srci + i]
 


### PR DESCRIPTION
Use [Ruff formatter](https://astral.sh/blog/the-ruff-formatter) on the generated Python output files. This makes the generated files easier to read and also makes it easier to spot any issues with the generated code. Ruff format is Black compatible but super fast so it doesn't really add much to the total compile time.