### PR TITLE
Revert "[Python] Add kind property for datetime"

### DIFF
--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -5053,9 +5053,7 @@ let dates
             ?loc = r
         )
         |> Some
-    | "get_Kind" ->
-        Helper.LibCall(com, "date", "get_kind", t, [ thisArg.Value ], ?loc = r)
-        |> Some
+    | "get_Kind"
     | "get_Offset" ->
         Naming.removeGetSetPrefix i.CompiledName
         |> Naming.lowerFirst

--- a/src/fable-library-py/fable_library/date.py
+++ b/src/fable-library-py/fable_library/date.py
@@ -198,7 +198,7 @@ def utc_now() -> datetime:
 
 
 def to_local_time(date: datetime) -> datetime:
-    return date.astimezone().replace(tzinfo=None)
+    return date.astimezone()
 
 
 def compare(x: datetime, y: datetime) -> int:
@@ -249,13 +249,6 @@ def add_milliseconds(d: datetime, v: int) -> datetime:
     return d + timedelta(milliseconds=v)
 
 
-def get_kind(d: datetime) -> DateKind:
-    if d.tzinfo == timezone.utc:
-        return DateKind.UTC
-
-    return DateKind.Local
-
-
 __all__ = [
     "add",
     "op_subtraction",
@@ -265,7 +258,6 @@ __all__ = [
     "date_to_string_with_custom_format",
     "date_to_string_with_offset",
     "date_to_string_with_kind",
-    "get_kind",
     "to_string",
     "now",
     "utc_now",

--- a/tests/Python/TestDateTime.fs
+++ b/tests/Python/TestDateTime.fs
@@ -101,15 +101,9 @@ let ``test DateTime Subtraction with DateTime works`` () =
     test 0. 0.0
 
 
-[<Fact>]
-let ``test DateTime.ToLocalTime works`` () =
-    let d = DateTime(2014, 10, 9, 13, 23, 30, DateTimeKind.Utc)
-    let d' = d.ToLocalTime()
-    d.Kind <> d'.Kind
-    |> equal true
-
-[<Fact>]
-let ``test DateTime.ToUniversalTime works`` () =
-    let d = DateTime(2014, 10, 9, 13, 23, 30, DateTimeKind.Local)
-    d.ToUniversalTime().Kind <> d.Kind
-    |> equal true
+// [<Fact>]
+// let ``test DateTime.ToLocalTime works`` () =
+//     let d = DateTime(2014, 10, 9, 13, 23, 30, DateTimeKind.Utc)
+//     let d' = d.ToLocalTime()
+//     d.Kind <> d'.Kind
+//     |> equal true


### PR DESCRIPTION
Reverts fable-compiler/Fable#3691

@dbrattli 

I think I merged your PR proposition too quickly. There is definitely some limitations in both our proposition regarding `DateTimeKind` support.