### PR TITLE
Fix type of dereferenced byref

### DIFF
--- a/src/Fable.Transforms/FSharp2Fable.fs
+++ b/src/Fable.Transforms/FSharp2Fable.fs
@@ -943,7 +943,12 @@ let private transformExpr
                     && com.Options.Language <> Rust
                 then
                     // Getting byref value is compiled as FSharpRef op_Dereference
-                    return Replacements.Api.getRefCell com r v.Type v
+                    return
+                        Replacements.Api.getRefCell
+                            com
+                            r
+                            (List.head v.Type.Generics)
+                            v
                 else
                     return v
 

--- a/tests/Js/Main/TypeTests.fs
+++ b/tests/Js/Main/TypeTests.fs
@@ -503,6 +503,12 @@ let inline callWithByrefCreatedFromByrefInlined(n: byref<int>) =
     let f = &n
     byrefFunc &f
 
+let inline inlinedFunc(n: 't[]) =
+    n.Length
+
+let genericByrefFunc(n: byref<'t[]>) =
+    inlinedFunc n
+
 let tests =
   testList "Types" [
     // TODO: This test produces different results in Fable and .NET
@@ -1100,4 +1106,9 @@ let tests =
         ignore intRef
         callWithByrefCreatedFromByrefInlined &intRef
         an_int |> equal 66
+
+    testCase "inline with generic byref works" <| fun () ->
+        let mutable arr = [| 1; 2; 3 |]
+        let result = genericByrefFunc &arr
+        result |> equal 3
   ]


### PR DESCRIPTION
The type of the dereferenced value was incorrectly being marked as the type of the byref, when it should be the type of its contents.

In addition to the added test, this REPL also demonstrates the issue:
https://fable.io/repl/#?code=PTAEHUCcEsBcFNQGMD2ATRLKgDYoIZqj6gDO+AtgA46IBmkKFZ0GARvpAFBcpXwA7UADF8bWgDoAwlngSAUqQCSAhIyo8QoGVWjwiDJqAAWsWFVIAuEAHM4xgK5sJqCsDpjaAWle7akYFFxeGBxFDZgCnxoAWBSSCR3T3gvHGg2SE4AT2AAOXxYaAA3OTpSAGIAGQBGAAZarlpYUBi0gURSJwBBSEyspWocUAAKTj7LUAByABUAbQBdAEoR0lhOWAmY2GXh1AdVTdVliZmF0ABeLlBr0ABCW+Je-CyAflI0pHhh1fWAGjI1pBmgBqZAofbbHhNUCwSD7JAFRCjXoTNhZSDwOgAHlO8wAfDt2gB3ADK0AAXvBDtsLlcbmNQFivGRuk9+oNHthaqBiWTKTwgA&html=Q&css=Q