### PR TITLE
Add missing dates to changelog.

### DIFF
--- a/src/Fable.AST/CHANGELOG.md
+++ b/src/Fable.AST/CHANGELOG.md
@@ -6,69 +6,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 4.3.0
+## 4.3.0 - 2023-09-29
 
 ### Added
 
 * Add `Attributes` to `MemberRefInfo`
 
-## 4.2.1
+## 4.2.1 - 2022-10-31
 
 * Get sources from PluginHelper
 
-## 4.2.0
+## 4.2.0 - 2022-09-09
 
 * Add Entity.DeclaringEntity
 
-## 4.1.0
+## 4.1.0 - 2022-09-07
 
 * Add IsInternal/IsPrivate to Entity and MemberFunctionOrValue
 
-## 4.0.0
+## 4.0.0 - 2022-09-01
 
 * Stable AST for Fable 4
 
-## 4.0.0-snake-island-alpha-001
+## 4.0.0-snake-island-alpha-001 - 2022-08-24
 
 * Snake Island alpha release
 
-## 3.1.1
+## 3.1.1 - 2021-05-14
 
 * Publish with icon and symbols @cartermp
 
-## 3.1.0
+## 3.1.0 - 2021-04-16
 
 * Add GetOutputPath to PluginHelper
 
-## 3.0.0
+## 3.0.0 - 2020-12-04
 
 * Official release
 
-## 3.0.0-nagareyama-rc-001
+## 3.0.0-nagareyama-rc-001 - 2020-11-25
 
 * Add `Expr.LetRec`
 * Add `ScanForPluginsAttribute`
 * Add `AST.Fable.File` argument to `MemberDeclarationPlugin.Transform`
 
-## 3.0.0-nagareyama-beta-002
+## 3.0.0-nagareyama-beta-002 - 2020-10-27
 
 * Add `MemberDecl.ExportDefault`
 
-## 3.0.0-nagareyama-beta-001
+## 3.0.0-nagareyama-beta-001 - 2020-10-23
 
 * Beta release
 * Use string literals in ImportInfo
 
-## 3.0.0-nagareyama-alpha-003
+## 3.0.0-nagareyama-alpha-003 - 2020-10-22
 
 * Add optional string tag to TypeCast
 * Add methods from Compiler to PluginHelper
 * Add CallMemberInfo to Call expr
 
-## 3.0.0-nagareyama-alpha-002
+## 3.0.0-nagareyama-alpha-002 - 2020-10-19
 
 * Merge Member/Call plugins
 
-## 3.0.0-nagareyama-alpha-001
+## 3.0.0-nagareyama-alpha-001 - 2020-10-15
 
 * First alpha release

--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -171,7 +171,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     This is especially useful when working on Fable itself, and should save time to others.
     Each time I got this is error, I needed several minutes to remember the cause of it.
 
-## 4.1.4
+## 4.1.4 - 2023-05-16
 
 * Fix #3438: Source maps
 * Fix #3440: Don't curry arity-1 functions
@@ -193,7 +193,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Rust: Updated TimeSpan
 * Rust: Added DateTimeOffset
 
-## 4.1.3
+## 4.1.3 - 2023-04-28
 
 * JS/TS/Rust: Added bigint log, log2, log10, minMag, maxMag
 * TS: Fix extension of files in fable_modules with out dir
@@ -201,20 +201,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * JS/TS: Output JS docs
 * Fix range of inlined functions
 
-## 4.1.2
+## 4.1.2 - 2023-04-22
 
 * Print minimum fable-library version from npm
 
-## 4.1.1
+## 4.1.1 - 2023-04-22
 
 * Fix fable-library package.json
 
-## 4.1.0
+## 4.1.0 - 2023-04-18
 
 * Set TypeScript compilation as stable
 * Added Map.minKeyValue and maxKeyValue
 
-## 4.1.0-beta-001
+## 4.1.0-beta-001 - 2023-04-16
 
 * Fix #3418: Single-Case Union Reflection
 * Include declaration .d.ts files in fable-library
@@ -226,19 +226,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * TS: Get generic types of generated members
 * TS/JS: Sanitize class fields
 
-## 4.0.6
+## 4.0.6 - 2023-04-08
 
 * JS Hotfix: Skip compiler generated decls
 * TS: Fixes for unions, pattern matching and interface function getters
 
-## 4.0.5
+## 4.0.5 - 2023-04-08
 
 * Use native JS BigInt for int64/uint64
 * Fix #3402: Rust type mismatch error when compiling F# closure code
 * Improve optional field and argument typing in TypeScript
 * Fix fable-library-ts when used with Vite
 
-## 4.0.4
+## 4.0.4 - 2023-04-04
 
 * Fix #3397: Curry only user imports
 * Fix: Compiler Exception when `!!`, Anon Record, and aliased `Ux` (also behind option) @Booksbaum
@@ -247,13 +247,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Optimize compile time equality and testing (union, list, options)
 * TypeScript: enable Comparison, Convert and Event tests
 
-## 4.0.3
+## 4.0.3 - 2023-03-30
 
 * Fix #3389: Don't wrap TemplateStringArray
 * Rust: Fix recursive closures and some type tests,
 * TypeScript: Emit interfaces and anonymous record annotations
 
-## 4.0.2
+## 4.0.2 - 2023-03-27
 
 * Enable Unicode identifiers @kant2002
 * Add ability for plugins to remove member declaration @Zaid-Ajaj
@@ -261,42 +261,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Rust: Enable applicative tests and other fixes
 * TypeScript: Enable 1909 tests
 
-## 4.0.1
+## 4.0.1 - 2023-03-18
 
 * Fix #3371: Copying struct records
 * Php: Improve output @entropitor
 * Rust: string improvements
 * TypeScript: Fix applicative tests
 
-## 4.0.0
+## 4.0.0 - 2023-03-14
 
 * Fable JS stable release
 
-## 4.0.0-theta-018
+## 4.0.0-theta-018 - 2022-11-19
 
 * When using a .csproj, make sure the project is restored before parsing
 * Rust, added Stack, Queue
 
-## 4.0.0-theta-017
+## 4.0.0-theta-017 - 2022-11-16
 
 * Use TargetFramework from .fsproj and ask users to upgrade from netstandard2.0 if necessary
 * Update FCS (F# 7)
 * Python, handling static getters
 * Rust, fix deprecated API
 
-## 4.0.0-theta-016
+## 4.0.0-theta-016 - 2022-11-13
 
 * Attempt to improve project parsing
 * Added Double.Pow static
 
-## 4.0.0-theta-015
+## 4.0.0-theta-015 - 2022-11-05
 
 * JS, enable calls with `importValueDynamic`
 * JS, Support System.Delegate.DynamicInvoke
 * Rust, Added feature for func_type_enum
 * Rust, Added Func type wrappers (#3250)
 
-## 4.0.0-theta-014
+## 4.0.0-theta-014 - 2022-10-31
 
 * Try to fix #3244 (cannot parse .fsproj)
 * Rust, added small string type
@@ -304,7 +304,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * JS, don't mangle idents from imports in emitted code
 * JS, optimize some array transforms
 
-## 4.0.0-theta-012
+## 4.0.0-theta-012 - 2022-10-14
 
 * Python, option fixes
 * Python, fixes for reference equals with literals
@@ -312,7 +312,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Rust, Added bigint support
 * Use Buildalyzer for parsing .fsproj
 
-## 4.0.0-theta-011
+## 4.0.0-theta-011 - 2022-10-04
 
 * Python, add read/write files
 * Python, fix URI and number types
@@ -320,11 +320,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * JS, improve import path resolution (interpolation, inlined functions)
 * TypeScript, fix arithmetic tests
 
-## 4.0.0-theta-010
+## 4.0.0-theta-010 - 2022-09-28
 
 * Use StringTemplate expr in Fable AST for Python
 
-## 4.0.0-theta-009
+## 4.0.0-theta-009 - 2022-09-28
 
 * Add language status to version
 * Make --runScript compatible with Python, Rust and Dart
@@ -332,7 +332,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Compile as net6 binary
 * TypeScript, type-safe union types and other fixes
 
-## 4.0.0-theta-008
+## 4.0.0-theta-008 - 2022-09-22
 
 * Enable emitExpr/Statement with interpolation, @alfonsogarciacaro
 * Python, fix imported interfaces from other modules, @dbrattli
@@ -341,18 +341,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * TypeScript, added library-ts to packages, @ncave
 * Python, do not trim emitted statements
 
-## 4.0.0-theta-007
+## 4.0.0-theta-007 - 2022-09-21
 
 * TypeScript, fix fable-library-ts @ncave
 * Python, fix regex tests @dbrattli
 * Python, fix emit expressions
 * JS, helpers for JSX/React apps
 
-## 4.0.0-theta-006
+## 4.0.0-theta-006 - 2022-09-18
 
 * Python, regex fixes for group collection
 
-## 4.0.0-theta-005
+## 4.0.0-theta-005 - 2022-09-17
 
 * Python, fix type annotation for imports of erased interfaces
 * Python, better regex handling
@@ -360,16 +360,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Allow alias for default/namespace imports
 * TypeScript, added some interface annotations
 
-## 4.0.0-theta-004
+## 4.0.0-theta-004 - 2022-09-14
 
 * JS, allow alias for default/namespace imports
 
-## 4.0.0-theta-003
+## 4.0.0-theta-003 - 2022-09-12
 
 * Python, fix regression when building on Windows
 * Rust, added Default for array, string, hashmap, hashset, guid
 
-## 4.0.0-theta-002
+## 4.0.0-theta-002 - 2022-09-11
 
 * Rust, removed cloning after emit
 * Python, make sure module names are valid
@@ -377,20 +377,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Python, fixes for .ToArray and is_array_like
 * Rust, fixed TimeSpan fields
 
-## 4.0.0-theta-001
+## 4.0.0-theta-001 - 2022-09-09
 
 * JSX, enable dynamic children
 * Python, fix dict remove
 * Rust, updated module visibility
 
-## 4.0.0-snake-island-alpha-026
+## 4.0.0-snake-island-alpha-026 - 2022-09-08
 
 * Rust, more dates, @alexswan10k
 * Python, fix slice of string statements, @dbrattli
 * Python add task RunSynchronously, @dbrattli
 * Rust, ade startup an opt-in dependency, @ncave
 
-## 4.0.0-snake-island-alpha-025
+## 4.0.0-snake-island-alpha-025 - 2022-09-06
 
 * Added IsInternal and IsPrivate properties in AST, @ncave
 * Rust, better datetime comparison + conversion. DateTimeOffset first, @alexswan10k
@@ -398,12 +398,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Python, async/await fixes for Task returning functions, @dbrattli
 * Rust, another problematic ref counting scenario + fix, @alexswan10k
 
-## 4.0.0-snake-island-alpha-024
+## 4.0.0-snake-island-alpha-024 - 2022-09-02
 
 * Fable.AST 4.0 stable
 * Rust, StringBuilder, Dates, ref counting
 
-## 4.0.0-snake-island-alpha-023
+## 4.0.0-snake-island-alpha-023 - 2022-08-30
 
 * Update F# compiler
 * Make Fable 4 compatible with Feliz plugins
@@ -419,7 +419,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Rust, Fixed closure ident cloning (#3106)
 * Rust, Fixed static, member and interface imports (#3105)
 
-## 4.0.0-snake-island-alpha-021
+## 4.0.0-snake-island-alpha-021 - 2022-08-21
 
 * Rust, fixed curried apply, @ncave
 * Python, allow modules with uppercase letters, @dbrattli
@@ -429,7 +429,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Rust, union fix for import prefixes, @alexswan10k
 * Rust, fixed build dependency for wasm32, @ncave
 
-## 4.0.0-snake-island-alpha-020
+## 4.0.0-snake-island-alpha-020 - 2022-08-14
 
 * Rust, added Display trait, @ncave
 * Rust, Initial type testing support, @ncave
@@ -443,14 +443,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Rust, implement unsafe-cells feature switch + Monitor, @alexswan10k
 * Rust, initial support for object expressions, @ncave
 
-## 4.0.0-snake-island-alpha-019
+## 4.0.0-snake-island-alpha-019 - 2022-07-31
 
 * Python, use --fableLib to choose between embedded or site-packages, @dbrattli
 * Rust - Make Map and Set support PartialEq, @alexswan10k
 * Rust, List/Map/Set cleanup, @ncave
 * Rust - more collection interop improvements, @alexswan10k
 
-## 4.0.0-snake-island-alpha-018
+## 4.0.0-snake-island-alpha-018 - 2022-07-30
 
 * Python, array, list and resize-array fixes, @dbrattli
 * Rust, fable-library-rust cleanup, @ncave
@@ -460,22 +460,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Rust, - More work on collection interop (Set, List, Map), @alexswan10k
 * Rust, - First pass at getting the interop experience with built in collections a little better, @alexswan10k
 
-## 4.0.0-snake-island-alpha-017
+## 4.0.0-snake-island-alpha-017 - 2022-07-27
 
 * Python, reverted back to using modules instead of packages, @dbrattli
 * Rust, Fixed overload suffix for anon records, @ncave
 
-## 4.0.0-snake-island-alpha-016
+## 4.0.0-snake-island-alpha-016 - 2022-07-26
 
 * Python, fixes for requirements.txt
 
-## 4.0.0-snake-island-alpha-015
+## 4.0.0-snake-island-alpha-015 - 2022-07-26
 
 * Python, generate requirements.txt within fable_modules, @dbrattli
 * Rust, represent self as a Lrc[T] for method calls using double pointer indirection, @alexswan10k
 * Rust, fixed build issue, @ncave
 
-## 4.0.0-snake-island-alpha-014
+## 4.0.0-snake-island-alpha-014 - 2022-07-25
 
 * Python, import fixes, @dbrattli
 * Rust, records and Unions now are correctly unwrapped when Struct attribute is used to tag as value, @alexswan10k
@@ -488,12 +488,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Make CancellationTokenSource implement IDisposable, @alfonsogarciacaro
 * Fixed Array.compareWith issue, @alfonsogarciacaro
 
-## 4.0.0-snake-island-alpha-013
+## 4.0.0-snake-island-alpha-013 - 2022-07-25
 
 * Python, import fixes and package generation, @dbrattli
 * Python, use poetry for Python, @dbrattli
 
-## 4.0.0-snake-island-alpha-012
+## 4.0.0-snake-island-alpha-012 - 2022-07-12
 
 * Update to latest FCS @ncave
 * Rust Support module imports @ncave
@@ -501,52 +501,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Rust: Async builder, tasks, configurable pointer types @alexswan10k
 * Rust: attribute support @ncave
 
-## 4.0.0-snake-island-alpha-011
+## 4.0.0-snake-island-alpha-011 - 2022-06-23
 
 * Fix import paths in Python
 
-## 4.0.0-snake-island-alpha-010
+## 4.0.0-snake-island-alpha-010 - 2022-06-03
 
 * Use wrapping options for Dart
 
-## 4.0.0-snake-island-alpha-008
+## 4.0.0-snake-island-alpha-008 - 2022-06-01
 
 * Rust and Dart fixes
 
-## 4.0.0-snake-island-alpha-007
+## 4.0.0-snake-island-alpha-007 - 2022-05-25
 
 * JSX string templates
 
-## 4.0.0-snake-island-alpha-006
+## 4.0.0-snake-island-alpha-006 - 2022-05-24
 
 * Dart: compile union cases as child classes
 
-## 4.0.0-snake-island-alpha-005
+## 4.0.0-snake-island-alpha-005 - 2022-05-23
 
 * Dart fixes
 
-## 4.0.0-snake-island-alpha-004
+## 4.0.0-snake-island-alpha-004 - 2022-05-21
 
 * Don't destructure props arg in JSX components
 
-## 4.0.0-snake-island-alpha-003
+## 4.0.0-snake-island-alpha-003 - 2022-05-20
 
 * JSX Support
 
-## 4.0.0-snake-island-alpha-002
+## 4.0.0-snake-island-alpha-002 - 2022-05-19
 
 * Snake Island alpha release 2
 
-## 4.0.0-snake-island-alpha-001
+## 4.0.0-snake-island-alpha-001 - 2022-05-11
 
 * Snake Island alpha release
 
-## 3.7.18
+## 3.7.18 - 2022-08-16
 
 * Fix #3052: Nested options with Option.orElse #3052 @IanManske
 * Fix Fix #3078: Nested interpolation
 
-## 3.7.17
+## 3.7.17 - 2022-07-21
 
 * Fix #2961: Make Array.compareWith behaviour consistent with dotnet F#
 * Fix #2955: units of mesure with unsigned ints
@@ -554,83 +554,83 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix #2879: Make CancellationTokenSource implement IDisposable
 * Don't print multiple sourceMappingURL comments
 
-## 3.7.16
+## 3.7.16 - 2022-07-05
 
 * Fix #2869: Don't update maps @hensou
 * Fix #2869: Use deterministic names for compiler-generate variables
 * Update FCS @ncave
 
-## 3.7.15
+## 3.7.15 - 2022-06-29
 
 * Fix #2869: Avoid unnecessary updates @hensou
 * Fix #2931: Array.IndexOf with non-primitive
 
-## 3.7.14
+## 3.7.14 - 2022-06-14
 
 * Fix #2924: Invalidate cache if source maps option changes
 * Fix #2925: Always set unicode flag for Regex
 * Enable non-booleans in Emit optional syntax
 
-## 3.7.12
+## 3.7.12 - 2022-05-27
 
 * Resolve `defaultArg` at compile time when possible
 * Fix #2900: Equality with prototype-less JS objects
 * Fix #2895: FableLibDir in cached info is empty when using --precompiledLib
 * Fix #2880: Trait call with unit of measure
 
-## 3.7.11
+## 3.7.11 - 2022-05-01
 
 * Fix generic param user/compiler generated name conflicts
 
-## 3.7.10
+## 3.7.10 - 2022-04-29
 
 * Fix #2864: Interface names don't conflict in JS
 * Fix #2855: duplicate idents from witness in inline expr
 * Fix #2868: don't write empty files
 * Add warning when duplicated generic params are detected
 
-## 3.7.9
+## 3.7.9 - 2022-04-01
 
 * Fix #2851: References captured by >> eagerly eval
 * Fix wrong out paths when using lower case drive letter
 
-## 3.7.8
+## 3.7.8 - 2022-03-24
 
 * Fix #2845: Cover more edge cases @Prunkles
 
-## 3.7.7
+## 3.7.7 - 2022-03-22
 
 * Fix #2840: Keep delegates of arity 1 curried @JaggerJo
 * Fix #2844: 1-len array slices starting at 0 work @jpacker
 * Fix #2845: Regex.Matches infinite loop @Prunkles
 
-## 3.7.6
+## 3.7.6 - 2022-03-16
 
 * Type.IsInstanceOfType works for interfaces decorated with Global/Import @chkn
 
-## 3.7.5
+## 3.7.5 - 2022-03-01
 
 * Prevent combining absolute paths
 
-## 3.7.4
+## 3.7.4 - 2022-02-25
 
 * Change intro message
 
-## 3.7.3
+## 3.7.3 - 2022-02-23
 
 * Fix #2832: Adding a converted char to string
 * Fix Type.IsSubclassOf(obj) @chkn
 
-## 3.7.2
+## 3.7.2 - 2022-02-22
 
 * Fix the fixes in the previous release
 
-## 3.7.1
+## 3.7.1 - 2022-02-17
 
 * Fix #2809: Generic trait calls in multiple nested inlined functions
 * Fix #2817: Optimization - Remove wrapping lambdas when possible
 
-## 3.7.0
+## 3.7.0 - 2022-02-07
 
 * Cache .fsproj parsing result
 * Run F# type check and Fable in parallel (use --noParallelTypeCheck flag to disable)
@@ -643,40 +643,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix #2709: error when using JsInterop.import in inlined functions
 * Fix #2719: use with null disposable
 
-## 3.7.0-beta-015
+## 3.7.0-beta-015 - 2022-01-26
 
 * Run sub-process even if compilation was skipped
 
-## 3.7.0-beta-014
+## 3.7.0-beta-014 - 2022-01-24
 
 * Add --noParallelTypeCheck option to disable F#/Fable parallel compilation
 
-## 3.7.0-beta-012
+## 3.7.0-beta-012 - 2022-01-18
 
 * Disable uncurrying functions passed as arguments to local lambdas
 * Fix typeof(obj).IsInstanceOfType @chkn
 
-## 3.7.0-beta-011
+## 3.7.0-beta-011 - 2022-01-14
 
 * Fixes for precompiling inline expressions
 * Fix #2719: use with null disposable
 * Fix #2727: don't write in same line when output redirected
 
-## 3.7.0-beta-009
+## 3.7.0-beta-009 - 2022-01-12
 
 * Fix #2718
 * Other stability issues and add more verbose logs
 
-## 3.7.0-beta-008
+## 3.7.0-beta-008 - 2022-01-11
 
 * Prevent Fable from getting stuck on fatal errors
 * Show File compiled messages in CI
 
-## 3.7.0-beta-007
+## 3.7.0-beta-007 - 2022-01-11
 
 * Lock file for outDir (mainly intended for parallel processes precompiling the same library)
 
-## 3.7.0-beta-006
+## 3.7.0-beta-006 - 2022-01-11
 
 * Allow inlined functions accessing internal values in Fable.Precompiled.dll (FCS)
 * Shorten logs in same line if longer than 80 chars (so they don't jump to next line)
@@ -684,39 +684,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add flag to disable reflection
 * Fix #2709: error when using JsInterop.import in inlined functions
 
-## 3.7.0-beta-005
+## 3.7.0-beta-005 - 2022-01-07
 
 * Fix cache issues
 * Seeded random
 
-## 3.7.0-beta-004
+## 3.7.0-beta-004 - 2022-01-05
 
 * Fix watch mode and runFast optimization
 
-## 3.7.0-beta-003
+## 3.7.0-beta-003 - 2022-01-04
 
 * Fix precompile errors
 
-## 3.7.0-beta-002
+## 3.7.0-beta-002 - 2021-12-28
 
 * Performance improvements
 
-## 3.7.0-beta-001
+## 3.7.0-beta-001 - 2021-12-20
 
 * Add precompile command
 
-## 3.6.3
+## 3.6.3 - 2021-12-01
 
 * New FSharp.Core 6 APIs: updateAt/insertAt/insertManyAt/removeAt/removeManyAt
 * Support thousand separators in String.Format
 * Fix #2628 @stroborobo
 
-## 3.6.2
+## 3.6.2 - 2021-11-26
 
 * TypescriptTaggedUnion @cannorin
 * Speed up recompilation when adding/removing files
 
-## 3.6.1
+## 3.6.1 - 2021-11-23
 
 * Fix #2614: Char addition
 * Fix #2615: Math.DivRem
@@ -724,26 +724,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Improve Regex.Match/IsMatch/Matches
 * Update FCS
 
-## 3.6.0
+## 3.6.0 - 2021-11-19
 
 * Support F# 6
 * Support DateOnly/TimeOnly @kerams
 * Improve watch mode
 * Cache project options
 
-## 3.6.0-beta-003
+## 3.6.0-beta-003 - 2021-11-17
 
 * Add Fable.Core.Compiler.triggeredByDependency flag
 * Support DefaultParameterValue attribute (not for JS interop)
 * Update F# compiler
 
-## 3.6.0-beta-002
+## 3.6.0-beta-002 - 2021-11-15
 
 * Fix watch mode when saving multiple files at same time
 * TimeOnly.FromDateTime @kerams
 * Remove --watchDeps flag
 
-## 3.6.0-beta-001
+## 3.6.0-beta-001 - 2021-11-14
 
 * Support F# 6
 * Support DateOnly/TimeOnly @kerams
@@ -751,21 +751,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add `--watchDeps` flag
 * Cache project options
 
-## 3.4.10
+## 3.4.10 - 2021-11-08
 
 * Add support for StringSplitOptions.TrimEntries @steveofficer
 * Fix #2587: DateTimeOffset.Parse issues with some locales @ncave
 * Use Process.ArgumentList to escape args passed to subprocess
 * Print paths relative to --cwd if set
 
-## 3.4.9
+## 3.4.9 - 2021-11-05
 
 * Add CLI arg --watchDelay
 * Show relative paths in logs
 * Fixed Seq.toArray @ncave
 * Fix FullName/Name/Namespace of complex array types
 
-## 3.4.8
+## 3.4.8 - 2021-11-04
 
 * Fix #2572 #2579: Watch .fsi files and referenced .fsproj
 * Fix #2576: Last file can omit module declaration
@@ -773,23 +773,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix DateTime Offset parsing with date only and hyphens
 * Set NODE_ENV when running a sub-process
 
-## 3.4.7
+## 3.4.7 - 2021-10-28
 
 * Fix #2571: Forward slash not escaped when creating regex
 
-## 3.4.6
+## 3.4.6 - 2021-10-26
 
 * Small improvements in Async.ts
 
-## 3.4.5
+## 3.4.5 - 2021-10-21
 
 * Accept ${entryDir} macro in imports
 
-## 3.4.4
+## 3.4.4 - 2021-10-20
 
 * Use relative paths for source maps
 
-## 3.4.3
+## 3.4.3 - 2021-10-14
 
 * Add support of System.Activator for primitive types @Happypig375
 * Fix #2566: HashSet.IntersectWith does not respect custom comparer
@@ -798,19 +798,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Pass Fable compiled name to ReflectedDecorator
 * Remove void wrapper in expression statements
 
-## 3.4.2
+## 3.4.2 - 2021-10-05
 
 * Fix #2561: Case insensitive args and check
 * Fix generic parameters with JS.ReflectedDecorator
 
-## 3.4.1
+## 3.4.1 - 2021-10-04
 
 * Support System.Collections.Generic.Queue @davedawkins
 * Fix custom array equality
 * Remove class restriction for ParamObject
 * Skip parens in emit if placeholder is already surrounded by parens
 
-## 3.4.0
+## 3.4.0 - 2021-10-01
 
 * ParamObject attribute
 * Rename .fable folder to fable_modules
@@ -818,7 +818,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add Type.IsInstanceOfType @chkn
 * Fix #2229: Parsing succeeded for some invalid dates @njlr
 
-## 3.3.1
+## 3.3.1 - 2021-09-27
 
 * Fix #2097: Async.StartChild does not apply timeout @njlr
 * Fix #2530: System.Collections.Generic.Stack @njlr
@@ -826,7 +826,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix #2549: Native ESM support
 * Serialize compiler_info as JSON
 
-## 3.3.0
+## 3.3.0 - 2021-09-16
 
 * JS.Decorator/ReflectedDecorator attributes
 * Fix isSubclassOf to walk up the inheritance chain @chkn
@@ -834,25 +834,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix #2532: Measure products
 * Optimize interpolate strings without formatting into JS templates
 
-## 3.2.14
+## 3.2.14 - 2021-09-11
 
 * Fix #2480: Include package.json in fable-library
 * Fix #2522: Warn if user sets .fable as outDir
 * Fix #2525: Support infinite arity for currying/uncurrying
 * Fix plugin version check
 
-## 3.2.12
+## 3.2.12 - 2021-08-26
 
 * Fix #2505: Make String.Split match .NET with no or null separators
 * Add TimeSpan.Divide and Multiply @0x53A
 * Add Async.Sequential @0x53A
 * Compile `FormattableString` as JS Templates
 
-## 3.2.11
+## 3.2.11 - 2021-08-19
 
 * Add --rootModule CLI flag
 
-## 3.2.10
+## 3.2.10 - 2021-08-02
 
 * Support System.Uri.TryCreate @Choc13
 * Fix #2477: Don't drop "DEBUG" and "TRACE" DefineConstants @stroborobo
@@ -861,68 +861,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix #2491: Unchecked.defaultof with struct tuples
 * Fix #2496: Custom Pow operator
 
-## 3.2.9
+## 3.2.9 - 2021-07-08
 
 * Don't print JS files in watch mode if there're F# errors
 * Fix SRTP with local inline functions
 
-## 3.2.8
+## 3.2.8 - 2021-06-26
 
 * Fix regression in FCS: passing __SOURCE_IDENTIFIER__ to static parameters in type providers
 
-## 3.2.7
+## 3.2.7 - 2021-06-25
 
 * Fix regression: all files were recompiled in watch mode in 3.2.5
 * Fix #2472: Tuple-related methods
 
-## 3.2.6
+## 3.2.6 - 2021-06-22
 
 * Fix #2471: Trait call regression
 
-## 3.2.5
+## 3.2.5 - 2021-06-21
 
 * Fix #2468: SRTP Parser
 * Only show Compile file log in watch compilations
 
-## 3.2.4
+## 3.2.4 - 2021-06-16
 
 * Fix #2438: Print JS sequence expressions always between parentheses
 * Don't jump over mutable idents when inlining
 
-## 3.2.3
+## 3.2.3 - 2021-06-11
 
 * Experimental.namesofLambda
 
-## 3.2.2
+## 3.2.2 - 2021-06-03
 
 * Check for correct types in Anonymous Record when assigning to Interface with [<EmitIndexer>] via !! @Booksbaum
 * Fix #1973: FormattableString support
 
-## 3.2.1
+## 3.2.1 - 2021-05-28
 
 * Fix Event issues and and implement FSharpEvent`2 @chkn
 * Fix #2451: throw exception when sequence is empty @MNie
 * Fix #2445: Improve error message when fable doesn't implement an API
 
-## 3.2.0
+## 3.2.0 - 2021-05-28
 
 * Update to net5.0 and FCS, @ncave
 
-## 3.1.16
+## 3.1.16 - 2021-05-14
 
 * Publish with icon and symbols @cartermp
 
-## 3.1.15
+## 3.1.15 - 2021-04-16
 
 * Add a --sourceMapsRoot CLI option to set source maps sourceRoot @mlaily
 * Fix #2433: Improve type info for plugins like Fable.SvelteStore
 * Fix #2431: Pass output directory info to plugins
 
-## 3.1.14
+## 3.1.14 - 2021-04-09
 
 * Experimental `casenameWithFieldIndex`
 
-## 3.1.12
+## 3.1.12 - 2021-03-23
 
 * Fix #1678: BigInt native JS JSON serialization with toJSON
 * Fix #2151: Implement DateTimeOffset.toOffset @Booksbaum
@@ -933,29 +933,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Update big.js (decimals) @ncave
 * Update source-map-sharp to 1.0.5
 
-## 3.1.11
+## 3.1.11 - 2021-03-17
 
 * Fix watch compilation issues
 * Fix #2398: two successive string format placeholders and value of first one ends in `%`
 
-## 3.1.10
+## 3.1.10 - 2021-03-16
 
 * Revert breaking change, configuration should default to Debug only in watch mode @forki
 
-## 3.1.9
+## 3.1.9 - 2021-03-15
 
 * Fix crash with delegate alias
 
-## 3.1.8
+## 3.1.8 - 2021-03-15
 
 * Fix #2234: Recompile dependencies in watch mode when Emit/Import attributes change
 * Fix #2406: Check --outDir argument when running clean command
 
-## 3.1.7
+## 3.1.7 - 2021-03-11
 
 * Fix for Fable.Core.JsInterop.importValueDynamic
 
-## 3.1.6
+## 3.1.6 - 2021-03-11
 
 * Support setting a Build configuration with --configuration cli arg @stroborobo
 * Log compiled files in same line
@@ -966,16 +966,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix: Accessing named capture group in Regex only works with string constant @Booksbaum
 * Fable library improvements and other fixes @ncave
 
-## 3.1.5
+## 3.1.5 - 2021-02-18
 
 * Fix #2384: Polling file watcher @mlaily
 * Fix static constructors with attached members
 
-## 3.1.4
+## 3.1.4 - 2021-02-12
 
 * Fix #2045: Aliasing a function wrapping a multi-arity function in point-free style
 
-## 3.1.3
+## 3.1.3 - 2021-02-12
 
 * Add support for named capture groups in Regexes @Booksbaum
 * Babel AST: cleanup and refactor @dbrattli
@@ -992,7 +992,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix #2046: Assigning a function to scoped mutable variable
 * Fix #2045: Raise warning for point-free function declarations
 
-## 3.1.2
+## 3.1.2 - 2021-01-25
 
 * Fast copy for typed arrays @GordonBGood
 * Return error exit code when wront arguments passed
@@ -1001,24 +1001,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix #2355: System.Math.Ceiling() and System.Math.Floor returning incorrect values for some Decimals @ncave
 * Fix #2357: Remove duplicate switch branches
 
-## 3.1.1
+## 3.1.1 - 2021-01-13
 
 * Fix #2343: Remove conflicting export default
 * Fix #2336: Parameretized padding
 * Fix reflection for int64/decimal with units of measure
 
-## 3.1.0
+## 3.1.0 - 2021-01-11
 
 * Source map support @delneg
 * Fix #2342: recompile union tests in watch mode @tomcl
 * Fix #2332: watch broken for certain directory structures @jwosty
 
-## 3.1.0-beta-001
+## 3.1.0-beta-001 - 2021-01-08
 
 * Source map support @delneg
 * Fix #2332: watch broken for certain directory structures @jwosty
 
-## 3.0.5
+## 3.0.5 - 2020-12-22
 
 * Fixed compiler option parsing @ncave
 * Fix #2329: Class getters with import function helpers
@@ -1026,41 +1026,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix #2327: Inherit global class in nested module
 * Fix #2325: `AttachMembers` attribute
 
-## 3.0.4
+## 3.0.4 - 2020-12-19
 
 * Opt-in polling watcher @mlaily
 * Fix #2323: Uncurrying Emit obj args
 
-## 3.0.3
+## 3.0.3 - 2020-12-18
 
 * Fix #2318: char ranges @inosik
 * Fix #2320: `--yes` CLI arg
 * Fix (partially) #2321: `System.Type.GetInterface`
 
-## 3.0.2
+## 3.0.2 - 2020-12-16
 
 * Fix #2313: Measure abbreviations
 * Fix #2311: Arrow function printing
 
-## 3.0.1
+## 3.0.1 - 2020-12-11
 
 * Fix spread wrapped by parens @do-wa
 * Add runtime check for Option.Value
 * Remove equals/compare "fast" helper (sometimes fails)
 
-## 3.0.0
+## 3.0.0 - 2020-12-04
 
 * Official release
 * Fix #2293: Fix case of path passed as cli argument @tomcl
 * Fix #2277: Make FsWatcher case-insensitive @reinux
 * Fix local imports with `import` function helpers
 
-## 3.0.0-nagareyama-rc-011
+## 3.0.0-nagareyama-rc-011 - 2020-12-02
 
 * Fix #2303: spreading complex expressions
 * Fix #2302: Fable.JsonProvider
 
-## 3.0.0-nagareyama-rc-010
+## 3.0.0-nagareyama-rc-010 - 2020-11-28
 
 * Moar beta reduction improvements
 * Use caching only in watch mode
@@ -1068,7 +1068,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix watch dependencies when order of union cases changes
 * Fix #2295: Disable errors affecting Fable 2-compliant code
 
-## 3.0.0-nagareyama-rc-009
+## 3.0.0-nagareyama-rc-009 - 2020-11-25
 
 * Improve lambda beta reduction
 * Fix #1962: Find entities by core assembly name
@@ -1077,7 +1077,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix #2288: Ignore --warnaserror from project references
 * Fix #2291: Default hashing for classes
 
-## 3.0.0-nagareyama-rc-008
+## 3.0.0-nagareyama-rc-008 - 2020-11-19
 
 * Fix FSharpType.IsTuple for array of tuples @kerams
 * In watch mode, recompile all files if F# failed previously
@@ -1086,16 +1086,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix #2278: Optimize `createObj`
 * Fix #2276: Formatting Decimals
 
-## 3.0.0-nagareyama-rc-007
+## 3.0.0-nagareyama-rc-007 - 2020-11-15
 
 * Always lower case ToString
 
-## 3.0.0-nagareyama-rc-006
+## 3.0.0-nagareyama-rc-006 - 2020-11-13
 
 * Fix #2136: Type Provider invalidation @zanaptak
 * Support Nullables
 
-## 3.0.0-nagareyama-rc-005
+## 3.0.0-nagareyama-rc-005 - 2020-11-12
 
 * Fix #2267: Allow direct console output preserving colors @zanaptak
 * Fix #2259: File conflict in outDir
@@ -1103,40 +1103,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * StringBuilder.Append overloads @gusty
 * Make file watcher more robust
 
-## 3.0.0-nagareyama-rc-004
+## 3.0.0-nagareyama-rc-004 - 2020-11-10
 
 * LeanWork.IO.FileSystem.Watcher by Peter Meinl
 
-## 3.0.0-nagareyama-rc-003
+## 3.0.0-nagareyama-rc-003 - 2020-11-09
 
 * Fix #1962: FSharp.UMX measure annotated types
 * Fix #2250: Math.Clamp
 * Fix #2257: Remove warnings in keyValueList
 
-## 3.0.0-nagareyama-rc-002
+## 3.0.0-nagareyama-rc-002 - 2020-11-08
 
 * Patch FCS witness error @ncave
 * Set always --langversion:preview
 
-## 3.0.0-nagareyama-rc-001
+## 3.0.0-nagareyama-rc-001 - 2020-11-07
 
 * Release candidate
 * FCS witnesses!
 * Other fixes
 
-## 3.0.0-nagareyama-beta-005
+## 3.0.0-nagareyama-beta-005 - 2020-10-31
 
 * Fix #2238: Normalize paths on Windows
 * Fix #2212 (3rd attempt): Killing subprocess on Windows
 
-## 3.0.0-nagareyama-beta-004
+## 3.0.0-nagareyama-beta-004 - 2020-10-27
 
 * Typescript-related updates @ncave
 * Omit module prefix in imports @Zaid-Ajaj
 * Write compiler options to .fable/compiler_info.txt
 * Compatibility with Fable.AST beta-002
 
-## 3.0.0-nagareyama-beta-003
+## 3.0.0-nagareyama-beta-003 - 2020-10-25
 
 * Fix #2226: Wrong decimal separator depending on regional setting @bklop
 * Fix #2228: Remove unused values generated by imports meant for side effects
@@ -1144,26 +1144,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix #2216: Remove empty else blocks
 * Fix #2212: Ctrl+C doesn't kill subprocess in Windows
 
-## 3.0.0-nagareyama-beta-002
+## 3.0.0-nagareyama-beta-002 - 2020-10-23
 
 * Compatibility with Fable.AST beta-001
 
-## 3.0.0-nagareyama-beta-001
+## 3.0.0-nagareyama-beta-001 - 2020-10-23
 
 * Beta release
 * Fix .fsx compilation
 
-## 3.0.0-nagareyama-alpha-017
+## 3.0.0-nagareyama-alpha-017 - 2020-10-22
 
 * Only use cached (precompiled) files in debug mode
 
-## 3.0.0-nagareyama-alpha-016
+## 3.0.0-nagareyama-alpha-016 - 2020-10-22
 
 * Only use cached (precompiled) files in debug mode
 * Optimize list construction
 * Compatibility with latest Fable.AST
 
-## 3.0.0-nagareyama-alpha-015
+## 3.0.0-nagareyama-alpha-015 - 2020-10-19
 
 * Fix #2211: File extension in dynamic imports @Zaid-Ajaj
 * Fix #2212: Kill subprocess in Windows @Zaid-Ajaj
@@ -1171,68 +1171,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Compatibility with latest Fable.AST release
 * Minor improvements in code generation
 
-## 3.0.0-nagareyama-alpha-014
+## 3.0.0-nagareyama-alpha-014 - 2020-10-18
 
 * Fixed entity resolution @ncave
 * Cli improvements
 
-## 3.0.0-nagareyama-alpha-012
+## 3.0.0-nagareyama-alpha-012 - 2020-10-15
 
 * Fix plugins
 
-## 3.0.0-nagareyama-alpha-011
+## 3.0.0-nagareyama-alpha-011 - 2020-10-15
 
 * Plugins
 
-## 3.0.0-nagareyama-alpha-010
+## 3.0.0-nagareyama-alpha-010 - 2020-10-13
 
 * Fix #2202: Using System.Type as Dictionary key @Zaid-Ajaj
 * Fix #2203: Comparing large sets @Zaid-Ajaj
 * Keep only entity refs in Fable AST
 
-## 3.0.0-nagareyama-alpha-009
+## 3.0.0-nagareyama-alpha-009 - 2020-10-11
 
 * Detect if command after `--run` is in `node_modules/.bin` dir
 * Set typedArrays=true as default again
 
-## 3.0.0-nagareyama-alpha-008
+## 3.0.0-nagareyama-alpha-008 - 2020-10-05
 
 * Use latest FCS @ncave
 * Disable file caching when compiler version changes
 * Add back base class for Union/Record
 * Fix calls to static members of imported classes
 
-## 3.0.0-nagareyama-alpha-007
+## 3.0.0-nagareyama-alpha-007 - 2020-10-02
 
 * --runScript option
 * Fix uncurrying of Emit calls
 * Fix type testing performance
 * Fix union/record string formattin
 
-## 3.0.0-nagareyama-alpha-006
+## 3.0.0-nagareyama-alpha-006 - 2020-09-30
 
 * Fix running process
 
-## 3.0.0-nagareyama-alpha-005
+## 3.0.0-nagareyama-alpha-005 - 2020-09-29
 
 * Fix watcher
 * Use latest implementation of FSharpMap and FSharpSet
 * Fix generic equality
 
-## 3.0.0-nagareyama-alpha-004
+## 3.0.0-nagareyama-alpha-004 - 2020-09-28
 
 * Improve CLI and other fixes
 
-## 3.0.0-nagareyama-alpha-003
+## 3.0.0-nagareyama-alpha-003 - 2020-09-14
 
 * Fix: Add names with $reflection suffix to root scope
 * Fix deriving from imported JS classes
 * Keep support for ParamList attribute until removed from Fable.React
 
-## 3.0.0-nagareyama-alpha-002
+## 3.0.0-nagareyama-alpha-002 - 2020-09-13
 
 * Ignore warnings from packages (as before)
 
-## 3.0.0-nagareyama-alpha-001
+## 3.0.0-nagareyama-alpha-001 - 2020-09-13
 
 * Nagareyama alpha

--- a/src/Fable.Core/CHANGELOG.md
+++ b/src/Fable.Core/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Change `NumberConstructor.isNaN` from `float -> bool` to `obj -> bool` (by @MangelMaxime)
 
-## 4.1.1
+## 4.1.1 - 2023-10-18
 
 ### Added
 
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Fix #3482: Revert removal of `Py.python` and `Py.expr_python` (by @dbrattli)
 
-## 4.1.0
+## 4.1.0 - 2023-09-29
 
 * Fix #3482: Remove `Py.python` and `Py.expr_python`
 * Add `!^` to `Fable.Core.RustInterop` module
@@ -43,137 +43,137 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix #3484: Rename `emitExpr` to `emitPyExpr` in `PyInterop`
 * Fix #3484: Replace `Rust.emitExpr` with `RustInterop.emitRustExpr`
 
-## 4.0.0
+## 4.0.0-beta-001 - 2022-09-07
 
 * Fable 4 stable
 
-## 4.0.0-theta-007
+## 4.0.0-theta-007 - 2022-11-13
 
 * Fix #3249 by enabling uncurrying for functions with multiple parameters @inosik
 
-## 4.0.0-theta-006
+## 4.0.0-theta-006 - 2022-10-14
 
 * Python fixes for decorator attribute
 
-## 4.0.0-theta-005
+## 4.0.0-theta-005 - 2022-10-04
 
 * Add JSX.jsx function
 
-## 4.0.0-theta-004
+## 4.0.0-theta-004 - 2022-09-28
 
 * Add ??= operator to JsInterop
 
-## 4.0.0-theta-003
+## 4.0.0-theta-003 - 2022-09-22
 
 * Python fixes for Interactive
 
-## 4.0.0-theta-002
+## 4.0.0-theta-002 - 2022-09-21
 
 * Python helpers for Interactive
 * JS helpers for JSX/React integration
 
-## 4.0.0-theta-001
+## 4.0.0-theta-001 - 2022-09-09
 
 * Fable 4 theta release
 
-## 4.0.0-snake-island-alpha-007
+## 4.0.0-snake-island-alpha-007 - 2022-07-25
 
 * Snake Island alpha release
 
-## 4.0.0-snake-island-alpha-006
+## 4.0.0-snake-island-alpha-006 - 2022-07-12
 
 * Some Rust helpers
 
-## 4.0.0-snake-island-alpha-005
+## 4.0.0-snake-island-alpha-005 - 2022-06-03
 
 * DartNullable and other Dart helpers
 
-## 4.0.0-snake-island-alpha-004
+## 4.0.0-snake-island-alpha-004 - 2022-05-25
 
 * JSX string templates
 
-## 4.0.0-snake-island-alpha-003
+## 4.0.0-snake-island-alpha-003 - 2022-05-23
 
 * Add Dart print/Future/Stream
 
-## 4.0.0-snake-island-alpha-002
+## 4.0.0-snake-island-alpha-002 - 2022-05-20
 
 * JSX Support
 
-## 4.0.0-snake-island-alpha-001
+## 4.0.0-snake-island-alpha-001 - 2022-05-11
 
 * Snake Island alpha release
 
-## 3.7.1
+## 3.7.1 - 2022-05-27
 
 * Add `AsyncIterable` to Fable.Core.JS
 
-## 3.7.0
+## 3.7.0 - 2022-04-29
 
 * Fix #2863: Add a nestable union type U9 @cannorin
 * Fix links in doc comments
 
-## 3.6.2
+## 3.6.2 - 2022-02-17
 
 * Fix #2805: Improve jsNative error messages
 * Revert changes in Core.JS, see Fulma/issues/294
 
-## 3.6.1
+## 3.6.1 - 2021-11-26
 
 * TypescriptTaggedUnion @cannorin
 
-## 3.6.0
+## 3.6.0-beta-001 - 2021-11-17
 
 * Add Fable.Core.Compiler.triggeredByDependency flag
 
-## 3.4.0
+## 3.4.0 - 2021-10-01
 
 * ParamObject attribute
 
-## 3.3.1
+## 3.3.1 - 2021-09-16
 
 * JS.Decorator/ReflectedDecorator attributes
 * JS.Function
 
-## 3.2.9
+## 3.2.9 - 2021-08-26
 
 * Add `FormattableString.GetStrings()` extension
 
-## 3.2.8
+## 3.2.8 - 2021-06-11
 
 * Experimental.namesofLambda
 
-## 3.2.7
+## 3.2.7 - 2021-05-14
 
 * Publish with icon and symbols @cartermp
 
-## 3.2.6
+## 3.2.6 - 2021-04-09
 
 * Experimental `casenameWithFieldIndex`
 
-## 3.2.5
+## 3.2.5 - 2021-03-11
 
 * Add `Compiler.extension`
 
-## 3.2.4
+## 3.2.4 - 2021-02-12
 
 * Add Object.values, Object.entries @kerams
 * Add JsInterop.jsTypeof/jsInstanceof
 * Add JS.Constructors.Array.Create/from
 
-## 3.2.3
+## 3.2.3 - 2021-01-08
 
 * Fix incompatibility with Feliz @TIHan
 
-## 3.2.2
+## 3.2.2 - 2020-12-22
 
 * `AttachMembers` attribute
 
-## 3.2.1
+## 3.2.1 - 2020-12-16
 
 * Lower FSharp.Core requirement to 4.7.2
 
-## 3.2.0
+## 3.2.0 - 2020-12-04
 
 * New helpers for Fable 3
 * `Mangle` attribute
@@ -181,36 +181,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `emitJsExpr` and `emitJsStatement` helpers
 * Access compiler options in `Compiler` module
 
-## 3.1.6
+## 3.1.6 - 2020-09-22
 
 * Fixed TypedArray.set signature @Shmew
 
-## 3.1.5
+## 3.1.5 - 2020-02-10
 
 * Fixed missing indexer in JS TypedArray.
 
-## 3.1.4
+## 3.1.4 - 2019-12-23
 
 * Fix JS Map constructor @Luiz-Monad
 
-## 3.1.3
+## 3.1.3 - 2019-11-07
 
 * PR #1935: Put JS constructors in different module to prevent conflicts @pauldorehill
 
-## 3.1.2
+## 3.1.2 - 2019-10-14
 
 * Add CaseRules.SnakeCase
 
-## 3.1.1
+## 3.1.1 - 2019-09-25
 
 * Fix TypedArray bindings @Titaye
 
-## 3.1.0
+## 3.1.0 - 2019-09-17
 
 * Add JS Typed Arrays @Titaye
 * Fix names of arguments in Testing.Assert @zanaptak
 
-## 3.0.0
+## 3.0.0-beta-001 - 2019-02-28
 
 * Add `JsInterop.importValueDynamic`
 * Move `nameof` operators to Experimental module
@@ -218,155 +218,155 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add Emit and Import attribute aliases
 * Namespace restructure
 
-## 3.0.0-beta-006
+## 3.0.0-beta-006 - 2019-04-12
 
 * Add `JsInterop.importValueDynamic`
 
-## 3.0.0-beta-005
+## 3.0.0-beta-005 - 2019-03-13
 
 * Move `nameof` operators to Experimental module
 
-## 3.0.0-beta-004
+## 3.0.0-beta-004 - 2019-03-12
 
 * Move JS extensions to Fable.Core.Extensions file
 
-## 3.0.0-beta-003
+## 3.0.0-beta-003 - 2019-03-05
 
 * Add some missing JS APIs
 
-## 3.0.0-beta-002
+## 3.0.0-beta-002 - 2019-03-04
 
 * Array .buffer extension
 * Add Emit and Import attribute aliases
 
-## 3.0.0-beta-001
+## 3.0.0-beta-001 - 2019-02-28
 
 * Namespace restructure
 
-## 2.1.0-alpha-002
+## 2.1.0-alpha-002 - 2019-01-22
 
 * Clean Fable.Import.JS module and rename it to Fable.Core.JS
 * Add unions of measure for non-numeric primitive types
 
-## 2.0.3
+## 2.0.3 - 2018-12-10
 
 * Add `Fable.Core.Reflection` module
 
-## 2.0.2
+## 2.0.2 - 2018-11-20
 
 * Add `nameof2` and `exportDefault`
 
-## 2.0.1
+## 2.0.1 - 2018-10-26
 
 * Fix `ReadonlyArray` spelling
 
-## 2.0.0
+## 2.0.0-alpha-001 - 2018-05-24
 
 * Fable 2
 
-## 1.3.7
+## 1.3.7 - 2017-12-21
 
 * See dotnet-fable 1.3.7 release notes
 
-## 1.3.0-beta-009
+## 1.3.0-beta-009 - 2017-11-15
 
 * See dotnet-fable 1.3.0-beta-009 release notes
 
-## 1.2.4
+## 1.2.4 - 2017-09-27
 
 * See dotnet-fable 1.2.4 release notes
 
-## 1.2.3
+## 1.2.3 - 2017-09-18
 
 * Fix #1135, #1136: `unit option` hack doesn't work with generic functions
 
-## 1.2.2
+## 1.2.2 - 2017-09-18
 
 * See Fable.Compiler 1.2.2
 
-## 1.2.1
+## 1.2.1 - 2017-09-10
 
 * Guid validation and byte[] conversion
 * Date Fix #1139
 
-## 1.2.0
+## 1.2.0-beta-001 - 2017-08-23
 
 * Add support for String.filter #1133
 * Fix #1131: DateTime.ToString not working without separator
 
-## 1.2.0-beta-004
+## 1.2.0-beta-004 - 2017-09-05
 
 * Fix format over local dates #1129
 * Fix 2 digits years datetime #1127
 
-## 1.2.0-beta-003
+## 1.2.0-beta-003 - 2017-08-31
 
 * Don't calculate relative path for paths in different drive letters on Windows
 
-## 1.2.0-beta-002
+## 1.2.0-beta-002 - 2017-08-30
 
 * Target netstandard1.6 again
 
-## 1.2.0-beta-001
+## 1.2.0-beta-001 - 2017-08-23
 
 * Upgrade to netstandard2.0
 
-## 1.1.15
+## 1.1.15 - 2017-08-22
 
 * Fix #1113: Set.union
 
-## 1.1.14
+## 1.1.14 - 2017-08-08
 
 * Fix #1104: JSON serialization of Long and BigInt
 
-## 1.1.12
+## 1.1.12 - 2017-07-31
 
 * Add DateTime ticks constructor
 * Convert to and from Base64String
 
-## 1.1.11
+## 1.1.11 - 2017-07-27
 
 * Fix #1094: Implement "indexed" in collection modules
 
-## 1.1.10
+## 1.1.10 - 2017-07-24
 
 * Fix recursive functions in Seq module
 
-## 1.1.9
+## 1.1.9 - 2017-07-22
 
 * Add constructors to JsFunc
 
-## 1.1.8
+## 1.1.8 - 2017-07-18
 
 * Small refactoring
 * Add `DateTime.IsDaylightSavingTime` replacement (#1082, #1083)
 
-## 1.1.7
+## 1.1.7 - 2017-07-11
 
 * Support String.Join with objects (#1058)
 
-## 1.1.6
+## 1.1.6 - 2017-07-04
 
 * Fix #1046: Parse time-only strings
 * Support some System.Uri static methods (#1048)
 
-## 1.1.5
+## 1.1.5 - 2017-06-28
 
 * Fix #1028: Arguments of auto-generated lambdas conflicting with outer variables
 
-## 1.1.4
+## 1.1.4 - 2017-06-24
 
 * Fix fable-import/#9: Don't try to replace method calls in bindings
 
-## 1.1.3
+## 1.1.3 - 2017-06-20
 
 * Add System.Console reference
 
-## 1.1.2
+## 1.1.2 - 2017-06-20
 
 * Fix Paket groups for Fable.Core
 
-## 1.1.1
+## 1.1.1 - 2017-06-19
 
 * Fix F# compiler errors in recompilation
 * Fix Elmish.Browser parser (#1003)
@@ -375,143 +375,143 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add replacement for System.Environment.NewLine (#993)
 * Expose Console among JS import globals
 
-## 1.1.0
+## 1.1.0-rc-001 - 2017-06-10
 
 * Fable stablish, yeah!
 
-## 1.1.0-rc-002
+## 1.1.0-rc-002 - 2017-06-12
 
 * Fix #996: Don't wrap dynamic CurriedLambdas
 
-## 1.1.0-rc-001
+## 1.1.0-rc-001 - 2017-06-10
 
 * Support Paket groups and move Browser and Node bindings out of Fable.Core
 
-## 1.0.8
+## 1.0.8 - 2017-06-02
 
 * Fix #940: Compilation of multiple projects in parallel
 
-## 1.0.7
+## 1.0.7 - 2017-05-27
 
 * Fix #952: Don't remove non-null unit arguments
 * Fix #944: Import and Emit on same function
 
-## 1.0.6
+## 1.0.6 - 2017-05-24
 
 * Propagate subprocess exit code
 
-## 1.0.5
+## 1.0.5 - 2017-05-24
 
 * Fix #946: --port free throws exception
 
-## 1.0.4
+## 1.0.4 - 2017-05-17
 
 * Don't redirect dotnet-fable commands but check version and locate fable-core JS files in packages/Fable.Core
 
-## 1.0.0-narumi-917
+## 1.0.0-narumi-917 - 2017-05-16
 
 * Fix location of fable-core files
 
-## 1.0.0-narumi-916
+## 1.0.0-narumi-916 - 2017-05-15
 
 * We're going PAKET!
 
-## 1.0.0-narumi-915
+## 1.0.0-narumi-915 - 2017-05-09
 
 * Fix curried lambdas assigned to generic params (see #888)
 
-## 0.7.49
+## 0.7.49 - 2017-03-29
 
 * Fix #744: CLI argument flags
 
-## 0.7.48
+## 0.7.48 - 2017-03-29
 
 * Fix #736: Case testing with erased unions
 
-## 0.7.47
+## 0.7.47 - 2017-03-29
 
 * Tailcall optimizes function arguments: #681
 
-## 0.7.45
+## 0.7.45 - 2017-03-29
 
 * Fix import expressions with methods with function arguments: #721
 
-## 0.7.43
+## 0.7.43 - 2017-03-29
 
 * Add reflection methods (see ReflectionTests.fs)
 * Improve import expressions #721
 
-## 0.7.42
+## 0.7.42 - 2017-03-29
 
 * Tailcall optimizations: PR #669 + Fixes
 
-## 0.7.37
+## 0.7.37 - 2017-03-29
 
 * Add FSharp.Core.dll to fable-compiler package
 * Improve handling of `jsThis`
 
-## 0.7.35
+## 0.7.35 - 2017-03-29
 
 * Only show Rollup warnings in `--verbose` mode
 * Minor fixes
 
-## 0.7.34
+## 0.7.34 - 2017-03-29
 
 * Fix #660: `Option.fold` and `Option.foldBack`
 
-## 0.7.33
+## 0.7.33 - 2017-03-29
 
 * Add operator `enum`
 
-## 0.7.32
+## 0.7.32 - 2017-03-29
 
 * Fixed default comparer: PR #658
 
-## 0.7.31
+## 0.7.31 - 2017-03-29
 
 * Added BigInt conversions: PR #650
 
-## 0.7.30
+## 0.7.30 - 2017-03-28
 
 * Fix #649: Int64 serialization
 * Fix #648: Caching of namespace F# entities
 * Fix #646: Zero fill shift right (>>>) for uint32
 
-## 0.7.29
+## 0.7.29 - 2017-03-14
 
 * Add `BigInteger` support
 
-## 0.7.28
+## 0.7.28 - 2017-02-21
 
 * Fix #640: Omitted non optional nulls
 * Fix #638: Inlined methods with `this` argument
 
-## 0.7.27
+## 0.7.27 - 2017-02-21
 
 * Add `--includeJs` compiler argument
 * Fix #629: Visual Studio error format
 * Fix  #637: IEnumerable runtime issue
 
-## 0.7.26
+## 0.7.26 - 2017-01-25
 
 * Fixed Option.foldBack (#634)
 * Improve .NET Enumerator/JS Iterator compatibility
 * Fix #633: jsThis
 * Fixed Option.foldBack (PR #634)
 
-## 0.7.25
+## 0.7.25 - 2017-01-20
 
 * Fix #623: JS Global properties
 * Fix #624: Aether compilation
 
-## 0.7.24
+## 0.7.24 - 2017-01-19
 
 * Fix module generic methods without arguments
 * Added `String.IndexOfAny/Compare/Equals` with `StringComparison` enum
 * Fix generic types when compiling to ES2015
 * Unify `Equals` and `CompareTo` methods of `Long.ts`
 
-## 0.7.23
+## 0.7.23 - 2017-01-17
 
 * Fix #348 #608 Double/Int32 Parse & TryParse
 * Fix #609: Event unsubscription
@@ -523,23 +523,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix #237: Recursive value definitions
 * Added char to int (#594)
 
-## 0.7.22
+## 0.7.22 - 2017-01-13
 
 * Fix secondary constructors of imported classes
 * Improvements in option handling
 
-## 0.7.20
+## 0.7.20 - 2017-01-09
 
 * Prevent infinite loops for bundle errors in watch mode
 
-## 0.7.19
+## 0.7.19 - 2017-01-06
 
 * Fix #509: Add KeyValuePattern
 * Fix #544 #585: Bundling in watch mode
 * Fix #589: Regex Provider with Fable 0.7
 * Add optional argument to GlobalAttribute
 
-## 0.7.18
+## 0.7.18 - 2017-01-05
 
 * Add validation to `ofJson`
 * Make `Assert.AreEqual` work with F# equality
@@ -548,217 +548,217 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix sprintf "%X" (#580)
 * Fix #579: Printf.printfn
 
-## 0.7.17
+## 0.7.17 - 2016-12-30
 
 * Add `Pojo` union types
 
-## 0.7.16
+## 0.7.16 - 2016-12-26
 
 * Fix issues in generic resolution
 
-## 0.7.15
+## 0.7.15 - 2016-12-06
 
 * Issue warning when calling `typeof` on a generic parameter
 * Use absolute paths for assembly references in `node_modules`
 
-## 0.7.14
+## 0.7.14 - 2016-12-04
 
 * Use "umd" distribution of fable-core and other libs when compiling for umd modules
 * Fix #569: Types with circular dependencies
 
-## 0.7.12
+## 0.7.12 - 2016-12-01
 
 * Fix #568: Types with `StructAttribute` (compiled as records)
 * Better checking when calling functions with `PassGenericsAttribute`
 
-## 0.7.11
+## 0.7.11 - 2016-11-28
 
 * Some adjustments in attribute resolution
 
-## 0.7.10
+## 0.7.10 - 2016-11-27
 
 * Fix #565, #566: Only watch F# files
 * Fix #564: Don't overload methods from imported classes
 * Fix #563: Overloads with `PassGenericsAttribute`
 
-## 0.7.9
+## 0.7.9 - 2016-11-24
 
 * Fix `Array.rev` (see #559)
 * Added UnboxFast intrinsic / List.truncate (see #561)
 
-## 0.7.8
+## 0.7.8 - 2016-11-22
 
 * `System.Exception` translates to JS `Error`
 * Fix #556: inline methods placed after calls
 
-## 0.7.7
+## 0.7.7 - 2016-11-22
 
 * Fix ES2015 imports
 
-## 0.7.6
+## 0.7.6 - 2016-11-22
 
 * Too many changes to be listed, check the [migration guide](http://fable.io/blog/Introducing-0-7.html)
 
-## 0.7.5-alpha.41
+## 0.7.5-alpha.41 - 2016-11-22
 
 * Fix cyclic dependencies in fable-core
 
-## 0.7.5-alpha.40
+## 0.7.5-alpha.40 - 2016-11-22
 
 * Minor fix
 
-## 0.7.5-alpha.39
+## 0.7.5-alpha.39 - 2016-11-22
 
 * Simplify Reflection system
 * Add `PojoAttribute`
 * Replace baseDir of references with --refs argument
 
-## 0.7.5-alpha.38
+## 0.7.5-alpha.38 - 2016-11-22
 
 * Fix #547: Ignored entities conflicting when calculating root namespace
 
-## 0.7.5-alpha.37
+## 0.7.5-alpha.37 - 2016-11-22
 
 * Mangle class methods when they conflict with an implemented interface
 
-## 0.7.5-alpha.35
+## 0.7.5-alpha.35 - 2016-11-22
 
 * Fix #545: Using `Microsoft.FSharp` namespace
 
-## 0.7.5-alpha.34
+## 0.7.5-alpha.34 - 2016-11-22
 
 * Add `import: selector->path->'T` to import expressions
 * Make arguments of JsConstructor statically typed
 * Add logs when compiling files for bundling
 
-## 0.7.5-alpha.33
+## 0.7.5-alpha.33 - 2016-11-22
 
 * Fix default watch directories
 * Ignore interfaces
 
-## 0.7.5-alpha.32
+## 0.7.5-alpha.32 - 2016-11-22
 
 * Compile scripts referenced as plugins
 * Apply Replace plugins to any call
 * Include in compilation JS files with relative paths
 
-## 0.7.5-alpha.31
+## 0.7.5-alpha.31 - 2016-11-22
 
 * Fix #535: Script referenced entity replacements
 
-## 0.7.5-alpha.30
+## 0.7.5-alpha.30 - 2016-11-22
 
 * Allow configuration of watching dirs
 
-## 0.7.5-alpha.29
+## 0.7.5-alpha.29 - 2016-11-22
 
 * Fix infinite recursion when resolving generic parameters
 
-## 0.7.5-alpha.28
+## 0.7.5-alpha.28 - 2016-11-22
 
 * More meaningful runtime representation of non-declared types
 
-## 0.7.5-alpha.27
+## 0.7.5-alpha.27 - 2016-11-22
 
 * When inlining, assign arguments referenced more than once to a temp var
 * `Array.zeroCreate` fills non-numeric arrays with null
 
-## 0.7.5-alpha.26
+## 0.7.5-alpha.26 - 2016-11-22
 
 * Resolve trait calls as normal method calls (check EmitAttribute, etc)
 
-## 0.7.5-alpha.24
+## 0.7.5-alpha.24 - 2016-11-22
 
 * Fix mangled interfaces
 * Improve error messages
 
-## 0.7.5-alpha.23
+## 0.7.5-alpha.23 - 2016-11-22
 
 * Add `MangleAttribute` to prevent conflicts with interfaces
 * Allow combination of `ImportAttribute` and `EmitAttribute`
 * Several fixes
 
-## 0.7.5-alpha.22
+## 0.7.5-alpha.22 - 2016-11-22
 
 * Add catch-all for missing replacements when referencing
   types of the BCL or FSharp.Core
 * Omit `.js` extension again in imports to keep
   compatibility with Require.js
 
-## 0.7.5-alpha.21
+## 0.7.5-alpha.21 - 2016-11-22
 
 * Don't print warnings in process.stderr (see #516)
 * Add `String/formatError` (see #519)
 * Add `.js` extension to `fable-core` and internal imports
 
-## 0.7.5-alpha.19
+## 0.7.5-alpha.19 - 2016-11-22
 
 * Distribute fable-core with ES2015 (default) and UMD module formats
 
-## 0.7.5-alpha.18
+## 0.7.5-alpha.18 - 2016-11-20
 
 * Don't deem interface setters as overloads (see #505)
 
-## 0.7.5-alpha.17
+## 0.7.5-alpha.17 - 2016-11-16
 
 * Update FCS and use Forge to read .fsproj files (removes MSBuild dependency)
 * Bug fixes and optimizations
 
-## 0.7.5-alpha.16
+## 0.7.5-alpha.16 - 2016-11-13
 
 * Add JsFunc and JsCons to Fable.Core.JsInterop
 
-## 0.7.5-alpha.15
+## 0.7.5-alpha.15 - 2016-11-12
 
 * Use outDir to place the generated dll with .fsproj projects
 * Only emit warnings when generating dlls in verbose mode
 * Fix error when reading Rollup options
 
-## 0.7.5-alpha.14
+## 0.7.5-alpha.14 - 2016-11-09
 
 * Fix errors in Fable JS API
 
-## 0.7.5-alpha.12
+## 0.7.5-alpha.12 - 2016-11-04
 
 * Change `--bundle` option to `--rollup`
 * `--rollup` can accept an object (in fableconfig.json) with Rollup config
 * Improve plugin resolution for Babel and Rollup
 
-## 0.7.5-alpha.11
+## 0.7.5-alpha.11 - 2016-10-30
 
 * Add a block scope to switch cases (see #483)
 
-## 0.7.5-alpha.10
+## 0.7.5-alpha.10 - 2016-10-29
 
 * Fix invalid identifiers in top level members (see #482)
 * Generate `dll` also for `fsproj` files
 * Expose Fable library to JS API
 
-## 0.7.5-alpha.9
+## 0.7.5-alpha.9 - 2016-10-29
 
 * Fix issues with bundling and `System.Exception`
 
-## 0.7.5-alpha.8
+## 0.7.5-alpha.8 - 2016-10-28
 
 * Fix problems with `dll` generation
 
-## 0.7.5-alpha.7
+## 0.7.5-alpha.7 - 2016-10-23
 
 * Add experimental `--dll` compiler option to generate assemblies
 
-## 0.7.5-alpha.6
+## 0.7.5-alpha.6 - 2016-10-22
 
 * Fix path resolution when referencing assemblies
 
-## 0.7.5-alpha.5
+## 0.7.5-alpha.5 - 2016-10-19
 
 * Fix partial patterns not returning any value (see #478)
 
-## 0.7.5-alpha.4
+## 0.7.5-alpha.4 - 2016-10-19
 
 * Minor fixes
 
-## 0.7.5-alpha.2
+## 0.7.5-alpha.2 - 2016-10-17
 
 * Resolve relative paths of referenced projects/dlls as
   if they were pointing to generated JS code from the fsproj/dll file
@@ -767,34 +767,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Always resolve relative paths in command line options with
   the directory from where fable is called
 
-## 0.7.5-alpha.1
+## 0.7.5-alpha.1 - 2016-10-16
 
 * Fix prerelease semver. See: https://docs.npmjs.com/misc/semver#prerelease-tags
 
-## 0.7.5-alpha
+## 0.7.5-alpha - 2016-10-16
 
 * Add `typedefof<>`, `.IsGenericType`, `.GetGenericTypeDefinition`
 
-## 0.7.4-alpha
+## 0.7.4-alpha - 2016-10-15
 
 * Resolve import relative paths so they can be reached from `outDir`
   if they don't point to an internal file (see #472)
 
-## 0.7.3-alpha
+## 0.7.3-alpha - 2016-10-15
 
 * Add warning when creating references of types unknown at compile time
 
-## 0.7.2-alpha
+## 0.7.2-alpha - 2016-10-14
 
 * Convert functions to delegates when passed as arguments to EmitAttribute
 * Add warning when passing generic param to Serialize.ofJson/inflate
 
-## 0.7.1-alpha
+## 0.7.1-alpha - 2016-10-13
 
 * Add `--bundle` compiler option
 * Bring back JSON serialization with `$type` info
 
-## 0.7.0-alpha
+## 0.7.0-alpha - 2016-10-10
 
 * Add type info to JS constructors: cases (unions) and properties (records and classes)
 * Extend type references with generic info when calling `typeof`
@@ -802,25 +802,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add `MutatingUpdateAttribute` to compile record updates as mutations
 * Add `EntryModuleAttribute` to mark assemblies as Fable libraries
 
-## 0.6.15
+## 0.6.15 - 2016-10-11
 
 * Revert change from 0.6.14: ES6 modules automatically enable
   strict mode, so the directive is not needed
 
-## 0.6.14
+## 0.6.14 - 2016-10-11
 
 * Add always "use strict" directive
 
-## 0.6.12
+## 0.6.12 - 2016-10-11
 
 * Now fableconfig.json can be in JSON5 format (comments!)
 * Omit lambda argument when it's of unit type
 
-## 0.6.11
+## 0.6.11 - 2016-10-11
 
 * Don't wait until "postbuild-once" script is finished (see #432)
 
-## 0.6.9
+## 0.6.9 - 2016-10-11
 
 * Fix #431: Add --babelrc compiler option
 * Fix #432: Add "postbuild-once" script
@@ -830,34 +830,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix #439: IDE locking project file and preventing watch compilations
 * Change compilation defaults: module=commonjs & loose=true
 
-## 0.6.7
+## 0.6.7 - 2016-10-02
 
 * Fix #416: Can't ifdef around a load directive
 * Fix List.unfold: PR #428
 * Use reference hint paths for netcore: PR #423
 
-## 0.6.6
+## 0.6.6 - 2016-09-30
 
 * Support ResizeArray.FindAll: PR #412
 
-## 0.6.5
+## 0.6.5 - 2016-09-29
 
 * Support decimal (converted to JS number): PR #413
 * Support recursive records: PR #417
 
-## 0.6.4
+## 0.6.4 - 2016-09-28
 
 * Fix #411: for .. downto
 
-## 0.6.3
+## 0.6.3 - 2016-09-15
 
 * Fix watch compilation on Windows
 
-## 0.6.2
+## 0.6.2 - 2016-09-15
 
 * Integer conversions (see #407)
 
-## 0.6.1
+## 0.6.1 - 2016-09-12
 
 * Multiple bug fixes
 * Internal Fable AST additions
@@ -865,25 +865,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Use let/const when compiling value bindings to ES6
 * Compile pattern matching with string or number literals as switch statements
 
-## 0.5.11
+## 0.5.11 - 2016-09-11
 
 * Fix #382 (partially): Exclude files in "node_modules" when calculating the base
   directory of referenced dlls.
 
-## 0.5.10
+## 0.5.10 - 2016-09-11
 
 * Fix #369: Extra blank lines when running postbuild script
 * Fix #375: Add warning when replacements change semantics (printf, Async.Start...)
 * Fix #377: Remove null args at the end of method/constructor calls also with macros
 
-## 0.5.9
+## 0.5.9 - 2016-09-11
 
 * Fix type testing with Erased Unions
 * Erase assigments generated for tuple, record and union gets
 * Fix #370: Add warning when using unions or records with Dictionary (as keys) or HashSet
 * Internal cleanup
 
-## 0.5.8
+## 0.5.8 - 2016-09-11
 
 * Use chokidar to watch for file changes
 * Fix calculation of relative paths with special characters (like "#")

--- a/src/Fable.PublishUtils/CHANGELOG.md
+++ b/src/Fable.PublishUtils/CHANGELOG.md
@@ -6,38 +6,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 2.4.0
+## 2.4.0 - 2021-10-07
 
 * Remove node compatibility and async methods
 
-## 2.3.0
+## 2.3.0 - 2021-10-07
 
 * Publish as Nuget package
 
-## 2.2.0
+## 2.2.0 - 2021-05-28
 
 * Add explicit `pushFableNuget` helper that uses FABLE_NUGET_KEY envVar @MangelMaxime
 
-## 2.1.0
+## 2.1.0 - 2021-05-19
 
 * Publish symbols for Nuget packages @cartermp
 
-## 2.0.0
+## 2.0.0 - 2020-12-02
 
 * Compatibility both with dotnet and nodejs
 
-## 1.2.1
+## 1.2.1 - 2020-04-09
 
 * Update to Fable.Core 3.1.5
 
-## 1.2.0
+## 1.2.0 - 2020-03-04
 
 * Use npm token when publishing an npm package
 
-## 1.1.1
+## 1.1.1 - 2019-10-11
 
 * Several additions for Fable build
 
-## 1.0.5
+## 1.0.5 - 2019-01-22
 
 * First publish

--- a/src/fable-compiler-js/CHANGELOG.md
+++ b/src/fable-compiler-js/CHANGELOG.md
@@ -16,132 +16,132 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Remove `--typescript` options support, use `--lang <target>` instead
 
-## 3.0.1
+## 3.0.1 - 2020-12-22
 
 * Reduced package dependencies
 
-## 3.0.0
+## 3.0.0 - 2020-12-22
 
 * Nagareyama official release
 
-## 3.0.0-rc
+## 3.0.0-rc - 2020-11-16
 
 * Nagareyama RC
 
-## 3.0.0-alpha
+## 3.0.0-alpha - 2020-11-16
 
 * Nagareyama
 
-## 1.3.1
+## 1.3.1 - 2020-04-12
 
 * Improve globbing support (by @ncave)
 
-## 1.3.0
+## 1.3.0 - 2020-04-10
 
 * Add globbing support in fsproj
 
-## 1.2.4
+## 1.2.4 - 2020-04-09
 
 * fable-metadata 1.4.0
 
-## 1.2.3
+## 1.2.3 - 2020-03-09
 
 * Update to fable-babel-plugins 2.3.0
 
-## 1.2.2
+## 1.2.2 - 2020-02-14
 
 * fable-metadata 1.3.0
 
-## 1.2.1
+## 1.2.1 - 2019-12-23
 
 * fable-standalone 1.3.0
 * Removed perf_hooks dependency
 * Added support for source maps
 
-## 1.2.0
+## 1.2.0 - 2019-11-20
 
 * Added NuGet packages support
 
-## 1.1.1
+## 1.1.1 - 2019-09-30
 
 * Update to fable-metadata 1.2.0 & fable-standalone 1.2.3
 
-## 1.1.0
+## 1.1.0 - 2019-09-25
 
 * fable-standalone 1.2.0
 * Define FABLE_COMPILER_JS constant
 
-## 1.0.6
+## 1.0.6 - 2019-09-25
 
 * fable-standalone 1.1.8
 
-## 1.0.5
+## 1.0.5 - 2019-08-14
 
 * fable-standalone 1.1.5
 
-## 1.0.4
+## 1.0.4 - 2019-06-16
 
 * fable-metadata 1.1.2
 * fable-standalone 1.1.4
 
-## 1.0.3
+## 1.0.3 - 2019-04-02
 
 * fable-metadata 1.0.1
 * fable-standalone 1.0.3
 
-## 1.0.2
+## 1.0.2 - 2019-03-05
 
 * Fixed duplicate project references
 
-## 1.0.1
+## 1.0.1 - 2019-03-01
 
 * Fixed fable-library reference
 * Added warn level and warnaserror options
 
-## 1.0.0
+## 1.0.0 - 2019-02-28
 
 * Publish stable
 
-## 1.0.0-beta-002
+## 1.0.0-beta-002 - 2019-02-21
 
 * Added project options parsing @ncave
 
-## 1.0.0-beta-001
+## 1.0.0-beta-001 - 2019-02-19
 
 * Beta release @ncave
 
-## 1.0.0-alpha-017
+## 1.0.0-alpha-017 - 2019-02-12
 
 * Update dependencies and other fixes
 
-## 1.0.0-alpha-016
+## 1.0.0-alpha-016 - 2019-02-11
 
 * Add fable-standalone and fable-metadata dependencies
 
-## 1.0.0-alpha-014
+## 1.0.0-alpha-014 - 2019-02-07
 
 * End process with exit code -1 if --run fails
 
-## 1.0.0-alpha-012
+## 1.0.0-alpha-012 - 2019-01-22
 
 * Fix argument parsing and update deps
 
-## 1.0.0-alpha-010
+## 1.0.0-alpha-010 - 2018-12-17
 
 * Fix #1674: paths on Windows @ncave
 
-## 1.0.0-alpha-008
+## 1.0.0-alpha-008 - 2018-12-14
 
 * Add fable-babel-plugins
 
-## 1.0.0-alpha-005
+## 1.0.0-alpha-005 - 2018-12-13
 
 * Fix Fable.Core method calls
 
-## 1.0.0-alpha-003
+## 1.0.0-alpha-003 - 2018-12-13
 
 * Add `--run` option and other changes
 
-## 1.0.0-alpha-002
+## 1.0.0-alpha-002 - 2018-12-13
 
 * First release as `fable-compiler-js` package

--- a/src/fable-metadata/CHANGELOG.md
+++ b/src/fable-metadata/CHANGELOG.md
@@ -12,57 +12,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Updated .NET metadata to 8.0.100 (by @ncave)
 
-## 2.1.0
+## 2.1.0 - 2023-11-10
 
 * Force a release of the package because it seems like new DLLs are missing from the previous release
 
-## 2.0.0
+## 2.0.0 - 2020-11-12
 
 * Updated Fable.Core to latest
 * Updated FSharp.Core to 5.0.0
 * Updated .NET Core to 5.0.100
 
-## 1.5.0
+## 1.5.0 - 2020-05-26
 
 * Updated FSharp.Core to 4.7.2
 * Updated .NET Core to 3.1.300
 
-## 1.4.0
+## 1.4.0 - 2020-04-09
 
 * Updated FSharp.Core to 4.7.1
 * Updated .NET Core to 3.1.201
 
-## 1.3.0
+## 1.3.0 - 2020-02-14
 
 * Updated Fable.Core to 3.1.5
 * Fix #1972
 * Updated .NET Core to 3.1.101
 
-## 1.2.0
+## 1.2.0 - 2019-09-30
 
 * Update FSharp.Core to 4.7.0
 * Add System.Net.Requests & System.Net.WebClient
 
-## 1.1.2
+## 1.1.2 - 2019-05-10
 
 * Add Recharts to Fable.Repl.Lib
 
-## 1.1.1
+## 1.1.1 - 2019-05-10
 
 * Fable.Repl.Lib
 
-## 1.1.0
+## 1.1.0 - 2019-05-10
 
 * Fable.Core 3 and Fable.Browser.Dom 1.0
 
-## 1.0.1
+## 1.0.1 - 2019-04-02
 
 * .NET Core 2.2.105, FSharp.Core 4.6.2, Fable.Core 3.0.0-beta
 
-## 1.0.0
+## 1.0.0 - 2019-02-28
 
 * Add System.Globalization
 
-## 1.0.0-beta-002
+## 1.0.0-beta-002 - 2019-02-11
 
 * First publish

--- a/src/fable-standalone/CHANGELOG.md
+++ b/src/fable-standalone/CHANGELOG.md
@@ -22,179 +22,179 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Remove `--typescript` options support, use `--lang <target>` instead
 
-## 3.2.11
+## 3.2.11 - 2021-08-19
 
 * Enable Fable.Repl.Lib
 
-## 3.1.12
+## 3.1.12 - 2021-04-16
 
 * Sync with Fable dotnet tool
 
-## 3.0.0
+## 3.0.0 - 2020-12-22
 
 * Nagareyama official release
 
-## 3.0.0-nagareyama-rc-008
+## 3.0.0-nagareyama-rc-008 - 2020-11-16
 
 * Fable.Transforms 3.0.0-nagareyama-rc-007
 
-## 1.3.18
+## 1.3.18 - 2020-09-03
 
 * fable-compiler 2.13.0
 
-## 1.3.17
+## 1.3.17 - 2020-08-25
 
 * fable-compiler 2.11.0
 
-## 1.3.16
+## 1.3.16 - 2020-07-08
 
 * fable-compiler 2.10.1
 
-## 1.3.15
+## 1.3.15 - 2020-04-28
 
 * fable-compiler 2.8.3
 
-## 1.3.14
+## 1.3.14 - 2020-04-21
 
 * fable-compiler 2.8.1
 
-## 1.3.13
+## 1.3.13 - 2020-04-15
 
 * fable-compiler 2.8.0
 
-## 1.3.12
+## 1.3.12 - 2020-04-15
 
 * fable-compiler 2.7.0
 
-## 1.3.11
+## 1.3.11 - 2020-04-14
 
 * fable-compiler 2.6.0
 
-## 1.3.10
+## 1.3.10 - 2020-04-12
 
 * fable-compiler 2.5.1
 
-## 1.3.9
+## 1.3.9 - 2020-04-09
 
 * fable-compiler 2.4.23
 * Use fable-splitter and rollup to generate the bundles
 
-## 1.3.8
+## 1.3.8 - 2020-03-10
 
 * fable-compiler 2.4.22
 
-## 1.3.8
+## 1.3.8 - 2020-03-10
 
 * fable-compiler 2.4.21
 
-## 1.3.7
+## 1.3.7 - 2020-03-09
 
 * fable-compiler 2.4.20
 
-## 1.3.6
+## 1.3.6 - 2020-03-06
 
 * fable-compiler 2.4.19
 
-## 1.3.5
+## 1.3.5 - 2020-03-04
 
 * fable-compiler 2.4.18
 
-## 1.3.4
+## 1.3.4 - 2020-03-03
 
 * fable-compiler 2.4.17
 
-## 1.3.3
+## 1.3.3 - 2020-02-25
 
 * fable-compiler 2.4.16
 
-## 1.3.2
+## 1.3.2 - 2020-02-20
 
 * fable-compiler 2.4.15
 
-## 1.3.1
+## 1.3.1 - 2020-02-19
 
 * fable-compiler 2.4.14
 
-## 1.3.0
+## 1.3.0 - 2019-11-20
 
 * Catch up with fable-compiler 2.4.11
 
-## 1.2.3
+## 1.2.3 - 2019-09-30
 
 * Include System.Net.Requests & System.Net.WebClient in references
 
-## 1.2.2
+## 1.2.2 - 2019-09-26
 
 * Enable passing otherFSharpOptions
 
-## 1.2.0
+## 1.2.0 - 2019-09-25
 
 * fable-compiler 2.4.2
 
-## 1.1.8
+## 1.1.8 - 2019-09-25
 
 * fable-compiler 2.3.25
 
-## 1.1.7
+## 1.1.7 - 2019-09-11
 
 * fable-compiler 2.3.24
 
-## 1.1.6
+## 1.1.6 - 2019-09-02
 
 * fable-compiler 2.3.21
 
-## 1.1.5
+## 1.1.5 - 2019-08-13
 
 * fable-compiler 2.3.19
 
-## 1.1.4
+## 1.1.4 - 2019-06-16
 
 * fable-compiler 2.3.12
 
-## 1.1.3
+## 1.1.3 - 2019-05-22
 
 * Don't crash REPL compilation on Babel errors
 
-## 1.1.2
+## 1.1.2 - 2019-05-20
 
 * fable-compiler 2.3.10
 
-## 1.1.1
+## 1.1.1 - 2019-05-10
 
 * Update bundle and Worker dependencies
 
-## 1.0.4
+## 1.0.4 - 2019-04-12
 
 * Fixed optimized patterns
 
-## 1.0.3
+## 1.0.3 - 2019-04-02
 
 * fcs-fable sync
 
-## 1.0.1
+## 1.0.1 - 2019-03-19
 
 * Decimal fixes
 
-## 1.0.0
+## 1.0.0 - 2019-02-28
 
 * Publish stable
 
-## 1.0.0-beta-009
+## 1.0.0-beta-009 - 2019-02-27
 
 * Anonymous records
 
-## 1.0.0-beta-004
+## 1.0.0-beta-004 - 2019-02-19
 
 * Compile tests with fable-compiler-js @ncave
 
-## 1.0.0-beta-003
+## 1.0.0-beta-003 - 2019-02-12
 
 * Fix web worker
 
-## 1.0.0-beta-002
+## 1.0.0-beta-002 - 2019-02-12
 
 * Update sources and add worker
 
-## 1.0.0-beta-001
+## 1.0.0-beta-001 - 2019-02-11
 
 * First publish


### PR DESCRIPTION
I pulled data from nuget.org and npmjs.com to fill in the missing dates in the changelog files. For some of the older versions where the dates were missing, I had to wing it and just picked a date that seemed about right.