### PR TITLE
[JS] System.Array.Resize: also handle the case where the array is null

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+#### JavaScript
+
+* [GH-3716](https://github.com/fable-compiler/Fable/pull/3716) System.Array.Resize: also handle the case where the array is null (by @chkn)
+
 ## 4.10.0 - 2024-01-25
 
 ### Fixed

--- a/src/fable-library/Array.fs
+++ b/src/fable-library/Array.fs
@@ -1418,6 +1418,9 @@ let resize
 
     let len =
         if isNull xs then
+            if newSize = 0 then
+                xs <- allocateArrayFromCons cons 0
+
             0
         else
             xs.Length

--- a/src/fable-library/Array.fs
+++ b/src/fable-library/Array.fs
@@ -1416,27 +1416,21 @@ let resize
     if newSize < 0 then
         invalidArg "newSize" "The input must be non-negative."
 
-    let len =
-        if isNull xs then
-            if newSize = 0 then
-                xs <- allocateArrayFromCons cons 0
+    let zero = defaultArg zero Unchecked.defaultof<_>
 
-            0
-        else
-            xs.Length
+    if isNull xs then
+        xs <- fillImpl (allocateArrayFromCons cons newSize) zero 0 newSize
 
-    if newSize < len then
-        xs <- subArrayImpl xs 0 newSize
+    else
+        let len = xs.Length
 
-    elif newSize > len then
-        let target = allocateArrayFromCons cons newSize
+        if newSize < len then
+            xs <- subArrayImpl xs 0 newSize
 
-        if len > 0 then
-            copyTo xs 0 target 0 len
+        elif newSize > len then
+            let target = allocateArrayFromCons cons newSize
 
-        xs <-
-            fillImpl
-                target
-                (defaultArg zero Unchecked.defaultof<_>)
-                len
-                (newSize - len)
+            if len > 0 then
+                copyTo xs 0 target 0 len
+
+            xs <- fillImpl target zero len (newSize - len)

--- a/src/fable-library/Array.fs
+++ b/src/fable-library/Array.fs
@@ -1416,14 +1416,20 @@ let resize
     if newSize < 0 then
         invalidArg "newSize" "The input must be non-negative."
 
-    let len = xs.Length
+    let len =
+        if isNull xs then
+            0
+        else
+            xs.Length
 
     if newSize < len then
         xs <- subArrayImpl xs 0 newSize
 
     elif newSize > len then
         let target = allocateArrayFromCons cons newSize
-        copyTo xs 0 target 0 len
+
+        if len > 0 then
+            copyTo xs 0 target 0 len
 
         xs <-
             fillImpl

--- a/tests/Js/Main/ArrayTests.fs
+++ b/tests/Js/Main/ArrayTests.fs
@@ -1199,9 +1199,10 @@ let tests =
         xs |> equal [|1; 2; 3; 0; 0; 0; 0|]
         Array.Resize(&xs, 0)
         xs |> equal [||]
+        xs <- null
         Array.Resize(&xs, 3)
         xs |> equal [|0; 0; 0|]
         xs <- null
-        Array.Resize(&xs, 1)
-        xs |> equal [|0|]
+        Array.Resize(&xs, 0)
+        xs |> equal [||]
   ]

--- a/tests/Js/Main/ArrayTests.fs
+++ b/tests/Js/Main/ArrayTests.fs
@@ -1199,4 +1199,9 @@ let tests =
         xs |> equal [|1; 2; 3; 0; 0; 0; 0|]
         Array.Resize(&xs, 0)
         xs |> equal [||]
+        Array.Resize(&xs, 3)
+        xs |> equal [|0; 0; 0|]
+        xs <- null
+        Array.Resize(&xs, 1)
+        xs |> equal [|0|]
   ]


### PR DESCRIPTION
In my [initial PR](https://github.com/fable-compiler/Fable/pull/3715), I missed that [the docs](https://learn.microsoft.com/en-us/dotnet/api/system.array.resize?view=net-8.0) say the array can be `null`, in which case a new array is allocated.