### PR TITLE
Added range overload for String.ToCharArray

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### JavaScript
 
 * [GH-3759](https://github.com/fable-compiler/Fable/issues/3759) Add `StringBuilder.Chars` (by @MangelMaxime)
+* Added range overload for `String.ToCharArray` (by @ncave)
 
 ## 4.12.2 - 2024-02-13
 

--- a/src/Fable.Transforms/Dart/Replacements.fs
+++ b/src/Fable.Transforms/Dart/Replacements.fs
@@ -1428,7 +1428,16 @@ let strings (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr opt
                 | char -> makeArray Char [ char ]
 
             Helper.LibCall(com, "String", methName, t, c :: [ chars ], ?loc = r) |> Some
-    | "ToCharArray", Some c, _ -> stringToCharArray c |> Some
+    | "ToCharArray", Some c, _ ->
+        match args with
+        | [] -> stringToCharArray c |> Some
+        | [ ExprTypeAs(Number(Int32, _), startIdx); ExprTypeAs(Number(Int32, _), count) ] ->
+            let args = toStartEndIndices startIdx count
+
+            Helper.InstanceCall(c, "substring", t, args, ?loc = r)
+            |> stringToCharArray
+            |> Some
+        | _ -> None
     | "Split", Some c, _ ->
         match args with
         // Optimization

--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -1429,7 +1429,12 @@ let strings (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr opt
 
             Helper.LibCall(com, "string", Naming.lowerFirst i.CompiledName, t, c :: args, hasSpread = spread, ?loc = r)
             |> Some
-    | "ToCharArray", Some c, _ -> stringToCharArray t c |> Some
+    | "ToCharArray", Some c, _ ->
+        match args with
+        | [] -> stringToCharArray t c |> Some
+        | [ ExprType(Number(Int32, _)); ExprType(Number(Int32, _)) ] ->
+            Helper.LibCall(com, "string", "toCharArray2", t, c :: args, ?loc = r) |> Some
+        | _ -> None
     | "Split", Some c, _ ->
         match args with
         // Optimization

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -1565,7 +1565,12 @@ let strings (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr opt
 
             Helper.LibCall(com, "String", methName, t, c :: args, hasSpread = spread, ?loc = r)
             |> Some
-    | "ToCharArray", Some c, _ -> stringToCharArray c |> Some
+    | "ToCharArray", Some c, _ ->
+        match args with
+        | [] -> stringToCharArray c |> Some
+        | [ ExprType(Number(Int32, _)); ExprType(Number(Int32, _)) ] ->
+            Helper.LibCall(com, "String", "toCharArray2", t, c :: args, ?loc = r) |> Some
+        | _ -> None
     | "Split", Some c, _ ->
         match args with
         // Optimization

--- a/src/fable-library-py/fable_library/string_.py
+++ b/src/fable-library-py/fable_library/string_.py
@@ -427,6 +427,10 @@ def substring(string: str, startIndex: int, length: int | None = None) -> str:
     return string[startIndex:]
 
 
+def to_char_array2(string: str, startIndex: int, length: int) -> list[str]:
+    return list(substring(string, startIndex, length))
+
+
 class StringComparison(IntEnum):
     CurrentCulture = 0
     CurrentCultureIgnoreCase = 1

--- a/src/fable-library-ts/String.ts
+++ b/src/fable-library-ts/String.ts
@@ -568,6 +568,10 @@ export function substring(str: string, startIndex: number, length?: number) {
   return length != null ? str.substr(startIndex, length) : str.substr(startIndex);
 }
 
+export function toCharArray2(str: string, startIndex: number, length: number) {
+  return substring(str, startIndex, length).split("")
+}
+
 interface FormattableString {
   strs: TemplateStringsArray,
   args: any[],

--- a/tests/Dart/src/StringTests.fs
+++ b/tests/Dart/src/StringTests.fs
@@ -893,9 +893,11 @@ let tests() =
 
     testCase "String.ToCharArray works" <| fun () ->
         let arr = "abcd".ToCharArray()
-        equal "c" (string arr.[2])
-        arr |> Array.map (fun _ -> 1) |> Array.sum
-        |> equal arr.Length
+        arr |> equal [|'a';'b';'c';'d'|]
+
+    testCase "String.ToCharArray with range works" <| fun () ->
+        let arr = "abcd".ToCharArray(1, 2)
+        arr |> equal [|'b';'c'|]
 
     // // TODO: surrogate pairs
     // testCase "String enumeration handles surrogates pairs" <| fun () -> // See #1279

--- a/tests/Js/Main/StringTests.fs
+++ b/tests/Js/Main/StringTests.fs
@@ -907,9 +907,11 @@ let tests = testList "Strings" [
 
     testCase "String.ToCharArray works" <| fun () ->
         let arr = "abcd".ToCharArray()
-        equal "c" (string arr.[2])
-        arr |> Array.map (fun _ -> 1) |> Array.sum
-        |> equal arr.Length
+        arr |> equal [|'a';'b';'c';'d'|]
+
+    testCase "String.ToCharArray with range works" <| fun () ->
+        let arr = "abcd".ToCharArray(1, 2)
+        arr |> equal [|'b';'c'|]
 
     testCase "String enumeration handles surrogates pairs" <| fun () -> // See #1279
         let unicodeString = ".\U0001f404."

--- a/tests/Python/TestString.fs
+++ b/tests/Python/TestString.fs
@@ -668,9 +668,12 @@ let ``test String item works`` () =
 [<Fact>]
 let ``test String.ToCharArray works`` () =
     let arr = "abcd".ToCharArray()
-    equal "c" (string arr.[2])
-    arr |> Array.map (fun _ -> 1) |> Array.sum
-    |> equal arr.Length
+    arr |> equal [|'a';'b';'c';'d'|]
+
+[<Fact>]
+let ``test String.ToCharArray with range works`` () =
+    let arr = "abcd".ToCharArray(1, 2)
+    arr |> equal [|'b';'c'|]
 
 // [<Fact>]
 // let ``test String enumeration handles surrogates pairs`` () =

--- a/tests/Rust/tests/src/StringTests.fs
+++ b/tests/Rust/tests/src/StringTests.fs
@@ -1188,6 +1188,11 @@ let ``String.ToCharArray works`` () =
     let arr = "abcd".ToCharArray()
     arr |> equal [|'a';'b';'c';'d'|]
 
+[<Fact>]
+let ``String.ToCharArray with range works`` () =
+    let arr = "abcd".ToCharArray(1, 2)
+    arr |> equal [|'b';'c'|]
+
 // [<Fact>]
 // let ``String enumeration handles surrogates pairs`` () = // See #1279
 //     let unicodeString = ".\U0001f404."


### PR DESCRIPTION
- Added range overload for `String.ToCharArray`
- Fixes #3762