### PR TITLE
Change outFile extension later otherwise the modules is incorrectly computed because of an offset of 1 char length

### DIFF
--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -180,9 +180,7 @@ module private Util =
                         projDir
                         outDir
 
-                let fileName =
-                    IO.Path.GetFileName(file)
-                    |> Pipeline.Python.getTargetPath cliArgs
+                let fileName = IO.Path.GetFileName(file)
 
                 let modules =
                     absPath
@@ -226,6 +224,8 @@ module private Util =
                         )
                     |> List.toArray
                     |> IO.Path.Join
+
+                let fileName = fileName |> Pipeline.Python.getTargetPath cliArgs
 
                 IO.Path.Join(outDir, modules, fileName)
 


### PR DESCRIPTION
@dbrattli 

#3659 introduce a bug because there is an different lenght of `1` between `fsx` and `py`.

This changes fix that, I think it should be possible to change the extension of the file sooner in this function but I am not sure if this could have others side effects.