### PR TITLE
[Python] Fix file output naming

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [GH-3645](https://github.com/fable-compiler/Fable/pull/3645) Add `TimeSpan.Parse` and `TimeSpan.TryParse` support to Python (by @MangelMaxime)
 * [GH-3649](https://github.com/fable-compiler/Fable/issues/3649) Fixes for `List.sortBy` (by @dbrattli)
 * [GH-3638](https://github.com/fable-compiler/Fable/issues/3638) Fixes for `Array.sort` and `Array.sortDescending` (by @dbrattli)
+* [GH-3655](https://github.com/fable-compiler/Fable/issues/3655) Fixes for Python output file names (by @dbrattli)
 
 ## 4.7.0 - 2023-12-06
 

--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -28,10 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Python
 
 * [GH-3645](https://github.com/fable-compiler/Fable/pull/3645) Add `TimeSpan.Parse` and `TimeSpan.TryParse` support to Python (by @MangelMaxime)
-* [GH-3649](https://github.com/fable-compiler/Fable/issues/3649) Fixes for `List.sortBy` (by @dbrattli)
-* [GH-3638](https://github.com/fable-compiler/Fable/issues/3638) Fixes for `Array.sort` and `Array.sortDescending` (by @dbrattli)
-* [GH-3655](https://github.com/fable-compiler/Fable/issues/3655) Fixes for Python output file names (by @dbrattli)
-* [GH-3660](https://github.com/fable-compiler/Fable/issues/3660) Fixes for decimal to string with culture (by @dbrattli)
+* [GH-3649](https://github.com/fable-compiler/Fable/issues/3649) Add `List.sortBy` (by @dbrattli)
+* [GH-3638](https://github.com/fable-compiler/Fable/issues/3638) Add `Array.sort` and `Array.sortDescending` (by @dbrattli)
 
 #### Fixed
 
@@ -42,6 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Python
 
 * [GH-3465](https://github.com/fable-compiler/Fable/issues/3465) Fix `string.IndexOfAny` (by @pkese)
+* [GH-3655](https://github.com/fable-compiler/Fable/issues/3655) Fix for Python output file names (by @dbrattli)
+* [GH-3660](https://github.com/fable-compiler/Fable/issues/3660) Fix for decimal to string with culture (by @dbrattli)
 
 ## 4.7.0 - 2023-12-06
 

--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -180,7 +180,9 @@ module private Util =
                         projDir
                         outDir
 
-                let fileName = IO.Path.GetFileName(file)
+                let fileName =
+                    IO.Path.GetFileName(file)
+                    |> Pipeline.Python.getTargetPath cliArgs
 
                 let modules =
                     absPath
@@ -219,7 +221,7 @@ module private Util =
                         modules
                         |> List.map (fun m ->
                             match m with
-                            | "." -> m
+                            | "." -> ""
                             | m -> m.Replace(".", "_")
                         )
                     |> List.toArray

--- a/src/Fable.Cli/Pipeline.fs
+++ b/src/Fable.Cli/Pipeline.fs
@@ -444,8 +444,6 @@ module Python =
                 |> Fable2Python.Compiler.transformFile com
 
             if not (isSilent || PythonPrinter.isEmpty python) then
-                let outPath = getTargetPath cliArgs outPath
-
                 let writer =
                     new PythonFileWriter(com, cliArgs, pathResolver, outPath)
 


### PR DESCRIPTION
Generate the right Python output file name earlier in the pipeline so that commands such as `runScript` also gets the correct filename.

Fixes #3655