### PR TITLE
Redirect plugin build stdout and pass to logger.

### DIFF
--- a/src/Fable.Compiler/CHANGELOG.md
+++ b/src/Fable.Compiler/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [GH-3758](https://github.com/fable-compiler/Fable/pull/3758) Endpoint to get Fable.AST for a file. (by @nojaf)
 
+### Fixed
+
+* [GH-3763](https://github.com/fable-compiler/Fable/pull/3763) Redirect plugin build stdout and pass to logger. (by @nojaf)
+
 ## 4.0.0-alpha-006 - 2024-02-12
 
 ### Changed

--- a/src/Fable.Compiler/ProjectCracker.fs
+++ b/src/Fable.Compiler/ProjectCracker.fs
@@ -138,8 +138,10 @@ type CrackerOptions(cliArgs: CliArgs, evaluateOnly: bool) =
                 |> Array.rev
                 |> String.concat "/"
 
-            Process.runSync projDir "dotnet" [ "build"; "-c"; cliArgs.Configuration ]
-            |> ignore
+            let stdout =
+                Process.runSyncWithOutput projDir "dotnet" [ "build"; "-c"; cliArgs.Configuration ]
+
+            Log.always stdout
 
             builtDlls.Add(normalizedDllPath) |> ignore
 

--- a/src/Fable.Compiler/Util.fsi
+++ b/src/Fable.Compiler/Util.fsi
@@ -91,6 +91,8 @@ module Process =
 
     val runSync: workingDir: string -> exePath: string -> args: string list -> int
 
+    val runSyncWithOutput: string -> string -> string list -> string
+
 type PathResolver =
     abstract TryPrecompiledOutPath: sourceDir: string * relativePath: string -> string option
 


### PR DESCRIPTION
When working a local fable plugin in `Fable.Compiler` I noticed that the build of the plugin was producing output in the process stdout. Which cannot happen in my vite-plugin setup.

This change redirects the output and prints it via the logger. Behaviour from `Fable.Cli` would be unaltered and `Fable.Compiler` would not write to the stdout.

Ready for review @MangelMaxime.
Could you also publish a new alpha for `Fable.Compiler` with this fix 😇?