### PR TITLE
Refactor time_span.py to use an int representation instead of timedelta

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix `DateTime(..., DateTimeKind.Local).ToString("O")` (by @MangelMaxime)
 * Fix calling `value.ToString(CultureInfo.InvariantCulture)` (by @MangelMaxime)
 * Fix #3605: Fix record equality comparison to works with optional fields (by @MangelMaxime & @dbrattli)
+* PR #3608: Rewrite `time_span.py` allowing for better precision by using a number representation intead of native `timedelta`. (by @MangelMaxime)
 
 ## 4.5.0 - 2023-11-07
 

--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -5231,20 +5231,7 @@ let timeSpans
     // let callee = match i.callee with Some c -> c | None -> i.args.Head
     match i.CompiledName with
     | ".ctor" ->
-        let meth =
-            match args with
-            | [ ticks ] -> "fromTicks"
-            | _ -> "create"
-
-        Helper.LibCall(
-            com,
-            "time_span",
-            meth,
-            t,
-            args,
-            i.SignatureArgTypes,
-            ?loc = r
-        )
+        Helper.LibCall(com, "time_span", "create", t, args, i.SignatureArgTypes, ?loc = r)
         |> Some
     | "ToString" when (args.Length = 1) ->
         "TimeSpan.ToString with one argument is not supported, because it depends of local culture, please add CultureInfo.InvariantCulture"

--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -5246,14 +5246,6 @@ let timeSpans
             ?loc = r
         )
         |> Some
-    // | "FromMilliseconds" ->
-    //     //TypeCast(args.Head, t) |> Some
-    //     Helper.LibCall(com, "time_span", "from_milliseconds", t, args, i.SignatureArgTypes, ?thisArg = thisArg, ?loc = r)
-    //     |> Some
-    // | "get_TotalMilliseconds" ->
-    //     //TypeCast(thisArg.Value, t) |> Some
-    //     Helper.LibCall(com, "time_span", "to_milliseconds", t, args, i.SignatureArgTypes, ?thisArg = thisArg, ?loc = r)
-    //     |> Some
     | "ToString" when (args.Length = 1) ->
         "TimeSpan.ToString with one argument is not supported, because it depends of local culture, please add CultureInfo.InvariantCulture"
         |> addError com ctx.InlinePath r

--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -5229,9 +5229,18 @@ let timeSpans
     (args: Expr list)
     =
     // let callee = match i.callee with Some c -> c | None -> i.args.Head
+
     match i.CompiledName with
     | ".ctor" ->
-        Helper.LibCall(com, "time_span", "create", t, args, i.SignatureArgTypes, ?loc = r)
+        Helper.LibCall(
+            com,
+            "time_span",
+            "create",
+            t,
+            args,
+            i.SignatureArgTypes,
+            ?loc = r
+        )
         |> Some
     | "ToString" when (args.Length = 1) ->
         "TimeSpan.ToString with one argument is not supported, because it depends of local culture, please add CultureInfo.InvariantCulture"
@@ -5259,6 +5268,8 @@ let timeSpans
             |> addError com ctx.InlinePath r
 
             None
+    | "get_Nanoseconds"
+    | "get_TotalNanoseconds" -> None
     | meth ->
         let meth = Naming.removeGetSetPrefix meth |> Naming.lowerFirst
 

--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -5246,32 +5246,14 @@ let timeSpans
             ?loc = r
         )
         |> Some
-    | "FromMilliseconds" ->
-        //TypeCast(args.Head, t) |> Some
-        Helper.LibCall(
-            com,
-            "time_span",
-            "from_milliseconds",
-            t,
-            args,
-            i.SignatureArgTypes,
-            ?thisArg = thisArg,
-            ?loc = r
-        )
-        |> Some
-    | "get_TotalMilliseconds" ->
-        //TypeCast(thisArg.Value, t) |> Some
-        Helper.LibCall(
-            com,
-            "time_span",
-            "to_milliseconds",
-            t,
-            args,
-            i.SignatureArgTypes,
-            ?thisArg = thisArg,
-            ?loc = r
-        )
-        |> Some
+    // | "FromMilliseconds" ->
+    //     //TypeCast(args.Head, t) |> Some
+    //     Helper.LibCall(com, "time_span", "from_milliseconds", t, args, i.SignatureArgTypes, ?thisArg = thisArg, ?loc = r)
+    //     |> Some
+    // | "get_TotalMilliseconds" ->
+    //     //TypeCast(thisArg.Value, t) |> Some
+    //     Helper.LibCall(com, "time_span", "to_milliseconds", t, args, i.SignatureArgTypes, ?thisArg = thisArg, ?loc = r)
+    //     |> Some
     | "ToString" when (args.Length = 1) ->
         "TimeSpan.ToString with one argument is not supported, because it depends of local culture, please add CultureInfo.InvariantCulture"
         |> addError com ctx.InlinePath r

--- a/src/fable-library-py/fable_library/date.py
+++ b/src/fable-library-py/fable_library/date.py
@@ -7,13 +7,18 @@ from typing import Any
 
 from .types import FSharpRef
 from .util import DateKind
+from .time_span import TimeSpan, create as create_time_span
 
 
 formatRegExp = re.compile(r"(\w)\1*")
 
 
-def op_subtraction(x: datetime, y: datetime) -> timedelta:
-    return x - y
+def op_subtraction(x: datetime, y: datetime) -> TimeSpan:
+    delta = x - y
+    # ts.microseconds only contains the microseconds provided to the constructor
+    # so we need to calculate the total microseconds ourselves
+    deltaMicroseconds = delta.days * (24*3600) + delta.seconds * 10**6 + delta.microseconds
+    return create_time_span(0,0,0,0,0,deltaMicroseconds)
 
 
 def create(

--- a/src/fable-library-py/fable_library/date.py
+++ b/src/fable-library-py/fable_library/date.py
@@ -17,8 +17,8 @@ def op_subtraction(x: datetime, y: datetime) -> TimeSpan:
     delta = x - y
     # ts.microseconds only contains the microseconds provided to the constructor
     # so we need to calculate the total microseconds ourselves
-    deltaMicroseconds = delta.days * (24*3600) + delta.seconds * 10**6 + delta.microseconds
-    return create_time_span(0,0,0,0,0,deltaMicroseconds)
+    delta_microseconds = delta.days * (24*3600) + delta.seconds * 10**6 + delta.microseconds
+    return create_time_span(0,0,0,0,0,delta_microseconds)
 
 
 def create(

--- a/src/fable-library-py/fable_library/date_offset.py
+++ b/src/fable-library-py/fable_library/date_offset.py
@@ -39,15 +39,15 @@ def create(
     ms: int | TimeSpan,
     offset: TimeSpan | None = None,
 ) -> datetime:
-    pythonOffset: timedelta | None = None
+    python_offset: timedelta | None = None
     if isinstance(ms, TimeSpan):
-        pythonOffset = timedelta(microseconds=time_span.total_microseconds(ms))
+        python_offset = timedelta(microseconds=time_span.total_microseconds(ms))
         ms = 0
 
-    if pythonOffset is None:
+    if python_offset is None:
         return datetime(year, month, day, h, m, s, ms)
 
-    tzinfo = timezone(pythonOffset)
+    tzinfo = timezone(python_offset)
     return datetime(year, month, day, h, m, s, ms, tzinfo=tzinfo)
 
 

--- a/src/fable-library-py/fable_library/time_span.py
+++ b/src/fable-library-py/fable_library/time_span.py
@@ -6,118 +6,155 @@ from typing import Any
 from .util import pad_left_and_right_with_zeros, pad_with_zeros
 
 
-def total_seconds(ts: timedelta) -> float:
-    return ts.total_seconds()
-
-
-def total_days(ts: timedelta) -> float:
-    return total_seconds(ts) / 86400
-
-
-def total_minutes(ts: timedelta) -> float:
-    return total_seconds(ts) / 60
-
-
-def total_hours(ts: timedelta) -> float:
-    return total_seconds(ts) / 3600
-
-
-def from_milliseconds(msecs: int) -> timedelta:
-    return timedelta(milliseconds=msecs)
-
-
-def from_ticks(ticks: int) -> timedelta:
-    return timedelta(microseconds=ticks // 10)
-
-
-def from_seconds(s: int) -> timedelta:
-    return timedelta(seconds=s)
-
-
-def from_minutes(m: int) -> timedelta:
-    return timedelta(minutes=m)
-
-
-def from_hours(h: int) -> timedelta:
-    return timedelta(hours=h)
-
-
-def from_days(d: int) -> timedelta:
-    return timedelta(days=d)
-
-
-def to_milliseconds(td: timedelta) -> int:
-    return int(td.total_seconds() * 1000)
-
-
-def days(ts: timedelta) -> int:
-    return int(total_seconds(ts) / 86400)
-
-
-def hours(ts: timedelta) -> int:
-    return int(abs(total_seconds(ts)) % 86400 / 3600)
-
-
-def minutes(ts: timedelta) -> int:
-    return int(abs(total_seconds(ts)) % 3600 / 60)
-
-
-def seconds(ts: timedelta) -> int:
-    return int(abs(total_seconds(ts)) % 60)
-
-
-def milliseconds(ts: timedelta) -> int:
-    return int(total_seconds(ts) % 1 * 1000)
-
-
-def ticks(ts: timedelta) -> int:
-    return int(total_seconds(ts) * 10000000)
-
-
-def negate(ts: timedelta) -> timedelta:
-    return -ts
-
-
-def duration(ts: timedelta) -> timedelta:
-    if ts < timedelta(0):
-        return -ts
-
-    return ts
-
-
-def add(ts: timedelta, other: timedelta) -> timedelta:
-    return ts + other
-
-
-def subtract(ts: timedelta, other: timedelta) -> timedelta:
-    return ts - other
-
-
-def multiply(ts: timedelta, factor: int) -> timedelta:
-    return ts * factor
-
-
-def divide(ts: timedelta, divisor: int) -> timedelta:
-    return ts / divisor
+# TimeSpan is represented as an int which is the Tick value
+# We can recompute everything from this value
+class TimeSpan(int):
+    pass
 
 
 def create(
-    d: int = 0,
-    h: int | None = None,
-    m: int | None = None,
-    s: int | None = None,
-    ms: int | None = None,
-) -> timedelta:
-    if h is None and m is None and s is None and ms is None:
-        return from_ticks(d)
+    days: float = 0,
+    hours: float | None = None,
+    minutes: float | None = None,
+    seconds: float | None = None,
+    milliseconds: float | None = None,
+    microseconds: float | None = None,
+) -> TimeSpan:
+    match (days, hours, minutes, seconds, milliseconds, microseconds):
+        # ticks constructor
+        case (_, None, None, None, None, None):
+            return TimeSpan(days)
+        # hours, minutes, seconds constructor
+        case (_, _, _, None, None, None):
+            print("hours, minutes, seconds constructor")
+            seconds = minutes
+            minutes = hours
+            hours = days
+            days = 0
+        # others constructor follows the correct order of arguments
+        case _:
+            pass
 
-    elif s is None and ms is None:
-        return timedelta(hours=d or 0, minutes=h or 0, seconds=m or 0)
+    return TimeSpan(
+        days * 864000000000
+        + (hours or 0) * 36000000000
+        + (minutes or 0) * 600000000
+        + (seconds or 0) * 10000000
+        + (milliseconds or 0) * 10000
+        + (microseconds or 0) * 10
+    )
 
-    return timedelta(days=d, hours=h or 0, minutes=m or 0, seconds=s or 0, milliseconds=ms or 0)
+
+def total_nanoseconds(ts: TimeSpan) -> float:
+    # We store timespan as the Tick value so nanoseconds step is 100
+    return ts * 100
 
 
-def to_string(ts: timedelta, format: str = "c", _provider: Any | None = None) -> str:
+def total_microseconds(ts: TimeSpan) -> float:
+    return ts / 10
+
+
+def total_milliseconds(ts: TimeSpan) -> float:
+    return ts / 10000
+
+
+def total_seconds(ts: TimeSpan) -> float:
+    return ts / 10000000
+
+
+def total_minutes(ts: TimeSpan) -> float:
+    return ts / 600000000
+
+
+def total_hours(ts: TimeSpan) -> float:
+    return ts / 36000000000
+
+
+def total_days(ts: TimeSpan) -> float:
+    return ts / 864000000000
+
+def from_microseconds(micros: float) -> TimeSpan:
+    return create(0,0,0,0,0,micros)
+
+def from_milliseconds(msecs: int) -> TimeSpan:
+    return create(0,0,0,0,msecs)
+
+
+def from_ticks(ticks: int) -> TimeSpan:
+    return create(ticks)
+
+
+def from_seconds(s: int) -> TimeSpan:
+    return create(0, 0, s)
+
+
+def from_minutes(m: int) -> TimeSpan:
+    return create(0, m, 0)
+
+
+def from_hours(h: int) -> TimeSpan:
+    return create(h, 0, 0)
+
+
+def from_days(d: int) -> TimeSpan:
+    return create(d, 0, 0, 0)
+
+
+def ticks(ts: TimeSpan) -> int:
+    return int(ts)
+
+
+def microseconds(ts: TimeSpan) -> int:
+    return int(ts % 10000 / 10)
+
+
+def milliseconds(ts: TimeSpan) -> int:
+    return int(ts % 10000000 / 10000)
+
+
+def seconds(ts: TimeSpan) -> int:
+    return int(ts % 600000000 / 10000000)
+
+
+def minutes(ts: TimeSpan) -> int:
+    return int(ts % 36000000000 / 600000000)
+
+
+def hours(ts: TimeSpan) -> int:
+    return int(ts % 864000000000 / 36000000000)
+
+
+def days(ts: TimeSpan) -> int:
+    return int(ts / 864000000000)
+
+
+def negate(ts: TimeSpan) -> TimeSpan:
+    return TimeSpan(-ts)
+
+
+def duration(ts: TimeSpan) -> TimeSpan:
+    return TimeSpan(abs(int(ts)))
+
+
+def add(ts: TimeSpan, other: TimeSpan) -> TimeSpan:
+    return TimeSpan(ts + other)
+
+
+def subtract(ts: TimeSpan, other: TimeSpan) -> TimeSpan:
+    return TimeSpan(ts - other)
+
+
+def multiply(ts: TimeSpan, factor: float) -> TimeSpan:
+    # We represents TimeSpan as a Tick which can't be a float
+    # This also allows us
+    return TimeSpan(int(ts * factor))
+
+
+def divide(ts: TimeSpan, divisor: float) -> TimeSpan:
+    return TimeSpan(int(ts / divisor))
+
+
+def to_string(ts: TimeSpan, format: str = "c", _provider: Any | None = None) -> str:
     if format not in ["c", "g", "G"]:
         raise ValueError("Custom formats are not supported")
 
@@ -126,7 +163,7 @@ def to_string(ts: timedelta, format: str = "c", _provider: Any | None = None) ->
     m = minutes(ts)
     s = seconds(ts)
     ms = abs(milliseconds(ts))
-    sign: str = "-" if ts < timedelta(0) else ""
+    sign: str = "-" if ts < 0 else ""
 
     ms_str = (
         ""
@@ -143,9 +180,14 @@ def to_string(ts: timedelta, format: str = "c", _provider: Any | None = None) ->
 
 __all__ = [
     "create",
-    "to_milliseconds",
-    "to_string",
+    "total_microseconds",
+    "total_milliseconds",
+    "total_seconds",
+    "total_minutes",
+    "total_hours",
+    "total_days",
     "from_ticks",
+    "from_microseconds",
     "from_milliseconds",
     "from_hours",
     "from_minutes",

--- a/src/fable-library-py/fable_library/time_span.py
+++ b/src/fable-library-py/fable_library/time_span.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from datetime import timedelta
 from typing import Any
 
 from .util import pad_left_and_right_with_zeros, pad_with_zeros
+from math import fmod, ceil, floor
 
 
 # TimeSpan is represented as an int which is the Tick value
@@ -105,27 +105,28 @@ def ticks(ts: TimeSpan) -> int:
 
 
 def microseconds(ts: TimeSpan) -> int:
-    return int(ts % 10000 / 10)
+    return int(fmod(ts, 10000) / 10)
 
 
 def milliseconds(ts: TimeSpan) -> int:
-    return int(ts % 10000000 / 10000)
+    return int(fmod(ts, 10000000) / 10000)
 
 
 def seconds(ts: TimeSpan) -> int:
-    return int(ts % 600000000 / 10000000)
+    return int(fmod(ts, 600000000) / 10000000)
 
 
 def minutes(ts: TimeSpan) -> int:
-    return int(ts % 36000000000 / 600000000)
+    return int(fmod(ts, 36000000000) / 600000000)
 
 
 def hours(ts: TimeSpan) -> int:
-    return int(ts % 864000000000 / 36000000000)
+    return int(fmod(ts, 864000000000) / 36000000000)
 
 
 def days(ts: TimeSpan) -> int:
-    return int(ts / 864000000000)
+    res = ts / 864000000000
+    return ceil(res) if res < 0 else floor(res)
 
 
 def negate(ts: TimeSpan) -> TimeSpan:
@@ -159,9 +160,9 @@ def to_string(ts: TimeSpan, format: str = "c", _provider: Any | None = None) -> 
         raise ValueError("Custom formats are not supported")
 
     d = abs(days(ts))
-    h = hours(ts)
-    m = minutes(ts)
-    s = seconds(ts)
+    h = abs(hours(ts))
+    m = abs(minutes(ts))
+    s = abs(seconds(ts))
     ms = abs(milliseconds(ts))
     sign: str = "-" if ts < 0 else ""
 

--- a/src/fable-library-py/fable_library/time_span.py
+++ b/src/fable-library-py/fable_library/time_span.py
@@ -26,7 +26,6 @@ def create(
             return TimeSpan(days)
         # hours, minutes, seconds constructor
         case (_, _, _, None, None, None):
-            print("hours, minutes, seconds constructor")
             seconds = minutes
             minutes = hours
             hours = days

--- a/src/quicktest-py/quicktest.fsx
+++ b/src/quicktest-py/quicktest.fsx
@@ -7,7 +7,8 @@ open Fable.Python.Builtins
 open System
 
 let equal expected actual =
-    Assert.AreEqual(expected, actual)
+    // According the console log arguments are reversed
+    Assert.AreEqual(actual, expected)
 
 [<EntryPoint>]
 let main argv =
@@ -17,89 +18,5 @@ let main argv =
     // Open file with builtin `open`
     // use file = builtins.``open``(StringPath "data.txt")
     // file.read() |> printfn "File contents: %s"
-
-    let t1 = TimeSpan(10, 10, 10)
-    let t2 = TimeSpan(1, 1, 1, 1, 1, 1)
-    let t3 = TimeSpan(1, 1, 1, 1, 1)
-
-    // printfn "%A" t1.TotalSeconds
-    // printfn "%A" t2.TotalSeconds
-    // printfn "%A" t3.TotalMilliseconds
-
-    // printfn "%A" t3.TotalMicroseconds
-    // printfn "%A" t3.TotalMilliseconds
-    // printfn "%A" t3.TotalSeconds
-    // printfn "%A" t3.TotalMinutes
-    // printfn "%A" t3.TotalHours
-    // printfn "%A" t3.TotalDays
-    // printfn "%A" 1.042372697
-    // printfn "%A" (t3.TotalDays = 1.042372697)
-
-    // TimeSpan(10, 20, 30, 10, 10, 10).Ticks |> printfn "TotalMicroseconds: %A"
-    // TimeSpan(10, 20, 30, 10, 5, 12).Milliseconds |> printfn "TotalMicroseconds: %A"
-    // TimeSpan(10, 20, 30, 10, -5, 12).Milliseconds |> printfn "TotalMicroseconds: %A"
-    // TimeSpan(10, 20, 30, 10, 10, 10).Milliseconds |> printfn "Milliseconds: %A"
-    // TimeSpan(10, 20, 30, 10, 10, 10).Seconds |> printfn "Seconds: %A"
-    // TimeSpan(10, 20, 30, 10, 10, 10).Minutes |> printfn "Minutes: %A"
-    // TimeSpan(10, 20, 30, 10, 10, 10).Hours |> printfn "Hours: %A"
-    // TimeSpan(10, 20, 30, 10, 10, 10).Days |> printfn "TotalDays: %A"
-
-    // TimeSpan(10, 0, 0, 0, 0).Divide(3.26).Ticks |> printfn "TotalMicroseconds: %A"
-
-    // TimeSpan.FromTicks(2650306748466L).TotalSeconds |> printfn "TotalSeconds: %A"
-
-    // TimeSpan(1).TotalNanoseconds |> printfn "TotalNanoseconds: %A"
-    // TimeSpan(1).Ticks |> printfn "Ticks: %A"
-    // TimeSpan.FromHours(3).TotalHours |> printfn "TotalHours: %A"
-    // TimeSpan.FromHours(3).Hours |> printfn "TotalHours: %A"
-    // TimeSpan(0,3,0,0,0).Hours |> printfn "TotalHours: %A"
-
-    // TimeSpan.fro
-
-    // TimeSpan(10, 20, 30, 10, 10, 10).TotalMicroseconds.ToString() |> printfn "TotalMicroseconds: %A"
-    // TimeSpan(10, 20, 30, 10, 10, 10).TotalMilliseconds.ToString() |> printfn "TotalMilliseconds: %A"
-    // TimeSpan(10, 20, 30, 10, 10, 10).TotalSeconds.ToString() |> printfn "TotalSeconds: %A"
-    // TimeSpan(10, 20, 30, 10, 10, 10).TotalMinutes.ToString() |> printfn "TotalMinutes: %A"
-    // TimeSpan(10, 20, 30, 10, 10, 10).TotalHours.ToString() |> printfn "TotalHours: %A"
-    // TimeSpan(10, 20, 30, 10, 10, 10).TotalDays.ToString() |> printfn "TotalDays: %A"
-
-    // TimeSpan(10, 20, 30, 10, 10, 10).Ticks.ToString() |> printfn "TotalDays: %A"
-
-    // printfn "%A" (TimeSpan(10, 20, 30, 10, 10, 10).TotalMicroseconds = 9.3781001e+11)
-
-    // printfn "%A" 9.3781001e+11
-
-    // TimeSpan(10, 20, 30, 10, 10, 10).TotalDays |> printfn "%A"
-    // printfn "%A" 10.85428252
-
-
-    async {
-        let mutable _aggregate = 0
-
-        let makeWork i =
-            async {
-                // check that the individual work items run sequentially and not interleaved
-                _aggregate <- _aggregate + i
-                let copyOfI = _aggregate
-                do! Async.Sleep 100
-                equal copyOfI _aggregate
-                do! Async.Sleep 100
-                equal copyOfI _aggregate
-                return i
-            }
-        let works = [ for i in 1 .. 5 -> makeWork i ]
-        let now = DateTimeOffset.Now
-        let! result = Async.Sequential works
-        let ``then`` = DateTimeOffset.Now
-        let d = ``then`` - now
-        if d.TotalSeconds < 0.99 then
-            failwithf "expected sequential operations to take 1 second or more, but took %.3f" d.TotalSeconds
-        result |> equal [| 1 .. 5 |]
-        result |> Seq.sum |> equal _aggregate
-    } |> Async.RunSynchronously
-
-
-
-
 
     0

--- a/src/quicktest-py/quicktest.fsx
+++ b/src/quicktest-py/quicktest.fsx
@@ -1,8 +1,13 @@
 #r "nuget:Fable.Python"
 
 open Fable.Core
+open Fable.Core.Testing
 open Fable.Core.PyInterop
 open Fable.Python.Builtins
+open System
+
+let equal expected actual =
+    Assert.AreEqual(expected, actual)
 
 [<EntryPoint>]
 let main argv =
@@ -12,5 +17,89 @@ let main argv =
     // Open file with builtin `open`
     // use file = builtins.``open``(StringPath "data.txt")
     // file.read() |> printfn "File contents: %s"
+
+    let t1 = TimeSpan(10, 10, 10)
+    let t2 = TimeSpan(1, 1, 1, 1, 1, 1)
+    let t3 = TimeSpan(1, 1, 1, 1, 1)
+
+    // printfn "%A" t1.TotalSeconds
+    // printfn "%A" t2.TotalSeconds
+    // printfn "%A" t3.TotalMilliseconds
+
+    // printfn "%A" t3.TotalMicroseconds
+    // printfn "%A" t3.TotalMilliseconds
+    // printfn "%A" t3.TotalSeconds
+    // printfn "%A" t3.TotalMinutes
+    // printfn "%A" t3.TotalHours
+    // printfn "%A" t3.TotalDays
+    // printfn "%A" 1.042372697
+    // printfn "%A" (t3.TotalDays = 1.042372697)
+
+    // TimeSpan(10, 20, 30, 10, 10, 10).Ticks |> printfn "TotalMicroseconds: %A"
+    // TimeSpan(10, 20, 30, 10, 5, 12).Milliseconds |> printfn "TotalMicroseconds: %A"
+    // TimeSpan(10, 20, 30, 10, -5, 12).Milliseconds |> printfn "TotalMicroseconds: %A"
+    // TimeSpan(10, 20, 30, 10, 10, 10).Milliseconds |> printfn "Milliseconds: %A"
+    // TimeSpan(10, 20, 30, 10, 10, 10).Seconds |> printfn "Seconds: %A"
+    // TimeSpan(10, 20, 30, 10, 10, 10).Minutes |> printfn "Minutes: %A"
+    // TimeSpan(10, 20, 30, 10, 10, 10).Hours |> printfn "Hours: %A"
+    // TimeSpan(10, 20, 30, 10, 10, 10).Days |> printfn "TotalDays: %A"
+
+    // TimeSpan(10, 0, 0, 0, 0).Divide(3.26).Ticks |> printfn "TotalMicroseconds: %A"
+
+    // TimeSpan.FromTicks(2650306748466L).TotalSeconds |> printfn "TotalSeconds: %A"
+
+    // TimeSpan(1).TotalNanoseconds |> printfn "TotalNanoseconds: %A"
+    // TimeSpan(1).Ticks |> printfn "Ticks: %A"
+    // TimeSpan.FromHours(3).TotalHours |> printfn "TotalHours: %A"
+    // TimeSpan.FromHours(3).Hours |> printfn "TotalHours: %A"
+    // TimeSpan(0,3,0,0,0).Hours |> printfn "TotalHours: %A"
+
+    // TimeSpan.fro
+
+    // TimeSpan(10, 20, 30, 10, 10, 10).TotalMicroseconds.ToString() |> printfn "TotalMicroseconds: %A"
+    // TimeSpan(10, 20, 30, 10, 10, 10).TotalMilliseconds.ToString() |> printfn "TotalMilliseconds: %A"
+    // TimeSpan(10, 20, 30, 10, 10, 10).TotalSeconds.ToString() |> printfn "TotalSeconds: %A"
+    // TimeSpan(10, 20, 30, 10, 10, 10).TotalMinutes.ToString() |> printfn "TotalMinutes: %A"
+    // TimeSpan(10, 20, 30, 10, 10, 10).TotalHours.ToString() |> printfn "TotalHours: %A"
+    // TimeSpan(10, 20, 30, 10, 10, 10).TotalDays.ToString() |> printfn "TotalDays: %A"
+
+    // TimeSpan(10, 20, 30, 10, 10, 10).Ticks.ToString() |> printfn "TotalDays: %A"
+
+    // printfn "%A" (TimeSpan(10, 20, 30, 10, 10, 10).TotalMicroseconds = 9.3781001e+11)
+
+    // printfn "%A" 9.3781001e+11
+
+    // TimeSpan(10, 20, 30, 10, 10, 10).TotalDays |> printfn "%A"
+    // printfn "%A" 10.85428252
+
+
+    async {
+        let mutable _aggregate = 0
+
+        let makeWork i =
+            async {
+                // check that the individual work items run sequentially and not interleaved
+                _aggregate <- _aggregate + i
+                let copyOfI = _aggregate
+                do! Async.Sleep 100
+                equal copyOfI _aggregate
+                do! Async.Sleep 100
+                equal copyOfI _aggregate
+                return i
+            }
+        let works = [ for i in 1 .. 5 -> makeWork i ]
+        let now = DateTimeOffset.Now
+        let! result = Async.Sequential works
+        let ``then`` = DateTimeOffset.Now
+        let d = ``then`` - now
+        if d.TotalSeconds < 0.99 then
+            failwithf "expected sequential operations to take 1 second or more, but took %.3f" d.TotalSeconds
+        result |> equal [| 1 .. 5 |]
+        result |> Seq.sum |> equal _aggregate
+    } |> Async.RunSynchronously
+
+
+
+
 
     0

--- a/tests/Python/Fable.Tests.Python.fsproj
+++ b/tests/Python/Fable.Tests.Python.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>

--- a/tests/Python/TestTimeSpan.fs
+++ b/tests/Python/TestTimeSpan.fs
@@ -11,12 +11,12 @@ let ``test TimeSpan.ToString() works`` () =
     TimeSpan.FromSeconds(12345.).ToString() |> equal "03:25:45"
     TimeSpan.FromDays(18.).ToString() |> equal "18.00:00:00"
     TimeSpan.FromMilliseconds(25.).ToString() |> equal "00:00:00.0250000"
-    
+
 [<Fact>]
 let ``test TimeSpan.ToString() works for negative TimeSpan`` () =
     TimeSpan.FromSeconds(-5.).ToString() |> equal "-00:00:05"
     TimeSpan.FromDays(-5.23).ToString() |> equal "-5.05:31:12"
-    
+
 [<Fact>]
 let ``test TimeSpan.ToString(\"c\", CultureInfo.InvariantCulture) works`` () =
     TimeSpan(0L).ToString("c", CultureInfo.InvariantCulture) |> equal "00:00:00"
@@ -37,7 +37,7 @@ let ``test TimeSpan.ToString(\"General long\", CultureInfo.InvariantCulture) wor
     TimeSpan.FromSeconds(12345.).ToString("G", CultureInfo.InvariantCulture) |> equal "0:03:25:45.0000000"
     TimeSpan.FromDays(18.).ToString("G", CultureInfo.InvariantCulture) |> equal "18:00:00:00.0000000"
     TimeSpan.FromMilliseconds(25.).ToString("G", CultureInfo.InvariantCulture) |> equal "0:00:00:00.0250000"
-    
+
 [<Fact>]
 let ``test TimeSpan constructors work`` () =
     let t1 = TimeSpan(20000L)
@@ -124,6 +124,53 @@ let ``test TimeSpan Addition works`` () =
     test -2000. 0. -2000.
     test 0. 0. 0.
 
+[<Fact>]
+let ``test TimeSpan implementation coherence`` () =
+    TimeSpan.FromTicks(1L).Ticks |> equal 1L
+    TimeSpan.FromMilliseconds(1).Milliseconds |> equal 1
+    TimeSpan.FromMilliseconds(1).TotalMilliseconds |> equal 1.
+    TimeSpan.FromSeconds(1).Seconds |> equal 1
+    TimeSpan.FromSeconds(1).TotalSeconds |> equal 1.
+    TimeSpan.FromMinutes(1).Minutes |> equal 1
+    TimeSpan.FromMinutes(1).TotalMinutes |> equal 1.
+    TimeSpan.FromHours(1).Hours |> equal 1
+    TimeSpan.FromHours(1).TotalHours |> equal 1.
+    TimeSpan.FromDays(1).Days |> equal 1
+    TimeSpan.FromDays(1).TotalDays |> equal 1.
+
+    TimeSpan.FromMilliseconds(-1).Milliseconds |> equal -1
+    TimeSpan.FromMilliseconds(-1).TotalMilliseconds |> equal -1.
+    TimeSpan.FromSeconds(-1).Seconds |> equal -1
+    TimeSpan.FromSeconds(-1).TotalSeconds |> equal -1.
+    TimeSpan.FromMinutes(-1).Minutes |> equal -1
+    TimeSpan.FromMinutes(-1).TotalMinutes |> equal -1.
+    TimeSpan.FromHours(-1).Hours |> equal -1
+    TimeSpan.FromHours(-1).TotalHours |> equal -1.
+    TimeSpan.FromDays(-1).Days |> equal -1
+    TimeSpan.FromDays(-1).TotalDays |> equal -1.
+
+    TimeSpan(49, 0, 0).Days |> equal 2
+    TimeSpan(0, 200, 0).Hours |> equal 3
+    TimeSpan(0, 0, 300).Minutes |> equal 5
+    TimeSpan(0, 0, 0, 0, 5089).Seconds |> equal 5
+    TimeSpan(0, 0, 0, 0, 0, 5999).Milliseconds |> equal 5
+
+    let t1 = TimeSpan(10, 20, 39, 42, 57, 589)
+
+    t1.Days |> equal 10
+    t1.Hours |> equal 20
+    t1.Minutes |> equal 39
+    t1.Seconds |> equal 42
+    t1.Milliseconds |> equal 57
+    t1.Ticks |> equal 9383820575890L
+    t1.TotalDays |> equal 10.86090344431713
+    t1.TotalHours |> equal 260.6616826636111
+    t1.TotalMinutes |> equal 15639.700959816666
+    t1.TotalSeconds |> equal 938382.057589
+    t1.TotalMilliseconds |> equal 938382057.589
+    t1.TotalMicroseconds |> equal 938382057589.0
+
+
 //[<Theory>]
 //[<InlineData(1000., 2000., -1000.)>]
 //[<InlineData(200., -2000., 2200.)>]
@@ -139,7 +186,7 @@ let ``test TimeSpan Addition works`` () =
 //    let res2 = (t1 - t2).TotalMilliseconds
 //    equal true (res1 = res2)
 //    equal expected res1
-//    
+//
 //[<Theory>]
 //[<InlineData(1000., -1., -1000.)>]
 //[<InlineData(200., 11., 2200.)>]
@@ -154,7 +201,7 @@ let ``test TimeSpan Addition works`` () =
 //    equal res1 res2
 //    equal true (res1 = res2)
 //    equal expected res1
-    
+
 
 //[<Fact>]
 //let ``test TimeSpan Division works" [


### PR DESCRIPTION
- [x] Add tests to check that `TotalXXX`, `Days`, `Seconds`, etc. returns the expected value

TimeSpan precision is at the Ticks levels, in .NET the precision is nanoseconds but I have no idea how to implement it correctly.

The TimeSpan constructor goes up to `Tick` levels so we can't create a `TimeSpan` based on the nanosecond value. 

For this reason, I am making Fable emit an error if the user tries to use any of the `Nanoseconds` getter.

![CleanShot 2023-11-24 at 16 11 27@2x](https://github.com/fable-compiler/Fable/assets/4760796/8efe8aa6-4476-4c06-97ff-5209a320e07e)
