### PR TITLE
Python: added 'Double.IsPositiveInfinity'

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Python
 
 * Fixed nested type with custom hashcode (by @dbrattli)
+* Add 'Double.IsPositiveInfinity' (by @PierreYvesR)
 
 #### Rust
 

--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -3850,6 +3850,17 @@ let parseNum
             ?loc = r
         )
         |> Some
+    | "IsPositiveInfinity", [ _ ] when isFloat ->
+        Helper.LibCall(
+            com,
+            "double",
+            "is_positive_inf",
+            t,
+            args,
+            i.SignatureArgTypes,
+            ?loc = r
+        )
+        |> Some
     | ("Parse" | "TryParse") as meth,
       str :: NumberConst(:? int as style, _, _) :: _ ->
         let hexConst = int System.Globalization.NumberStyles.HexNumber

--- a/src/fable-library-py/fable_library/double.py
+++ b/src/fable-library-py/fable_library/double.py
@@ -49,6 +49,10 @@ def sqrt(x: float) -> float:
         return float("nan")
 
 
+def is_positive_inf(value: float) -> bool:
+    return math.isinf(value) and value > 0
+
+
 def is_negative_inf(value: float) -> bool:
     return math.isinf(value) and value < 0
 
@@ -68,4 +72,16 @@ def try_parse(string: str, def_value: FSharpRef[float]) -> bool:
         return False
 
 
-__all__ = ["abs", "sign", "max", "min", "parse", "try_parse", "divide", "log", "sqrt", "is_negative_inf"]
+__all__ = [
+    "abs",
+    "sign",
+    "max",
+    "min",
+    "parse",
+    "try_parse",
+    "divide",
+    "log",
+    "sqrt",
+    "is_negative_inf",
+    "is_positive_inf",
+]

--- a/tests/Python/TestArithmetic.fs
+++ b/tests/Python/TestArithmetic.fs
@@ -1118,5 +1118,13 @@ let ``test extreme values work`` () =
     |> Double.IsNegativeInfinity
     |> equal false
 
+    1.0 / 0.0
+    |> Double.IsPositiveInfinity
+    |> equal true
+
+    1.0 / (-0.0)
+    |> Double.IsPositiveInfinity
+    |> equal false
+
     -infinity < infinity |> equal true
     (-0.0) < 0.0 |> equal false


### PR DESCRIPTION
`System.Double.IsPositivieInfinity` was only missing from Python.