### PR TITLE
Add support for Result.isOk and Result.isError to Dart and Python

### DIFF
--- a/src/Fable.Transforms/Dart/Replacements.fs
+++ b/src/Fable.Transforms/Dart/Replacements.fs
@@ -3145,7 +3145,8 @@ let results
     (args: Expr list)
     =
     match i.CompiledName with
-    | ("Bind" | "Map" | "MapError") as meth -> Some("Result_" + meth)
+    | ("Bind" | "Map" | "MapError" | "IsOk" | "IsError") as meth ->
+        Some("Result_" + meth)
     | _ -> None
     |> Option.map (fun meth ->
         Helper.LibCall(

--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -3607,7 +3607,8 @@ let results
     (args: Expr list)
     =
     match i.CompiledName with
-    | ("Bind" | "Map" | "MapError") as meth -> Some("Result_" + meth)
+    | ("Bind" | "Map" | "MapError" | "IsOk" | "IsError") as meth ->
+        Some("Result_" + meth)
     | _ -> None
     |> Option.map (fun meth ->
         Helper.LibCall(

--- a/src/fable-library-dart/Choice.fs
+++ b/src/fable-library-dart/Choice.fs
@@ -24,6 +24,18 @@ module Result =
         | Error e -> Error e
         | Ok x -> binder x
 
+    [<CompiledName("IsOk")>]
+    let isOk (result: Result<'a, 'b>) : bool =
+        match result with
+        | Error _ -> false
+        | Ok _ -> true
+
+    [<CompiledName("IsError")>]
+    let isError (result: Result<'a, 'b>) : bool =
+        match result with
+        | Error _ -> true
+        | Ok _ -> false
+
 [<CompiledName("FSharpChoice`2")>]
 type Choice<'T1, 'T2> =
     | Choice1Of2 of 'T1

--- a/tests/Dart/src/ResultTests.fs
+++ b/tests/Dart/src/ResultTests.fs
@@ -46,3 +46,11 @@ let tests() =
     testCase "Nesting Result in pattern matching works" <| fun () -> // See #816
         Ok 5 |> Foo |> foo |> equal true
         Error "error" |> Foo |> foo |> equal false
+
+    testCase "isOk function can be generated" <| fun () ->
+        Ok 10 |> Result.isOk |> equal true
+        Error 10 |> Result.isOk |> equal false
+
+    testCase "isError function can be generated" <| fun () ->
+        Ok 10 |> Result.isError |> equal false
+        Error 10 |> Result.isError |> equal true

--- a/tests/Python/TestResult.fs
+++ b/tests/Python/TestResult.fs
@@ -51,3 +51,13 @@ let ``test bind function can be generated`` () =
 let ``test Nesting Result in pattern matching works`` () =
     Ok 5 |> Foo |> foo |> equal true
     Error "error" |> Foo |> foo |> equal false
+
+[<Fact>]
+let ``test isOk function can be generated`` () =
+    Ok 5 |> Result.isOk |> equal true
+    Error "error" |> Result.isOk |> equal false
+
+[<Fact>]
+let ``test isError function can be generated`` () =
+    Ok 5 |> Result.isError |> equal false
+    Error "error" |> Result.isError |> equal true


### PR DESCRIPTION
Initial issue was #3726 with a recommendation from @ncave on the PR #3727 

I've implemented `Result.isOk` and `Result.isError` for both Dart and Python. Was the same as for JS and TS.

I have a stash with the code for Rust, but I'm getting errors because it can't infer the type. I'll play with it a little more and see if I can't get it to compile/run tests with some more type annotations.