### PR TITLE
Implement Result module for Javascript/Typescript/Dart/Python/Rust

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -7,20 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-* [GH-3727](https://github.com/fable-compiler/Fable/pull/3727) Add support for `Result.isOk` and `Result.isError` (by @zprobinson)
-
-* Remove `Choice.d.ts` from source code of `fable-library` (by @MangelMaxime)
-* [GH-3727](https://github.com/fable-compiler/Fable/pull/3727) Add support for `Result.isOk` and `Result.isError` (by @zprobinson)
-
 ### Added
 
-#### JavaScript
+#### All
 
-* [GH-3727](https://github.com/fable-compiler/Fable/pull/3727) Add support for `Result.isOk` and `Result.isError` (by @zprobinson)
-
-#### TypeScript
-
-* [GH-3727](https://github.com/fable-compiler/Fable/pull/3727) Add support for `Result.isOk` and `Result.isError` (by @zprobinson)
+* [GH-3733](https://github.com/fable-compiler/Fable/pull/3733) [GH-3727](https://github.com/fable-compiler/Fable/pull/3727) Add support for more `Result` API (by @zprobinson)
+    * `Result.isOk`
+    * `Result.isError`
+    * `Result.Contains`
+    * `Result.Count`
+    * `Result.DefaultValue`
+    * `Result.DefaultWith`
+    * `Result.Exists`
+    * `Result.Fold`
+    * `Result.FoldBack`
+    * `Result.ForAll`
+    * `Result.Iterate`
+    * `Result.ToArray`
+    * `Result.ToList`
+    * `Result.ToOption`
 
 ### Removed
 

--- a/src/Fable.Transforms/Dart/Replacements.fs
+++ b/src/Fable.Transforms/Dart/Replacements.fs
@@ -2345,7 +2345,8 @@ let disposables (com: ICompiler) (_: Context) r (t: Type) (i: CallInfo) (thisArg
 
 let results (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (_: Expr option) (args: Expr list) =
     match i.CompiledName with
-    | ("Bind" | "Map" | "MapError" | "IsOk" | "IsError") as meth -> Some("Result_" + meth)
+    | ("Bind" | "Map" | "MapError" | "IsOk" | "IsError" | "Contains" | "Count" | "DefaultValue" | "DefaultWith" | "Exists" | "Fold" | "FoldBack" | "ForAll" | "Iterate" | "ToArray" | "ToList" | "ToOption") as meth ->
+        Some("Result_" + meth)
     | _ -> None
     |> Option.map (fun meth ->
         Helper.LibCall(com, "Choice", meth, t, args, i.SignatureArgTypes, genArgs = i.GenericArgs, ?loc = r)

--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -2589,7 +2589,8 @@ let mapModule (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (_: Expr
 
 let results (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (_: Expr option) (args: Expr list) =
     match i.CompiledName with
-    | ("Bind" | "Map" | "MapError" | "IsOk" | "IsError") as meth -> Some("Result_" + meth)
+    | ("Bind" | "Map" | "MapError" | "IsOk" | "IsError" | "Contains" | "Count" | "DefaultValue" | "DefaultWith" | "Exists" | "Fold" | "FoldBack" | "ForAll" | "Iterate" | "ToArray" | "ToList" | "ToOption") as meth ->
+        Some("Result_" + meth)
     | _ -> None
     |> Option.map (fun meth -> Helper.LibCall(com, "choice", meth, t, args, i.SignatureArgTypes, ?loc = r))
 

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -2713,7 +2713,8 @@ let disposables (com: ICompiler) (_: Context) r (t: Type) (i: CallInfo) (thisArg
 
 let results (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (_: Expr option) (args: Expr list) =
     match i.CompiledName with
-    | ("Bind" | "Map" | "MapError" | "IsOk" | "IsError") as meth -> Some("Result_" + meth)
+    | ("Bind" | "Map" | "MapError" | "IsOk" | "IsError" | "Contains" | "Count" | "DefaultValue" | "DefaultWith" | "Exists" | "Fold" | "FoldBack" | "ForAll" | "Iterate" | "ToArray" | "ToList" | "ToOption") as meth ->
+        Some("Result_" + meth)
     | _ -> None
     |> Option.map (fun meth ->
         Helper.LibCall(com, "Choice", meth, t, args, i.SignatureArgTypes, genArgs = i.GenericArgs, ?loc = r)

--- a/src/Fable.Transforms/Rust/Replacements.fs
+++ b/src/Fable.Transforms/Rust/Replacements.fs
@@ -2689,27 +2689,8 @@ let mapModule (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (_: Expr
 
 let results (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (_: Expr option) (args: Expr list) =
     match i.CompiledName with
-    | ("Bind" | "Map" | "MapError" | "IsOk" | "IsError" | "Contains" | "Count" | "DefaultValue" | "DefaultWith" | "Exists" | "Fold" | "FoldBack" | "Iterate" | "ToArray" | "ToList" | "ToOption") as meth ->
-        Helper.LibCall(
-            com,
-            "Result",
-            Naming.lowerFirst meth,
-            t,
-            args,
-            i.SignatureArgTypes,
-            ?loc = r
-        )
-        |> Some
-    | "ForAll" ->
-        Helper.LibCall(
-            com,
-            "Result",
-            "forall",
-            t,
-            args,
-            i.SignatureArgTypes,
-            ?loc = r
-        )
+    | ("Bind" | "Map" | "MapError" | "IsOk" | "IsError" | "Contains" | "Count" | "DefaultValue" | "DefaultWith" | "Exists" | "Fold" | "FoldBack" | "Iterate" | "ToArray" | "ToList" | "ToOption" | "ForAll") as meth ->
+        Helper.LibCall(com, "Result", Naming.lowerFirst meth, t, args, i.SignatureArgTypes, ?loc = r)
         |> Some
     | _ -> None
 

--- a/src/Fable.Transforms/Rust/Replacements.fs
+++ b/src/Fable.Transforms/Rust/Replacements.fs
@@ -2689,8 +2689,27 @@ let mapModule (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (_: Expr
 
 let results (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (_: Expr option) (args: Expr list) =
     match i.CompiledName with
-    | ("Bind" | "Map" | "MapError" | "IsOk" | "IsError") as meth ->
-        Helper.LibCall(com, "Result", Naming.lowerFirst meth, t, args, i.SignatureArgTypes, ?loc = r)
+    | ("Bind" | "Map" | "MapError" | "IsOk" | "IsError" | "Contains" | "Count" | "DefaultValue" | "DefaultWith" | "Exists" | "Fold" | "FoldBack" | "Iterate" | "ToArray" | "ToList" | "ToOption") as meth ->
+        Helper.LibCall(
+            com,
+            "Result",
+            Naming.lowerFirst meth,
+            t,
+            args,
+            i.SignatureArgTypes,
+            ?loc = r
+        )
+        |> Some
+    | "ForAll" ->
+        Helper.LibCall(
+            com,
+            "Result",
+            "forall",
+            t,
+            args,
+            i.SignatureArgTypes,
+            ?loc = r
+        )
         |> Some
     | _ -> None
 

--- a/src/fable-library-dart/Choice.fs
+++ b/src/fable-library-dart/Choice.fs
@@ -36,6 +36,88 @@ module Result =
         | Error _ -> true
         | Ok _ -> false
 
+    [<CompiledName("Contains")>]
+    let contains (value: 'a) (result: Result<'a, 'b>) : bool =
+        match result with
+        | Error _ -> false
+        | Ok x -> x = value
+
+    [<CompiledName("Count")>]
+    let count (result: Result<'a, 'b>) : int =
+        match result with
+        | Error _ -> 0
+        | Ok _ -> 1
+
+    [<CompiledName("DefaultValue")>]
+    let defaultValue (defaultValue: 'a) (result: Result<'a, 'b>) : 'a =
+        match result with
+        | Error _ -> defaultValue
+        | Ok x -> x
+
+    [<CompiledName("DefaultWith")>]
+    let defaultWith (defThunk: 'b -> 'a) (result: Result<'a, 'b>) : 'a =
+        match result with
+        | Error e -> defThunk e
+        | Ok x -> x
+
+    [<CompiledName("Exists")>]
+    let exists (predicate: 'a -> bool) (result: Result<'a, 'b>) : bool =
+        match result with
+        | Error _ -> false
+        | Ok x -> predicate x
+
+    [<CompiledName("Fold")>]
+    let fold<'a, 'b, 's>
+        (folder: 's -> 'a -> 's)
+        (state: 's)
+        (result: Result<'a, 'b>)
+        : 's
+        =
+        match result with
+        | Error _ -> state
+        | Ok x -> folder state x
+
+    [<CompiledName("FoldBack")>]
+    let foldBack<'a, 'b, 's>
+        (folder: 'a -> 's -> 's)
+        (result: Result<'a, 'b>)
+        (state: 's)
+        : 's
+        =
+        match result with
+        | Error _ -> state
+        | Ok x -> folder x state
+
+    [<CompiledName("ForAll")>]
+    let forall (predicate: 'a -> bool) (result: Result<'a, 'b>) : bool =
+        match result with
+        | Error _ -> true
+        | Ok x -> predicate x
+
+    [<CompiledName("Iterate")>]
+    let iterate (action: 'a -> unit) (result: Result<'a, 'b>) : unit =
+        match result with
+        | Error _ -> ()
+        | Ok x -> action x
+
+    [<CompiledName("ToArray")>]
+    let toArray (result: Result<'a, 'b>) : 'a[] =
+        match result with
+        | Error _ -> [||]
+        | Ok x -> [| x |]
+
+    [<CompiledName("ToList")>]
+    let toList (result: Result<'a, 'b>) : 'a list =
+        match result with
+        | Error _ -> []
+        | Ok x -> [ x ]
+
+    [<CompiledName("ToOption")>]
+    let toOption (result: Result<'a, 'b>) : Option<'a> =
+        match result with
+        | Error _ -> None
+        | Ok x -> Some x
+
 [<CompiledName("FSharpChoice`2")>]
 type Choice<'T1, 'T2> =
     | Choice1Of2 of 'T1

--- a/src/fable-library-dart/Choice.fs
+++ b/src/fable-library-dart/Choice.fs
@@ -67,23 +67,13 @@ module Result =
         | Ok x -> predicate x
 
     [<CompiledName("Fold")>]
-    let fold<'a, 'b, 's>
-        (folder: 's -> 'a -> 's)
-        (state: 's)
-        (result: Result<'a, 'b>)
-        : 's
-        =
+    let fold<'a, 'b, 's> (folder: 's -> 'a -> 's) (state: 's) (result: Result<'a, 'b>) : 's =
         match result with
         | Error _ -> state
         | Ok x -> folder state x
 
     [<CompiledName("FoldBack")>]
-    let foldBack<'a, 'b, 's>
-        (folder: 'a -> 's -> 's)
-        (result: Result<'a, 'b>)
-        (state: 's)
-        : 's
-        =
+    let foldBack<'a, 'b, 's> (folder: 'a -> 's -> 's) (result: Result<'a, 'b>) (state: 's) : 's =
         match result with
         | Error _ -> state
         | Ok x -> folder x state

--- a/src/fable-library-rust/src/Result.fs
+++ b/src/fable-library-rust/src/Result.fs
@@ -24,3 +24,63 @@ let isError result : bool =
     match result with
     | Error _ -> true
     | Ok _ -> false
+
+let contains value result =
+    match result with
+    | Error _ -> false
+    | Ok x -> x = value
+
+let count result =
+    match result with
+    | Error _ -> 0
+    | Ok _ -> 1
+
+let defaultValue defaultValue result =
+    match result with
+    | Error _ -> defaultValue
+    | Ok x -> x
+
+let defaultWith defThunk result =
+    match result with
+    | Error e -> defThunk e
+    | Ok x -> x
+
+let exists predicate result =
+    match result with
+    | Error _ -> false
+    | Ok x -> predicate x
+
+let fold folder state result =
+    match result with
+    | Error _ -> state
+    | Ok x -> folder state x
+
+let foldBack folder result state =
+    match result with
+    | Error _ -> state
+    | Ok x -> folder x state
+
+let forall predicate result =
+    match result with
+    | Error _ -> true
+    | Ok x -> predicate x
+
+let iterate action result =
+    match result with
+    | Error _ -> ()
+    | Ok x -> action x
+
+let toArray result =
+    match result with
+    | Error _ -> [||]
+    | Ok x -> [| x |]
+
+let toList result =
+    match result with
+    | Error _ -> []
+    | Ok x -> [ x ]
+
+let toOption result =
+    match result with
+    | Error _ -> None
+    | Ok x -> Some x

--- a/src/fable-library-rust/src/Result.fs
+++ b/src/fable-library-rust/src/Result.fs
@@ -60,7 +60,7 @@ let foldBack folder result state =
     | Error _ -> state
     | Ok x -> folder x state
 
-let forall predicate result =
+let forAll predicate result =
     match result with
     | Error _ -> true
     | Ok x -> predicate x

--- a/src/fable-library/Choice.fs
+++ b/src/fable-library/Choice.fs
@@ -36,6 +36,88 @@ module Result =
         | Error _ -> true
         | Ok _ -> false
 
+    [<CompiledName("Contains")>]
+    let contains (value: 'a) (result: Result<'a, 'b>) : bool =
+        match result with
+        | Error _ -> false
+        | Ok x -> x = value
+
+    [<CompiledName("Count")>]
+    let count (result: Result<'a, 'b>) : int =
+        match result with
+        | Error _ -> 0
+        | Ok _ -> 1
+
+    [<CompiledName("DefaultValue")>]
+    let defaultValue (defaultValue: 'a) (result: Result<'a, 'b>) : 'a =
+        match result with
+        | Error _ -> defaultValue
+        | Ok x -> x
+
+    [<CompiledName("DefaultWith")>]
+    let defaultWith (defThunk: 'b -> 'a) (result: Result<'a, 'b>) : 'a =
+        match result with
+        | Error e -> defThunk e
+        | Ok x -> x
+
+    [<CompiledName("Exists")>]
+    let exists (predicate: 'a -> bool) (result: Result<'a, 'b>) : bool =
+        match result with
+        | Error _ -> false
+        | Ok x -> predicate x
+
+    [<CompiledName("Fold")>]
+    let fold<'a, 'b, 's>
+        (folder: 's -> 'a -> 's)
+        (state: 's)
+        (result: Result<'a, 'b>)
+        : 's
+        =
+        match result with
+        | Error _ -> state
+        | Ok x -> folder state x
+
+    [<CompiledName("FoldBack")>]
+    let foldBack<'a, 'b, 's>
+        (folder: 'a -> 's -> 's)
+        (result: Result<'a, 'b>)
+        (state: 's)
+        : 's
+        =
+        match result with
+        | Error _ -> state
+        | Ok x -> folder x state
+
+    [<CompiledName("ForAll")>]
+    let forall (predicate: 'a -> bool) (result: Result<'a, 'b>) : bool =
+        match result with
+        | Error _ -> true
+        | Ok x -> predicate x
+
+    [<CompiledName("Iterate")>]
+    let iterate (action: 'a -> unit) (result: Result<'a, 'b>) : unit =
+        match result with
+        | Error _ -> ()
+        | Ok x -> action x
+
+    [<CompiledName("ToArray")>]
+    let toArray (result: Result<'a, 'b>) : 'a[] =
+        match result with
+        | Error _ -> [||]
+        | Ok x -> [| x |]
+
+    [<CompiledName("ToList")>]
+    let toList (result: Result<'a, 'b>) : 'a list =
+        match result with
+        | Error _ -> []
+        | Ok x -> [ x ]
+
+    [<CompiledName("ToOption")>]
+    let toOption (result: Result<'a, 'b>) : Option<'a> =
+        match result with
+        | Error _ -> None
+        | Ok x -> Some x
+
 [<CompiledName("FSharpChoice`2")>]
 type Choice<'T1, 'T2> =
     | Choice1Of2 of 'T1

--- a/src/fable-library/Choice.fs
+++ b/src/fable-library/Choice.fs
@@ -67,23 +67,13 @@ module Result =
         | Ok x -> predicate x
 
     [<CompiledName("Fold")>]
-    let fold<'a, 'b, 's>
-        (folder: 's -> 'a -> 's)
-        (state: 's)
-        (result: Result<'a, 'b>)
-        : 's
-        =
+    let fold<'a, 'b, 's> (folder: 's -> 'a -> 's) (state: 's) (result: Result<'a, 'b>) : 's =
         match result with
         | Error _ -> state
         | Ok x -> folder state x
 
     [<CompiledName("FoldBack")>]
-    let foldBack<'a, 'b, 's>
-        (folder: 'a -> 's -> 's)
-        (result: Result<'a, 'b>)
-        (state: 's)
-        : 's
-        =
+    let foldBack<'a, 'b, 's> (folder: 'a -> 's -> 's) (result: Result<'a, 'b>) (state: 's) : 's =
         match result with
         | Error _ -> state
         | Ok x -> folder x state

--- a/tests/Dart/src/ResultTests.fs
+++ b/tests/Dart/src/ResultTests.fs
@@ -54,3 +54,95 @@ let tests() =
     testCase "isError function can be generated" <| fun () ->
         Ok 10 |> Result.isError |> equal false
         Error 10 |> Result.isError |> equal true
+
+    testCase "contains function can be generated" <| fun () ->
+        let ok: Result<int, string> = Ok 42
+        let err: Result<int, string> = Error "error"
+
+        ok |> Result.contains 42 |> equal true
+        ok |> Result.contains 43 |> equal false
+        err |> Result.contains 42 |> equal false
+
+    testCase "count function can be generated" <| fun () ->
+        let ok: Result<int, string> = Ok 42
+        let err: Result<int, string> = Error "error"
+
+        ok |> Result.count |> equal 1
+        err |> Result.count |> equal 0
+
+    testCase "defaultValue function can be generated" <| fun () ->
+        let ok: Result<int, string> = Ok 42
+        let err: Result<int, string> = Error "error"
+
+        ok |> Result.defaultValue 0 |> equal 42
+        err |> Result.defaultValue 0 |> equal 0
+
+    testCase "defaultWith function can be generated" <| fun () ->
+        let ok: Result<int, string> = Ok 42
+        let err: Result<int, string> = Error "error"
+
+        ok |> Result.defaultWith (fun e -> e.Length) |> equal 42
+        err |> Result.defaultWith (fun e -> e.Length) |> equal 5
+
+    testCase "exists function can be generated" <| fun () ->
+        let ok: Result<int, string> = Ok 42
+        let err: Result<int, string> = Error "error"
+
+        ok |> Result.exists ((=) 42) |> equal true
+        ok |> Result.exists ((=) 43) |> equal false
+        err |> Result.exists ((=) 42) |> equal false
+
+    testCase "fold function can be generated" <| fun () ->
+        let ok: Result<int, string> = Ok 42
+        let err: Result<int, string> = Error "error"
+
+        ok |> Result.fold (fun s x -> s || x % 2 = 0) false |> equal true
+        err |> Result.fold (fun s x -> s || x % 2 = 0) false |> equal false
+
+    testCase "foldBack function can be generated" <| fun () ->
+        let ok: Result<int, string> = Ok 42
+        let err: Result<int, string> = Error "error"
+
+        (ok, false) ||> Result.foldBack (fun x s -> s || x % 2 = 0) |> equal true
+        (err, false) ||> Result.foldBack (fun x s -> s || x % 2 = 0) |> equal false
+
+    testCase "forAll function can be generated" <| fun () ->
+        let ok: Result<int, string> = Ok 42
+        let err: Result<int, string> = Error "error"
+
+        ok |> Result.forall ((=) 42) |> equal true
+        ok |> Result.forall ((=) 43) |> equal false
+        err |> Result.forall ((=) 42) |> equal true
+
+    testCase "iter function can be generated" <| fun () ->
+        let ok: Result<int, string> = Ok 42
+        let err: Result<int, string> = Error "error"
+
+        let mutable count = 0
+        ok |> Result.iter (fun x -> count <- count + x)
+        equal 42 count
+
+        count <- 0
+        err |> Result.iter (fun x -> count <- count + x)
+        equal 0 count
+
+    testCase "toArray function can be generated" <| fun () ->
+        let ok: Result<int, string> = Ok 42
+        let err: Result<int, string> = Error "error"
+
+        ok |> Result.toArray |> equal [| 42 |]
+        err |> Result.toArray |> equal [||]
+
+    testCase "toList function can be generated" <| fun () ->
+        let ok: Result<int, string> = Ok 42
+        let err: Result<int, string> = Error "error"
+
+        ok |> Result.toList |> equal [ 42 ]
+        err |> Result.toList |> equal []
+
+    testCase "toOption function can be generated" <| fun () ->
+        let ok: Result<int, string> = Ok 42
+        let err: Result<int, string> = Error "error"
+
+        ok |> Result.toOption |> Option.get |> equal 42
+        err |> Result.toOption |> Option.isNone |> equal true

--- a/tests/Js/Main/ResultTests.fs
+++ b/tests/Js/Main/ResultTests.fs
@@ -58,4 +58,96 @@ let tests =
     testCase "isError function can be generated" <| fun () ->
         Ok 10 |> Result.isError |> equal false
         Error 10 |> Result.isError |> equal true
+
+    testCase "contains works" <| fun () ->
+        let ok: Result<int, string> = Ok 42
+        let err: Result<int, string> = Error "error"
+
+        ok |> Result.contains 42 |> equal true
+        ok |> Result.contains 43 |> equal false
+        err |> Result.contains 42 |> equal false
+
+    testCase "count works" <| fun () ->
+        let ok: Result<int, string> = Ok 42
+        let err: Result<int, string> = Error "error"
+
+        ok |> Result.count |> equal 1
+        err |> Result.count |> equal 0
+
+    testCase "defaultValue works" <| fun () ->
+        let ok: Result<int, string> = Ok 42
+        let err: Result<int, string> = Error "error"
+
+        ok |> Result.defaultValue 0 |> equal 42
+        err |> Result.defaultValue 0 |> equal 0
+
+    testCase "defaultWith works" <| fun () ->
+        let ok: Result<int, string> = Ok 42
+        let err: Result<int, string> = Error "error"
+
+        ok |> Result.defaultWith (fun e -> e.Length) |> equal 42
+        err |> Result.defaultWith (fun e -> e.Length) |> equal 5
+
+    testCase "exists works" <| fun () ->
+        let ok: Result<int, string> = Ok 42
+        let err: Result<int, string> = Error "error"
+
+        ok |> Result.exists ((=) 42) |> equal true
+        ok |> Result.exists ((=) 43) |> equal false
+        err |> Result.exists ((=) 42) |> equal false
+
+    testCase "fold works" <| fun () ->
+        let ok: Result<int, string> = Ok 42
+        let err: Result<int, string> = Error "error"
+
+        ok |> Result.fold (fun s x -> s || x % 2 = 0) false |> equal true
+        err |> Result.fold (fun s x -> s || x % 2 = 0) false |> equal false
+
+    testCase "foldBack works" <| fun () ->
+        let ok: Result<int, string> = Ok 42
+        let err: Result<int, string> = Error "error"
+
+        (ok, false) ||> Result.foldBack (fun x s -> s || x % 2 = 0) |> equal true
+        (err, false) ||> Result.foldBack (fun x s -> s || x % 2 = 0) |> equal false
+
+    testCase "forAll works" <| fun () ->
+        let ok: Result<int, string> = Ok 42
+        let err: Result<int, string> = Error "error"
+
+        ok |> Result.forall ((=) 42) |> equal true
+        ok |> Result.forall ((=) 43) |> equal false
+        err |> Result.forall ((=) 42) |> equal true
+
+    testCase "iter works" <| fun () ->
+        let ok: Result<int, string> = Ok 42
+        let err: Result<int, string> = Error "error"
+
+        let mutable count = 0
+        ok |> Result.iter (fun x -> count <- count + x)
+        equal 42 count
+
+        count <- 0
+        err |> Result.iter (fun x -> count <- count + x)
+        equal 0 count
+
+    testCase "toArray works" <| fun () ->
+        let ok: Result<int, string> = Ok 42
+        let err: Result<int, string> = Error "error"
+
+        ok |> Result.toArray |> equal [| 42 |]
+        err |> Result.toArray |> equal [||]
+
+    testCase "toList works" <| fun () ->
+        let ok: Result<int, string> = Ok 42
+        let err: Result<int, string> = Error "error"
+
+        ok |> Result.toList |> equal [ 42 ]
+        err |> Result.toList |> equal []
+
+    testCase "toOption works" <| fun () ->
+        let ok: Result<int, string> = Ok 42
+        let err: Result<int, string> = Error "error"
+
+        ok |> Result.toOption |> Option.get |> equal 42
+        err |> Result.toOption |> Option.isNone |> equal true
   ]

--- a/tests/Python/TestResult.fs
+++ b/tests/Python/TestResult.fs
@@ -61,3 +61,107 @@ let ``test isOk function can be generated`` () =
 let ``test isError function can be generated`` () =
     Ok 5 |> Result.isError |> equal false
     Error "error" |> Result.isError |> equal true
+
+[<Fact>]
+let ``test contains function can be generated`` () =
+    let ok: Result<int, string> = Ok 42
+    let err: Result<int, string> = Error "error"
+
+    ok |> Result.contains 42 |> equal true
+    ok |> Result.contains 43 |> equal false
+    err |> Result.contains 42 |> equal false
+
+[<Fact>]
+let ``count function can be generated`` () =
+    let ok: Result<int, string> = Ok 42
+    let err: Result<int, string> = Error "error"
+
+    ok |> Result.count |> equal 1
+    err |> Result.count |> equal 0
+
+[<Fact>]
+let ``defaultValue function can be generated`` () =
+    let ok: Result<int, string> = Ok 42
+    let err: Result<int, string> = Error "error"
+
+    ok |> Result.defaultValue 0 |> equal 42
+    err |> Result.defaultValue 0 |> equal 0
+
+[<Fact>]
+let ``defaultWith function can be generated`` () =
+    let ok: Result<int, string> = Ok 42
+    let err: Result<int, string> = Error "error"
+
+    ok |> Result.defaultWith (fun e -> e.Length) |> equal 42
+    err |> Result.defaultWith (fun e -> e.Length) |> equal 5
+
+[<Fact>]
+let ``exists function can be generated`` () =
+    let ok: Result<int, string> = Ok 42
+    let err: Result<int, string> = Error "error"
+
+    ok |> Result.exists ((=) 42) |> equal true
+    ok |> Result.exists ((=) 43) |> equal false
+    err |> Result.exists ((=) 42) |> equal false
+
+[<Fact>]
+let ``fold function can be generated`` () =
+    let ok: Result<int, string> = Ok 42
+    let err: Result<int, string> = Error "error"
+
+    ok |> Result.fold (fun s x -> s || x % 2 = 0) false |> equal true
+    err |> Result.fold (fun s x -> s || x % 2 = 0) false |> equal false
+
+[<Fact>]
+let ``foldBack function can be generated`` () =
+    let ok: Result<int, string> = Ok 42
+    let err: Result<int, string> = Error "error"
+
+    (ok, false) ||> Result.foldBack (fun x s -> s || x % 2 = 0) |> equal true
+    (err, false) ||> Result.foldBack (fun x s -> s || x % 2 = 0) |> equal false
+
+[<Fact>]
+let ``forAll function can be generated`` () =
+    let ok: Result<int, string> = Ok 42
+    let err: Result<int, string> = Error "error"
+
+    ok |> Result.forall ((=) 42) |> equal true
+    ok |> Result.forall ((=) 43) |> equal false
+    err |> Result.forall ((=) 42) |> equal true
+
+[<Fact>]
+let ``iter function can be generated`` () =
+    let ok: Result<int, string> = Ok 42
+    let err: Result<int, string> = Error "error"
+
+    let mutable count = 0
+    ok |> Result.iter (fun x -> count <- count + x)
+    equal 42 count
+
+    count <- 0
+    err |> Result.iter (fun x -> count <- count + x)
+    equal 0 count
+
+[<Fact>]
+let ``toArray function can be generated`` () =
+    let ok: Result<int, string> = Ok 42
+    let err: Result<int, string> = Error "error"
+
+    ok |> Result.toArray |> equal [| 42 |]
+    err |> Result.toArray |> equal [||]
+
+[<Fact>]
+let ``toList function can be generated`` () =
+    let ok: Result<int, string> = Ok 42
+    let err: Result<int, string> = Error "error"
+
+    ok |> Result.toList |> equal [ 42 ]
+    err |> Result.toList |> equal []
+
+[<Fact>]
+let ``toOption function can be generated`` () =
+    let ok: Result<int, string> = Ok 42
+    let err: Result<int, string> = Error "error"
+
+    ok |> Result.toOption |> Option.get |> equal 42
+    err |> Result.toOption |> Option.isNone |> equal true

--- a/tests/Rust/tests/src/ResultTests.fs
+++ b/tests/Rust/tests/src/ResultTests.fs
@@ -68,6 +68,111 @@ let ``isError function can be generated`` () =
     err |> Result.isError |> equal true
 
 [<Fact>]
+let ``test contains function can be generated`` () =
+    let ok: Result<int, string> = Ok 42
+    let err: Result<int, string> = Error "error"
+
+    ok |> Result.contains 42 |> equal true
+    ok |> Result.contains 43 |> equal false
+    err |> Result.contains 42 |> equal false
+
+[<Fact>]
+let ``count function can be generated`` () =
+    let ok: Result<int, string> = Ok 42
+    let err: Result<int, string> = Error "error"
+
+    ok |> Result.count |> equal 1
+    err |> Result.count |> equal 0
+
+[<Fact>]
+let ``defaultValue function can be generated`` () =
+    let ok: Result<int, string> = Ok 42
+    let err: Result<int, string> = Error "error"
+
+    ok |> Result.defaultValue 0 |> equal 42
+    err |> Result.defaultValue 0 |> equal 0
+
+[<Fact>]
+let ``defaultWith function can be generated`` () =
+    let ok: Result<int, string> = Ok 42
+    let err: Result<int, string> = Error "error"
+
+    ok |> Result.defaultWith (fun e -> e.Length) |> equal 42
+    err |> Result.defaultWith (fun e -> e.Length) |> equal 5
+
+[<Fact>]
+let ``exists function can be generated`` () =
+    let ok: Result<int, string> = Ok 42
+    let err: Result<int, string> = Error "error"
+
+    ok |> Result.exists ((=) 42) |> equal true
+    ok |> Result.exists ((=) 43) |> equal false
+    err |> Result.exists ((=) 42) |> equal false
+
+[<Fact>]
+let ``fold function can be generated`` () =
+    let ok: Result<int, string> = Ok 42
+    let err: Result<int, string> = Error "error"
+
+    ok |> Result.fold (fun s x -> s || x % 2 = 0) false |> equal true
+    err |> Result.fold (fun s x -> s || x % 2 = 0) false |> equal false
+
+[<Fact>]
+let ``foldBack function can be generated`` () =
+    let ok: Result<int, string> = Ok 42
+    let err: Result<int, string> = Error "error"
+
+    (ok, false) ||> Result.foldBack (fun x s -> s || x % 2 = 0) |> equal true
+    (err, false) ||> Result.foldBack (fun x s -> s || x % 2 = 0) |> equal false
+
+[<Fact>]
+let ``forAll function can be generated`` () =
+    let ok: Result<int, string> = Ok 42
+    let err: Result<int, string> = Error "error"
+
+    ok |> Result.forall ((=) 42) |> equal true
+    ok |> Result.forall ((=) 43) |> equal false
+    err |> Result.forall ((=) 42) |> equal true
+
+[<Fact>]
+let ``iter function can be generated`` () =
+    let ok: Result<int, string> = Ok 42
+    let err: Result<int, string> = Error "error"
+
+    let mutable count = 0
+    ok |> Result.iter (fun x -> count <- count + x)
+    equal 42 count
+
+    count <- 0
+    err |> Result.iter (fun x -> count <- count + x)
+    equal 0 count
+
+[<Fact>]
+let ``toArray function can be generated`` () =
+    let ok: Result<int, string> = Ok 42
+    let err: Result<int, string> = Error "error"
+
+    ok |> Result.toArray |> equal [| 42 |]
+    err |> Result.toArray |> equal [||]
+
+[<Fact>]
+let ``toList function can be generated`` () =
+    let ok: Result<int, string> = Ok 42
+    let err: Result<int, string> = Error "error"
+
+    ok |> Result.toList |> equal [ 42 ]
+    err |> Result.toList |> equal []
+
+[<Fact>]
+let ``toOption function can be generated`` () =
+    let ok: Result<int, string> = Ok 42
+    let err: Result<int, string> = Error "error"
+
+    ok |> Result.toOption |> Option.get |> equal 42
+    err |> Result.toOption |> Option.isNone |> equal true
+
+
+[<Fact>]
 let ``Choice matching works`` () =
     let ok: Choice<string, int> = Choice1Of2 "foo"
     match ok with


### PR DESCRIPTION
Issue #3732

Seemed like low hanging fruit to implement the rest of the Result module after `Result.isOk` and `Result.isError`.

There was a slight issue with Rust.Replacements that I don't quite understand yet. The workaround is there but if there is a suggestion I'll gladly take another look.

Note that `Result.toValueOption` was _not_ implemented.