### PR TITLE
[Python] datetime timespan addition works

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [GH-3655](https://github.com/fable-compiler/Fable/issues/3655) Fix for Python output file names (by @dbrattli)
 * [GH-3660](https://github.com/fable-compiler/Fable/issues/3660) Fix for decimal to string with culture (by @dbrattli)
+* Fix for `DateTime` and `TimeSpan` addition (by @dbrattli)
 
 ## 4.8.1 - 2023-12-12
 

--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [GH-3655](https://github.com/fable-compiler/Fable/issues/3655) Fix for Python output file names (by @dbrattli)
 * [GH-3660](https://github.com/fable-compiler/Fable/issues/3660) Fix for decimal to string with culture (by @dbrattli)
-* Fix for `DateTime` and `TimeSpan` addition (by @dbrattli)
+* [GH-3666](https://github.com/fable-compiler/Fable/pull/3666) Fix for `DateTime` and `TimeSpan` addition (by @dbrattli)
 
 ## 4.8.1 - 2023-12-12
 

--- a/src/fable-library-py/fable_library/date.py
+++ b/src/fable-library-py/fable_library/date.py
@@ -261,6 +261,7 @@ def add_milliseconds(d: datetime, v: int) -> datetime:
 
 
 __all__ = [
+    "add",
     "op_subtraction",
     "subtract",
     "create",

--- a/src/fable-library-py/fable_library/date.py
+++ b/src/fable-library-py/fable_library/date.py
@@ -232,20 +232,9 @@ def add(x: datetime, y: TimeSpan) -> datetime:
 
 
 def parse(string: str, detectUTC: bool = False) -> datetime:
-    formats = {
-        # Matches a date-time string in the format "YYYY-MM-DDTHH:MM:SS"
-        r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}": "%Y-%m-%dT%H:%M:%S",
-        # Matches a time string in 24-hour format "HH:MM:SS"
-        r"\d{2}:\d{2}:\d{2}": "%H:%M:%S",
-        # Matches a time string in 12-hour format with AM/PM "HH:MM:SS AM" or "HH:MM:SS PM"
-        r"\d{2}:\d{2}:\d{2} [AP]M": "%I:%M:%S %p",
-    }
+    from dateutil import parser
 
-    for pattern, format in formats.items():
-        if re.fullmatch(pattern, string):
-            return datetime.strptime(string, format)
-
-    raise ValueError("Unsupported format by Fable")
+    return parser.parse(string)
 
 
 def try_parse(string: str, style: int, unsigned: bool, bitsize: int, defValue: FSharpRef[datetime]) -> bool:

--- a/src/fable-library-py/fable_library/map_util.py
+++ b/src/fable-library-py/fable_library/map_util.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from collections.abc import ByteString, Iterable, MutableSequence
+from collections.abc import Iterable
 from enum import IntEnum
 from re import Match
 from typing import (
@@ -12,6 +12,7 @@ from typing import (
 )
 
 from .types import FSharpRef, Union
+from .util import Array
 
 
 _K = TypeVar("_K")
@@ -124,7 +125,7 @@ def key_value_list(fields: Iterable[Any], case_rule: CaseRules = CaseRules.Ignor
             kv_pair = name if len(kv_pair.fields) == 0 else [name, *kv_pair.fields]
             case_rule = defined_case_rule
 
-        if isinstance(kv_pair, list | MutableSequence | ByteString):
+        if isinstance(kv_pair, Array):
             length = len(kv_pair)
             if length == 0:
                 fail(kv_pair)

--- a/tests/Python/TestTimeSpan.fs
+++ b/tests/Python/TestTimeSpan.fs
@@ -125,6 +125,19 @@ let ``test TimeSpan Addition works`` () =
     test 0. 0. 0.
 
 [<Fact>]
+let ``test DateTime and TimeSpan Addition works`` () =
+    let test ms expected =
+        let dt = DateTime(2014,9,12,0,0,0,DateTimeKind.Utc)
+        let ts = TimeSpan.FromMilliseconds(ms)
+        let res1 = dt.Add(ts).ToUniversalTime()
+        let res2 = (dt + ts).ToUniversalTime()
+        equal true (res1 = res2)
+        equal expected res1
+
+    DateTime(2014,9,12,0,0,1,DateTimeKind.Utc) |> test 1000.
+    DateTime(2014,9,11,23,59,59,DateTimeKind.Utc) |> test -1000.
+
+[<Fact>]
 let ``test TimeSpan implementation coherence`` () =
     TimeSpan.FromTicks(1L).Ticks |> equal 1L
     TimeSpan.FromMilliseconds(1).Milliseconds |> equal 1


### PR DESCRIPTION
Fixes a regression with `DateTime` and `TimeSpan` addition after the previous `timedelta` to `TimeSpan` refactor. This broke the Fable.Python [Timeflies](https://github.com/fable-compiler/Fable.Python/tree/main/examples/timeflies) demo. FYI: @MangelMaxime  

Also simplifies some type checking in `map_util.py`