### PR TITLE
Accessing an array out of bounds, should generates an exception like on .NET

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Update to Fable.AST 4.4.0
 
+### Fixed
+
+#### JavaScript
+
+* [GH-3748](https://github.com/fable-compiler/Fable/pull/3748) Accessing an array out of bounds should emit an exception (by @MangelMaxime)
+* [GH-3748](https://github.com/fable-compiler/Fable/pull/3748) Setting an array out of bounds should emit an exception (by @MangelMaxime)
+
 ## 4.12.1 - 2024-02-13
 
 ### Fixed

--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -63,10 +63,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### JavaScript
 
 * Remove `Choice.d.ts` from source code of `fable-library` (by @MangelMaxime)
+* [GH-3748](https://github.com/fable-compiler/Fable/pull/3748) Accessing an array out of bounds should emit an exception (by @MangelMaxime)
 
 #### TypeScript
 
 * Remove `Choice.d.ts` from source code of `fable-library` (by @MangelMaxime)
+* [GH-3748](https://github.com/fable-compiler/Fable/pull/3748) Accessing an array out of bounds should emit an exception (by @MangelMaxime)
 
 ### Fixed
 

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -2341,7 +2341,19 @@ module Util =
             | Fable.ExprSet(TransformExpr com ctx e) -> getExpr None expr e
             | Fable.FieldSet(fieldName) -> get None expr fieldName
 
-        assign range ret value
+        // If this is an arry setter, we need to use the `setItem` method
+        // as it allows to check the bounds of the array
+        match fableExpr with
+        | Fable.IdentExpr ident ->
+            match ident.Type with
+            | Fable.Type.Array _ ->
+                match kind with
+                | Fable.ExprSet(TransformExpr com ctx index) ->
+                    libCall com ctx range "Array" "setItem" [] [ expr; index; value ]
+
+                | _ -> assign range ret value
+            | _ -> assign range ret value
+        | _ -> assign range ret value
 
     let transformBindingExprBody (com: IBabelCompiler) (ctx: Context) (var: Fable.Ident) (value: Fable.Expr) =
         match value with

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -1948,8 +1948,34 @@ let arrayModule (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (_: Ex
         Helper.LibCall(com, "List", "ofArray", t, args, i.SignatureArgTypes, genArgs = i.GenericArgs, ?loc = r)
         |> Some
     | ("Length" | "Count"), [ arg ] -> getFieldWith r t arg "length" |> Some
-    | "Item", [ idx; ar ] -> getExpr r t ar idx |> Some
-    | "Get", [ ar; idx ] -> getExpr r t ar idx |> Some
+    | "Item", [ idx; ar ] ->
+        Helper.LibCall(
+            com,
+            "Array",
+            "item",
+            t,
+            [
+                idx
+                ar
+            ],
+            i.SignatureArgTypes,
+            ?loc = r
+        )
+        |> Some
+    | "Get", [ ar; idx ] ->
+        Helper.LibCall(
+            com,
+            "Array",
+            "item",
+            t,
+            [
+                idx
+                ar
+            ],
+            i.SignatureArgTypes |> List.rev,
+            ?loc = r
+        )
+        |> Some
     | "Set", [ ar; idx; value ] -> setExpr r ar idx value |> Some
     | "ZeroCreate", [ count ] -> createArray count None |> Some
     | "Create", [ count; value ] -> createArray count (Some value) |> Some
@@ -2500,8 +2526,21 @@ let intrinsicFunctions (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisAr
         |> withTag "downcast"
         |> Some
     | "MakeDecimal", _, _ -> decimals com ctx r t i thisArg args
-    | "GetString", _, [ ar; idx ]
-    | "GetArray", _, [ ar; idx ] -> getExpr r t ar idx |> Some
+    | "GetString", _, [ ar; idx ] -> getExpr r t ar idx |> Some
+    | "GetArray", _, [ ar; idx ] ->
+        Helper.LibCall(
+            com,
+            "Array",
+            "item",
+            t,
+            [
+                idx
+                ar
+            ],
+            i.SignatureArgTypes |> List.rev,
+            ?loc = r
+        )
+        |> Some
     | "SetArray", _, [ ar; idx; value ] -> setExpr r ar idx value |> Some
     | ("GetArraySlice" | "GetStringSlice"), None, [ ar; lower; upper ] ->
         let upper =

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -1922,6 +1922,10 @@ let arrays (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (thisArg: E
         |> Some
     | _ -> None
 
+let arrayGetItem (com: ICompiler) r (t: Type) (args: Expr list) (signatureArgTypes: Type list) =
+    Helper.LibCall(com, "Array", "item", t, args, signatureArgTypes, ?loc = r)
+    |> Some
+
 let arrayModule (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (_: Expr option) (args: Expr list) =
     let newArrayAlloc size t =
         Value(NewArray(ArrayAlloc size, t, MutableArray), None)
@@ -1948,34 +1952,8 @@ let arrayModule (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (_: Ex
         Helper.LibCall(com, "List", "ofArray", t, args, i.SignatureArgTypes, genArgs = i.GenericArgs, ?loc = r)
         |> Some
     | ("Length" | "Count"), [ arg ] -> getFieldWith r t arg "length" |> Some
-    | "Item", [ idx; ar ] ->
-        Helper.LibCall(
-            com,
-            "Array",
-            "item",
-            t,
-            [
-                idx
-                ar
-            ],
-            i.SignatureArgTypes,
-            ?loc = r
-        )
-        |> Some
-    | "Get", [ ar; idx ] ->
-        Helper.LibCall(
-            com,
-            "Array",
-            "item",
-            t,
-            [
-                idx
-                ar
-            ],
-            i.SignatureArgTypes |> List.rev,
-            ?loc = r
-        )
-        |> Some
+    | "Item", [ idx; ar ] -> arrayGetItem com r t [ idx; ar ] i.SignatureArgTypes
+    | "Get", [ ar; idx ] -> arrayGetItem com r t [ idx; ar ] (i.SignatureArgTypes |> List.rev)
     | "Set", [ ar; idx; value ] -> setExpr r ar idx value |> Some
     | "ZeroCreate", [ count ] -> createArray count None |> Some
     | "Create", [ count; value ] -> createArray count (Some value) |> Some
@@ -2527,20 +2505,7 @@ let intrinsicFunctions (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisAr
         |> Some
     | "MakeDecimal", _, _ -> decimals com ctx r t i thisArg args
     | "GetString", _, [ ar; idx ] -> getExpr r t ar idx |> Some
-    | "GetArray", _, [ ar; idx ] ->
-        Helper.LibCall(
-            com,
-            "Array",
-            "item",
-            t,
-            [
-                idx
-                ar
-            ],
-            i.SignatureArgTypes |> List.rev,
-            ?loc = r
-        )
-        |> Some
+    | "GetArray", _, [ ar; idx ] -> arrayGetItem com r t [ idx; ar ] (i.SignatureArgTypes |> List.rev)
     | "SetArray", _, [ ar; idx; value ] -> setExpr r ar idx value |> Some
     | ("GetArraySlice" | "GetStringSlice"), None, [ ar; lower; upper ] ->
         let upper =

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -1954,7 +1954,9 @@ let arrayModule (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (_: Ex
     | ("Length" | "Count"), [ arg ] -> getFieldWith r t arg "length" |> Some
     | "Item", [ idx; ar ] -> arrayGetItem com r t [ idx; ar ] i.SignatureArgTypes
     | "Get", [ ar; idx ] -> arrayGetItem com r t [ idx; ar ] (i.SignatureArgTypes |> List.rev)
-    | "Set", [ ar; idx; value ] -> setExpr r ar idx value |> Some
+    | "Set", [ ar; idx; value ] ->
+        Helper.LibCall(com, "Array", "setItem", t, [ ar; idx; value ], i.SignatureArgTypes, ?loc = r)
+        |> Some
     | "ZeroCreate", [ count ] -> createArray count None |> Some
     | "Create", [ count; value ] -> createArray count (Some value) |> Some
     | "Empty", _ ->

--- a/src/fable-compiler-js/CHANGELOG.md
+++ b/src/fable-compiler-js/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.1.0 - 2024-02-20
+
+* Add `NPM_PACKAGE_FABLE_COMPILER_JAVASCRIPT` compiler directive (by @MangelMaxime)
+
 ## 1.0.0 - 2024-02-12
 
 * Release stable version

--- a/src/fable-compiler-js/src/ProjectParser.fs
+++ b/src/fable-compiler-js/src/ProjectParser.fs
@@ -108,7 +108,13 @@ let parseCompilerOptions projectXml =
         projectXml
         |> getXmlTagContents "DefineConstants"
         |> Seq.collect (fun s -> s.Split(';'))
-        |> Seq.append [ "FABLE_COMPILER"; "FABLE_COMPILER_4"; "FABLE_COMPILER_JAVASCRIPT" ]
+        |> Seq.append
+            [
+                "FABLE_COMPILER"
+                "FABLE_COMPILER_4"
+                "FABLE_COMPILER_JAVASCRIPT"
+                "NPM_PACKAGE_FABLE_COMPILER_JAVASCRIPT"
+            ]
         |> Seq.map (fun s -> s.Trim())
         |> Seq.distinct
         |> Seq.except [ "$(DefineConstants)"; "" ]
@@ -202,6 +208,7 @@ let parseProjectScript projectFilePath =
             "--define:FABLE_COMPILER"
             "--define:FABLE_COMPILER_4"
             "--define:FABLE_COMPILER_JAVASCRIPT"
+            "--define:NPM_PACKAGE_FABLE_COMPILER_JAVASCRIPT"
         |]
 
     (projectRefs, dllRefs, sourceFiles, otherOptions)

--- a/src/fable-library-ts/Array.fs
+++ b/src/fable-library-ts/Array.fs
@@ -877,13 +877,23 @@ let tail (array: 'T[]) =
 
     skipImpl array 1
 
-let item index (array: _[]) = array.[index]
+let item (index: int) (array: 'T[]) : 'T =
+    if index < 0 || index >= array.Length then
+        invalidArg "index" "Index was outside the bounds of the array."
+    else
+        // We need to emit JavaScript directly here
+        // otherwise we will call `item` function recursively
+        // and it will cause a stack overflow
+        emitJsExpr (index, array) "$1[$0]"
 
-let tryItem index (array: 'T[]) =
+let tryItem (index: int) (array: 'T[]) : 'T option =
     if index < 0 || index >= array.Length then
         None
     else
-        Some array.[index]
+        // We need to emit JavaScript directly here
+        // otherwise we will call `item` which will
+        // redo the bounds check
+        Some(emitJsExpr (index, array) "$1[$0]")
 
 let foldBackIndexed<'T, 'State> folder (array: 'T[]) (state: 'State) =
     // if isTypedArrayImpl array then

--- a/src/fable-library-ts/Array.fs
+++ b/src/fable-library-ts/Array.fs
@@ -883,6 +883,13 @@ let item (index: int) (array: 'T[]) : 'T =
     else
         arrayAccessImpl index array
 
+// Using `set` seems to cause issues with the TS
+let setItem (array: 'T[]) (index: int) (value: 'T) =
+    if index < 0 || index >= array.Length then
+        invalidArg "index" "Index was outside the bounds of the array."
+    else
+        arraySetItemImpl array index value
+
 let tryItem (index: int) (array: 'T[]) : 'T option =
     if index < 0 || index >= array.Length then
         None

--- a/src/fable-library-ts/Array.fs
+++ b/src/fable-library-ts/Array.fs
@@ -881,19 +881,13 @@ let item (index: int) (array: 'T[]) : 'T =
     if index < 0 || index >= array.Length then
         invalidArg "index" "Index was outside the bounds of the array."
     else
-        // We need to emit JavaScript directly here
-        // otherwise we will call `item` function recursively
-        // and it will cause a stack overflow
-        emitJsExpr (index, array) "$1[$0]"
+        arrayAccessImpl index array
 
 let tryItem (index: int) (array: 'T[]) : 'T option =
     if index < 0 || index >= array.Length then
         None
     else
-        // We need to emit JavaScript directly here
-        // otherwise we will call `item` which will
-        // redo the bounds check
-        Some(emitJsExpr (index, array) "$1[$0]")
+        Some(arrayAccessImpl index array)
 
 let foldBackIndexed<'T, 'State> folder (array: 'T[]) (state: 'State) =
     // if isTypedArrayImpl array then

--- a/src/fable-library-ts/CHANGELOG.md
+++ b/src/fable-library-ts/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### JavaScript
 
 * [GH-3759](https://github.com/fable-compiler/Fable/issues/3759) Add `StringBuilder.Chars` (by @MangelMaxime)
+* Add `StringBuilder.AppendFormat` (by @ncave)
+* [GH-3748](https://github.com/fable-compiler/Fable/pull/3748) Add `Array.getItem` and `Array.setItem` (by @MangelMaxime)
 
 ## 1.0.0 - 2024-02-13
 

--- a/src/fable-library-ts/Native.fs
+++ b/src/fable-library-ts/Native.fs
@@ -94,3 +94,5 @@ module Helpers =
     // Using Emit keeps the argument signature
     [<Emit("$1.sort($0)")>]
     let sortInPlaceWithImpl (comparer: 'T -> 'T -> int) (array: 'T[]) : unit = nativeOnly
+
+    let inline arrayAccessImpl (index: int) (array: 'T[]) : 'T = emitJsExpr (index, array) "$1[$0]"

--- a/src/fable-library-ts/Native.fs
+++ b/src/fable-library-ts/Native.fs
@@ -96,3 +96,6 @@ module Helpers =
     let sortInPlaceWithImpl (comparer: 'T -> 'T -> int) (array: 'T[]) : unit = nativeOnly
 
     let inline arrayAccessImpl (index: int) (array: 'T[]) : 'T = emitJsExpr (index, array) "$1[$0]"
+
+    let inline arraySetItemImpl (array: 'T[]) (index: int) (item: 'T) : unit =
+        emitJsExpr (array, index, item) "$0[$1] = $2"

--- a/tests/Js/Main/ArrayTests.fs
+++ b/tests/Js/Main/ArrayTests.fs
@@ -206,6 +206,20 @@ let tests =
         Array.set x 3 10.
         equal 10. x.[3]
 
+    testCase "Array setter throws an exception when out of bounds" <| fun () ->
+        let a = [| 1.; 2.; 3.; 4.; 5. |]
+        throwsAnyError (fun () -> Array.set a 5 10.)
+        throwsAnyError (fun () -> Array.set a -10 10.)
+        throwsAnyError (fun () -> a[5] <- 10.)
+        throwsAnyError (fun () -> a[-5] <- 10.)
+        throwsAnyError (fun () -> a.[5] <- 10.)
+        throwsAnyError (fun () -> a.[-5] <- 10.)
+        // Check empty array
+        let b = [| |]
+        throwsAnyError (fun () -> Array.set b 0 10.)
+        throwsAnyError (fun () -> b[0] <- 10.)
+        throwsAnyError (fun () -> b.[0] <- 10.)
+
     testCase "Array.Length works" <| fun () ->
         let xs = [| 1.; 2.; 3.; 4. |]
         xs.Length |> equal 4

--- a/tests/Js/Main/ArrayTests.fs
+++ b/tests/Js/Main/ArrayTests.fs
@@ -177,6 +177,30 @@ let tests =
         let x = [| 1.; 2.; 3.; 4.; 5. |]
         Array.get x 2 |> equal 3.
 
+    testCase "Array getter throws an exception when out of bounds" <| fun () ->
+        let a = [| 1.; 2.; 3.; 4.; 5. |]
+        throwsAnyError (fun () -> Array.get a 5)
+        throwsAnyError (fun () -> Array.get a -10)
+        // Check empty array
+        let b = [| |]
+        throwsAnyError (fun () -> Array.get b 0)
+
+    testCase "Array `arr[idx]` throws an exception when out of bounds" <| fun () ->
+        let a = [| 1.; 2.; 3.; 4.; 5. |]
+        throwsAnyError (fun () -> a[5])
+        throwsAnyError (fun () -> a[-10])
+        // Check empty array
+        let b = [| |]
+        throwsAnyError (fun () -> b[0])
+
+    testCase "Array `arr.[idx]` throws an exception when out of bounds" <| fun () ->
+        let a = [| 1.; 2.; 3.; 4.; 5. |]
+        throwsAnyError (fun () -> a.[5])
+        throwsAnyError (fun () -> a.[-10])
+        // Check empty array
+        let b = [| |]
+        throwsAnyError (fun () -> b.[0])
+
     testCase "Array setter works" <| fun () ->
         let x = [| 1.; 2.; 3.; 4.; 5. |]
         Array.set x 3 10.
@@ -929,14 +953,6 @@ let tests =
         Array.except [|Map.empty |> (fun m -> m.Add(1, 2))|] [|Map.ofList [(1, 2)]|] |> Array.isEmpty |> equal true
         Array.except [|{ Bar= "test" }|] [|{ Bar = "test" }|] |> Array.isEmpty |> equal true
 
-    testCase "Array.[i] is undefined in Fable when i is out of range" <| fun () ->
-        let xs = [|0|]
-#if FABLE_COMPILER
-        isNull <| box xs.[1]
-#else
-        try xs.[1] |> ignore; false with _ -> true
-#endif
-        |> equal true
 
     testCase "Array iterators from range do rewind" <| fun () ->
         let xs = [|1..5|] |> Array.toSeq

--- a/tests/Js/Main/MiscTests.fs
+++ b/tests/Js/Main/MiscTests.fs
@@ -489,7 +489,12 @@ let tests =
         to_str () |> equal $"{()}"
 
 #if FABLE_COMPILER
-#if !FABLE_COMPILER_JAVASCRIPT
+#if !FABLE_COMPILER_TYPESCRIPT
+    // The tests seems to cause problems in TypeScript because of the typing
+    // system. We suppose this is probably due to the TypeProvider generation
+    // so for now we just ignore that situation hoping this is not
+    // indicative of other potential issues like this
+    // See: https://github.com/fable-compiler/Fable/pull/3748
     testCase "Fable.JsonProvider works" <| fun _ ->
         let parsed = LiteralJson(ANOTHER_JSON)
         parsed.widget.debug |> equal false

--- a/tests/Js/Main/MiscTests.fs
+++ b/tests/Js/Main/MiscTests.fs
@@ -468,7 +468,7 @@ type Order =
         quantity : int<kg>
     }
 
-#if !FABLE_COMPILER_JAVASCRIPT
+#if !FABLE_COMPILER_TYPESCRIPT
 type LiteralJson = Fable.JsonProvider.Generator<LITERAL_JSON>
 #endif
 

--- a/tests/Js/Main/MiscTests.fs
+++ b/tests/Js/Main/MiscTests.fs
@@ -468,7 +468,7 @@ type Order =
         quantity : int<kg>
     }
 
-#if !FABLE_COMPILER_TYPESCRIPT
+#if FABLE_COMPILER && !FABLE_COMPILER_TYPESCRIPT && !NPM_PACKAGE_FABLE_COMPILER_JAVASCRIPT
 type LiteralJson = Fable.JsonProvider.Generator<LITERAL_JSON>
 #endif
 
@@ -489,7 +489,7 @@ let tests =
         to_str () |> equal $"{()}"
 
 #if FABLE_COMPILER
-#if !FABLE_COMPILER_TYPESCRIPT
+#if !FABLE_COMPILER_TYPESCRIPT && !NPM_PACKAGE_FABLE_COMPILER_JAVASCRIPT
     // The tests seems to cause problems in TypeScript because of the typing
     // system. We suppose this is probably due to the TypeProvider generation
     // so for now we just ignore that situation hoping this is not


### PR DESCRIPTION
Fix #3729

@ncave Could you please have a look at what I did? 

By some trial and error, I found that these places are where we handle array index access + `Array.item` which have the same behaviour.