### PR TITLE
Add Result.toValueOption to Node/Python/Dart and *cough* Rust

### DIFF
--- a/src/Fable.Transforms/Dart/Replacements.fs
+++ b/src/Fable.Transforms/Dart/Replacements.fs
@@ -2345,8 +2345,24 @@ let disposables (com: ICompiler) (_: Context) r (t: Type) (i: CallInfo) (thisArg
 
 let results (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (_: Expr option) (args: Expr list) =
     match i.CompiledName with
-    | ("Bind" | "Map" | "MapError" | "IsOk" | "IsError" | "Contains" | "Count" | "DefaultValue" | "DefaultWith" | "Exists" | "Fold" | "FoldBack" | "ForAll" | "Iterate" | "ToArray" | "ToList" | "ToOption") as meth ->
-        Some("Result_" + meth)
+    | "Bind"
+    | "Map"
+    | "MapError"
+    | "IsOk"
+    | "IsError"
+    | "Contains"
+    | "Count"
+    | "DefaultValue"
+    | "DefaultWith"
+    | "Exists"
+    | "Fold"
+    | "FoldBack"
+    | "ForAll"
+    | "Iterate"
+    | "ToArray"
+    | "ToList"
+    | "ToOption"
+    | "ToValueOption" as meth -> Some("Result_" + meth)
     | _ -> None
     |> Option.map (fun meth ->
         Helper.LibCall(com, "Choice", meth, t, args, i.SignatureArgTypes, genArgs = i.GenericArgs, ?loc = r)

--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -2589,8 +2589,24 @@ let mapModule (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (_: Expr
 
 let results (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (_: Expr option) (args: Expr list) =
     match i.CompiledName with
-    | ("Bind" | "Map" | "MapError" | "IsOk" | "IsError" | "Contains" | "Count" | "DefaultValue" | "DefaultWith" | "Exists" | "Fold" | "FoldBack" | "ForAll" | "Iterate" | "ToArray" | "ToList" | "ToOption") as meth ->
-        Some("Result_" + meth)
+    | "Bind"
+    | "Map"
+    | "MapError"
+    | "IsOk"
+    | "IsError"
+    | "Contains"
+    | "Count"
+    | "DefaultValue"
+    | "DefaultWith"
+    | "Exists"
+    | "Fold"
+    | "FoldBack"
+    | "ForAll"
+    | "Iterate"
+    | "ToArray"
+    | "ToList"
+    | "ToOption"
+    | "ToValueOption" as meth -> Some("Result_" + meth)
     | _ -> None
     |> Option.map (fun meth -> Helper.LibCall(com, "choice", meth, t, args, i.SignatureArgTypes, ?loc = r))
 

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -2713,8 +2713,24 @@ let disposables (com: ICompiler) (_: Context) r (t: Type) (i: CallInfo) (thisArg
 
 let results (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (_: Expr option) (args: Expr list) =
     match i.CompiledName with
-    | ("Bind" | "Map" | "MapError" | "IsOk" | "IsError" | "Contains" | "Count" | "DefaultValue" | "DefaultWith" | "Exists" | "Fold" | "FoldBack" | "ForAll" | "Iterate" | "ToArray" | "ToList" | "ToOption") as meth ->
-        Some("Result_" + meth)
+    | "Bind"
+    | "Map"
+    | "MapError"
+    | "IsOk"
+    | "IsError"
+    | "Contains"
+    | "Count"
+    | "DefaultValue"
+    | "DefaultWith"
+    | "Exists"
+    | "Fold"
+    | "FoldBack"
+    | "ForAll"
+    | "Iterate"
+    | "ToArray"
+    | "ToList"
+    | "ToOption"
+    | "ToValueOption" as meth -> Some("Result_" + meth)
     | _ -> None
     |> Option.map (fun meth ->
         Helper.LibCall(com, "Choice", meth, t, args, i.SignatureArgTypes, genArgs = i.GenericArgs, ?loc = r)

--- a/src/Fable.Transforms/Rust/Replacements.fs
+++ b/src/Fable.Transforms/Rust/Replacements.fs
@@ -2689,7 +2689,24 @@ let mapModule (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (_: Expr
 
 let results (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (_: Expr option) (args: Expr list) =
     match i.CompiledName with
-    | ("Bind" | "Map" | "MapError" | "IsOk" | "IsError" | "Contains" | "Count" | "DefaultValue" | "DefaultWith" | "Exists" | "Fold" | "FoldBack" | "Iterate" | "ToArray" | "ToList" | "ToOption" | "ForAll") as meth ->
+    | "Bind"
+    | "Map"
+    | "MapError"
+    | "IsOk"
+    | "IsError"
+    | "Contains"
+    | "Count"
+    | "DefaultValue"
+    | "DefaultWith"
+    | "Exists"
+    | "Fold"
+    | "FoldBack"
+    | "ForAll"
+    | "Iterate"
+    | "ToArray"
+    | "ToList"
+    | "ToOption"
+    | "ToValueOption" as meth ->
         Helper.LibCall(com, "Result", Naming.lowerFirst meth, t, args, i.SignatureArgTypes, ?loc = r)
         |> Some
     | _ -> None

--- a/src/fable-library-dart/Choice.fs
+++ b/src/fable-library-dart/Choice.fs
@@ -108,6 +108,12 @@ module Result =
         | Error _ -> None
         | Ok x -> Some x
 
+    [<CompiledName("ToValueOption")>]
+    let toValueOption (result: Result<'a, 'b>) : ValueOption<'a> =
+        match result with
+        | Error _ -> ValueNone
+        | Ok x -> ValueSome x
+
 [<CompiledName("FSharpChoice`2")>]
 type Choice<'T1, 'T2> =
     | Choice1Of2 of 'T1

--- a/src/fable-library-rust/src/Result.fs
+++ b/src/fable-library-rust/src/Result.fs
@@ -84,3 +84,8 @@ let toOption result =
     match result with
     | Error _ -> None
     | Ok x -> Some x
+
+let toValueOption result =
+    match result with
+    | Error _ -> ValueNone
+    | Ok x -> ValueSome x

--- a/src/fable-library/Choice.fs
+++ b/src/fable-library/Choice.fs
@@ -108,6 +108,12 @@ module Result =
         | Error _ -> None
         | Ok x -> Some x
 
+    [<CompiledName("ToValueOption")>]
+    let toValueOption (result: Result<'a, 'b>) : ValueOption<'a> =
+        match result with
+        | Error _ -> ValueNone
+        | Ok x -> ValueSome x
+
 [<CompiledName("FSharpChoice`2")>]
 type Choice<'T1, 'T2> =
     | Choice1Of2 of 'T1

--- a/tests/Dart/src/ResultTests.fs
+++ b/tests/Dart/src/ResultTests.fs
@@ -146,3 +146,10 @@ let tests() =
 
         ok |> Result.toOption |> Option.get |> equal 42
         err |> Result.toOption |> Option.isNone |> equal true
+
+    testCase "toValueOption works" <| fun () ->
+        let ok: Result<int, string> = Ok 42
+        let err: Result<int, string> = Error "error"
+
+        ok |> Result.toValueOption |> ValueOption.get |> equal 42
+        err |> Result.toValueOption |> ValueOption.isNone |> equal true

--- a/tests/Js/Main/ResultTests.fs
+++ b/tests/Js/Main/ResultTests.fs
@@ -150,4 +150,11 @@ let tests =
 
         ok |> Result.toOption |> Option.get |> equal 42
         err |> Result.toOption |> Option.isNone |> equal true
+
+    testCase "toValueOption works" <| fun () ->
+        let ok: Result<int, string> = Ok 42
+        let err: Result<int, string> = Error "error"
+
+        ok |> Result.toValueOption |> ValueOption.get |> equal 42
+        err |> Result.toValueOption |> ValueOption.isNone |> equal true
   ]

--- a/tests/Python/TestResult.fs
+++ b/tests/Python/TestResult.fs
@@ -165,3 +165,11 @@ let ``toOption function can be generated`` () =
 
     ok |> Result.toOption |> Option.get |> equal 42
     err |> Result.toOption |> Option.isNone |> equal true
+
+[<Fact>]
+let ``toValueOption function can be generated`` () =
+    let ok: Result<int, string> = Ok 42
+    let err: Result<int, string> = Error "error"
+
+    ok |> Result.toValueOption |> ValueOption.get |> equal 42
+    err |> Result.toValueOption |> ValueOption.isNone |> equal true

--- a/tests/Rust/tests/src/ResultTests.fs
+++ b/tests/Rust/tests/src/ResultTests.fs
@@ -171,6 +171,13 @@ let ``toOption function can be generated`` () =
     ok |> Result.toOption |> Option.get |> equal 42
     err |> Result.toOption |> Option.isNone |> equal true
 
+[<Fact>]
+let ``toValueOption function can be generated`` () =
+    let ok: Result<int, string> = Ok 42
+    let err: Result<int, string> = Error "error"
+
+    ok |> Result.toValueOption |> ValueOption.get |> equal 42
+    err |> Result.toValueOption |> ValueOption.isNone |> equal true
 
 [<Fact>]
 let ``Choice matching works`` () =


### PR DESCRIPTION
Should complete #3732 

I swear, one day Rust will be the death of me.

I'm not quite sure what I'm doing wrong, but **the Rust tests are currently not compiling for me**. I'm getting the same error as found my comment on the previous PR (#3733).

```
malloc(): unaligned tcache chunk detected
error: test failed, to rerun pass `--test src`

Caused by:
  process didn't exit successfully: `/workspaces/Fable/temp/tests/Rust/target/debug/deps/src-7c4fdba163c9ac55` (signal: 5, SIGTRAP: trace/breakpoint trap)
Compilation failed
Unhandled exception. SimpleExec.ExitCodeException: The command exited with code 1.
   at SimpleExec.Command.Run(ProcessStartInfo startInfo, Boolean noEcho, String echoPrefix, Func`2 handleExitCode, CancellationToken cancellationToken) in /_/SimpleExec/Command.cs:line 121
   at SimpleExec.Command.Run(String name, String args, String workingDirectory, Boolean noEcho, String echoPrefix, Action`1 configureEnvironment, Boolean createNoWindow, Func`2 handleExitCode, CancellationToken cancellationToken) in /_/SimpleExec/Command.cs:line 54
   at SimpleExec.Command.Fable.Static(CmdLine args, FSharpOption`1 workingDirectory, FSharpOption`1 noEcho, FSharpOption`1 echoPrefix) in /workspaces/Fable/src/Fable.Build/SimpleExec.Extensions.fs:line 26
   at Build.Test.Rust.handle(FSharpList`1 args) in /workspaces/Fable/src/Fable.Build/Test/Rust.fs:line 104
   at Build.Main.main(String[] argv) in /workspaces/Fable/src/Fable.Build/Main.fs:line 127
```

I'm assuming it's something simple and silly I'm missing because when I pulled down main after the changes from the last PR, all tests passed. If you see it, let me know and I'll gladly push a new change.