### PR TITLE
Fix vscode local settings for Rust analyzer and Python testing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,11 +23,14 @@
         "src/fcs-fable"
     ],
     "rust-analyzer.linkedProjects": [
-        "build/fable-library-rust/Cargo.toml",
-        "build/tests/Rust/Cargo.toml",
         "temp/fable-library-rust/Cargo.toml",
         "temp/tests/Rust/Cargo.toml"
     ],
     "editor.inlayHints.enabled": "offUnlessPressed",
-    "dotnet.defaultSolution": "disable"
+    "dotnet.defaultSolution": "disable",
+    "python.testing.pytestArgs": [
+        "temp"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
 }


### PR DESCRIPTION
- Remove build directory from Rust linked projects. Gives red error in Rust analyzer that it cannot find the linked projects
- Add default Python settings