### PR TITLE
WIP: Add support for `StringBuilder.Chars` for Rust

### DIFF
--- a/src/fable-library-rust/src/System.Text.fs
+++ b/src/fable-library-rust/src/System.Text.fs
@@ -44,6 +44,24 @@ type StringBuilder(value: string, capacity: int) =
         buf.Clear()
         x
 
+    member x.Chars
+        with get (index: int) =
+            let bufferText = x.ToString()
+
+            if index < 0 || index >= bufferText.Length then
+                failwith "Index was outside the bounds of the array"
+            else
+                bufferText.[index]
+        and set (index: int) (value: char) =
+            let bufferText = x.ToString()
+
+            if index < 0 || index >= bufferText.Length then
+                failwith "Index was outside the bounds of the array"
+            else
+                let bufferText = bufferText.ToCharArray()
+                bufferText.[index] <- value
+                x.Clear().Append(bufferText) |> ignore
+
     member x.Length = buf |> asArray |> Array.sumBy (fun s -> s.Length)
     override _.ToString() = System.String.Concat(buf |> asArray)
 

--- a/tests/Rust/tests/src/StringTests.fs
+++ b/tests/Rust/tests/src/StringTests.fs
@@ -125,6 +125,44 @@ let ``StringBuilder.AppendFormat with provider works`` () =
     sb.AppendFormat(CultureInfo.InvariantCulture, "Hello{0}World{1}", " ", "!") |> ignore
     sb.ToString() |> equal "Hello World!"
 
+
+[<Fact>]
+let ``test StringBuilder.Chars works`` =
+    let builder = Text.StringBuilder()
+                    .Append("abc")
+    equal 'b' (builder.Chars(1))
+
+[<Fact>]
+let ``test StringBuilder.Chars throws when index is out of bounds`` =
+    throwsAnyError <| fun () ->
+        let builder = Text.StringBuilder()
+                        .Append("abc")
+        builder.Chars(-1) |> ignore
+
+        builder.Chars(3) |> ignore
+
+[<Fact>]
+let ``test StringBuilder.Replace works`` =
+    let builder = Text.StringBuilder()
+                    .Append("abc")
+                    .Append("abc")
+                    .Replace('a', 'x')
+                    .Replace("bc", "yz")
+    equal "xyzxyz" (builder.ToString())
+
+[<Fact>]
+let ``test StringBuilder index accessor works`` =
+    let builder = Text.StringBuilder()
+                    .Append("abc")
+    equal 'b' (builder[1])
+
+[<Fact>]
+let ``test StringBuilder index setter works`` =
+    let builder = Text.StringBuilder()
+                    .Append("abc")
+    builder[1] <- 'x'
+    equal "axc" (builder.ToString())
+
 [<Fact>]
 let ``kprintf works`` () =
     let f (s:string) = s + "XX"


### PR DESCRIPTION
Hello @ncave ,

While trying to add support for `StringBuilder.Charts` to Rust I run into an issue where `fable-library-rust` cannot be compiled.

```
Checking fable_library_rust v0.1.0 (/Users/mmangel/Workspaces/Github/fable-compiler/Fable/temp/fable-library-rust)
error[E0599]: no method named `Clear` found for reference `&module_5bc0559d::System::Text::StringBuilder` in the current scope
   --> src/./System.Text.rs:210:37
    |
210 | ...                   (_self_.Clear()).Append_Z372E4D23(bufferText_1);
    |                               ^^^^^ method not found in `&StringBuilder`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
note: `ICollection_1` defines an item `Clear`, perhaps you need to implement it
   --> src/./Interfaces.rs:245:17
    |
245 |                 pub trait ICollection_1<T: Clone + 'static> {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0599`.
error: could not compile `fable_library_rust` (lib) due to previous error
warning: build failed, waiting for other jobs to finish...
error: could not compile `fable_library_rust` (lib test) due to previous error
```

While looking at the generated source code I discovered that `member` have `self: &Lrc<Self>` generated but `getter/setter` have `&self`.

Manually changing

```rs
pub fn set_Chars_413E0D0A(self, index: i32, value: char) {
```

to


```rs
pub fn set_Chars_413E0D0A(self: &Lrc<Self>, index: i32, value: char) {
```

seems to make the error go away at least in the IDE.

I found that the line responsible for generating `&Lrc<Self>` is 

https://github.com/fable-compiler/Fable/blob/f96d458f044e98cf158dad8567691a7fab127b7e/src/Fable.Transforms/Rust/Fable2Rust.fs#L3352-L3374

But it doesn't work in the current situation because the `ident.Type` and `returnType` are different. I am not sure what is the path of action to take from here.