### PR TITLE
Restore original fsproj after cracking the *.fable-temp.csproj

### DIFF
--- a/src/Fable.Cli/BuildalyzerCrackerResolver.fs
+++ b/src/Fable.Cli/BuildalyzerCrackerResolver.fs
@@ -88,7 +88,7 @@ type BuildalyzerCrackerResolver() =
                         let xmlComment =
                             XComment(
                                 """This is a temporary file used by Fable to restore dependencies.
-                    If you see this file in your project, you can delete it safely"""
+If you see this file in your project, you can delete it safely"""
                             )
 
                         // An fsproj/csproj should always have a root element
@@ -137,6 +137,21 @@ type BuildalyzerCrackerResolver() =
                         )
                     finally
                         File.safeDelete csprojFile
+                        // Restore the original fsproj because when restoring/analyzing the
+                        // csproj implicit references added by F# SDKs are not included
+                        // See https://github.com/fable-compiler/Fable/issues/3719
+                        // Restoring the F# project should restore the bin/obj folders
+                        // to their expected state
+                        let projDir = IO.Path.GetDirectoryName projectFile
+
+                        Process.runSync
+                            projDir
+                            "dotnet"
+                            [
+                                "restore"
+                                projectFile
+                            ]
+                        |> ignore
 
             let compilerArgs, result =
                 csprojResult

--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Fixed
+### Changed
+
+#### All
+
+* [GH-3719](https://github.com/fable-compiler/Fable/issues/3719) Restore dependencies against the `.fsproj` after evaluating the `fable-temp.csproj` file (Improves IDE supports) (by @MangelMaxime)
+* Don't delete `fable_modules` when re-evaluating the project file after a changes has been detected (Improves HMR experience) (by @MangelMaxime)
 
 #### JavaScript
 

--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -458,13 +458,14 @@ type ProjectCracked
     member _.MapSourceFiles(f) =
         ProjectCracked(cliArgs, crackerResponse, Array.map f sourceFiles)
 
-    static member Init(cliArgs: CliArgs) =
+    static member Init(cliArgs: CliArgs, ?evaluateOnly: bool) =
+        let evaluateOnly = defaultArg evaluateOnly false
         Log.always $"Parsing {cliArgs.ProjectFileAsRelativePath}..."
 
         let result, ms =
             Performance.measure
             <| fun () ->
-                CrackerOptions(cliArgs)
+                CrackerOptions(cliArgs, evaluateOnly)
                 |> getFullProjectOpts (BuildalyzerCrackerResolver())
 
         // We display "parsed" because "cracked" may not be understood by users
@@ -1242,7 +1243,10 @@ let private compilationCycle (state: State) (changes: ISet<string>) =
                     let oldProjCracked = projCracked
 
                     let newProjCracked =
-                        ProjectCracked.Init({ cliArgs with NoCache = true })
+                        ProjectCracked.Init(
+                            { cliArgs with NoCache = true },
+                            evaluateOnly = true
+                        )
 
                     // If only source files have changed, keep the project checker to speed up recompilation
                     let fableCompiler =

--- a/src/Fable.Compiler/ProjectCracker.fsi
+++ b/src/Fable.Compiler/ProjectCracker.fsi
@@ -26,7 +26,7 @@ type CacheInfo =
     }
 
 type CrackerOptions =
-    new: cliArgs: CliArgs -> CrackerOptions
+    new: cliArgs: CliArgs * evaluateOnly: bool -> CrackerOptions
     member NoCache: bool
     member CacheInfo: CacheInfo option
     member FableModulesDir: string
@@ -41,11 +41,16 @@ type CrackerOptions =
     member ProjFile: string
     member SourceMaps: bool
     member SourceMapsRoot: string option
+    member EvaluateOnly: bool
     member BuildDll: normalizedDllPath: string -> unit
     static member GetFableModulesFromDir: baseDir: string -> string
 
     static member GetFableModulesFromProject:
-        projDir: string * outDir: string option * noCache: bool -> string
+        projDir: string *
+        outDir: string option *
+        noCache: bool *
+        evaluateOnly: bool ->
+            string
 
 type CrackerResponse =
     {


### PR DESCRIPTION
Changes related to https://github.com/fable-compiler/Fable/pull/3684 had a bad side effects when using HMR.

Indeed, deleting the `fable_modules` caused problem with HMR because then an HMR call would generated at each file compilation. But because some files could be missing then this resulted into a lot of errors in the application and the application was not always able to restore its state.

The changes in this PR should restore the previous behaviour of Fable which is to keep in place the libraries in the `fable_modules` when the `fsproj` changes.

