### PR TITLE
[Python] Add literal kind field to constant

### DIFF
--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -164,7 +164,7 @@ module Reflection =
         =
         // TODO: Refactor these three bindings to reuse in transformUnionReflectionInfo
         let fullname = ent.FullName
-        let fullnameExpr = Expression.constant fullname
+        let fullnameExpr = Expression.stringConstant fullname
 
         let genMap =
             let genParamNames =
@@ -180,11 +180,11 @@ module Reflection =
                 let typeInfo, stmts =
                     transformTypeInfo com ctx r genMap fi.FieldType
 
+                let name = fi.Name |> Naming.toSnakeCase |> Helpers.clean
+
                 (Expression.tuple
                     [
-                        Expression.constant (
-                            fi.Name |> Naming.toSnakeCase |> Helpers.clean
-                        )
+                        Expression.stringConstant (name)
                         typeInfo
                     ]),
                 stmts
@@ -214,7 +214,7 @@ module Reflection =
         generics
         =
         let fullname = ent.FullName
-        let fullnameExpr = Expression.constant fullname
+        let fullnameExpr = Expression.stringConstant fullname
 
         let genMap =
             let genParamNames =
@@ -231,7 +231,7 @@ module Reflection =
                 |> List.map (fun fi ->
                     Expression.tuple
                         [
-                            fi.Name |> Expression.constant
+                            fi.Name |> Expression.stringConstant
                             let expr, _stmts =
                                 transformTypeInfo
                                     com
@@ -276,7 +276,7 @@ module Reflection =
             getNumberKindName kind |> primitiveTypeInfo
 
         let nonGenericTypeInfo fullname =
-            [ Expression.constant fullname ]
+            [ Expression.stringConstant fullname ]
             |> libReflectionCall com ctx None "class"
 
         let resolveGenerics generics : Expression list * Statement list =
@@ -296,7 +296,7 @@ module Reflection =
                 None
                 "class"
                 [
-                    Expression.constant fullname
+                    Expression.stringConstant fullname
                     if not (List.isEmpty generics) then
                         Expression.list generics
                 ]
@@ -333,8 +333,8 @@ module Reflection =
 
                             Expression.tuple
                                 [
-                                    Expression.constant name
-                                    Expression.constant value
+                                    Expression.stringConstant name
+                                    Expression.floatConstant value
                                 ]
                             |> Some
                     )
@@ -342,7 +342,7 @@ module Reflection =
                     |> Expression.list
 
                 [
-                    Expression.constant entRef.FullName
+                    Expression.stringConstant entRef.FullName
                     numberInfo kind
                     cases
                 ]
@@ -377,7 +377,7 @@ module Reflection =
             |> List.map (fun (k, t) ->
                 Expression.tuple
                     [
-                        Expression.constant k
+                        Expression.stringConstant k
                         t
                     ]
             )
@@ -488,7 +488,7 @@ module Reflection =
 
             let exprs, stmts =
                 [
-                    yield Expression.constant fullname, []
+                    yield Expression.stringConstant fullname, []
                     match generics with
                     | [] -> yield Util.undefined None, []
                     | generics -> yield Expression.list generics, []
@@ -511,7 +511,7 @@ module Reflection =
 
             exprs |> libReflectionCall com ctx r "class", stmts
 
-    let private ofString s = Expression.constant s
+    let private ofString s = Expression.stringConstant s
     let private ofArray exprs = Expression.list exprs
 
     let transformTypeTest
@@ -526,7 +526,7 @@ module Reflection =
             "Cannot type test (evals to false): " + msg
             |> addWarning com [] range
 
-            Expression.constant false
+            Expression.boolConstant false
 
         let pyTypeof
             (primitiveType: string)
@@ -542,7 +542,7 @@ module Reflection =
             Expression.compare (
                 typeof,
                 [ Eq ],
-                [ Expression.constant primitiveType ],
+                [ Expression.stringConstant primitiveType ],
                 ?loc = range
             ),
             stmts
@@ -564,7 +564,7 @@ module Reflection =
 
         match typ with
         | Fable.Measure _ // Dummy, shouldn't be possible to test against a measure type
-        | Fable.Any -> Expression.constant true, []
+        | Fable.Any -> Expression.boolConstant true, []
         | Fable.Unit ->
             let expr, stmts = com.TransformAsExpr(ctx, expr)
 
@@ -637,7 +637,7 @@ module Reflection =
                     com.GetEntity(ent2)
                     |> FSharp2Fable.Util.hasInterface Types.idisposable
                     ->
-                    Expression.constant true, []
+                    Expression.boolConstant true, []
                 | _ ->
                     let expr, stmts = com.TransformAsExpr(ctx, expr)
                     libCall com ctx None "util" "isDisposable" [ expr ], stmts
@@ -1072,8 +1072,8 @@ module Annotation =
 
                         Expression.tuple
                             [
-                                Expression.constant name
-                                Expression.constant value
+                                Expression.stringConstant name
+                                Expression.floatConstant value
                             ]
                         |> Some
                 )
@@ -1081,7 +1081,7 @@ module Annotation =
                 |> Expression.list
 
             [
-                Expression.constant entRef.FullName
+                Expression.stringConstant entRef.FullName
                 numberInfo kind
                 cases
             ]
@@ -1507,9 +1507,9 @@ module Util =
 
     let thisExpr = Expression.name "self"
 
-    let ofInt (i: int) = Expression.constant (int i)
+    let ofInt (i: int) = Expression.intConstant (int i)
 
-    let ofString (s: string) = Expression.constant s
+    let ofString (s: string) = Expression.stringConstant s
 
     let memberFromName
         (_com: IPythonCompiler)
@@ -1541,7 +1541,7 @@ module Util =
         // printfn "get: %A" (memberName, subscript)
         match subscript with
         | true ->
-            let expr = Expression.constant memberName
+            let expr = Expression.stringConstant memberName
             Expression.subscript (value = left, slice = expr, ctx = Load)
         | _ ->
             let expr = com.GetIdentifier(ctx, memberName)
@@ -1549,8 +1549,8 @@ module Util =
 
     let getExpr _com _ctx _r (object: Expression) (expr: Expression) =
         match expr with
-        | Expression.Constant(value = name) when (name :? string) ->
-            let name = name :?> string |> Identifier
+        | Expression.Constant(value = StringLiteral name) ->
+            let name = name |> Identifier
             Expression.attribute (value = object, attr = name, ctx = Load), []
         | e -> Expression.subscript (value = object, slice = e, ctx = Load), []
 
@@ -1597,7 +1597,7 @@ module Util =
 
             Expression.call (
                 array,
-                Expression.constant l :: [ Expression.list expr ]
+                Expression.stringConstant l :: [ Expression.list expr ]
             ),
             stmts
         | _ -> expr |> Expression.list, stmts
@@ -1612,7 +1612,7 @@ module Util =
         =
         //printfn "makeArrayAllocated"
         let size, stmts = com.TransformAsExpr(ctx, size)
-        let array = Expression.list [ Expression.constant 0 ]
+        let array = Expression.list [ Expression.intConstant 0 ]
         Expression.binOp (array, Mult, size), stmts
 
     let makeArrayFrom
@@ -1648,12 +1648,14 @@ module Util =
         expr |> Expression.tuple, stmts
 
     let makeStringArray strings =
-        strings |> List.map (fun x -> Expression.constant x) |> Expression.list
+        strings
+        |> List.map (fun x -> Expression.stringConstant x)
+        |> Expression.list
 
     let makePyObject (pairs: seq<string * Expression>) =
         pairs
         |> Seq.map (fun (name, value) ->
-            let prop = Expression.constant name
+            let prop = Expression.stringConstant name
             prop, value
         )
         |> Seq.toList
@@ -1860,7 +1862,9 @@ module Util =
 
     let getUnionExprTag (com: IPythonCompiler) ctx r (fableExpr: Fable.Expr) =
         let expr, stmts = com.TransformAsExpr(ctx, fableExpr)
-        let expr, stmts' = getExpr com ctx r expr (Expression.constant "tag")
+
+        let expr, stmts' =
+            getExpr com ctx r expr (Expression.stringConstant "tag")
 
         expr, stmts @ stmts'
 
@@ -1873,7 +1877,7 @@ module Util =
                 BoolOperator.Or,
                 [
                     e
-                    Expression.constant 0
+                    Expression.intConstant 0
                 ]
             )
         | _ -> e
@@ -2184,10 +2188,23 @@ module Util =
         )
 
 
-    let makeNumber (com: IPythonCompiler) (ctx: Context) r _t intName x =
+    let makeInteger
+        (com: IPythonCompiler)
+        (ctx: Context)
+        r
+        _t
+        intName
+        (x: obj)
+        =
         let cons = libValue com ctx "types" intName
-        let value = Expression.constant (x, ?loc = r)
+        let value = Expression.intConstant (x, ?loc = r)
         Expression.call (cons, [ value ], ?loc = r), []
+
+    let makeFloat (com: IPythonCompiler) (ctx: Context) r _t floatName x =
+        let cons = libValue com ctx "types" floatName
+        let value = Expression.floatConstant (x, ?loc = r)
+        Expression.call (cons, [ value ], ?loc = r), []
+
 
     let transformValue
         (com: IPythonCompiler)
@@ -2204,9 +2221,10 @@ module Util =
         | Fable.TypeInfo(t, _) -> transformTypeInfo com ctx r Map.empty t
         | Fable.Null _t -> Expression.none, []
         | Fable.UnitConstant -> undefined r, []
-        | Fable.BoolConstant x -> Expression.constant (x, ?loc = r), []
-        | Fable.CharConstant x -> Expression.constant (string x, ?loc = r), []
-        | Fable.StringConstant x -> Expression.constant (x, ?loc = r), []
+        | Fable.BoolConstant x -> Expression.boolConstant (x, ?loc = r), []
+        | Fable.CharConstant x ->
+            Expression.stringConstant (string x, ?loc = r), []
+        | Fable.StringConstant x -> Expression.stringConstant (x, ?loc = r), []
         | Fable.StringTemplate(_, parts, values) ->
             match parts with
             | [] -> makeStrConst ""
@@ -2237,19 +2255,19 @@ module Util =
                 Py.Replacements.makeDecimal com r value.Type x
                 |> transformAsExpr com ctx
             | Int64, (:? int64 as x) ->
-                makeNumber com ctx r value.Type "int64" x
+                makeInteger com ctx r value.Type "int64" x
             | UInt64, (:? uint64 as x) ->
-                makeNumber com ctx r value.Type "uint64" x
-            | Int8, (:? int8 as x) -> makeNumber com ctx r value.Type "int8" x
+                makeInteger com ctx r value.Type "uint64" x
+            | Int8, (:? int8 as x) -> makeInteger com ctx r value.Type "int8" x
             | UInt8, (:? uint8 as x) ->
-                makeNumber com ctx r value.Type "uint8" x
+                makeInteger com ctx r value.Type "uint8" x
             | Int16, (:? int16 as x) ->
-                makeNumber com ctx r value.Type "int16" x
+                makeInteger com ctx r value.Type "int16" x
             | UInt16, (:? uint16 as x) ->
-                makeNumber com ctx r value.Type "uint16" x
-            | Int32, (:? int32 as x) -> Expression.constant (x, ?loc = r), []
+                makeInteger com ctx r value.Type "uint16" x
+            | Int32, (:? int32 as x) -> Expression.intConstant (x, ?loc = r), []
             | UInt32, (:? uint32 as x) ->
-                makeNumber com ctx r value.Type "uint32" x
+                makeInteger com ctx r value.Type "uint32" x
             //| _, (:? char as x) -> makeNumber com ctx r value.Type "char" x
             | _, x when x = infinity -> Expression.name "float('inf')", []
             | _, x when x = -infinity -> Expression.name "float('-inf')", []
@@ -2262,12 +2280,12 @@ module Util =
                     r
                     "types"
                     "float32"
-                    [ Expression.constant "nan" ],
+                    [ Expression.stringConstant "nan" ],
                 []
             | _, (:? float32 as x) ->
-                makeNumber com ctx r value.Type "float32" x
-            | _, (:? float as x) -> Expression.constant (x, ?loc = r), []
-            | _ -> Expression.constant (x, ?loc = r), []
+                makeFloat com ctx r value.Type "float32" (float x)
+            | _, (:? float as x) -> Expression.floatConstant (x, ?loc = r), []
+            | _ -> Expression.intConstant (x, ?loc = r), []
         | Fable.NewArray(newKind, typ, kind) ->
             match newKind with
             | Fable.ArrayValues values -> makeArray com ctx values kind typ
@@ -3029,11 +3047,8 @@ module Util =
         let expr, stmts = com.TransformAsExpr(ctx, guardExpr)
 
         match expr with
-        | Constant(value = value) when (value :? bool) ->
-            match value with
-            | :? bool as value when value ->
-                stmts @ com.TransformAsStatements(ctx, ret, thenStmnt)
-            | _ -> stmts @ com.TransformAsStatements(ctx, ret, elseStmnt)
+        | Constant(value = BoolLiteral value) ->
+            stmts @ com.TransformAsStatements(ctx, ret, thenStmnt)
         | guardExpr ->
             let thenStmnt, stmts' =
                 transformBlock com ctx ret thenStmnt
@@ -3147,7 +3162,7 @@ module Util =
             let expr, stmts = com.TransformAsExpr(ctx, fableExpr)
 
             let expr, stmts' =
-                getExpr com ctx None expr (Expression.constant "fields")
+                getExpr com ctx None expr (Expression.stringConstant "fields")
 
             let expr, stmts'' = getExpr com ctx range expr (ofInt i.FieldIndex)
 
@@ -4113,7 +4128,10 @@ module Util =
             | Some l ->
                 let array = com.GetImportExpr(ctx, "array", "array")
 
-                Expression.call (array, Expression.constant l :: [ value ]),
+                Expression.call (
+                    array,
+                    Expression.stringConstant l :: [ value ]
+                ),
                 stmts
             | _ -> transformAsSlice com ctx expr info
         | _ -> transformAsSlice com ctx expr info
@@ -4413,16 +4431,16 @@ module Util =
             let limit, step =
                 if isUp then
                     let limit =
-                        Expression.binOp (limit, Add, Expression.constant 1) // Python `range` has exclusive end.
+                        Expression.binOp (limit, Add, Expression.intConstant 1) // Python `range` has exclusive end.
 
                     limit, 1
                 else
                     let limit =
-                        Expression.binOp (limit, Sub, Expression.constant 1) // Python `range` has exclusive end.
+                        Expression.binOp (limit, Sub, Expression.intConstant 1) // Python `range` has exclusive end.
 
                     limit, -1
 
-            let step = Expression.constant step
+            let step = Expression.intConstant step
 
             let iter =
                 Expression.call (
@@ -4585,7 +4603,7 @@ module Util =
 
                 args',
                 [],
-                Statement.while' (Expression.constant true, body)
+                Statement.while' (Expression.boolConstant true, body)
                 |> List.singleton
             | _ ->
                 // Make sure all of the last optional arguments will accept None as their default value
@@ -4667,7 +4685,7 @@ module Util =
             Expression.compare (
                 Expression.name "__name__",
                 [ ComparisonOperator.Eq ],
-                [ Expression.constant "__main__" ]
+                [ Expression.stringConstant "__main__" ]
             )
 
         let main =
@@ -4789,11 +4807,11 @@ module Util =
                         [
                             Keyword.keyword (
                                 Identifier "eq",
-                                Expression.constant false
+                                Expression.boolConstant false
                             )
                             Keyword.keyword (
                                 Identifier "repr",
-                                Expression.constant false
+                                Expression.boolConstant false
                             )
                         ]
                 )
@@ -4898,7 +4916,9 @@ module Util =
             let elements =
                 getEntityFieldsAsProps com ctx classEnt
                 |> Array.map (
-                    nameFromKey com ctx >> strFromIdent >> Expression.string
+                    nameFromKey com ctx
+                    >> strFromIdent
+                    >> Expression.stringConstant
                 )
                 |> Array.toList
 
@@ -5033,10 +5053,8 @@ module Util =
     let nameFromKey (com: IPythonCompiler) (ctx: Context) key =
         match key with
         | Expression.Name { Id = ident } -> ident
-        | Expression.Constant(value = value) ->
-            match value with
-            | :? string as name -> com.GetIdentifier(ctx, name)
-            | _ -> failwith $"Not a valid value: {value}"
+        | Expression.Constant(value = StringLiteral name) ->
+            com.GetIdentifier(ctx, name)
         | name -> failwith $"Not a valid name: {name}"
 
     let transformAttachedProperty
@@ -5194,7 +5212,7 @@ module Util =
                                     BoolOperator.Or,
                                     [
                                         identAsExpr com ctx id
-                                        Expression.constant 0
+                                        Expression.intConstant 0
                                     ]
                                 )
                             | Fable.Array _ ->
@@ -5635,7 +5653,7 @@ module Util =
             for var in typeVars do
                 let targets = Expression.name var |> List.singleton
                 let value = com.GetImportExpr(ctx, "typing", "TypeVar")
-                let args = Expression.constant var |> List.singleton
+                let args = Expression.stringConstant var |> List.singleton
                 let value = Expression.call (value, args)
                 Statement.assign (targets, value)
         ]
@@ -5653,7 +5671,7 @@ module Util =
             let all = Expression.name "__all__"
 
             let names =
-                exports |> List.map Expression.constant |> Expression.list
+                exports |> List.map Expression.stringConstant |> Expression.list
 
             [ Statement.assign ([ all ], names) ]
 

--- a/src/Fable.Transforms/Python/Python.fs
+++ b/src/Fable.Transforms/Python/Python.fs
@@ -27,7 +27,7 @@ type Expression =
     /// A constant value. The value attribute of the Constant literal contains the Python object it represents. The
     /// values represented can be simple types such as a number, string or None, but also immutable container types
     /// (tuples and frozensets) if all of their elements are constant.
-    | Constant of value: obj * loc: SourceLocation option
+    | Constant of value: Literal * loc: SourceLocation option
     | Call of Call
     | Compare of Compare
     | Lambda of Lambda
@@ -42,6 +42,16 @@ type Expression =
         lower: Expression option *
         upper: Expression option *
         step: Expression option
+
+type Literal =
+    | FloatLiteral of float
+    | IntLiteral of obj
+    | BoolLiteral of bool
+    | BytesLiteral of byte[]
+    | StringLiteral of string
+    | NoneLiteral
+    | TupleLiteral of Literal list
+    | FrozensetLiteral of Literal list
 
 type Operator =
     | Add
@@ -1193,10 +1203,19 @@ module PythonExtensions =
 
             Expression.boolOp (op, values, ?loc = loc)
 
-        static member constant(value: obj, ?loc) : Expression =
-            Constant(value = value, loc = loc)
+        static member boolConstant(value: bool, ?loc) : Expression =
+            Constant(value = BoolLiteral value, loc = loc)
 
-        static member string(value: string, ?loc) : Expression =
+        static member intConstant(value: obj, ?loc) : Expression =
+            Constant(value = IntLiteral value, loc = loc)
+
+        static member floatConstant(value: float, ?loc) : Expression =
+            Constant(value = FloatLiteral value, loc = loc)
+
+        static member stringConstant(value: string, ?loc) : Expression =
+            Constant(value = StringLiteral value, loc = loc)
+
+        static member constant(value: Literal, ?loc) : Expression =
             Constant(value = value, loc = loc)
 
         static member starred

--- a/src/Fable.Transforms/Python/PythonPrinter.fs
+++ b/src/Fable.Transforms/Python/PythonPrinter.fs
@@ -88,7 +88,7 @@ module PrinterExtensions =
             | [], Some vararg ->
                 printer.Print("*")
                 printer.Print(vararg)
-            | args, Some vararg ->
+            | _, Some vararg ->
                 printer.Print(", *")
                 printer.Print(vararg)
             | _ -> ()
@@ -142,7 +142,7 @@ module PrinterExtensions =
             printer.PrintStatements(forIn.Body)
             printer.PopIndentation()
 
-        member printer.Print(asyncFor: AsyncFor) = printer.Print("(AsyncFor)")
+        member printer.Print(_asyncFor: AsyncFor) = printer.Print("(AsyncFor)")
 
         member printer.Print(wh: While) =
             printer.Print("while ")
@@ -323,7 +323,7 @@ module PrinterExtensions =
             printer.Print(node.Op)
             printer.ComplexExpressionWithParens(node.Operand)
 
-        member printer.Print(node: FormattedValue) =
+        member printer.Print(_node: FormattedValue) =
             printer.Print("(FormattedValue)")
 
         member printer.Print(node: Call) =
@@ -367,7 +367,7 @@ module PrinterExtensions =
                     @"\$(\d+)\.\.\."
                     (fun m ->
                         let rep = ResizeArray()
-                        let i = int m.Groups.[1].Value
+                        let i = int m.Groups[1].Value
 
                         for j = i to node.Args.Length - 1 do
                             rep.Add("$" + string j)
@@ -378,12 +378,12 @@ module PrinterExtensions =
                 |> replace
                     @"\{\{\s*\$(\d+)\s*\?(.*?):(.*?)\}\}"
                     (fun m ->
-                        let i = int m.Groups.[1].Value
+                        let i = int m.Groups[1].Value
 
-                        match node.Args.[i] with
-                        | Constant(value = :? bool as value) when value ->
+                        match node.Args[i] with
+                        | Constant(value = BoolLiteral value) when value ->
                             m.Groups[2].Value
-                        | _ -> m.Groups.[3].Value
+                        | _ -> m.Groups[3].Value
                     )
 
                 |> replace
@@ -400,10 +400,10 @@ module PrinterExtensions =
                 |> replace
                     @"\$(\d+)!"
                     (fun m ->
-                        let i = int m.Groups.[1].Value
+                        let i = int m.Groups[1].Value
 
                         match List.tryItem i node.Args with
-                        | Some(Constant(:? string as value, _)) -> value
+                        | Some(Constant(StringLiteral value, _)) -> value
                         | _ -> ""
                     )
 
@@ -417,12 +417,12 @@ module PrinterExtensions =
                     let isSurroundedWithParens =
                         m.Index > 0
                         && m.Index + m.Length < value.Length
-                        && value.[m.Index - 1] = '('
-                        && value.[m.Index + m.Length] = ')'
+                        && value[m.Index - 1] = '('
+                        && value[m.Index + m.Length] = ')'
 
                     let segmentStart =
                         if i > 0 then
-                            matches[i - 1].Index + matches.[i - 1].Length
+                            matches[i - 1].Index + matches[i - 1].Length
                         else
                             0
 
@@ -435,7 +435,7 @@ module PrinterExtensions =
                     | Some e -> printer.ComplexExpressionWithParens(e)
                     | None -> printer.Print("None")
 
-                let lastMatch = matches.[matches.Count - 1]
+                let lastMatch = matches[matches.Count - 1]
 
                 printSegment
                     printer
@@ -473,9 +473,9 @@ module PrinterExtensions =
 
             printer.Print(")")
 
-        member printer.Print(node: List) = printer.Print("(List)")
+        member printer.Print(_node: List) = printer.Print("(List)")
 
-        member printer.Print(node: Set) = printer.Print("(Set)")
+        member printer.Print(_node: Set) = printer.Print("(Set)")
 
         member printer.Print(node: Dict) =
             printer.Print("{")
@@ -593,31 +593,30 @@ module PrinterExtensions =
             | Emit ex -> printer.Print(ex)
             | UnaryOp ex -> printer.Print(ex)
             | FormattedValue ex -> printer.Print(ex)
-            | Constant(value = value) ->
-                match value with
-                | :? string as value ->
-                    printer.Print("\"")
-                    printer.Print(Naming.escapeString (fun _ -> false) value)
-                    printer.Print("\"")
-                | :? float as value ->
-                    let value = string value
-                    printer.Print(value)
+            | Constant(value = StringLiteral value) ->
+                printer.Print("\"")
+                printer.Print(Naming.escapeString (fun _ -> false) value)
+                printer.Print("\"")
+            | Constant(value = FloatLiteral value) ->
+                let value = string value
+                printer.Print(value)
 
-                    // Make sure it's a valid Python float (not int)
-                    if
-                        String.forall
-                            (fun char -> char = '-' || Char.IsDigit char)
-                            value
-                    then
-                        printer.Print(".0")
-                | :? bool as value ->
-                    printer.Print(
-                        if value then
-                            "True"
-                        else
-                            "False"
-                    )
-                | _ -> printer.Print(string value)
+                // Make sure it's a valid Python float (not int)
+                if
+                    String.forall
+                        (fun char -> char = '-' || Char.IsDigit char)
+                        value
+                then
+                    printer.Print(".0")
+            | Constant(value = BoolLiteral value) ->
+                printer.Print(
+                    if value then
+                        "True"
+                    else
+                        "False"
+                )
+            | Constant(value = IntLiteral value) -> printer.Print(string value)
+            | Constant(value = value) -> printer.Print(string value)
 
             | IfExp ex -> printer.Print(ex)
             | Call ex -> printer.Print(ex)
@@ -632,7 +631,7 @@ module PrinterExtensions =
             | Compare cp -> printer.Print(cp)
             | Dict di -> printer.Print(di)
             | Tuple tu -> printer.Print(tu)
-            | Slice(lower, upper, step) ->
+            | Slice(lower, upper, _step) ->
                 if lower.IsSome then
                     printer.Print(lower.Value)
 
@@ -640,10 +639,10 @@ module PrinterExtensions =
 
                 if upper.IsSome then
                     printer.Print(upper.Value)
-            | Starred(ex, ctx) ->
+            | Starred(ex, _ctx) ->
                 printer.Print("*")
                 printer.Print(ex)
-            | List(elts, ctx) ->
+            | List(elts, _ctx) ->
                 printer.Print("[")
                 printer.PrintCommaSeparatedList(elts)
                 printer.Print("]")
@@ -771,7 +770,7 @@ module PrinterExtensions =
         member printer.PrintCommaSeparatedList(nodes: Expression list) =
             printer.PrintList(
                 nodes,
-                (fun p x -> printer.Print(x)),
+                (fun _ -> printer.Print),
                 (fun p -> p.Print(", "))
             )
 
@@ -860,7 +859,7 @@ let printLine (printer: Printer) (line: string) =
     printer.Print(line)
     printer.PrintNewLine()
 
-let isEmpty (program: Module) : bool = false //TODO: determine if printer will not print anything
+let isEmpty (_program: Module) : bool = false // TODO: determine if printer will not print anything
 
 let run writer (program: Module) : Async<unit> =
     async {


### PR DESCRIPTION
This should hopefully avoid type checking to decide between integers and floats which fails in the REPL (js)

<img width="645" alt="Screenshot 2023-12-02 at 09 44 20" src="https://github.com/fable-compiler/Fable/assets/849479/0591fe9f-a2ec-4da7-a50f-d3885913e5b8">
