### PR TITLE
Dependent signature files

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+#### All
+
+* [GH-3769](https://github.com/fable-compiler/Fable/pull/3769) Local plugin build does not run indefinably. (by @nojaf)
+
+#### JavaScript
+
+* [GH-3769](https://github.com/fable-compiler/Fable/pull/3769) Types hidden by signature files should not be exported. (by @nojaf)
+
 ## 4.13.0 - 2024-02-13
 
 ### Added

--- a/src/Fable.Compiler/CHANGELOG.md
+++ b/src/Fable.Compiler/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+* [GH-3769](https://github.com/fable-compiler/Fable/pull/3769) The dependent files of the current file should be detected for the signature file if there is one present. (by @nojaf)
+* [GH-3769](https://github.com/fable-compiler/Fable/pull/3769) Local plugin build does not run indefinably. (by @nojaf)
+
 ## 4.0.0-alpha-007 - 2024-02-20
 
 ### Added

--- a/src/Fable.Compiler/Library.fs
+++ b/src/Fable.Compiler/Library.fs
@@ -263,6 +263,9 @@ module CodeServices =
             let! dependentFiles =
                 checker.GetDependentFiles(currentFile, crackerResponse.ProjectOptions.SourceFiles, sourceReader)
 
+            let combinedDependentFiles = String.concat "\n" dependentFiles
+            Log.info $"Dependent files for %s{currentFile} are:\n%s{combinedDependentFiles}"
+
             let lastFile =
                 if Array.isEmpty dependentFiles then
                     currentFile

--- a/src/Fable.Compiler/Util.fs
+++ b/src/Fable.Compiler/Util.fs
@@ -460,7 +460,9 @@ module Process =
 
     let runSyncWithOutput workingDir exePath args =
         let p = startProcess true [] workingDir exePath args
-        p.WaitForExit()
+        // Don't wait indefinitely to run process
+        // This call is used to build local plugins, if the binary is used by another process this process will never end.
+        p.WaitForExit 7000 |> ignore
         p.StandardOutput.ReadToEnd()
 
 [<RequireQualifiedAccess>]

--- a/tests/Integration/Integration/CompilationTests.fs
+++ b/tests/Integration/Integration/CompilationTests.fs
@@ -26,8 +26,8 @@ let tests =
                 for expected in Directory.GetFileSystemEntries(testCaseDir, "*.expected") do
                     let actual = Path.ChangeExtension(expected, ".actual")
                     Expect.isTrue (File.Exists actual) $"No actual file was produced for {expected}"
-                    let expectedContent = File.ReadAllText expected
-                    let actualContent = File.ReadAllText actual
+                    let expectedContent = File.ReadAllText expected |> _.ReplaceLineEndings()
+                    let actualContent = File.ReadAllText actual |> _.ReplaceLineEndings()
                     Expect.equal actualContent expectedContent "The expected content differs from the actual content"
 
                 return ()

--- a/tests/Integration/Integration/data/signatureHidesFunction/HideType.fs
+++ b/tests/Integration/Integration/data/signatureHidesFunction/HideType.fs
@@ -1,0 +1,11 @@
+module HideType
+
+open Fable.Core
+
+/// This type should be hidden by the signature file
+type public Foobar =
+    | Foo of int
+    | Bar of string
+
+let someFunction () =
+    JS.console.log "meh"

--- a/tests/Integration/Integration/data/signatureHidesFunction/HideType.fsi
+++ b/tests/Integration/Integration/data/signatureHidesFunction/HideType.fsi
@@ -1,0 +1,3 @@
+module HideType
+
+val someFunction: unit -> unit

--- a/tests/Integration/Integration/data/signatureHidesFunction/HideType.js.expected
+++ b/tests/Integration/Integration/data/signatureHidesFunction/HideType.js.expected
@@ -1,0 +1,23 @@
+import { Union } from "./fable_modules/fable-library-js.4.13.0/Types.js";
+import { union_type, string_type, int32_type } from "./fable_modules/fable-library-js.4.13.0/Reflection.js";
+import { some } from "./fable_modules/fable-library-js.4.13.0/Option.js";
+
+class Foobar extends Union {
+    constructor(tag, fields) {
+        super();
+        this.tag = tag;
+        this.fields = fields;
+    }
+    cases() {
+        return ["Foo", "Bar"];
+    }
+}
+
+function Foobar_$reflection() {
+    return union_type("HideType.Foobar", [], Foobar, () => [[["Item", int32_type]], [["Item", string_type]]]);
+}
+
+export function someFunction() {
+    console.log(some("meh"));
+}
+

--- a/tests/Integration/Integration/data/signatureHidesFunction/signatureHidesFunction.fsproj
+++ b/tests/Integration/Integration/data/signatureHidesFunction/signatureHidesFunction.fsproj
@@ -9,6 +9,8 @@
   <ItemGroup>
     <Compile Include="Library.fsi" />
     <Compile Include="Library.fs" />
+    <Compile Include="HideType.fsi" />
+    <Compile Include="HideType.fs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I noticed some gaps when working with signature files in my project:

- A type was not hidden by the signature file (similar to https://github.com/fable-compiler/Fable/pull/3530)
- The dependent files of the current file should be detected for the signature file if there is one present. (This is due to the nature of graph-based checking)