### PR TITLE
Normalize fable-library argument

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,10 @@ jobs:
 
   # Separate build job for JavaScript
   build-javascript:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
 
     steps:
     - uses: actions/checkout@v2
@@ -39,8 +42,13 @@ jobs:
     - name: Setup Node.js environment
       uses: actions/setup-node@v2.4.1
 
-    - name: Fable Tests - JavaScript
+    - name: Fable Tests - JavaScript (linux)
+      if: matrix.platform == 'ubuntu-latest'
       run: ./build.sh test javascript
+
+    - name: Fable Tests - JavaScript (Windows)
+      if: matrix.platform == 'windows-latest'
+      run: .\build.bat test javascript
 
   # Separate build job for TypeScript
   build-typescript:

--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### All
+
+* [GH-3668](https://github.com/fable-compiler/Fable/pull/3668) Normalize fable-library argument (by @nojaf)
+
 #### Rust
 
 * Fixed unary negation for signed integer MinValue (by @ncave)

--- a/src/Fable.Cli/Entry.fs
+++ b/src/Fable.Cli/Entry.fs
@@ -316,7 +316,8 @@ type Runner =
                 args.Value("--precompiledLib")
                 |> Option.map normalizeAbsolutePath
 
-            let fableLib = args.Value "--fableLib"
+            let fableLib =
+                args.Value "--fableLib" |> Option.map Path.normalizePath
 
             do!
                 match watch, outDir, fableLib with


### PR DESCRIPTION
Fixes #3653

The problematic code is, I believe, that https://github.com/fable-compiler/Fable/blob/38c8e10293af02adb25a9c82336ff4b940a81fad/src/Fable.Transforms/Global/Prelude.fs#L394-L427

expects the paths already to be in `/` notation. 
Converting this earlier on will ensure the relative paths in the import statements are fixed.

Also, trying out Windows CI again for JS. It worked on my machine.