### PR TITLE
Queue collection bug fix

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [GH-3668](https://github.com/fable-compiler/Fable/pull/3668) Normalize fable-library argument (by @nojaf)
 
+#### Javascript
+
+* Fixed 'System.Collections.Generic.Queue' bug (by @PierreYvesR)
+
 #### Python
 
 * Fixed nested type with custom hashcode (by @dbrattli)
@@ -23,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed unary negation for signed integer MinValue (by @ncave)
 * Fixed excluding signature files from imports (by @ncave)
 * Fixed generic try_catch closure trait (by @ncave)
+* Fixed 'System.Collections.Generic.Queue' bug (by @PierreYvesR)
 
 ## 4.9.0 - 2023-12-14
 

--- a/src/fable-library-rust/src/System.Collections.Generic.fs
+++ b/src/fable-library-rust/src/System.Collections.Generic.fs
@@ -110,7 +110,12 @@ type Queue<'T when 'T: equality> private (initialContents, initialCount) =
     let mutable contents: 'T array = initialContents
     let mutable count = initialCount
     let mutable head = 0
-    let mutable tail = initialCount
+
+    let mutable tail =
+        if initialCount = contents.Length then
+            0
+        else
+            initialCount
 
     let size () = contents.Length
 
@@ -126,8 +131,13 @@ type Queue<'T when 'T: equality> private (initialContents, initialCount) =
             Array.blit contents 0 newBuffer (size () - head) tail
 
         head <- 0
-        tail <- count
         contents <- newBuffer
+
+        tail <-
+            if count = size () then
+                0
+            else
+                count
 
     let toSeq () =
         let head = head

--- a/src/fable-library/System.Collections.Generic.fs
+++ b/src/fable-library/System.Collections.Generic.fs
@@ -113,7 +113,12 @@ type Queue<'T> private (initialContents, initialCount) =
     let mutable contents: 'T array = initialContents
     let mutable count = initialCount
     let mutable head = 0
-    let mutable tail = initialCount
+
+    let mutable tail =
+        if initialCount = contents.Length then
+            0
+        else
+            initialCount
 
     let size () = contents.Length
 
@@ -129,8 +134,13 @@ type Queue<'T> private (initialContents, initialCount) =
             Array.blit contents 0 newBuffer (size () - head) tail
 
         head <- 0
-        tail <- count
         contents <- newBuffer
+
+        tail <-
+            if count = size () then
+                0
+            else
+                count
 
     let toSeq () =
         seq {

--- a/tests/Js/Main/QueueTests.fs
+++ b/tests/Js/Main/QueueTests.fs
@@ -55,6 +55,12 @@ let tests =
             q.Count |> equal 4
             q |> Seq.toList |> equal [1;2;3;4]
 
+        testCase "Can dequeue then enqueue to queue constructed from list" <| fun () ->
+            let q = Queue<int>([0])
+            q.Dequeue() |> ignore
+            q.Enqueue(42)
+            q.Dequeue() |> equal 42
+
         testCase "Enqueue / Dequeue works" <| fun () ->
             let q = Queue<int>()
             q.Enqueue(1)

--- a/tests/Rust/tests/src/QueueTests.fs
+++ b/tests/Rust/tests/src/QueueTests.fs
@@ -56,6 +56,13 @@ let ``Can enqueue to queue constructed from list`` () =
     q.ToArray() |> equal [|1;2;3;4|]
 
 [<Fact>]
+let ``Can dequeue then enqueue to queue constructed from list`` () =
+    let q = Queue<int>([0])
+    q.Dequeue() |> ignore
+    q.Enqueue(42)
+    q.Dequeue() |> equal 42
+
+[<Fact>]
 let ``Enqueue / Dequeue works`` () =
     let q = Queue<int>()
     q.Enqueue(1)


### PR DESCRIPTION
In certain case, `tail` would point past the end of inner storage of the queue, leading to incorrect behaviour.

