### PR TITLE
Extract type-checking from compilation

### DIFF
--- a/src/Fable.Compiler/CHANGELOG.md
+++ b/src/Fable.Compiler/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * [GH-3742](https://github.com/fable-compiler/Fable/pull/3742) Return diagnostics in compile response (by @nojaf)
+* [GH-3746](https://github.com/fable-compiler/Fable/pull/3746) Extract type-checking from compilation (by @nojaf)
 
 ## 4.0.0-alpha-004 - 2024-01-30
 

--- a/src/Fable.Compiler/Library.fsi
+++ b/src/Fable.Compiler/Library.fsi
@@ -1,7 +1,8 @@
-module Fable.Compiler.CodeServices
+namespace Fable.Compiler
 
 open FSharp.Compiler.SourceCodeServices
 open FSharp.Compiler.Diagnostics
+open FSharp.Compiler.CodeAnalysis
 open Fable
 open Fable.Compiler.Util
 open Fable.Compiler.ProjectCracker
@@ -14,23 +15,40 @@ type CompileResult =
         Diagnostics: FSharpDiagnostic array
     }
 
-/// Does a full type-check of the current project.
-/// And compiles the implementation files to JavaScript.
-val compileProjectToJavaScript:
-    sourceReader: SourceReader ->
-    checker: InteractiveChecker ->
-    pathResolver: PathResolver ->
-    cliArgs: CliArgs ->
-    crackerResponse: CrackerResponse ->
-        Async<CompileResult>
+type TypeCheckProjectResult =
+    {
+        Assemblies: FSharp.Compiler.Symbols.FSharpAssembly list
+        ProjectCheckResults: FSharpCheckProjectResults
+    }
 
-/// Type-checks the project up until the last transitive dependent file.
-/// Compile the current and the transitive dependent files to JavaScript.
-val compileFileToJavaScript:
-    sourceReader: SourceReader ->
-    checker: InteractiveChecker ->
-    pathResolver: PathResolver ->
-    cliArgs: CliArgs ->
-    crackerResponse: CrackerResponse ->
-    currentFile: string ->
-        Async<CompileResult>
+[<RequireQualifiedAccess>]
+module CodeServices =
+
+    /// Type check a project using the InteractiveChecker
+    val typeCheckProject:
+        sourceReader: SourceReader ->
+        checker: InteractiveChecker ->
+        cliArgs: CliArgs ->
+        crackerResponse: CrackerResponse ->
+            Async<TypeCheckProjectResult>
+
+    /// And compile multiple files of a project to JavaScript.
+    /// The expected usage of this function is either every file in the project or only the user files.
+    val compileMultipleFilesToJavaScript:
+        pathResolver: PathResolver ->
+        cliArgs: CliArgs ->
+        crackerResponse: CrackerResponse ->
+        typeCheckProjectResult: TypeCheckProjectResult ->
+        inputFiles: string seq ->
+            Async<CompileResult>
+
+    /// Type-checks the project up until the last transitive dependent file.
+    /// Compile the current and the transitive dependent files to JavaScript.
+    val compileFileToJavaScript:
+        sourceReader: SourceReader ->
+        checker: InteractiveChecker ->
+        pathResolver: PathResolver ->
+        cliArgs: CliArgs ->
+        crackerResponse: CrackerResponse ->
+        currentFile: string ->
+            Async<CompileResult>


### PR DESCRIPTION
It is slightly more convenient to have a separate type-check function and be able to compile a specific set of files.