### PR TITLE
Enable parallel compiler flags.

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -16,7 +16,6 @@
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <OtherFlags>$(OtherFlags) --test:GraphBasedChecking --test:ParallelOptimization --test:ParallelIlxGen</OtherFlags>
-        <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     </PropertyGroup>
     <ItemGroup>
         <None Include="$(MSBuildThisFileDirectory)\..\fable_logo.png" Pack="true" Visible="false" PackagePath="" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,6 +15,8 @@
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <OtherFlags>$(OtherFlags) --test:GraphBasedChecking --test:ParallelOptimization --test:ParallelIlxGen</OtherFlags>
+        <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     </PropertyGroup>
     <ItemGroup>
         <None Include="$(MSBuildThisFileDirectory)\..\fable_logo.png" Pack="true" Visible="false" PackagePath="" />

--- a/src/Fable.Cli/Fable.Cli.fsproj
+++ b/src/Fable.Cli/Fable.Cli.fsproj
@@ -57,11 +57,13 @@
     <Content Include="..\fable-library-php\**\*.*" PackagePath="fable-library-php\" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Util.fsi" />
     <Compile Include="Util.fs" />
     <Compile Include="Contributors.fs" />
     <Compile Include="Globbing.fs" />
     <Compile Include="ProjectCracker.fs" />
     <Compile Include="Printers.fs" />
+    <Compile Include="FileWatchers.fsi" />
     <Compile Include="FileWatchers.fs" />
     <Compile Include="Pipeline.fs" />
     <Compile Include="Main.fs" />

--- a/src/Fable.Cli/FileWatchers.fsi
+++ b/src/Fable.Cli/FileWatchers.fsi
@@ -1,0 +1,45 @@
+module Fable.Cli.FileWatcher
+
+open System
+open System.IO
+
+type IFileSystemWatcher =
+    inherit IDisposable
+
+    [<CLIEvent>]
+    abstract OnFileChange: IEvent<string>
+
+    [<CLIEvent>]
+    abstract OnError: IEvent<ErrorEventArgs>
+
+    /// Directory path
+    abstract BasePath: string with get, set
+    abstract EnableRaisingEvents: bool with get, set
+    /// File name filters
+    abstract GlobFilters: string list
+
+/// An alternative file watcher based on polling.
+/// ignoredDirectoryNameRegexes allows ignoring directories to improve performance.
+type PollingFileWatcher =
+    new:
+        watchedDirectoryPath: string * ignoredDirectoryNameRegexes: string seq ->
+            PollingFileWatcher
+
+    /// Defaults to false. Must be set to true to start raising events.
+    member EnableRaisingEvents: bool with get, set
+    interface IDisposable
+
+/// A wrapper around the immutable polling watcher,
+/// implementing IFileSystemWatcher with its mutable BasePath.
+type ResetablePollingFileWatcher =
+    new:
+        fileNameGlobFilters: string list *
+        ignoredDirectoryNameRegexes: string seq ->
+            ResetablePollingFileWatcher
+
+    interface IFileSystemWatcher
+
+/// A FileSystemWatcher wrapper that implements the IFileSystemWatcher interface.
+type DotnetFileWatcher =
+    new: globFilters: string list -> DotnetFileWatcher
+    interface IFileSystemWatcher

--- a/src/Fable.Cli/Util.fsi
+++ b/src/Fable.Cli/Util.fsi
@@ -83,7 +83,7 @@ module File =
     /// System.IO.GetFullPath doesn't change the case of the argument in case insensitive file systems
     /// even if it doesn't match the actual path, causing unexpected issues when comparing files later.
     val getExactFullPath: pathName: string -> string
-    //     /// FAKE and other tools clean dirs but don't remove them, so check whether it doesn't exist or it's empty
+    /// FAKE and other tools clean dirs but don't remove them, so check whether it doesn't exist or it's empty
     val isDirectoryEmpty: dir: string -> bool
     val safeDelete: path: string -> unit
     val withLock: dir: string -> action: (unit -> 'T) -> 'T
@@ -159,10 +159,6 @@ module Json =
 module Performance =
     val measure: f: (unit -> 'a) -> 'a * int64
     val measureAsync: f: (unit -> Async<'a>) -> Async<'a * int64>
-
-// type StringOrdinalComparer =
-//     new: unit -> StringOrdinalComparer
-//     interface System.Collections.Generic.IComparer<string>
 
 type PrecompiledFileJson =
     {

--- a/src/Fable.Cli/Util.fsi
+++ b/src/Fable.Cli/Util.fsi
@@ -1,0 +1,208 @@
+namespace Fable.Cli
+
+#nowarn "3391"
+
+open System
+
+type RunProcess =
+    new:
+        exeFile: string * args: string list * ?watch: bool * ?fast: bool ->
+            RunProcess
+
+    member ExeFile: string
+    member Args: string list
+    member IsWatch: bool
+    member IsFast: bool
+
+type CliArgs =
+    {
+        ProjectFile: string
+        RootDir: string
+        OutDir: string option
+        IsWatch: bool
+        Precompile: bool
+        PrecompiledLib: string option
+        PrintAst: bool
+        FableLibraryPath: string option
+        Configuration: string
+        NoRestore: bool
+        NoCache: bool
+        NoParallelTypeCheck: bool
+        SourceMaps: bool
+        SourceMapsRoot: string option
+        Exclude: string list
+        Replace: Map<string, string>
+        RunProcess: RunProcess option
+        CompilerOptions: Fable.CompilerOptions
+    }
+
+    member ProjectFileAsRelativePath: string
+    member RunProcessEnv: (string * string) list
+
+[<RequireQualifiedAccess>]
+module Log =
+    val newLine: string
+    /// To be called only at the beginning of the app
+    val makeVerbose: unit -> unit
+    val makeSilent: unit -> unit
+    val inSameLineIfNotCI: msg: string -> unit
+    val always: msg: string -> unit
+    val verbose: msg: Lazy<string> -> unit
+    val warning: msg: string -> unit
+    val error: msg: string -> unit
+    val showFemtoMsg: show: (unit -> bool) -> unit
+
+module File =
+    val defaultFileExt: usesOutDir: bool -> language: Fable.Language -> string
+
+    val changeExtensionButUseDefaultExtensionInFableModules:
+        lang: Fable.Language ->
+        isInFableModules: bool ->
+        filePath: string ->
+        fileExt: string ->
+            string
+
+    val relPathToCurDir: path: string -> string
+    /// File.ReadAllText fails with locked files. See https://stackoverflow.com/a/1389172
+    val readAllTextNonBlocking: path: string -> string
+
+    val tryFindNonEmptyDirectoryUpwards:
+        opts:
+            {|
+                exclude: string list
+                matches: string list
+            |} ->
+        dir: string ->
+            string option
+
+    val tryFindUpwards: fileName: string -> dir: string -> string option
+
+    val tryNodeModulesBin:
+        workingDir: string -> exeFile: string -> string option
+
+    /// System.IO.GetFullPath doesn't change the case of the argument in case insensitive file systems
+    /// even if it doesn't match the actual path, causing unexpected issues when comparing files later.
+    val getExactFullPath: pathName: string -> string
+    //     /// FAKE and other tools clean dirs but don't remove them, so check whether it doesn't exist or it's empty
+    val isDirectoryEmpty: dir: string -> bool
+    val safeDelete: path: string -> unit
+    val withLock: dir: string -> action: (unit -> 'T) -> 'T
+
+[<RequireQualifiedAccess>]
+module Process =
+    val startWithEnv:
+        envVars: (string * string) list ->
+            (string -> string -> string list -> unit)
+
+    val runSyncWithEnv:
+        envVars: (string * string) list ->
+        workingDir: string ->
+        exePath: string ->
+        args: string list ->
+            int
+
+    val runSync:
+        workingDir: string -> exePath: string -> args: string list -> int
+
+type PathResolver =
+    abstract TryPrecompiledOutPath:
+        sourceDir: string * relativePath: string -> string option
+
+    abstract GetOrAddDeduplicateTargetDir:
+        importDir: string * addTargetDir: (Set<string> -> string) -> string
+
+module Imports =
+    val getRelativePath: path: string -> pathTo: string -> string
+
+    val getTargetAbsolutePath:
+        pathResolver: PathResolver ->
+        importPath: string ->
+        projDir: string ->
+        outDir: string ->
+            string
+
+    val getImportPath:
+        pathResolver: PathResolver ->
+        sourcePath: string ->
+        targetPath: string ->
+        projDir: string ->
+        outDir: string option ->
+        importPath: string ->
+            string
+
+module Observable =
+    type SingleObservable<'T> =
+        new: dispose: (unit -> unit) -> SingleObservable<'T>
+        member Trigger: v: 'T -> unit
+        interface IObservable<'T>
+
+    val throttle: ms: int -> obs: IObservable<'T> -> IObservable<'T array>
+
+[<AutoOpen>]
+module ResultCE =
+    type ResultBuilder =
+        new: unit -> ResultBuilder
+        member Zero: Result<unit, obj>
+
+        member Bind:
+            v: Result<'d, 'e> * f: ('d -> Result<'f, 'e>) -> Result<'f, 'e>
+
+        member Return: v: 'b -> Result<'b, 'c>
+        member ReturnFrom: v: 'a -> 'a
+
+    val result: ResultBuilder
+
+module Json =
+    val read: path: string -> 'T
+    val write: path: string -> data: 'T -> unit
+
+module Performance =
+    val measure: f: (unit -> 'a) -> 'a * int64
+    val measureAsync: f: (unit -> Async<'a>) -> Async<'a * int64>
+
+// type StringOrdinalComparer =
+//     new: unit -> StringOrdinalComparer
+//     interface System.Collections.Generic.IComparer<string>
+
+type PrecompiledFileJson =
+    {
+        RootModule: string
+        OutPath: string
+    }
+
+type PrecompiledInfoJson =
+    {
+        CompilerVersion: string
+        CompilerOptions: Fable.CompilerOptions
+        FableLibDir: string
+        Files: Map<string, PrecompiledFileJson>
+        InlineExprHeaders: string[]
+    }
+
+type PrecompiledInfoImpl =
+    new:
+        fableModulesDir: string * info: PrecompiledInfoJson ->
+            PrecompiledInfoImpl
+
+    member CompilerVersion: string
+    member CompilerOptions: Fable.CompilerOptions
+    member Files: Map<string, PrecompiledFileJson>
+    member FableLibDir: string
+    member DllPath: string
+    member TryPrecompiledOutPath: normalizedFullPath: string -> string option
+    static member GetDllPath: fableModulesDir: string -> string
+    interface Fable.Transforms.State.PrecompiledInfo
+    static member GetPath: fableModulesDir: string -> string
+
+    static member GetInlineExprsPath:
+        fableModulesDir: string * index: int -> string
+
+    static member Load: fableModulesDir: string -> PrecompiledInfoImpl
+
+    static member Save:
+        files: Map<string, PrecompiledFileJson> *
+        inlineExprs: (string * 'a) array *
+        compilerOptions: Fable.CompilerOptions *
+        fableModulesDir: string *
+        fableLibDir: string ->
+            unit

--- a/src/Fable.Transforms/FSharp2Fable.fsi
+++ b/src/Fable.Transforms/FSharp2Fable.fsi
@@ -1,0 +1,18 @@
+module rec Fable.Transforms.FSharp2Fable.Compiler
+
+open FSharp.Compiler.Symbols
+open Fable
+open Fable.AST
+
+val getRootFSharpEntities:
+    declarations: FSharpImplementationFileDeclaration list -> FSharpEntity seq
+
+val getRootModule:
+    declarations: FSharpImplementationFileDeclaration list -> string
+
+val getInlineExprs:
+    fileName: string ->
+    declarations: FSharpImplementationFileDeclaration list ->
+        (string * InlineExprLazy) list
+
+val transformFile: com: Compiler -> Fable.File

--- a/src/Fable.Transforms/Fable.Transforms.fsproj
+++ b/src/Fable.Transforms/Fable.Transforms.fsproj
@@ -24,7 +24,9 @@
     <Compile Include="Dart/Replacements.fs" />
     <Compile Include="Replacements.fs" />
     <Compile Include="Replacements.Api.fs" />
+    <Compile Include="FSharp2Fable.fsi" />
     <Compile Include="FSharp2Fable.fs" />
+    <Compile Include="FableTransforms.fsi" />
     <Compile Include="FableTransforms.fs" />
     <Compile Include="Fable2Babel.fs" />
     <Compile Include="Printer.fs" />

--- a/src/Fable.Transforms/FableTransforms.fsi
+++ b/src/Fable.Transforms/FableTransforms.fsi
@@ -1,0 +1,20 @@
+module Fable.Transforms.FableTransforms
+
+open Fable
+open Fable.AST.Fable
+
+val isIdentCaptured: identName: string -> expr: Expr -> bool
+val isTailRecursive: identName: string -> expr: Expr -> bool * bool
+val replaceValues: replacements: Map<string, Expr> -> expr: Expr -> Expr
+val uncurryType: typ: Type -> Type
+
+val getTransformations: _com: Compiler -> (#Compiler -> Expr -> Expr) list
+
+val transformDeclaration:
+    transformations: (Compiler -> Expr -> Expr) list ->
+    com: Compiler ->
+    file: File ->
+    decl: Declaration ->
+        Declaration
+
+val transformFile: com: Compiler -> file: File -> File


### PR DESCRIPTION
This enabled some of the new [parallel compiler flags](https://devblogs.microsoft.com/dotnet/announcing-fsharp-8/#switches-for-compiler-parallelization).

Building `Fable.sln` went from `23.0s` to `19.3s` on my machine.

I also included a few signature files for maximum effect.