### PR TITLE
Enabled Log2/Min/Max/MinMag/MaxMag/Clamp tests

### DIFF
--- a/src/Fable.Build/Fable.Build.fsproj
+++ b/src/Fable.Build/Fable.Build.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
   </PropertyGroup>
   <ItemGroup>
@@ -43,7 +43,7 @@
     <Compile Include="Main.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="7.0.400" />
+    <PackageReference Update="FSharp.Core" Version="8.0.100" />
     <PackageReference Include="BlackFox.CommandLine" Version="1.0.0" />
     <PackageReference Include="EluciusFTW.SpectreCoff" Version="0.47.28" />
     <PackageReference Include="Fake.IO.FileSystem" Version="6.0.0" />

--- a/src/Fable.Transforms/Rust/AST/Tests/Rust.AST.Tests.fsproj
+++ b/src/Fable.Transforms/Rust/AST/Tests/Rust.AST.Tests.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>

--- a/src/fable-compiler-js/src/fable-compiler-js.fsproj
+++ b/src/fable-compiler-js/src/fable-compiler-js.fsproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="source-map-sharp" Version="1.0.8" />
+    <PackageReference Include="source-map-sharp" Version="1.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/fable-standalone/test/bench-compiler/bench-compiler.fsproj
+++ b/src/fable-standalone/test/bench-compiler/bench-compiler.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
     <DefineConstants>$(DefineConstants);DOTNET_FILE_SYSTEM</DefineConstants>
     <OtherFlags>$(OtherFlags) --crossoptimize-</OtherFlags>

--- a/src/fable-standalone/test/bench/bench.fsproj
+++ b/src/fable-standalone/test/bench/bench.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
     <DefineConstants>$(DefineConstants);DOTNET_FILE_SYSTEM</DefineConstants>
   </PropertyGroup>

--- a/src/quicktest-dart/Quicktest.Dart.fsproj
+++ b/src/quicktest-dart/Quicktest.Dart.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
   </PropertyGroup>
   <ItemGroup>
@@ -12,6 +12,6 @@
     <Content Include="pubspec.yaml" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Fable.Core\Fable.Core.fsproj" />
+    <ProjectReference Include="../Fable.Core/Fable.Core.fsproj" />
   </ItemGroup>
 </Project>

--- a/src/quicktest-rust/Quicktest.fsproj
+++ b/src/quicktest-rust/Quicktest.fsproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="src/main.fs" />
   </ItemGroup>
-  <!-- <ItemGroup>
-    <ProjectReference Include="..\Fable.Core\Fable.Core.fsproj" />
-  </ItemGroup> -->
+  <ItemGroup>
+    <!-- <ProjectReference Include="../Fable.Core/Fable.Core.fsproj" /> -->
+  </ItemGroup>
 </Project>

--- a/src/quicktest/Quicktest.fsproj
+++ b/src/quicktest/Quicktest.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
     <LangVersion>Preview</LangVersion>
   </PropertyGroup>
@@ -10,6 +10,6 @@
     <Content Include="quicktest.fs.js" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Fable.Core\Fable.Core.fsproj" />
+    <ProjectReference Include="../Fable.Core/Fable.Core.fsproj" />
   </ItemGroup>
 </Project>

--- a/src/tools/ASTViewer/ASTViewer.fsproj
+++ b/src/tools/ASTViewer/ASTViewer.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
   </PropertyGroup>
   <ItemGroup>
@@ -10,7 +10,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Dotnet.ProjInfo" Version="0.44.0" />
-    <!-- <PackageReference Include="FSharp.Compiler.Service" Version="28.0.0" /> -->
     <Reference Include="../../../lib/fcs/FSharp.Compiler.Service.dll" />
   </ItemGroup>
 </Project>

--- a/src/tools/InjectProcessor/InjectProcessor.fsproj
+++ b/src/tools/InjectProcessor/InjectProcessor.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
   </PropertyGroup>

--- a/tests/Dart/src/Fable.Tests.Dart.fsproj
+++ b/tests/Dart/src/Fable.Tests.Dart.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Dart/src/StringTests.fs
+++ b/tests/Dart/src/StringTests.fs
@@ -1101,8 +1101,4 @@ let tests() =
 //          let s4: FormattableString = $"I have `backticks`"
 //          s4.Format |> equal "I have `backticks`"
 //          let s5: FormattableString = $"I have {{escaped braces}} and %%percentage%%"
-// #if NET8_0_OR_GREATER
-//             s5.Format |> equal "I have {{escaped braces}} and %percentage%"
-// #elif FABLE_COMPILER
-//             s5.Format |> equal "I have {escaped braces} and %percentage%"
-// #endif
+//          s5.Format |> equal "I have {{escaped braces}} and %percentage%"

--- a/tests/Integration/Compiler/Fable.Tests.Compiler.fsproj
+++ b/tests/Integration/Compiler/Fable.Tests.Compiler.fsproj
@@ -2,18 +2,18 @@
   <PropertyGroup>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
     <DefineConstants>$(DefineConstants);DOTNET_FILE_SYSTEM</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Expecto" Version="9.0.4" />
+    <PackageReference Include="Expecto" Version="10.1.0" />
   </ItemGroup>
   <ItemGroup>
     <!-- <ProjectReference Include="../../src/Fable.Core/Fable.Core.fsproj" /> -->
-    <ProjectReference Include="..\..\..\src\Fable.AST\Fable.AST.fsproj" />
-    <ProjectReference Include="..\..\..\src\Fable.Transforms\Fable.Transforms.fsproj" />
-    <ProjectReference Include="..\..\..\src\Fable.Cli\Fable.Cli.fsproj" />
+    <ProjectReference Include="../../../src/Fable.AST/Fable.AST.fsproj" />
+    <ProjectReference Include="../../../src/Fable.Transforms/Fable.Transforms.fsproj" />
+    <ProjectReference Include="../../../src/Fable.Cli/Fable.Cli.fsproj" />
     <Reference Include="../../../lib/fcs/FSharp.Compiler.Service.dll" />
     <Reference Include="../../../lib/fcs/FSharp.Core.dll" />
   </ItemGroup>

--- a/tests/Integration/Compiler/Main.fs
+++ b/tests/Integration/Compiler/Main.fs
@@ -12,8 +12,8 @@ let allTests =
 
 [<EntryPoint>]
 let main args =
-    let config = { defaultConfig with runInParallel = false }
+    let config = [ Sequenced ]
 
     allTests
     |> testList "All"
-    |> runTestsWithArgs config args
+    |> runTestsWithCLIArgs config args

--- a/tests/Integration/Compiler/TestProject/TestProject.fsproj
+++ b/tests/Integration/Compiler/TestProject/TestProject.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
   </PropertyGroup>
 
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Fable.Core\Fable.Core.fsproj" />
+    <ProjectReference Include="../../../../src/Fable.Core/Fable.Core.fsproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Integration/Integration/Fable.Tests.Integration.fsproj
+++ b/tests/Integration/Integration/Fable.Tests.Integration.fsproj
@@ -2,11 +2,11 @@
   <PropertyGroup>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Expecto" Version="9.0.4" />
+    <PackageReference Include="Expecto" Version="10.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Fable.Cli\Fable.Cli.fsproj" />

--- a/tests/Integration/Integration/Main.fs
+++ b/tests/Integration/Integration/Main.fs
@@ -13,4 +13,4 @@ open Expecto
 [<EntryPoint>]
 let main args =
     testList "All" allTests
-    |> runTestsWithArgs defaultConfig args
+    |> runTestsWithCLIArgs [] args

--- a/tests/Integration/Integration/data/signatureHidesFunction/signatureHidesFunction.fsproj
+++ b/tests/Integration/Integration/data/signatureHidesFunction/signatureHidesFunction.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fable.Core" Version="4.1.0" />
+    <PackageReference Include="Fable.Core" Version="4.2.0" />
   </ItemGroup>
 
 </Project>

--- a/tests/Integration/ProjectConfigs/ConsoleApp/Fable.Tests.ConsoleApp.fsproj
+++ b/tests/Integration/ProjectConfigs/ConsoleApp/Fable.Tests.ConsoleApp.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
   </PropertyGroup>
 

--- a/tests/Integration/ProjectConfigs/CustomConfiguration/Fable.Tests.DefineConstants.CustomConfiguration.fsproj
+++ b/tests/Integration/ProjectConfigs/CustomConfiguration/Fable.Tests.DefineConstants.CustomConfiguration.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
     <OtherFlags>$(OtherFlags) --crossoptimize-</OtherFlags>
   </PropertyGroup>

--- a/tests/Integration/ProjectConfigs/DebugWithExtraDefines/Fable.Tests.DefineConstants.DebugWithExtraDefines.fsproj
+++ b/tests/Integration/ProjectConfigs/DebugWithExtraDefines/Fable.Tests.DefineConstants.DebugWithExtraDefines.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
     <OtherFlags>$(OtherFlags) --crossoptimize-</OtherFlags>
   </PropertyGroup>

--- a/tests/Integration/ProjectConfigs/ReleaseNoExtraDefines/Fable.Tests.DefineConstants.ReleaseNoExtraDefines.fsproj
+++ b/tests/Integration/ProjectConfigs/ReleaseNoExtraDefines/Fable.Tests.DefineConstants.ReleaseNoExtraDefines.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
     <OtherFlags>$(OtherFlags) --crossoptimize-</OtherFlags>
   </PropertyGroup>

--- a/tests/Js/Adaptive/Fable.Tests.Adaptive.fsproj
+++ b/tests/Js/Adaptive/Fable.Tests.Adaptive.fsproj
@@ -9,7 +9,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../../src/Fable.Core/Fable.Core.fsproj" />
-    <PackageReference Include="FSharp.Data.Adaptive" Version="1.2.3" />
-    <PackageReference Include="Expecto" Version="9.0.4" />
+    <PackageReference Include="FSharp.Data.Adaptive" Version="1.2.14" />
+    <PackageReference Include="Expecto" Version="10.1.0" />
   </ItemGroup>
 </Project>

--- a/tests/Js/Adaptive/Main.fs
+++ b/tests/Js/Adaptive/Main.fs
@@ -38,6 +38,6 @@ open Expecto
 let main args =
     Array.toList allTests
     |> testList "All"
-    |> runTestsWithArgs defaultConfig args
+    |> runTestsWithCLIArgs [] args
 
 #endif

--- a/tests/Js/Main/ArithmeticTests.fs
+++ b/tests/Js/Main/ArithmeticTests.fs
@@ -11,9 +11,9 @@ let [<Literal>] literalNegativeValue = -345
 let checkTo3dp (expected: float) actual =
     floor (actual * 1000.) |> equal expected
 
-let positiveInfinity = System.Double.PositiveInfinity
-let negativeInfinity = System.Double.NegativeInfinity
-let isNaN = fun x -> System.Double.IsNaN(x)
+let positiveInfinity = Double.PositiveInfinity
+let negativeInfinity = Double.NegativeInfinity
+let isNaN = fun x -> Double.IsNaN(x)
 
 let equals (x:'a) (y:'a) = x = y
 let compareTo (x:'a) (y:'a) = compare x y
@@ -34,10 +34,10 @@ let tests =
         -literalNegativeValue |> equal 345
 
     testCase "Unary negation with integer MinValue works" <| fun () ->
-        -(-128y) |> equal System.SByte.MinValue
-        -(-32768s) |> equal System.Int16.MinValue
-        -(-2147483648) |> equal System.Int32.MinValue
-        -(-9223372036854775808L) |> equal System.Int64.MinValue
+        -(-128y) |> equal SByte.MinValue
+        -(-32768s) |> equal Int16.MinValue
+        -(-2147483648) |> equal Int32.MinValue
+        -(-9223372036854775808L) |> equal Int64.MinValue
 
     testCase "Infix subtract can be generated" <| fun () ->
         4 - 2 |> equal 2
@@ -122,11 +122,11 @@ let tests =
         0x0UL * 0x1UL |> equal 0x0UL
 
     testCase "Decimal literals can be generated" <| fun () ->
-        0M |> equal System.Decimal.Zero
-        1M |> equal System.Decimal.One
-        -1M |> equal System.Decimal.MinusOne
-        79228162514264337593543950335M |> equal System.Decimal.MaxValue
-        -79228162514264337593543950335M |> equal System.Decimal.MinValue
+        0M |> equal Decimal.Zero
+        1M |> equal Decimal.One
+        -1M |> equal Decimal.MinusOne
+        79228162514264337593543950335M |> equal Decimal.MaxValue
+        -79228162514264337593543950335M |> equal Decimal.MinValue
 
     testCase "Decimal.ToString works" <| fun () ->
         string 001.23456M |> equal "1.23456"
@@ -432,20 +432,20 @@ let tests =
         checkTo3dp 1732. (sqrt 3.0)
         sqrt 0.0  |> equal 0.0
         isNaN (sqrt -3.0) |> equal true
-        isNaN (sqrt System.Double.NaN) |> equal true
+        isNaN (sqrt Double.NaN) |> equal true
         isNaN (sqrt negativeInfinity) |> equal true
         sqrt positiveInfinity |> equal positiveInfinity
 
     testCase "Double.Parse works with IFormatProvider" <| fun () ->
         // culture compiles to { } for now and it is ignored on the call-site
         let culture = Globalization.CultureInfo.InvariantCulture
-        let result = System.Double.Parse("10.5", culture)
+        let result = Double.Parse("10.5", culture)
         result |> equal 10.5
 
     testCase "Single.Parse works with IFormatProvider" <| fun () ->
         // culture compiles to { } for now and it is ignored on the call-site
         let culture = Globalization.CultureInfo.InvariantCulture
-        let result = System.Single.Parse("10.5", culture)
+        let result = Single.Parse("10.5", culture)
         float result |> equal 10.5
 
     testCase "acos works" <| fun () ->
@@ -487,19 +487,19 @@ let tests =
         checkTo3dp 1098. (log 3.0)
         log 0.0 |> equal negativeInfinity
         isNaN (log -2.0) |> equal true
-        isNaN (log System.Double.NaN) |> equal true
+        isNaN (log Double.NaN) |> equal true
         isNaN (log negativeInfinity) |> equal true
         log positiveInfinity |> equal positiveInfinity
 
     // https://github.com/dotnet/corefx/blob/master/src/System.Runtime.Extensions/tests/System/Math.cs#L239
-    testCase "Math.log with base works" <| fun () ->
+    testCase "Math.Log with base works" <| fun () ->
         Math.Log(8.0, 2.0) |> equal 3.0
         Math.Log(3.0, 3.0) |> equal 1.0
         Math.Log(14., 3.0) |> checkTo3dp 2402.
         Math.Log(0.0, 3.0) |> equal negativeInfinity
         Math.Log(positiveInfinity, 3.0) |> equal positiveInfinity
         isNaN (Math.Log(-3.0, 3.0)) |> equal true
-        isNaN (Math.Log(System.Double.NaN, 3.0)) |> equal true
+        isNaN (Math.Log(Double.NaN, 3.0)) |> equal true
         isNaN (Math.Log(negativeInfinity, 3.0)) |> equal true
 
     testCase "log10 works" <| fun () ->
@@ -511,69 +511,69 @@ let tests =
     testCase "Math.E works" <| fun () ->
         checkTo3dp 2718. Math.E
 
-    testCase "Math.abs works" <| fun () ->
+    testCase "Math.Abs works" <| fun () ->
         Math.Abs -4 |> equal 4
 
-    testCase "Math.pow works" <| fun () ->
+    testCase "Math.Pow works" <| fun () ->
         Math.Pow(2.2, 3.0) |> checkTo3dp 10648.
 
-    testCase "Math.sqrt works" <| fun () ->
+    testCase "Math.Sqrt works" <| fun () ->
         Math.Sqrt 4.5 |> checkTo3dp 2121.
 
-    testCase "Math.round works" <| fun () ->
+    testCase "Math.Round works" <| fun () ->
         Math.Round -12.5 |> equal -12.
         Math.Round 1.425 |> equal 1.
         Math.Round -1.425 |> equal -1.
         Math.Round 1.546 |> equal 2.
         Math.Round -1.546 |> equal -2.
 
-    testCase "Math.round with digits works" <| fun () ->
+    testCase "Math.Round with digits works" <| fun () ->
         Math.Round(1.426, 2) |> equal 1.43
         Math.Round(1.426, 1) |> equal 1.4
         Math.Round(-1.426, 2) |> equal -1.43
         Math.Round(-1.426, 1) |> equal -1.4
 
-    testCase "Math.truncate works" <| fun () ->
+    testCase "Math.Truncate works" <| fun () ->
         Math.Truncate -12.5 |> equal -12.
         Math.Truncate 1.425 |> equal 1.
         Math.Truncate -1.425 |> equal -1.
         Math.Truncate 1.546 |> equal 1.
         Math.Truncate -1.546 |> equal -1.
 
-    testCase "Math.ceil works" <| fun () ->
+    testCase "Math.Ceil works" <| fun () ->
         Math.Ceiling 11.25 |> equal 12.
 
-    testCase "Math.floor works" <| fun () ->
+    testCase "Math.Floor works" <| fun () ->
         Math.Floor 11.75 |> equal 11.
 
-    testCase "Math.acos works" <| fun () ->
+    testCase "Math.Acos works" <| fun () ->
         Math.Acos 0.25 |> checkTo3dp 1318.
 
-    testCase "Math.asin works" <| fun () ->
+    testCase "Math.Asin works" <| fun () ->
         Math.Asin 0.25 |> checkTo3dp 252.
 
-    testCase "Math.atan works" <| fun () ->
+    testCase "Math.Atan works" <| fun () ->
         Math.Atan 0.25 |> checkTo3dp 244.
 
-    testCase "Math.atan2 works" <| fun () ->
+    testCase "Math.Atan2 works" <| fun () ->
         Math.Atan2(90., 15.) |> checkTo3dp 1405.
 
-    testCase "Math.cos works" <| fun () ->
+    testCase "Math.Cos works" <| fun () ->
         Math.Cos(0.1 * Math.PI) |> checkTo3dp 951.
 
-    testCase "Math.sin works" <| fun () ->
+    testCase "Math.Sin works" <| fun () ->
         Math.Sin(0.25 * Math.PI) |> checkTo3dp 707.
 
-    testCase "Math.tan works" <| fun () ->
+    testCase "Math.Tan works" <| fun () ->
         Math.Tan(0.5) |> checkTo3dp 546.
 
-    testCase "Math.exp works" <| fun () ->
+    testCase "Math.Exp works" <| fun () ->
         Math.Exp 8.0 |> checkTo3dp 2980957.
 
-    testCase "Math.log works" <| fun () ->
+    testCase "Math.Log works" <| fun () ->
         Math.Log 232.12 |> checkTo3dp 5447.
 
-    testCase "Math.log2 works" <| fun () ->
+    testCase "Math.Log2 works" <| fun () ->
         Math.Log2 8.0 |> checkTo3dp 3000.
 
     testCase "Math.log10 works" <| fun () ->
@@ -588,99 +588,93 @@ let tests =
     testCase "BigInt.Log10 works" <| fun () ->
         bigint.Log10 123I |> checkTo3dp 2089.
 
-    // // TODO: enable for .NET 7.0/8.0
-    // testCase "Numeric Log2 works" <| fun () ->
-    //     System.SByte.Log2 8y |> equal 3y
-    //     System.Int16.Log2 8s |> equal 3s
-    //     System.Int32.Log2 8  |> equal 3
-    //     System.Int64.Log2 8L |> equal 3L
-    //     System.Byte.Log2 8uy |> equal 3uy
-    //     System.UInt16.Log2 8us |> equal 3us
-    //     System.UInt32.Log2 8u  |> equal 3u
-    //     System.UInt64.Log2 8UL |> equal 3UL
-    //     System.Double.Log2 8.0 |> equal 3.0
-    //     System.Single.Log2 8.0f |> equal 3.0f
-    //     bigint.Log2 8I |> equal 3I
+    testCase "Numeric Log2 works" <| fun () ->
+        SByte.Log2 8y |> equal 3y
+        Int16.Log2 8s |> equal 3s
+        Int32.Log2 8  |> equal 3
+        Int64.Log2 8L |> equal 3L
+        Byte.Log2 8uy |> equal 3uy
+        UInt16.Log2 8us |> equal 3us
+        UInt32.Log2 8u  |> equal 3u
+        UInt64.Log2 8UL |> equal 3UL
+        Double.Log2 8.0 |> equal 3.0
+        Single.Log2 8.0f |> equal 3.0f
+        bigint.Log2 8I |> equal 3I
 
-    // // TODO: enable for .NET 7.0/8.0
-    // testCase "Numeric Min works" <| fun () ->
-    //     System.SByte.Min(-4y, 3y) |> equal -4y
-    //     System.Int16.Min(-4s, 3s) |> equal -4s
-    //     System.Int32.Min(-4, 3)  |> equal -4
-    //     System.Int64.Min(-4L, 3L) |> equal -4L
-    //     System.Byte.Min(4uy, 3uy) |> equal 3uy
-    //     System.UInt16.Min(4us, 3us) |> equal 3us
-    //     System.UInt32.Min(4u, 3u)  |> equal 3u
-    //     System.UInt64.Min(4UL, 3UL) |> equal 3UL
-    //     System.Double.Min(-4.0, 3.0) |> equal -4.0
-    //     System.Single.Min(-4.0f, 3.0f) |> equal -4.0f
-    //     System.Decimal.Min(-4.0M, 3.0M) |> equal -4.0M
-    //     bigint.Min(-4I, 3I) |> equal -4I
+    testCase "Numeric Min works" <| fun () ->
+        SByte.Min(-4y, 3y) |> equal -4y
+        Int16.Min(-4s, 3s) |> equal -4s
+        Int32.Min(-4, 3)  |> equal -4
+        Int64.Min(-4L, 3L) |> equal -4L
+        Byte.Min(4uy, 3uy) |> equal 3uy
+        UInt16.Min(4us, 3us) |> equal 3us
+        UInt32.Min(4u, 3u)  |> equal 3u
+        UInt64.Min(4UL, 3UL) |> equal 3UL
+        Double.Min(-4.0, 3.0) |> equal -4.0
+        Single.Min(-4.0f, 3.0f) |> equal -4.0f
+        Decimal.Min(-4.0M, 3.0M) |> equal -4.0M
+        bigint.Min(-4I, 3I) |> equal -4I
 
-    // // TODO: enable for .NET 7.0/8.0
-    // testCase "Numeric Max works" <| fun () ->
-    //     System.SByte.Max(-4y, 3y) |> equal 3y
-    //     System.Int16.Max(-4s, 3s) |> equal 3s
-    //     System.Int32.Max(-4, 3)  |> equal 3
-    //     System.Int64.Max(-4L, 3L) |> equal 3L
-    //     System.Byte.Max(4uy, 3uy) |> equal 4uy
-    //     System.UInt16.Max(4us, 3us) |> equal 4us
-    //     System.UInt32.Max(4u, 3u)  |> equal 4u
-    //     System.UInt64.Max(4UL, 3UL) |> equal 4UL
-    //     System.Double.Max(-4.0, 3.0) |> equal 3.0
-    //     System.Single.Max(-4.0f, 3.0f) |> equal 3.0f
-    //     System.Decimal.Max(-4.0M, 3.0M) |> equal 3.0M
-    //     bigint.Max(-4I, 3I) |> equal 3I
+    testCase "Numeric Max works" <| fun () ->
+        SByte.Max(-4y, 3y) |> equal 3y
+        Int16.Max(-4s, 3s) |> equal 3s
+        Int32.Max(-4, 3)  |> equal 3
+        Int64.Max(-4L, 3L) |> equal 3L
+        Byte.Max(4uy, 3uy) |> equal 4uy
+        UInt16.Max(4us, 3us) |> equal 4us
+        UInt32.Max(4u, 3u)  |> equal 4u
+        UInt64.Max(4UL, 3UL) |> equal 4UL
+        Double.Max(-4.0, 3.0) |> equal 3.0
+        Single.Max(-4.0f, 3.0f) |> equal 3.0f
+        Decimal.Max(-4.0M, 3.0M) |> equal 3.0M
+        bigint.Max(-4I, 3I) |> equal 3I
 
-    // // TODO: enable for .NET 7.0/8.0
-    // testCase "Numeric MinMagnitude works" <| fun () ->
-    //     System.SByte.MinMagnitude(-4y, 3y) |> equal 3y
-    //     System.Int16.MinMagnitude(-4s, 3s) |> equal 3s
-    //     System.Int32.MinMagnitude(-4, 3)  |> equal 3
-    //     System.Int64.MinMagnitude(-4L, 3L) |> equal 3L
-    //     System.Double.MinMagnitude(-4.0, 3.0) |> equal 3.0
-    //     System.Single.MinMagnitude(-4.0f, 3.0f) |> equal 3.0f
-    //     System.Decimal.MinMagnitude(-4.0M, 3.0M) |> equal 3.0M
-    //     bigint.MinMagnitude(-4I, 3I) |> equal 3I
+    testCase "Numeric MinMagnitude works" <| fun () ->
+        SByte.MinMagnitude(-4y, 3y) |> equal 3y
+        Int16.MinMagnitude(-4s, 3s) |> equal 3s
+        Int32.MinMagnitude(-4, 3)  |> equal 3
+        Int64.MinMagnitude(-4L, 3L) |> equal 3L
+        Double.MinMagnitude(-4.0, 3.0) |> equal 3.0
+        Single.MinMagnitude(-4.0f, 3.0f) |> equal 3.0f
+        Decimal.MinMagnitude(-4.0M, 3.0M) |> equal 3.0M
+        bigint.MinMagnitude(-4I, 3I) |> equal 3I
 
-    // // TODO: enable for .NET 7.0/8.0
-    // testCase "Numeric MaxMagnitude works" <| fun () ->
-    //     System.SByte.MaxMagnitude(-4y, 3y) |> equal -4y
-    //     System.Int16.MaxMagnitude(-4s, 3s) |> equal -4s
-    //     System.Int32.MaxMagnitude(-4, 3)  |> equal -4
-    //     System.Int64.MaxMagnitude(-4L, 3L) |> equal -4L
-    //     System.Double.MaxMagnitude(-4.0, 3.0) |> equal -4.0
-    //     System.Single.MaxMagnitude(-4.0f, 3.0f) |> equal -4.0f
-    //     System.Decimal.MaxMagnitude(-4.0M, 3.0M) |> equal -4.0M
-    //     bigint.MaxMagnitude(-4I, 3I) |> equal -4I
+    testCase "Numeric MaxMagnitude works" <| fun () ->
+        SByte.MaxMagnitude(-4y, 3y) |> equal -4y
+        Int16.MaxMagnitude(-4s, 3s) |> equal -4s
+        Int32.MaxMagnitude(-4, 3)  |> equal -4
+        Int64.MaxMagnitude(-4L, 3L) |> equal -4L
+        Double.MaxMagnitude(-4.0, 3.0) |> equal -4.0
+        Single.MaxMagnitude(-4.0f, 3.0f) |> equal -4.0f
+        Decimal.MaxMagnitude(-4.0M, 3.0M) |> equal -4.0M
+        bigint.MaxMagnitude(-4I, 3I) |> equal -4I
 
-    // // TODO: enable for .NET 7.0/8.0
-    // testCase "Numeric Clamp works" <| fun () ->
-    //     System.SByte.Clamp(5y, -4y, 3y) |> equal 3y
-    //     System.Int16.Clamp(5s, -4s, 3s) |> equal 3s
-    //     System.Int32.Clamp(5, -4, 3)  |> equal 3
-    //     System.Int64.Clamp(5L, -4L, 3L) |> equal 3L
-    //     System.Byte.Clamp(5uy, 3uy, 4uy) |> equal 4uy
-    //     System.UInt16.Clamp(5us, 3us, 4us) |> equal 4us
-    //     System.UInt32.Clamp(5u, 3u, 4u)  |> equal 4u
-    //     System.UInt64.Clamp(5UL, 3UL, 4UL) |> equal 4UL
-    //     System.Double.Clamp(5.0, -4.0, 3.0) |> equal 3.0
-    //     System.Single.Clamp(5.0f, -4.0f, 3.0f) |> equal 3.0f
-    //     System.Decimal.Clamp(5.0M, -4.0M, 3.0M) |> equal 3.0M
-    //     bigint.Clamp(5I, -4I, 3I) |> equal 3I
+    testCase "Numeric Clamp works" <| fun () ->
+        SByte.Clamp(5y, -4y, 3y) |> equal 3y
+        Int16.Clamp(5s, -4s, 3s) |> equal 3s
+        Int32.Clamp(5, -4, 3)  |> equal 3
+        Int64.Clamp(5L, -4L, 3L) |> equal 3L
+        Byte.Clamp(5uy, 3uy, 4uy) |> equal 4uy
+        UInt16.Clamp(5us, 3us, 4us) |> equal 4us
+        UInt32.Clamp(5u, 3u, 4u)  |> equal 4u
+        UInt64.Clamp(5UL, 3UL, 4UL) |> equal 4UL
+        Double.Clamp(5.0, -4.0, 3.0) |> equal 3.0
+        Single.Clamp(5.0f, -4.0f, 3.0f) |> equal 3.0f
+        Decimal.Clamp(5.0M, -4.0M, 3.0M) |> equal 3.0M
+        bigint.Clamp(5I, -4I, 3I) |> equal 3I
 
     testCase "Math.Clamp works" <| fun () ->
-        System.Math.Clamp(5y, -4y, 3y) |> equal 3y
-        System.Math.Clamp(5s, -4s, 3s) |> equal 3s
-        System.Math.Clamp(5, -4, 3)  |> equal 3
-        System.Math.Clamp(5L, -4L, 3L) |> equal 3L
-        System.Math.Clamp(5uy, 3uy, 4uy) |> equal 4uy
-        System.Math.Clamp(5us, 3us, 4us) |> equal 4us
-        System.Math.Clamp(5u, 3u, 4u)  |> equal 4u
-        System.Math.Clamp(5UL, 3UL, 4UL) |> equal 4UL
-        System.Math.Clamp(5.0, -4.0, 3.0) |> equal 3.0
-        System.Math.Clamp(5.0f, -4.0f, 3.0f) |> equal 3.0f
-        System.Math.Clamp(5.0M, -4.0M, 3.0M) |> equal 3.0M
+        Math.Clamp(5y, -4y, 3y) |> equal 3y
+        Math.Clamp(5s, -4s, 3s) |> equal 3s
+        Math.Clamp(5, -4, 3)  |> equal 3
+        Math.Clamp(5L, -4L, 3L) |> equal 3L
+        Math.Clamp(5uy, 3uy, 4uy) |> equal 4uy
+        Math.Clamp(5us, 3us, 4us) |> equal 4us
+        Math.Clamp(5u, 3u, 4u)  |> equal 4u
+        Math.Clamp(5UL, 3UL, 4UL) |> equal 4UL
+        Math.Clamp(5.0, -4.0, 3.0) |> equal 3.0
+        Math.Clamp(5.0f, -4.0f, 3.0f) |> equal 3.0f
+        Math.Clamp(5.0M, -4.0M, 3.0M) |> equal 3.0M
 
     testCase "Math.Min works" <| fun () ->
         Math.Min(-4.0, 3.0) |> equal -4.0
@@ -709,50 +703,42 @@ let tests =
         !i |> equal 4
 
     testCase "System.Random works" <| fun () ->
-        let rnd = System.Random()
+        let rnd = Random()
         let x = rnd.Next()
         x >= 0 |> equal true
-
         let x = rnd.Next(5)
         (x >= 0 && x < 5) |> equal true
-
         let x = rnd.Next(14, 20)
         (x >= 14 && x < 20) |> equal true
-
         let x = rnd.Next(-14, -10)
         (x >= -14 && x < -10) |> equal true
-
         let x = rnd.NextDouble()
         (x >= 0.0 && x < 1.0) |> equal true
-
         throwsAnyError <| fun () -> rnd.Next(-10)
         throwsAnyError <| fun () -> rnd.Next(14, 10)
 
     // Note: Test could fail sometime during life of universe, if it picks all zeroes.
     testCase "System.Random.NextBytes works" <| fun () ->
         let buffer = Array.create 16 0uy // guid-sized buffer
-        System.Random().NextBytes(buffer)
+        Random().NextBytes(buffer)
         buffer.Length |> equal 16
         buffer = Array.create 16 0uy |> equal false
-
-        throwsAnyError <| fun () -> System.Random().NextBytes(null)
+        throwsAnyError <| fun () -> Random().NextBytes(null)
 
     testCase "System.Random seeded works" <| fun () ->
-        let rnd = System.Random(1234)
+        let rnd = Random(1234)
         rnd.Next() |> equal 857019877
         rnd.Next(100) |> equal 89
         rnd.Next(1000, 10000) |> equal 3872
         rnd.NextDouble() |> equal 0.9467375338760845
-
         throwsAnyError <| fun () -> rnd.Next(-10)
         throwsAnyError <| fun () -> rnd.Next(14, 10)
 
     testCase "System.Random.NextBytes seeded works" <| fun () ->
         let buffer = Array.create 4 0uy // guid-sized buffer
-        System.Random(5432).NextBytes(buffer)
+        Random(5432).NextBytes(buffer)
         buffer |> equal [|152uy; 238uy; 227uy; 30uy|]
-
-        throwsAnyError <| fun () -> System.Random().NextBytes(null)
+        throwsAnyError <| fun () -> Random().NextBytes(null)
 
     testCase "Long integers equality works" <| fun () ->
         let x = 5L

--- a/tests/Js/Main/DateOnlyTests.fs
+++ b/tests/Js/Main/DateOnlyTests.fs
@@ -151,10 +151,10 @@ let tests =
             equal (DateOnly (2000, 11, 30)) (DateOnly.Parse("11/30/2000", CultureInfo.InvariantCulture))
             equal (DateOnly (2020, 1, 3)) (DateOnly.Parse("01/03/20", CultureInfo.InvariantCulture))
             equal (DateOnly (1999, 1, 3)) (DateOnly.Parse("01,03,99", CultureInfo.InvariantCulture))
-#if NET8_0_OR_GREATER
-            equal (DateOnly (2030, 1, 3)) (DateOnly.Parse("01 -03- 30", CultureInfo.InvariantCulture))
-#elif FABLE_COMPILER
+#if FABLE_COMPILER
             equal (DateOnly (1930, 1, 3)) (DateOnly.Parse("01 -03- 30", CultureInfo.InvariantCulture))
+#else //NET8_0_OR_GREATER
+            equal (DateOnly (2030, 1, 3)) (DateOnly.Parse("01 -03- 30", CultureInfo.InvariantCulture))
 #endif
             equal (DateOnly (2000, 12, 3)) (DateOnly.Parse("12.03.00", CultureInfo.InvariantCulture))
             equal (DateOnly (2000, 1, 12)) (DateOnly.Parse("01-12-00", CultureInfo.InvariantCulture))

--- a/tests/Js/Main/Fable.Tests.fsproj
+++ b/tests/Js/Main/Fable.Tests.fsproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
     <OtherFlags>$(OtherFlags) --crossoptimize- --nowarn:3370</OtherFlags>
     <FableDefinesQueue>True</FableDefinesQueue>
  </PropertyGroup>
 
  <ItemGroup>
-    <PackageReference Include="Expecto" Version="9.0.4" />
+    <PackageReference Include="Expecto" Version="10.1.0" />
     <PackageReference Include="AltCover" Version="5.3.675" />
     <PackageReference Include="Fable.JsonProvider" Version="1.1.1" />
     <PackageReference Include="FSharp.UMX" Version="1.1.0" />

--- a/tests/Js/Main/Main.fs
+++ b/tests/Js/Main/Main.fs
@@ -88,6 +88,6 @@ open Expecto
 let main args =
     Array.toList allTests
     |> testList "All"
-    |> runTestsWithArgs defaultConfig args
+    |> runTestsWithCLIArgs [] args
 
 #endif

--- a/tests/Js/Main/StringTests.fs
+++ b/tests/Js/Main/StringTests.fs
@@ -1112,11 +1112,7 @@ let tests =
           let s4: FormattableString = $"I have `backticks`"
           s4.Format |> equal "I have `backticks`"
           let s5: FormattableString = $"I have {{escaped braces}} and %%percentage%%"
-#if NET8_0_OR_GREATER
           s5.Format |> equal "I have {{escaped braces}} and %percentage%"
-#elif FABLE_COMPILER
-          s5.Format |> equal "I have {escaped braces} and %percentage%"
-#endif
           ()
 
 #if FABLE_COMPILER

--- a/tests/Php/Fable.Tests.Php.fsproj
+++ b/tests/Php/Fable.Tests.Php.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>

--- a/tests/Python/TestArithmetic.fs
+++ b/tests/Python/TestArithmetic.fs
@@ -145,11 +145,11 @@ let ``test UInt64 multiplication with 0 returns uint`` () = // See #1480
 
 [<Fact>]
 let ``test Decimal literals can be generated`` () =
-    0M |> equal System.Decimal.Zero
-    1M |> equal System.Decimal.One
-    -1M |> equal System.Decimal.MinusOne
-    // FIXME: 79228162514264337593543950335M |> equal System.Decimal.MaxValue
-    // FIXME: -79228162514264337593543950335M |> equal System.Decimal.MinValue
+    0M |> equal Decimal.Zero
+    1M |> equal Decimal.One
+    -1M |> equal Decimal.MinusOne
+    // FIXME: 79228162514264337593543950335M |> equal Decimal.MaxValue
+    // FIXME: -79228162514264337593543950335M |> equal Decimal.MinValue
 
 [<Fact>]
 let ``test Decimal.ToString works`` () =
@@ -624,7 +624,7 @@ let ``test log works`` () =
 
 // https://github.com/dotnet/corefx/blob/master/src/System.Runtime.Extensions/tests/System/Math.cs#L239
 [<Fact>]
-let ``test Math.log with base works`` () =
+let ``test Math.Log with base works`` () =
     Math.Log(8.0, 2.0) |> equal 3.0
     Math.Log(3.0, 3.0) |> equal 1.0
     Math.Log(14., 3.0) |> checkTo3dp 2402.
@@ -647,19 +647,19 @@ let ``test Math.E works`` () =
     checkTo3dp 2718. Math.E
 
 [<Fact>]
-let ``test Math.abs works`` () =
+let ``test Math.Abs works`` () =
     Math.Abs -4 |> equal 4
 
 [<Fact>]
-let ``test Math.pow works`` () =
+let ``test Math.Pow works`` () =
     Math.Pow(2.2, 3.0) |> checkTo3dp 10648.
 
 [<Fact>]
-let ``test Math.sqrt works`` () =
+let ``test Math.Sqrt works`` () =
     Math.Sqrt 4.5 |> checkTo3dp 2121.
 
 [<Fact>]
-let ``test Math.round works`` () =
+let ``test Math.Round works`` () =
     Math.Round -12.5 |> equal -12.
     Math.Round 1.425 |> equal 1.
     Math.Round -1.425 |> equal -1.
@@ -667,14 +667,14 @@ let ``test Math.round works`` () =
     Math.Round -1.546 |> equal -2.
 
 [<Fact>]
-let ``test Math.round with digits works`` () =
+let ``test Math.Round with digits works`` () =
     Math.Round(1.426, 2) |> equal 1.43
     Math.Round(1.426, 1) |> equal 1.4
     Math.Round(-1.426, 2) |> equal -1.43
     Math.Round(-1.426, 1) |> equal -1.4
 
 [<Fact>]
-let ``test Math.truncate works`` () =
+let ``test Math.Truncate works`` () =
     Math.Truncate -12.5 |> equal -12.
     Math.Truncate 1.425 |> equal 1.
     Math.Truncate -1.425 |> equal -1.
@@ -682,55 +682,55 @@ let ``test Math.truncate works`` () =
     Math.Truncate -1.546 |> equal -1.
 
 [<Fact>]
-let ``test Math.ceil works`` () =
+let ``test Math.Ceil works`` () =
     Math.Ceiling 11.25 |> equal 12.
 
 [<Fact>]
-let ``test Math.floor works`` () =
+let ``test Math.Floor works`` () =
     Math.Floor 11.75 |> equal 11.
 
 [<Fact>]
-let ``test Math.acos works`` () =
+let ``test Math.Acos works`` () =
     Math.Acos 0.25 |> checkTo3dp 1318.
 
 [<Fact>]
-let ``test Math.asin works`` () =
+let ``test Math.Asin works`` () =
     Math.Asin 0.25 |> checkTo3dp 252.
 
 [<Fact>]
-let ``test Math.atan works`` () =
+let ``test Math.Atan works`` () =
     Math.Atan 0.25 |> checkTo3dp 244.
 
 [<Fact>]
-let ``test Math.atan2 works`` () =
+let ``test Math.Atan2 works`` () =
     Math.Atan2(90., 15.) |> checkTo3dp 1405.
 
 [<Fact>]
-let ``test Math.cos works`` () =
+let ``test Math.Cos works`` () =
     Math.Cos(0.1 * Math.PI) |> checkTo3dp 951.
 
 [<Fact>]
-let ``test Math.sin works`` () =
+let ``test Math.Sin works`` () =
     Math.Sin(0.25 * Math.PI) |> checkTo3dp 707.
 
 [<Fact>]
-let ``test Math.tan works`` () =
+let ``test Math.Tan works`` () =
     Math.Tan(0.5) |> checkTo3dp 546.
 
 [<Fact>]
-let ``test Math.exp works`` () =
+let ``test Math.Exp works`` () =
     Math.Exp 8.0 |> checkTo3dp 2980957.
 
 [<Fact>]
-let ``test Math.log works`` () =
+let ``test Math.Log works`` () =
     Math.Log 232.12 |> checkTo3dp 5447.
 
 // [<Fact>]
-// let ``test Math.log2 works`` () =
+// let ``test Math.Log2 works`` () =
 //     Math.Log2 8.0 |> checkTo3dp 3000.
 
 [<Fact>]
-let ``test Math.log10 works`` () =
+let ``test Math.Log10 works`` () =
     Math.Log10 232.12 |> checkTo3dp 2365.
 
 // [<Fact>]
@@ -745,106 +745,100 @@ let ``test Math.log10 works`` () =
 // let ``test BigInt.Log10 works`` () =
 //     bigint.Log10 123I |> checkTo3dp 2089.
 
-// // TODO: enable for .NET 7.0/8.0
 // [<Fact>]
 // let ``test Numeric Log2 works`` () =
-//     System.SByte.Log2 8y |> equal 3y
-//     System.Int16.Log2 8s |> equal 3s
-//     System.Int32.Log2 8  |> equal 3
-//     System.Int64.Log2 8L |> equal 3L
-//     System.Byte.Log2 8uy |> equal 3uy
-//     System.UInt16.Log2 8us |> equal 3us
-//     System.UInt32.Log2 8u  |> equal 3u
-//     System.UInt64.Log2 8UL |> equal 3UL
-//     System.Double.Log2 8.0 |> equal 3.0
-//     System.Single.Log2 8.0f |> equal 3.0f
+//     SByte.Log2 8y |> equal 3y
+//     Int16.Log2 8s |> equal 3s
+//     Int32.Log2 8  |> equal 3
+//     Int64.Log2 8L |> equal 3L
+//     Byte.Log2 8uy |> equal 3uy
+//     UInt16.Log2 8us |> equal 3us
+//     UInt32.Log2 8u  |> equal 3u
+//     UInt64.Log2 8UL |> equal 3UL
+//     Double.Log2 8.0 |> equal 3.0
+//     Single.Log2 8.0f |> equal 3.0f
 //     bigint.Log2 8I |> equal 3I
 
-// // TODO: enable for .NET 7.0/8.0
 // [<Fact>]
 // let ``test Numeric Min works`` () =
-//     System.SByte.Min(-4y, 3y) |> equal -4y
-//     System.Int16.Min(-4s, 3s) |> equal -4s
-//     System.Int32.Min(-4, 3)  |> equal -4
-//     System.Int64.Min(-4L, 3L) |> equal -4L
-//     System.Byte.Min(4uy, 3uy) |> equal 3uy
-//     System.UInt16.Min(4us, 3us) |> equal 3us
-//     System.UInt32.Min(4u, 3u)  |> equal 3u
-//     System.UInt64.Min(4UL, 3UL) |> equal 3UL
-//     System.Double.Min(-4.0, 3.0) |> equal -4.0
-//     System.Single.Min(-4.0f, 3.0f) |> equal -4.0f
-//     System.Decimal.Min(-4.0M, 3.0M) |> equal -4.0M
+//     SByte.Min(-4y, 3y) |> equal -4y
+//     Int16.Min(-4s, 3s) |> equal -4s
+//     Int32.Min(-4, 3)  |> equal -4
+//     Int64.Min(-4L, 3L) |> equal -4L
+//     Byte.Min(4uy, 3uy) |> equal 3uy
+//     UInt16.Min(4us, 3us) |> equal 3us
+//     UInt32.Min(4u, 3u)  |> equal 3u
+//     UInt64.Min(4UL, 3UL) |> equal 3UL
+//     Double.Min(-4.0, 3.0) |> equal -4.0
+//     Single.Min(-4.0f, 3.0f) |> equal -4.0f
+//     Decimal.Min(-4.0M, 3.0M) |> equal -4.0M
 //     bigint.Min(-4I, 3I) |> equal -4I
 
-// // TODO: enable for .NET 7.0/8.0
 // [<Fact>]
 // let ``test Numeric Max works`` () =
-//     System.SByte.Max(-4y, 3y) |> equal 3y
-//     System.Int16.Max(-4s, 3s) |> equal 3s
-//     System.Int32.Max(-4, 3)  |> equal 3
-//     System.Int64.Max(-4L, 3L) |> equal 3L
-//     System.Byte.Max(4uy, 3uy) |> equal 4uy
-//     System.UInt16.Max(4us, 3us) |> equal 4us
-//     System.UInt32.Max(4u, 3u)  |> equal 4u
-//     System.UInt64.Max(4UL, 3UL) |> equal 4UL
-//     System.Double.Max(-4.0, 3.0) |> equal 3.0
-//     System.Single.Max(-4.0f, 3.0f) |> equal 3.0f
-//     System.Decimal.Max(-4.0M, 3.0M) |> equal 3.0M
+//     SByte.Max(-4y, 3y) |> equal 3y
+//     Int16.Max(-4s, 3s) |> equal 3s
+//     Int32.Max(-4, 3)  |> equal 3
+//     Int64.Max(-4L, 3L) |> equal 3L
+//     Byte.Max(4uy, 3uy) |> equal 4uy
+//     UInt16.Max(4us, 3us) |> equal 4us
+//     UInt32.Max(4u, 3u)  |> equal 4u
+//     UInt64.Max(4UL, 3UL) |> equal 4UL
+//     Double.Max(-4.0, 3.0) |> equal 3.0
+//     Single.Max(-4.0f, 3.0f) |> equal 3.0f
+//     Decimal.Max(-4.0M, 3.0M) |> equal 3.0M
 //     bigint.Max(-4I, 3I) |> equal 3I
 
-// // TODO: enable for .NET 7.0/8.0
 // [<Fact>]
 // let ``test Numeric MinMagnitude works`` () =
-//     System.SByte.MinMagnitude(-4y, 3y) |> equal 3y
-//     System.Int16.MinMagnitude(-4s, 3s) |> equal 3s
-//     System.Int32.MinMagnitude(-4, 3)  |> equal 3
-//     System.Int64.MinMagnitude(-4L, 3L) |> equal 3L
-//     System.Double.MinMagnitude(-4.0, 3.0) |> equal 3.0
-//     System.Single.MinMagnitude(-4.0f, 3.0f) |> equal 3.0f
-//     System.Decimal.MinMagnitude(-4.0M, 3.0M) |> equal 3.0M
+//     SByte.MinMagnitude(-4y, 3y) |> equal 3y
+//     Int16.MinMagnitude(-4s, 3s) |> equal 3s
+//     Int32.MinMagnitude(-4, 3)  |> equal 3
+//     Int64.MinMagnitude(-4L, 3L) |> equal 3L
+//     Double.MinMagnitude(-4.0, 3.0) |> equal 3.0
+//     Single.MinMagnitude(-4.0f, 3.0f) |> equal 3.0f
+//     Decimal.MinMagnitude(-4.0M, 3.0M) |> equal 3.0M
 //     bigint.MinMagnitude(-4I, 3I) |> equal 3I
 
-// // TODO: enable for .NET 7.0/8.0
 // [<Fact>]
 // let ``test Numeric MaxMagnitude works`` () =
-//     System.SByte.MaxMagnitude(-4y, 3y) |> equal -4y
-//     System.Int16.MaxMagnitude(-4s, 3s) |> equal -4s
-//     System.Int32.MaxMagnitude(-4, 3)  |> equal -4
-//     System.Int64.MaxMagnitude(-4L, 3L) |> equal -4L
-//     System.Double.MaxMagnitude(-4.0, 3.0) |> equal -4.0
-//     System.Single.MaxMagnitude(-4.0f, 3.0f) |> equal -4.0f
-//     System.Decimal.MaxMagnitude(-4.0M, 3.0M) |> equal -4.0M
+//     SByte.MaxMagnitude(-4y, 3y) |> equal -4y
+//     Int16.MaxMagnitude(-4s, 3s) |> equal -4s
+//     Int32.MaxMagnitude(-4, 3)  |> equal -4
+//     Int64.MaxMagnitude(-4L, 3L) |> equal -4L
+//     Double.MaxMagnitude(-4.0, 3.0) |> equal -4.0
+//     Single.MaxMagnitude(-4.0f, 3.0f) |> equal -4.0f
+//     Decimal.MaxMagnitude(-4.0M, 3.0M) |> equal -4.0M
 //     bigint.MaxMagnitude(-4I, 3I) |> equal -4I
 
-// // TODO: enable for .NET 7.0/8.0
 // [<Fact>]
 // let ``test Numeric Clamp works`` () =
-//     System.SByte.Clamp(5y, -4y, 3y) |> equal 3y
-//     System.Int16.Clamp(5s, -4s, 3s) |> equal 3s
-//     System.Int32.Clamp(5, -4, 3)  |> equal 3
-//     System.Int64.Clamp(5L, -4L, 3L) |> equal 3L
-//     System.Byte.Clamp(5uy, 3uy, 4uy) |> equal 4uy
-//     System.UInt16.Clamp(5us, 3us, 4us) |> equal 4us
-//     System.UInt32.Clamp(5u, 3u, 4u)  |> equal 4u
-//     System.UInt64.Clamp(5UL, 3UL, 4UL) |> equal 4UL
-//     System.Double.Clamp(5.0, -4.0, 3.0) |> equal 3.0
-//     System.Single.Clamp(5.0f, -4.0f, 3.0f) |> equal 3.0f
-//     System.Decimal.Clamp(5.0M, -4.0M, 3.0M) |> equal 3.0M
+//     SByte.Clamp(5y, -4y, 3y) |> equal 3y
+//     Int16.Clamp(5s, -4s, 3s) |> equal 3s
+//     Int32.Clamp(5, -4, 3)  |> equal 3
+//     Int64.Clamp(5L, -4L, 3L) |> equal 3L
+//     Byte.Clamp(5uy, 3uy, 4uy) |> equal 4uy
+//     UInt16.Clamp(5us, 3us, 4us) |> equal 4us
+//     UInt32.Clamp(5u, 3u, 4u)  |> equal 4u
+//     UInt64.Clamp(5UL, 3UL, 4UL) |> equal 4UL
+//     Double.Clamp(5.0, -4.0, 3.0) |> equal 3.0
+//     Single.Clamp(5.0f, -4.0f, 3.0f) |> equal 3.0f
+//     Decimal.Clamp(5.0M, -4.0M, 3.0M) |> equal 3.0M
 //     bigint.Clamp(5I, -4I, 3I) |> equal 3I
 
 [<Fact>]
 let ``test Math.Clamp works`` () =
-    System.Math.Clamp(5y, -4y, 3y) |> equal 3y
-    System.Math.Clamp(5s, -4s, 3s) |> equal 3s
-    System.Math.Clamp(5, -4, 3)  |> equal 3
-    System.Math.Clamp(5L, -4L, 3L) |> equal 3L
-    System.Math.Clamp(5uy, 3uy, 4uy) |> equal 4uy
-    System.Math.Clamp(5us, 3us, 4us) |> equal 4us
-    System.Math.Clamp(5u, 3u, 4u)  |> equal 4u
-    System.Math.Clamp(5UL, 3UL, 4UL) |> equal 4UL
-    System.Math.Clamp(5.0, -4.0, 3.0) |> equal 3.0
-    System.Math.Clamp(5.0f, -4.0f, 3.0f) |> equal 3.0f
-    System.Math.Clamp(5.0M, -4.0M, 3.0M) |> equal 3.0M
+    Math.Clamp(5y, -4y, 3y) |> equal 3y
+    Math.Clamp(5s, -4s, 3s) |> equal 3s
+    Math.Clamp(5, -4, 3)  |> equal 3
+    Math.Clamp(5L, -4L, 3L) |> equal 3L
+    Math.Clamp(5uy, 3uy, 4uy) |> equal 4uy
+    Math.Clamp(5us, 3us, 4us) |> equal 4us
+    Math.Clamp(5u, 3u, 4u)  |> equal 4u
+    Math.Clamp(5UL, 3UL, 4UL) |> equal 4UL
+    Math.Clamp(5.0, -4.0, 3.0) |> equal 3.0
+    Math.Clamp(5.0f, -4.0f, 3.0f) |> equal 3.0f
+    Math.Clamp(5.0M, -4.0M, 3.0M) |> equal 3.0M
 
 [<Fact>]
 let ``test Math.Min works`` () =
@@ -884,20 +878,47 @@ let ``test decr works`` () =
     i.Value <- i.Value - 1
     i.Value |> equal 2
 
-// [<Fact>]
-// let ``test System.Random works`` () =
-//     let rnd = Random()
-//     let x = rnd.Next(5)
-//     (x >= 0 && x < 5) |> equal true
-//     let y = rnd.NextDouble()
-//     (y >= 0.0 && y < 1.0) |> equal true
+[<Fact>]
+let ``test System.Random works`` () =
+    let rnd = Random()
+    let x = rnd.Next()
+    x >= 0 |> equal true
+    let x = rnd.Next(5)
+    (x >= 0 && x < 5) |> equal true
+    let x = rnd.Next(14, 20)
+    (x >= 14 && x < 20) |> equal true
+    let x = rnd.Next(-14, -10)
+    (x >= -14 && x < -10) |> equal true
+    let x = rnd.NextDouble()
+    (x >= 0.0 && x < 1.0) |> equal true
+    throwsAnyError <| fun () -> rnd.Next(-10)
+    throwsAnyError <| fun () -> rnd.Next(14, 10)
 
 // // Note: Test could fail sometime during life of universe, if it picks all zeroes.
 // [<Fact>]
 // let ``test System.Random.NextBytes works`` () =
 //     let buffer = Array.create 16 0uy // guid-sized buffer
 //     Random().NextBytes(buffer)
+//     buffer.Length |> equal 16
 //     buffer = Array.create 16 0uy |> equal false
+//     throwsAnyError <| fun () -> Random().NextBytes(null)
+
+// [<Fact>]
+// let ``test System.Random seeded works`` () =
+//     let rnd = Random(1234)
+//     rnd.Next() |> equal 857019877
+//     rnd.Next(100) |> equal 89
+//     rnd.Next(1000, 10000) |> equal 3872
+//     rnd.NextDouble() |> equal 0.9467375338760845
+//     throwsAnyError <| fun () -> rnd.Next(-10)
+//     throwsAnyError <| fun () -> rnd.Next(14, 10)
+
+// [<Fact>]
+// let ``test System.Random.NextBytes seeded works`` () =
+//     let buffer = Array.create 4 0uy // guid-sized buffer
+//     Random(5432).NextBytes(buffer)
+//     buffer |> equal [|152uy; 238uy; 227uy; 30uy|]
+//     throwsAnyError <| fun () -> Random().NextBytes(null)
 
 [<Fact>]
 let ``test Long integer equality works`` () =
@@ -1080,27 +1101,6 @@ let ``test Sign operator works with bigints`` () =
 //         let b = { x = 3f<m>; y = 1f<m> }
 //         let res = a + b
 //         equal { x = 5f<m>; y = 2f<m> } res
-
-[<Fact>]
-let ``test System.Random works`` () =
-    let rnd = System.Random()
-    let x = rnd.Next()
-    x >= 0 |> equal true
-
-    let x = rnd.Next(5)
-    (x >= 0 && x < 5) |> equal true
-
-    let x = rnd.Next(14, 20)
-    (x >= 14 && x < 20) |> equal true
-
-    let x = rnd.Next(-14, -10)
-    (x >= -14 && x < -10) |> equal true
-
-    let x = rnd.NextDouble()
-    (x >= 0.0 && x < 1.0) |> equal true
-
-    throwsAnyError <| fun () -> rnd.Next(-10)
-    throwsAnyError <| fun () -> rnd.Next(14, 10)
 
 [<Fact>]
 let ``test extreme values work`` () =

--- a/tests/React/Fable.Tests.React.fsproj
+++ b/tests/React/Fable.Tests.React.fsproj
@@ -8,7 +8,7 @@
     <Compile Include="__tests__/Tests.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Fable.Core" Version="4.0.0-snake-island-alpha-007" />
+    <PackageReference Include="Fable.Core" Version="4.2.0" />
     <PackageReference Include="Fable.FluentUI" Version="0.7.0" />
     <PackageReference Include="Fable.Jester" Version="0.33.0" />
     <PackageReference Include="Fable.React" Version="8.0.1" />

--- a/tests/Rust/Fable.Tests.Rust.fsproj
+++ b/tests/Rust/Fable.Tests.Rust.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>

--- a/tests/Rust/tests/src/ArithmeticTests.fs
+++ b/tests/Rust/tests/src/ArithmeticTests.fs
@@ -144,11 +144,11 @@ let ``UInt64 multiplication with 0 returns uint`` () = // See #1480
 
 [<Fact>]
 let ``Decimal literals can be generated`` () =
-    0M |> equal System.Decimal.Zero
-    1M |> equal System.Decimal.One
-    -1M |> equal System.Decimal.MinusOne
-    79228162514264337593543950335M |> equal System.Decimal.MaxValue
-    -79228162514264337593543950335M |> equal System.Decimal.MinValue
+    0M |> equal Decimal.Zero
+    1M |> equal Decimal.One
+    -1M |> equal Decimal.MinusOne
+    79228162514264337593543950335M |> equal Decimal.MaxValue
+    -79228162514264337593543950335M |> equal Decimal.MinValue
 
 [<Fact>]
 let ``Decimal.ToString works`` () =
@@ -622,7 +622,7 @@ let ``log works`` () =
 
 // https://github.com/dotnet/corefx/blob/master/src/System.Runtime.Extensions/tests/System/Math.cs#L239
 [<Fact>]
-let ``Math.log with base works`` () =
+let ``Math.Log with base works`` () =
     Math.Log(8.0, 2.0) |> equal 3.0
     Math.Log(3.0, 3.0) |> equal 1.0
     Math.Log(14., 3.0) |> checkTo3dp 2402.
@@ -645,19 +645,22 @@ let ``Math.E works`` () =
     checkTo3dp 2718. Math.E
 
 [<Fact>]
-let ``Math.abs works`` () =
+let ``Math.Abs works`` () =
     Math.Abs -4 |> equal 4
 
 [<Fact>]
-let ``Math.pow works`` () =
+let ``Math.Pow works`` () =
     Math.Pow(2.2, 3.0) |> checkTo3dp 10648.
 
 [<Fact>]
-let ``Math.sqrt works`` () =
+let ``Math.Sqrt works`` () =
     Math.Sqrt 4.5 |> checkTo3dp 2121.
 
+// Default Rust round is away from zero, .NET is to even.
+// Uncomment these when Rust round-to-even is stable.
+
 // [<Fact>]
-// let ``Math.round works`` () =
+// let ``Math.Round works`` () =
 //     Math.Round -12.5 |> equal -12.
 //     Math.Round 1.425 |> equal 1.
 //     Math.Round -1.425 |> equal -1.
@@ -665,14 +668,14 @@ let ``Math.sqrt works`` () =
 //     Math.Round -1.546 |> equal -2.
 
 // [<Fact>]
-// let ``Math.round with digits works`` () =
+// let ``Math.Round with digits works`` () =
 //     Math.Round(1.426, 2) |> equal 1.43
 //     Math.Round(1.426, 1) |> equal 1.4
 //     Math.Round(-1.426, 2) |> equal -1.43
 //     Math.Round(-1.426, 1) |> equal -1.4
 
 [<Fact>]
-let ``Math.truncate works`` () =
+let ``Math.Truncate works`` () =
     Math.Truncate -12.5 |> equal -12.
     Math.Truncate 1.425 |> equal 1.
     Math.Truncate -1.425 |> equal -1.
@@ -680,55 +683,55 @@ let ``Math.truncate works`` () =
     Math.Truncate -1.546 |> equal -1.
 
 [<Fact>]
-let ``Math.ceil works`` () =
+let ``Math.Ceil works`` () =
     Math.Ceiling 11.25 |> equal 12.
 
 [<Fact>]
-let ``Math.floor works`` () =
+let ``Math.Floor works`` () =
     Math.Floor 11.75 |> equal 11.
 
 [<Fact>]
-let ``Math.acos works`` () =
+let ``Math.Acos works`` () =
     Math.Acos 0.25 |> checkTo3dp 1318.
 
 [<Fact>]
-let ``Math.asin works`` () =
+let ``Math.Asin works`` () =
     Math.Asin 0.25 |> checkTo3dp 252.
 
 [<Fact>]
-let ``Math.atan works`` () =
+let ``Math.Atan works`` () =
     Math.Atan 0.25 |> checkTo3dp 244.
 
 [<Fact>]
-let ``Math.atan2 works`` () =
+let ``Math.Atan2 works`` () =
     Math.Atan2(90., 15.) |> checkTo3dp 1405.
 
 [<Fact>]
-let ``Math.cos works`` () =
+let ``Math.Cos works`` () =
     Math.Cos(0.1 * Math.PI) |> checkTo3dp 951.
 
 [<Fact>]
-let ``Math.sin works`` () =
+let ``Math.Sin works`` () =
     Math.Sin(0.25 * Math.PI) |> checkTo3dp 707.
 
 [<Fact>]
-let ``Math.tan works`` () =
+let ``Math.Tan works`` () =
     Math.Tan(0.5) |> checkTo3dp 546.
 
 [<Fact>]
-let ``Math.exp works`` () =
+let ``Math.Exp works`` () =
     Math.Exp 8.0 |> checkTo3dp 2980957.
 
 [<Fact>]
-let ``Math.log works`` () =
+let ``Math.Log works`` () =
     Math.Log 232.12 |> checkTo3dp 5447.
 
 [<Fact>]
-let ``Math.log2 works`` () =
+let ``Math.Log2 works`` () =
     Math.Log2 8.0 |> checkTo3dp 3000.
 
 [<Fact>]
-let ``Math.log10 works`` () =
+let ``Math.Log10 works`` () =
     Math.Log10 232.12 |> checkTo3dp 2365.
 
 [<Fact>]
@@ -743,106 +746,100 @@ let ``BigInt.Log with base works`` () =
 let ``BigInt.Log10 works`` () =
     bigint.Log10 123I |> checkTo3dp 2089.
 
-// // TODO: enable for .NET 7.0/8.0
-// [<Fact>]
-// let ``Numeric Log2 works`` () =
-//     System.SByte.Log2 8y |> equal 3y
-//     System.Int16.Log2 8s |> equal 3s
-//     System.Int32.Log2 8  |> equal 3
-//     System.Int64.Log2 8L |> equal 3L
-//     System.Byte.Log2 8uy |> equal 3uy
-//     System.UInt16.Log2 8us |> equal 3us
-//     System.UInt32.Log2 8u  |> equal 3u
-//     System.UInt64.Log2 8UL |> equal 3UL
-//     System.Double.Log2 8.0 |> equal 3.0
-//     System.Single.Log2 8.0f |> equal 3.0f
-//     bigint.Log2 8I |> equal 3I
+[<Fact>]
+let ``Numeric Log2 works`` () =
+    SByte.Log2 8y |> equal 3y
+    Int16.Log2 8s |> equal 3s
+    Int32.Log2 8  |> equal 3
+    Int64.Log2 8L |> equal 3L
+    Byte.Log2 8uy |> equal 3uy
+    UInt16.Log2 8us |> equal 3us
+    UInt32.Log2 8u  |> equal 3u
+    UInt64.Log2 8UL |> equal 3UL
+    Double.Log2 8.0 |> equal 3.0
+    Single.Log2 8.0f |> equal 3.0f
+    bigint.Log2 8I |> equal 3I
 
-// // TODO: enable for .NET 7.0/8.0
-// [<Fact>]
-// let ``Numeric Min works`` () =
-//     System.SByte.Min(-4y, 3y) |> equal -4y
-//     System.Int16.Min(-4s, 3s) |> equal -4s
-//     System.Int32.Min(-4, 3)  |> equal -4
-//     System.Int64.Min(-4L, 3L) |> equal -4L
-//     System.Byte.Min(4uy, 3uy) |> equal 3uy
-//     System.UInt16.Min(4us, 3us) |> equal 3us
-//     System.UInt32.Min(4u, 3u)  |> equal 3u
-//     System.UInt64.Min(4UL, 3UL) |> equal 3UL
-//     System.Double.Min(-4.0, 3.0) |> equal -4.0
-//     System.Single.Min(-4.0f, 3.0f) |> equal -4.0f
-//     System.Decimal.Min(-4.0M, 3.0M) |> equal -4.0M
-//     bigint.Min(-4I, 3I) |> equal -4I
+[<Fact>]
+let ``Numeric Min works`` () =
+    SByte.Min(-4y, 3y) |> equal -4y
+    Int16.Min(-4s, 3s) |> equal -4s
+    Int32.Min(-4, 3)  |> equal -4
+    Int64.Min(-4L, 3L) |> equal -4L
+    Byte.Min(4uy, 3uy) |> equal 3uy
+    UInt16.Min(4us, 3us) |> equal 3us
+    UInt32.Min(4u, 3u)  |> equal 3u
+    UInt64.Min(4UL, 3UL) |> equal 3UL
+    Double.Min(-4.0, 3.0) |> equal -4.0
+    Single.Min(-4.0f, 3.0f) |> equal -4.0f
+    Decimal.Min(-4.0M, 3.0M) |> equal -4.0M
+    bigint.Min(-4I, 3I) |> equal -4I
 
-// // TODO: enable for .NET 7.0/8.0
-// [<Fact>]
-// let ``Numeric Max works`` () =
-//     System.SByte.Max(-4y, 3y) |> equal 3y
-//     System.Int16.Max(-4s, 3s) |> equal 3s
-//     System.Int32.Max(-4, 3)  |> equal 3
-//     System.Int64.Max(-4L, 3L) |> equal 3L
-//     System.Byte.Max(4uy, 3uy) |> equal 4uy
-//     System.UInt16.Max(4us, 3us) |> equal 4us
-//     System.UInt32.Max(4u, 3u)  |> equal 4u
-//     System.UInt64.Max(4UL, 3UL) |> equal 4UL
-//     System.Double.Max(-4.0, 3.0) |> equal 3.0
-//     System.Single.Max(-4.0f, 3.0f) |> equal 3.0f
-//     System.Decimal.Max(-4.0M, 3.0M) |> equal 3.0M
-//     bigint.Max(-4I, 3I) |> equal 3I
+[<Fact>]
+let ``Numeric Max works`` () =
+    SByte.Max(-4y, 3y) |> equal 3y
+    Int16.Max(-4s, 3s) |> equal 3s
+    Int32.Max(-4, 3)  |> equal 3
+    Int64.Max(-4L, 3L) |> equal 3L
+    Byte.Max(4uy, 3uy) |> equal 4uy
+    UInt16.Max(4us, 3us) |> equal 4us
+    UInt32.Max(4u, 3u)  |> equal 4u
+    UInt64.Max(4UL, 3UL) |> equal 4UL
+    Double.Max(-4.0, 3.0) |> equal 3.0
+    Single.Max(-4.0f, 3.0f) |> equal 3.0f
+    Decimal.Max(-4.0M, 3.0M) |> equal 3.0M
+    bigint.Max(-4I, 3I) |> equal 3I
 
-// // TODO: enable for .NET 7.0/8.0
-// [<Fact>]
-// let ``Numeric MinMagnitude works`` () =
-//     System.SByte.MinMagnitude(-4y, 3y) |> equal 3y
-//     System.Int16.MinMagnitude(-4s, 3s) |> equal 3s
-//     System.Int32.MinMagnitude(-4, 3)  |> equal 3
-//     System.Int64.MinMagnitude(-4L, 3L) |> equal 3L
-//     System.Double.MinMagnitude(-4.0, 3.0) |> equal 3.0
-//     System.Single.MinMagnitude(-4.0f, 3.0f) |> equal 3.0f
-//     System.Decimal.MinMagnitude(-4.0M, 3.0M) |> equal 3.0M
-//     bigint.MinMagnitude(-4I, 3I) |> equal 3I
+[<Fact>]
+let ``Numeric MinMagnitude works`` () =
+    SByte.MinMagnitude(-4y, 3y) |> equal 3y
+    Int16.MinMagnitude(-4s, 3s) |> equal 3s
+    Int32.MinMagnitude(-4, 3)  |> equal 3
+    Int64.MinMagnitude(-4L, 3L) |> equal 3L
+    Double.MinMagnitude(-4.0, 3.0) |> equal 3.0
+    Single.MinMagnitude(-4.0f, 3.0f) |> equal 3.0f
+    Decimal.MinMagnitude(-4.0M, 3.0M) |> equal 3.0M
+    bigint.MinMagnitude(-4I, 3I) |> equal 3I
 
-// // TODO: enable for .NET 7.0/8.0
-// [<Fact>]
-// let ``Numeric MaxMagnitude works`` () =
-//     System.SByte.MaxMagnitude(-4y, 3y) |> equal -4y
-//     System.Int16.MaxMagnitude(-4s, 3s) |> equal -4s
-//     System.Int32.MaxMagnitude(-4, 3)  |> equal -4
-//     System.Int64.MaxMagnitude(-4L, 3L) |> equal -4L
-//     System.Double.MaxMagnitude(-4.0, 3.0) |> equal -4.0
-//     System.Single.MaxMagnitude(-4.0f, 3.0f) |> equal -4.0f
-//     System.Decimal.MaxMagnitude(-4.0M, 3.0M) |> equal -4.0M
-//     bigint.MaxMagnitude(-4I, 3I) |> equal -4I
+[<Fact>]
+let ``Numeric MaxMagnitude works`` () =
+    SByte.MaxMagnitude(-4y, 3y) |> equal -4y
+    Int16.MaxMagnitude(-4s, 3s) |> equal -4s
+    Int32.MaxMagnitude(-4, 3)  |> equal -4
+    Int64.MaxMagnitude(-4L, 3L) |> equal -4L
+    Double.MaxMagnitude(-4.0, 3.0) |> equal -4.0
+    Single.MaxMagnitude(-4.0f, 3.0f) |> equal -4.0f
+    Decimal.MaxMagnitude(-4.0M, 3.0M) |> equal -4.0M
+    bigint.MaxMagnitude(-4I, 3I) |> equal -4I
 
-// // TODO: enable for .NET 7.0/8.0
-// [<Fact>]
-// let ``Numeric Clamp works`` () =
-//     System.SByte.Clamp(5y, -4y, 3y) |> equal 3y
-//     System.Int16.Clamp(5s, -4s, 3s) |> equal 3s
-//     System.Int32.Clamp(5, -4, 3)  |> equal 3
-//     System.Int64.Clamp(5L, -4L, 3L) |> equal 3L
-//     System.Byte.Clamp(5uy, 3uy, 4uy) |> equal 4uy
-//     System.UInt16.Clamp(5us, 3us, 4us) |> equal 4us
-//     System.UInt32.Clamp(5u, 3u, 4u)  |> equal 4u
-//     System.UInt64.Clamp(5UL, 3UL, 4UL) |> equal 4UL
-//     System.Double.Clamp(5.0, -4.0, 3.0) |> equal 3.0
-//     System.Single.Clamp(5.0f, -4.0f, 3.0f) |> equal 3.0f
-//     System.Decimal.Clamp(5.0M, -4.0M, 3.0M) |> equal 3.0M
-//     bigint.Clamp(5I, -4I, 3I) |> equal 3I
+[<Fact>]
+let ``Numeric Clamp works`` () =
+    SByte.Clamp(5y, -4y, 3y) |> equal 3y
+    Int16.Clamp(5s, -4s, 3s) |> equal 3s
+    Int32.Clamp(5, -4, 3)  |> equal 3
+    Int64.Clamp(5L, -4L, 3L) |> equal 3L
+    Byte.Clamp(5uy, 3uy, 4uy) |> equal 4uy
+    UInt16.Clamp(5us, 3us, 4us) |> equal 4us
+    UInt32.Clamp(5u, 3u, 4u)  |> equal 4u
+    UInt64.Clamp(5UL, 3UL, 4UL) |> equal 4UL
+    Double.Clamp(5.0, -4.0, 3.0) |> equal 3.0
+    Single.Clamp(5.0f, -4.0f, 3.0f) |> equal 3.0f
+    Decimal.Clamp(5.0M, -4.0M, 3.0M) |> equal 3.0M
+    bigint.Clamp(5I, -4I, 3I) |> equal 3I
 
 [<Fact>]
 let ``Math.Clamp works`` () =
-    System.Math.Clamp(5y, -4y, 3y) |> equal 3y
-    System.Math.Clamp(5s, -4s, 3s) |> equal 3s
-    System.Math.Clamp(5, -4, 3)  |> equal 3
-    System.Math.Clamp(5L, -4L, 3L) |> equal 3L
-    System.Math.Clamp(5uy, 3uy, 4uy) |> equal 4uy
-    System.Math.Clamp(5us, 3us, 4us) |> equal 4us
-    System.Math.Clamp(5u, 3u, 4u)  |> equal 4u
-    System.Math.Clamp(5UL, 3UL, 4UL) |> equal 4UL
-    System.Math.Clamp(5.0, -4.0, 3.0) |> equal 3.0
-    System.Math.Clamp(5.0f, -4.0f, 3.0f) |> equal 3.0f
-    System.Math.Clamp(5.0M, -4.0M, 3.0M) |> equal 3.0M
+    Math.Clamp(5y, -4y, 3y) |> equal 3y
+    Math.Clamp(5s, -4s, 3s) |> equal 3s
+    Math.Clamp(5, -4, 3)  |> equal 3
+    Math.Clamp(5L, -4L, 3L) |> equal 3L
+    Math.Clamp(5uy, 3uy, 4uy) |> equal 4uy
+    Math.Clamp(5us, 3us, 4us) |> equal 4us
+    Math.Clamp(5u, 3u, 4u)  |> equal 4u
+    Math.Clamp(5UL, 3UL, 4UL) |> equal 4UL
+    Math.Clamp(5.0, -4.0, 3.0) |> equal 3.0
+    Math.Clamp(5.0f, -4.0f, 3.0f) |> equal 3.0f
+    Math.Clamp(5.0M, -4.0M, 3.0M) |> equal 3.0M
 
 [<Fact>]
 let ``Math.Min works`` () =
@@ -885,17 +882,44 @@ let ``decr works`` () =
 // [<Fact>]
 // let ``System.Random works`` () =
 //     let rnd = Random()
+//     let x = rnd.Next()
+//     x >= 0 |> equal true
 //     let x = rnd.Next(5)
 //     (x >= 0 && x < 5) |> equal true
-//     let y = rnd.NextDouble()
-//     (y >= 0.0 && y < 1.0) |> equal true
+//     let x = rnd.Next(14, 20)
+//     (x >= 14 && x < 20) |> equal true
+//     let x = rnd.Next(-14, -10)
+//     (x >= -14 && x < -10) |> equal true
+//     let x = rnd.NextDouble()
+//     (x >= 0.0 && x < 1.0) |> equal true
+//     throwsAnyError <| fun () -> rnd.Next(-10)
+//     throwsAnyError <| fun () -> rnd.Next(14, 10)
 
 // // Note: Test could fail sometime during life of universe, if it picks all zeroes.
 // [<Fact>]
 // let ``System.Random.NextBytes works`` () =
 //     let buffer = Array.create 16 0uy // guid-sized buffer
 //     Random().NextBytes(buffer)
+//     buffer.Length |> equal 16
 //     buffer = Array.create 16 0uy |> equal false
+//     throwsAnyError <| fun () -> Random().NextBytes(null)
+
+// [<Fact>]
+// let ``System.Random seeded works`` () =
+//     let rnd = Random(1234)
+//     rnd.Next() |> equal 857019877
+//     rnd.Next(100) |> equal 89
+//     rnd.Next(1000, 10000) |> equal 3872
+//     rnd.NextDouble() |> equal 0.9467375338760845
+//     throwsAnyError <| fun () -> rnd.Next(-10)
+//     throwsAnyError <| fun () -> rnd.Next(14, 10)
+
+// [<Fact>]
+// let ``System.Random.NextBytes seeded works`` () =
+//     let buffer = Array.create 4 0uy // guid-sized buffer
+//     Random(5432).NextBytes(buffer)
+//     buffer |> equal [|152uy; 238uy; 227uy; 30uy|]
+//     throwsAnyError <| fun () -> Random().NextBytes(null)
 
 [<Fact>]
 let ``Long integer equality works`` () =

--- a/tests/Rust/tests/src/DateOnlyTests.fs
+++ b/tests/Rust/tests/src/DateOnlyTests.fs
@@ -167,10 +167,10 @@ let ``Parse parses valid DateOnly`` () =
     // test (DateOnly (2000, 11, 30)) "11/30/2000"
     // test (DateOnly (2020, 1, 3)) "01/03/20"
     // test (DateOnly (1999, 1, 3)) "01,03,99"
-    // #if NET8_0_OR_GREATER
-    //     test (DateOnly (2030, 1, 3)) "01 -03- 30"
-    // #elif FABLE_COMPILER
+    // #if FABLE_COMPILER
     //     test (DateOnly (1930, 1, 3)) "01 -03- 30"
+    // #else //NET8_0_OR_GREATER
+    //     test (DateOnly (2030, 1, 3)) "01 -03- 30"
     // #endif
     // test (DateOnly (2000, 12, 3)) "12.03.00"
     // test (DateOnly (2000, 1, 12)) "01-12-00"

--- a/tests/Rust/tests/src/StringTests.fs
+++ b/tests/Rust/tests/src/StringTests.fs
@@ -1440,11 +1440,7 @@ let ``String.filter with Char.IsDigit as a predicate doesn't hang`` () =
 //     let s4: FormattableString = $"I have `backticks`"
 //     s4.Format |> equal "I have `backticks`"
 //     let s5: FormattableString = $"I have {{escaped braces}} and %%percentage%%"
-// #if NET8_0_OR_GREATER
 //     s5.Format |> equal "I have {{escaped braces}} and %percentage%"
-// #elif FABLE_COMPILER
-//     s5.Format |> equal "I have {escaped braces} and %percentage%"
-// #endif
 //     ()
 
 // #if FABLE_COMPILER

--- a/tests/TypeScript/Fable.Tests.TypeScript.fsproj
+++ b/tests/TypeScript/Fable.Tests.TypeScript.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
     <DefineConstants>FABLE_COMPILER;FABLE_COMPILER_TYPESCRIPT;$(DefineConstants)</DefineConstants>
   </PropertyGroup>

--- a/tests/TypeScript/Main.fs
+++ b/tests/TypeScript/Main.fs
@@ -95,6 +95,6 @@ open Expecto
 let main args =
     Array.toList allTests
     |> testList "All"
-    |> runTestsWithArgs defaultConfig args
+    |> runTestsWithCLIArgs [] args
 
 #endif


### PR DESCRIPTION
- [JS, TS, Rust] Enabled some `Log2/Min/Max/MinMag/MaxMag/Clamp` tests.
- Updated all test projects to target .NET 8.0 (to enable .NET 8.0 BCL surface).
(but `Fable.Cli`, `Fable.Compiler `and `Fable.PublishUtils` still target .NET 6.0).