### PR TITLE
[Python] Fixes custom equality on records

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -37,6 +37,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Remove `Choice.d.ts` from source code of `fable-library` (by @MangelMaxime)
 
+### Fixed
+
+#### Python
+
+* [GH-3717](https://github.com/fable-compiler/Fable/issues/3717) Nested type with Custom Equality gives false negative equality (by @dbrattli)
+* Generate assert statements for `assert` expressions in debug mode (by @dbrattli)
+
 ## 4.11.0 - 2024-01-30
 
 ### Changed

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -3276,17 +3276,9 @@ module Util =
             | Fable.Throw(expr, _) ->
                 match expr with
                 | None -> failwith "TODO: rethrow"
-                | Some(TransformExpr com ctx (e, stmts)) ->
-                    stmts @ [ Statement.raise e ]
+                | Some(TransformExpr com ctx (e, stmts)) -> stmts @ [ Statement.raise e ]
             | Fable.Debugger ->
-                [
-                    Statement.assert' (
-                        Expression.boolOp (
-                            op = Or,
-                            values = [ Expression.boolConstant true ]
-                        )
-                    )
-                ]
+                [ Statement.assert' (Expression.boolOp (op = Or, values = [ Expression.boolConstant true ])) ]
 
         | Fable.TypeCast(e, t) ->
             let expr, stmts = transformCast com ctx t e
@@ -3430,8 +3422,7 @@ module Util =
             | _ -> stmts @ (expr' |> resolveExpr ctx expr.Type returnStrategy)
         | Fable.IfThenElse(guardExpr,
                            Fable.Expr.Extended(Fable.ExtendedSet.Debugger, _),
-                           Fable.Expr.Value(Fable.ValueKind.Null Fable.Type.Unit,
-                                            None),
+                           Fable.Expr.Value(Fable.ValueKind.Null Fable.Type.Unit, None),
                            r) ->
             // Rewrite `if (guard) { Debugger; null }` to assert (guard)
             let guardExpr', stmts = transformAsExpr com ctx guardExpr

--- a/src/Fable.Transforms/Python/Python.fs
+++ b/src/Fable.Transforms/Python/Python.fs
@@ -112,6 +112,7 @@ type Statement =
     | While of While
     | Raise of Raise
     | Import of Import
+    | Assert of Assert
     | Assign of Assign
     | Return of Return
     | Global of Global
@@ -511,6 +512,12 @@ type AsyncFunctionDef =
 /// `````
 type Import = { Names: Alias list }
 
+/// An assertion. test holds the condition, such as a Compare node. msg holds the failure message.
+type Assert =
+    {
+        Test: Expression
+        Msg: Expression option
+    }
 
 /// Represents from x import y. module is a raw string of the ‘from’ name, without any leading dots, or None for
 /// statements such as from . import foo. level is an integer holding the level of the relative import (0 means absolute
@@ -851,6 +858,13 @@ module PythonExtensions =
     let Ellipsis = "..."
 
     type Statement with
+
+        static member assert'(test, ?msg) : Statement =
+            {
+                Test = test
+                Msg = msg
+            }
+            |> Assert
 
         static member break'() : Statement = Break
         static member continue' ?loc : Statement = Continue

--- a/src/Fable.Transforms/Python/PythonPrinter.fs
+++ b/src/Fable.Transforms/Python/PythonPrinter.fs
@@ -21,6 +21,7 @@ module PrinterExtensions =
             | AsyncFor st -> printer.Print(st)
             | Return rtn -> printer.Print(rtn)
             | Global st -> printer.Print(st)
+            | Assert st -> printer.Print(st)
             | Import im -> printer.Print(im)
             | Assign st -> printer.Print(st)
             | AnnAssign st -> printer.Print(st)
@@ -59,6 +60,14 @@ module PrinterExtensions =
                 printer.Print(": ")
                 printer.Print(ann)
             | _ -> ()
+
+        member printer.Print(st: Assert) =
+            printer.Print("assert ")
+            printer.Print(st.Test)
+
+            if st.Msg.IsSome then
+                printer.Print(", ")
+                printer.Print(st.Msg.Value)
 
         member printer.Print(kw: Keyword) =
             let (Identifier name) = kw.Arg

--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -3364,15 +3364,17 @@ let debug (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr optio
     | "Break" -> makeDebugger r |> Some
     | "Assert" ->
         let unit = Value(Null Unit, None)
+        // printfn "Assert: %A" args
 
         match args with
         | []
         | [ Value(BoolConstant true, _) ] -> Some unit
         | [ Value(BoolConstant false, _) ] -> makeDebugger r |> Some
         | arg :: _ ->
-            // emit i "if (!$0) { debugger; }" i.args |> Some
-            let cond = Operation(Unary(UnaryNot, arg), Tags.empty, Boolean, r)
-            IfThenElse(cond, makeDebugger r, unit, r) |> Some
+            // For Python we don't have a debugger, so we use the if statement to
+            // capture the guard expression and then rewrite the code back to
+            // an assert statement when translating to Python
+            IfThenElse(arg, makeDebugger r, unit, r) |> Some
     | _ -> None
 
 let private ignoreFormatProvider com (ctx: Context) r (moduleName: string) meth args =

--- a/src/fable-library-py/fable_library/types.py
+++ b/src/fable-library-py/fable_library/types.py
@@ -126,6 +126,9 @@ def record_compare_to(self: Record, other: Record) -> int:
                 return -1
             case (_, None):
                 return 1
+            # Check for custom equality
+            case (self_value, other_value) if self_value == other_value:
+                return 0
             case (self_value, other_value) if self_value < other_value:
                 return -1
             case (self_value, other_value) if self_value > other_value:

--- a/tests/Python/TestNonRegression.fs
+++ b/tests/Python/TestNonRegression.fs
@@ -137,8 +137,8 @@ let ``test nested type with custom equality works`` () =
     // Should all be equal according to custom equality of inner type
     let y1 = {Issue3717.X = x1}
     let y2 = {Issue3717.X = x2}
-    //let y3 = {Issue3717.X = x1}
+    let y3 = {Issue3717.X = x1}
 
-    //equal x1 x2
+    equal x1 x2
     equal y1 y2
-    //equal y1 y3
+    equal y1 y3

--- a/tests/Python/TestNonRegression.fs
+++ b/tests/Python/TestNonRegression.fs
@@ -65,8 +65,8 @@ let ``test hashcodes are unique`` () =
     // objects to make sure they are not optimized away.
     let xHash = x.GetHashCode()
     let yHash = y.GetHashCode()
-    assert (xHash > 0)
-    assert (yHash > 0)
+    xHash <> 0 |> equal true
+    yHash <> 0 |> equal true
 
 let ``test record hashcodes are unique`` () =
     let x =
@@ -93,8 +93,8 @@ let ``test record hashcodes are unique`` () =
     // objects to make sure they are not optimized away.
     let xHash = x.GetHashCode()
     let yHash = y.GetHashCode()
-    assert (xHash > 0)
-    assert (yHash > 0)
+    xHash <> 0 |> equal true
+    yHash <> 0 |> equal true
 
 
 let ``test Nested type with Custom Hashcode works`` () =
@@ -106,5 +106,39 @@ let ``test Nested type with Custom Hashcode works`` () =
 
     let y = Issue3674.X x
 
-    assert (x.GetHashCode() > 0)
-    assert (y.GetHashCode() > 0)
+    x.GetHashCode() <> 0 |> equal true
+    y.GetHashCode() <> 0 |> equal true
+
+module Issue3717 =
+    [<CustomEquality; NoComparison>]
+    type X =
+        {
+            ID : int
+            Name : string
+        }
+
+        override x.GetHashCode() = x.ID
+
+        override this.Equals(other : obj) =
+            match other with
+            | :? X as other -> this.ID = other.ID
+            | _ -> false
+
+    // Record type here (unlike issue #3674)
+    type Y =
+        {X : X}
+
+let ``test nested type with custom equality works`` () =
+
+    // Should be equal according to custom equality
+    let x1 = {Issue3717.ID = 1; Issue3717.Name = "a"}
+    let x2 = {Issue3717.ID = 1; Issue3717.Name = "b"}
+
+    // Should all be equal according to custom equality of inner type
+    let y1 = {Issue3717.X = x1}
+    let y2 = {Issue3717.X = x2}
+    //let y3 = {Issue3717.X = x1}
+
+    //equal x1 x2
+    equal y1 y2
+    //equal y1 y3


### PR DESCRIPTION
- Nested type with Custom Equality gives false negative equality, fixes #3717 
- Generate assert statements for `assert` expressions in debug mode