### PR TITLE
Fix comparaison between optional list when one is None

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+#### Python
+
+* Fix #3617: Fix comparaison between list option when one is None
+
 ## 4.6.0 - 2023-11-27
 
 ### Changed

--- a/src/fable-library-py/fable_library/util.py
+++ b/src/fable-library-py/fable_library/util.py
@@ -217,11 +217,9 @@ class DateKind(IntEnum):
 
 
 def equals(a: Any, b: Any) -> bool:
-    if a is b:
-        return True
-
-    # Check for NoneTypes (ex Some [1] = None)
     match (a, b):
+        case (a, b) if a is b:
+            return True
         # Don't test (None, None) here, because a is b already covers that
         # case (None, None):
         #     return True
@@ -229,13 +227,10 @@ def equals(a: Any, b: Any) -> bool:
             return False
         case (_, None):
             return False
-        case (_, _):
-            pass
-
-    if is_array_like(a):
-        return equal_arrays(a, b)
-
-    return a == b
+        case (a, b) if is_array_like(a):
+            return equal_arrays(a, b)
+        case _:
+            return a == b
 
 
 def is_comparable(x: Any) -> bool:

--- a/src/fable-library-py/fable_library/util.py
+++ b/src/fable-library-py/fable_library/util.py
@@ -220,6 +220,18 @@ def equals(a: Any, b: Any) -> bool:
     if a is b:
         return True
 
+    # Check for NoneTypes (ex Some [1] = None)
+    match (a, b):
+        # Don't test (None, None) here, because a is b already covers that
+        # case (None, None):
+        #     return True
+        case (None, _):
+            return False
+        case (_, None):
+            return False
+        case (_, _):
+            pass
+
     if is_array_like(a):
         return equal_arrays(a, b)
 

--- a/tests/Python/TestComparison.fs
+++ b/tests/Python/TestComparison.fs
@@ -82,6 +82,24 @@ let ``test Typed array equality works`` () =
     equal true (xs1 <> xs4)
 
 [<Fact>]
+let ``test Typed array option equality works`` () =
+    let xs1 = Some [| 1; 2; 3 |]
+    let xs2 = Some [| 1; 2; 3 |]
+    let xs3 = Some [| 1; 2; 4 |]
+    let xs4 = Some [| 1; 2 |]
+    let xs5 = None
+    equal true (xs1 = xs2)
+    equal false (xs1 = xs3)
+    equal true (xs1 <> xs3)
+    equal false (xs1 <> xs2)
+    equal false (xs1 = xs4)
+    equal true (xs1 <> xs4)
+    equal false (xs1 = xs5)
+    equal true (xs1 <> xs5)
+    equal true (xs5 = None)
+    equal false (xs5 <> None)
+
+[<Fact>]
 let ``test Array equality works`` () =
     let xs1 = [| "1"; "2"; "3" |]
     let xs2 = [| "1"; "2"; "3" |]
@@ -94,6 +112,24 @@ let ``test Array equality works`` () =
     equal true (xs1 <> xs4)
 
 [<Fact>]
+let ``test Array option equality works`` () =
+    let xs1 = Some [| "1"; "2"; "3" |]
+    let xs2 = Some [| "1"; "2"; "3" |]
+    let xs3 = Some [| "1"; "2"; "4" |]
+    let xs4 = Some [| "1"; "2" |]
+    let xs5 = None
+    equal true (xs1 = xs2)
+    equal false (xs1 = xs3)
+    equal true (xs1 <> xs3)
+    equal false (xs1 <> xs2)
+    equal false (xs1 = xs4)
+    equal true (xs1 <> xs4)
+    equal false (xs1 = xs5)
+    equal true (xs1 <> xs5)
+    equal true (xs5 = None)
+    equal false (xs5 <> None)
+
+[<Fact>]
 let ``test Tuple equality works`` () =
     let xs1 = ( 1, 2, 3 )
     let xs2 = ( 1, 2, 3 )
@@ -104,6 +140,21 @@ let ``test Tuple equality works`` () =
     equal false (xs1 <> xs2)
 
 [<Fact>]
+let ``test Tuple option equality works``() =
+    let xs1 = Some ( 1, 2, 3 )
+    let xs2 = Some ( 1, 2, 3 )
+    let xs3 = Some ( 1, 2, 4 )
+    let xs5 = None
+    equal true (xs1 = xs2)
+    equal false (xs1 = xs3)
+    equal true (xs1 <> xs3)
+    equal false (xs1 <> xs2)
+    equal false (xs1 = xs5)
+    equal true (xs1 <> xs5)
+    equal true (xs5 = None)
+    equal false (xs5 <> None)
+
+[<Fact>]
 let ``test List equality works`` () =
     let xs1 = [ 1; 2; 3 ]
     let xs2 = [ 1; 2; 3 ]
@@ -112,6 +163,24 @@ let ``test List equality works`` () =
     equal false (xs1 = xs3)
     equal true (xs1 <> xs3)
     equal false (xs1 <> xs2)
+
+[<Fact>]
+let ``test List option equality works``() =
+    let xs1 = Some [ 1; 2; 3 ]
+    let xs2 = Some [ 1; 2; 3 ]
+    let xs3 = Some [ 1; 2; 4 ]
+    let xs4 = Some [ 1; 2; 3; 1 ]
+    let xs5 = None
+    equal true (xs1 = xs2)
+    equal false (xs1 = xs3)
+    equal true (xs1 <> xs3)
+    equal false (xs1 <> xs2)
+    equal false (xs1 = xs4)
+    equal true (xs1 <> xs4)
+    equal false (xs1 = xs5)
+    equal true (xs1 <> xs5)
+    equal true (xs5 = None)
+    equal false (xs5 <> None)
 
 [<Fact>]
 let ``test Set equality works`` () =
@@ -128,6 +197,25 @@ let ``test Set equality works`` () =
     equal false (xs1 <> xs5)
 
 [<Fact>]
+let ``test Set option equality works`` () =
+    let xs1 = Some (Set [ 1; 2; 3 ])
+    let xs2 = Some (Set [ 1; 2; 3 ])
+    let xs3 = Some (Set [ 1; 2; 4 ])
+    let xs4 = Some (Set [ 3; 2; 1 ])
+    let xs5 = Some (Set [ 1; 2; 3; 1 ])
+    let xs6 = None
+    equal true (xs1 = xs2)
+    equal false (xs1 = xs3)
+    equal true (xs1 <> xs3)
+    equal false (xs1 <> xs2)
+    equal true (xs1 = xs4)
+    equal false (xs1 <> xs5)
+    equal false (xs1 = xs6)
+    equal true (xs1 <> xs6)
+    equal true (xs6 = None)
+    equal false (xs6 <> None)
+
+[<Fact>]
 let ``test Map equality works`` () =
     let xs1 = Map [ ("a", 1); ("b", 2); ("c", 3) ]
     let xs2 = Map [ ("a", 1); ("b", 2); ("c", 3) ]
@@ -138,6 +226,25 @@ let ``test Map equality works`` () =
     equal true (xs1 <> xs3)
     equal false (xs1 <> xs2)
     equal true (xs1 = xs4)
+
+[<Fact>]
+let ``test Map option equality works`` () =
+    let xs1 = Some (Map [ ("a", 1); ("b", 2); ("c", 3) ])
+    let xs2 = Some (Map [ ("a", 1); ("b", 2); ("c", 3) ])
+    let xs3 = Some (Map [ ("a", 1); ("b", 2); ("c", 4) ])
+    let xs4 = Some (Map [ ("c", 3); ("b", 2); ("a", 1) ])
+    let xs5 = Some (Map [ ("a", 1); ("b", 2); ("c", 3); ("d", 1) ])
+    let xs6 = None
+    equal true (xs1 = xs2)
+    equal false (xs1 = xs3)
+    equal true (xs1 <> xs3)
+    equal false (xs1 <> xs2)
+    equal true (xs1 = xs4)
+    equal true (xs1 <> xs5)
+    equal false (xs1 = xs6)
+    equal true (xs1 <> xs6)
+    equal true (xs6 = None)
+    equal false (xs6 <> None)
 
 [<Fact>]
 let ``test Union equality works`` () =


### PR DESCRIPTION
Fix #3617

The error actually comes from:

![CleanShot 2023-11-28 at 11 34 08@2x](https://github.com/fable-compiler/Fable/assets/4760796/b58263d9-8a57-4a17-b26d-d9137b4ebbb7)

Because the code expect `xs_1` and `ys_1` to be list. But because the `def equal`  in `util.py` doesn't capture the `Some .. vs None` difference early, then we try to access `.tail` on a `None` value.

I believe JavaScript implementation does something similar to capture these case early (line 474 - 476)

https://github.com/fable-compiler/Fable/blob/8ee247a9f9aa3c25155e5390bf0a369a8a03f4da/src/fable-library/Util.ts#L471-L489

I am not sure what `a is b` does in Python, so I let it there and disabled the `None, None` check as it was already handled by `a is b`.

Also, I can't "fix" `List.equal` definition because this is coming from `List.fs` so I expect that it's implementation is correct and behaving the same as in FSharp.Core