### PR TITLE
[Python] Do not translate .toString methods to str

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix #3617: Fix comparaison between list option when one is None
 * Fix #3615: Fix remove from dictionary with tuple as key
 * Fix #3598: Using obj () now generated an empty dict instead of None
+* Fix #3597: Do not translate .toString methods to str
 
 ## 4.6.0 - 2023-11-27
 

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -3959,14 +3959,6 @@ module Util =
                      _,
                      _range) -> transformAsArray com ctx expr info
 
-        | Fable.Call(Fable.Get(expr, Fable.FieldGet { Name = name }, _, _),
-                     _info,
-                     _,
-                     _range) when name.ToLower() = "tostring" ->
-            let func = Expression.name "str"
-            let left, stmts = com.TransformAsExpr(ctx, expr)
-            Expression.call (func, [ left ]), stmts
-
         | Fable.Call(Fable.Get(expr, Fable.FieldGet { Name = "Equals" }, _, _),
                      { Args = [ arg ] },
                      _,
@@ -3974,25 +3966,6 @@ module Util =
             let right, stmts = com.TransformAsExpr(ctx, arg)
             let left, stmts' = com.TransformAsExpr(ctx, expr)
             Expression.compare (left, [ Eq ], [ right ]), stmts @ stmts'
-
-        | Fable.Call(Fable.Get(expr, Fable.FieldGet { Name = "split" }, _, _),
-                     { Args = [ Fable.Value(kind = Fable.StringConstant "") ] },
-                     _,
-                     _range) ->
-            let func = Expression.name "list"
-            let value, stmts = com.TransformAsExpr(ctx, expr)
-            Expression.call (func, [ value ]), stmts
-
-        | Fable.Call(Fable.Get(expr,
-                               Fable.FieldGet { Name = "charCodeAt" },
-                               _,
-                               _),
-                     _info,
-                     _,
-                     _range) ->
-            let func = Expression.name "ord"
-            let value, stmts = com.TransformAsExpr(ctx, expr)
-            Expression.call (func, [ value ]), stmts
 
         | Fable.Call(callee, info, _, range) ->
             transformCall com ctx range callee info

--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -648,7 +648,9 @@ let toList com returnType expr =
     Helper.LibCall(com, "list", "ofSeq", returnType, [ expr ])
 
 let stringToCharArray t e =
-    Helper.InstanceCall(e, "split", t, [ makeStrConst "" ])
+    //Helper.InstanceCall(e, "split", t, [ makeStrConst "" ])
+    // Write as global call `list` instead
+    Helper.GlobalCall("list", t, [ e ])
 
 let toSeq t (e: Expr) =
     match e.Type with


### PR DESCRIPTION
- Do not translate .toString methods to str. Fixes #3597 
- Move other translations to Replacements