### PR TITLE
[JS] Add ConditionalWeakTable

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+* [JS/TS] Add `ConditionalWeakTable` (by @chkn)
+
 ## 4.15.0 - 2024-03-18
 
 ### Fixed

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -331,6 +331,9 @@ module Types =
     let ireadonlydictionary = "System.Collections.Generic.IReadOnlyDictionary`2"
 
     [<Literal>]
+    let conditionalWeakTable = "System.Runtime.CompilerServices.ConditionalWeakTable`2"
+
+    [<Literal>]
     let hashset = "System.Collections.Generic.HashSet`1"
 
     [<Literal>]

--- a/src/fable-library-ts/CHANGELOG.md
+++ b/src/fable-library-ts/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+* [JS/TS] Add `ConditionalWeakTable` (by @chkn)
+
 ## 1.3.0 - 2024-03-18
 
 * [JS/TS] `Boolean.tryParse` should not crash on `null` string (@goswinr)

--- a/src/fable-library-ts/ConditionalWeakTable.ts
+++ b/src/fable-library-ts/ConditionalWeakTable.ts
@@ -1,0 +1,26 @@
+
+export class ConditionalWeakTable<TKey extends object, TValue> {
+  private weakMap: WeakMap<TKey, TValue> = new WeakMap<TKey, TValue>();
+
+  public delete(key: TKey) {
+    return this.weakMap.delete(key);
+  }
+
+  public get(key: TKey) {
+    return this.weakMap.get(key);
+  }
+
+  public has(key: TKey) {
+    return this.weakMap.has(key);
+  }
+
+  public set(key: TKey, value: TValue) {
+    return this.weakMap.set(key, value);
+  }
+
+  public clear() {
+    this.weakMap = new WeakMap<TKey, TValue>();
+  }
+}
+
+export default ConditionalWeakTable;

--- a/src/fable-library-ts/MapUtil.ts
+++ b/src/fable-library-ts/MapUtil.ts
@@ -1,4 +1,4 @@
-import { equals, IMap, ISet } from "./Util.js";
+import { equals, IMap, IMapOrWeakMap, ISet } from "./Util.js";
 import { FSharpRef, Union } from "./Types.js";
 
 const CaseRules = {
@@ -88,7 +88,7 @@ export function containsValue<K, V>(v: V, map: IMap<K, V>) {
   return false;
 }
 
-export function tryGetValue<K, V>(map: IMap<K, V>, key: K, defaultValue: FSharpRef<V>): boolean {
+export function tryGetValue<K, V>(map: IMapOrWeakMap<K, V>, key: K, defaultValue: FSharpRef<V>): boolean {
   if (map.has(key)) {
     defaultValue.contents = map.get(key) as V;
     return true;
@@ -104,7 +104,15 @@ export function addToSet<T>(v: T, set: ISet<T>) {
   return true;
 }
 
-export function addToDict<K, V>(dict: IMap<K, V>, k: K, v: V) {
+export function tryAddToDict<K, V>(dict: IMapOrWeakMap<K, V>, k: K, v: V) {
+  if (dict.has(k)) {
+    return false;
+  }
+  dict.set(k, v);
+  return true;
+}
+
+export function addToDict<K, V>(dict: IMapOrWeakMap<K, V>, k: K, v: V) {
   if (dict.has(k)) {
     throw new Error("An item with the same key has already been added. Key: " + k);
   }
@@ -117,4 +125,13 @@ export function getItemFromDict<K, V>(map: IMap<K, V>, key: K) {
   } else {
     throw new Error(`The given key '${key}' was not present in the dictionary.`);
   }
+}
+
+export function getItemFromDictOrCreate<K, V>(map: IMapOrWeakMap<K, V>, key: K, createValue: (key: K) => V) {
+  if (map.has(key)) {
+    return map.get(key) as V;
+  }
+  const value = createValue(key);
+  map.set(key, value);
+  return value;
 }

--- a/src/fable-library-ts/Util.ts
+++ b/src/fable-library-ts/Util.ts
@@ -183,13 +183,18 @@ export interface ISet<T> {
   values(): Iterable<T>;
 }
 
-export interface IMap<K, V> {
-  clear(): void;
+export interface IMapOrWeakMap<K, V> {
   delete(key: K): boolean;
-  forEach(callbackfn: (value: V, key: K, map: IMap<K, V>) => void, thisArg?: any): void;
   get(key: K): V | undefined;
   has(key: K): boolean;
+  set(key: K, value: V): IMapOrWeakMap<K, V>;
+}
+
+export interface IMap<K, V> extends IMapOrWeakMap<K, V> {
+  clear(): void;
   set(key: K, value: V): IMap<K, V>;
+
+  forEach(callbackfn: (value: V, key: K, map: IMap<K, V>) => void, thisArg?: any): void;
   readonly size: number;
 
   [Symbol.iterator](): Iterator<[K, V]>;

--- a/tests/Js/Main/ConditionalWeakTableTests.fs
+++ b/tests/Js/Main/ConditionalWeakTableTests.fs
@@ -1,0 +1,69 @@
+module Fable.Tests.ConditionalWeakTable
+
+open System
+open System.Collections.Generic
+open System.Runtime.CompilerServices
+open Util
+open Util.Testing
+
+let tests =
+  testList "ConditionalWeakTables" [
+    testCase "ConditionalWeakTable.TryGetValue works" <| fun () ->
+        let key1, key2 = obj(), obj()
+        let expected1, expected2 = obj(), obj()
+        let dic1 = ConditionalWeakTable()
+        let dic2 = ConditionalWeakTable()
+        dic1.Add(key1, expected1)
+        dic2.Add(key2, expected2)
+        let success1, val1 = dic1.TryGetValue(key1)
+        let success2, val2 = dic1.TryGetValue(key2)
+        let success3, val3 = dic2.TryGetValue(key2)
+        let success4, val4 = dic2.TryGetValue(obj())
+        equal success1 true
+        equal success2 false
+        equal success3 true
+        equal success4 false
+        equal val1 expected1
+        equal val2 null
+        equal val3 expected2
+        equal val4 null
+
+    testCase "ConditionalWeakTable.Clear works" <| fun () ->
+        let dic = ConditionalWeakTable<_,_>()
+        let key1, key2 = obj(), obj()
+        dic.Add(key1, obj())
+        dic.Add(key2, obj())
+        dic.Clear()
+        dic.TryGetValue(key1) |> equal (false, null)
+        dic.TryGetValue(key2) |> equal (false, null)
+
+    testCase "ConditionalWeakTable.Remove works" <| fun () ->
+        let dic = ConditionalWeakTable<_,_>()
+        let key1, key2 = obj(), obj()
+        dic.Add(key1, "Hello")
+        dic.Add(key2, "World!")
+        dic.Remove(key1) |> equal true
+        dic.Remove("C") |> equal false
+        dic.TryGetValue(key1) |> equal (false, null)
+        dic.TryGetValue(key2) |> equal (true, "World!")
+
+    testCase "Adding 2 items with the same key throws" <| fun () ->
+        let dic = ConditionalWeakTable<_,_>()
+        let key = obj()
+        dic.Add(key, "foo")
+        #if FABLE_COMPILER
+        throwsError "An item with the same key has already been added. Key: [object Object]" (fun _ -> dic.Add(key, "bar"))
+        #else
+        throwsError "An item with the same key has already been added." (fun _ -> dic.Add(key, "bar"))
+        #endif
+
+    testCase "ConditionalWeakTable.GetValue works" <| fun () ->
+        let dic = ConditionalWeakTable<_,_>()
+        let key1, key2 = obj(), obj()
+        let val1, val2 = obj(), obj()
+        dic.Add(key1, val1)
+        let value = dic.GetValue(key1, fun _ -> obj())
+        value |> equal val1
+        let value = dic.GetValue(key2, fun _ -> val2)
+        value |> equal val2
+  ]

--- a/tests/Js/Main/Fable.Tests.fsproj
+++ b/tests/Js/Main/Fable.Tests.fsproj
@@ -39,6 +39,7 @@
     <Compile Include="AsyncTests.fs" />
     <Compile Include="CharTests.fs" />
     <Compile Include="ComparisonTests.fs" />
+    <Compile Include="ConditionalWeakTableTests.fs" />
     <Compile Include="ConvertTests.fs" />
     <Compile Include="CustomOperatorsTests.fs" />
     <Compile Include="DateTimeOffsetTests.fs" />

--- a/tests/Js/Main/Main.fs
+++ b/tests/Js/Main/Main.fs
@@ -10,6 +10,7 @@ let allTests =
     Async.tests
     Chars.tests
     Comparison.tests
+    ConditionalWeakTable.tests
     Convert.tests
     CustomOperators.tests
     DateTimeOffset.tests

--- a/tests/TypeScript/Fable.Tests.TypeScript.fsproj
+++ b/tests/TypeScript/Fable.Tests.TypeScript.fsproj
@@ -32,6 +32,7 @@
     <Compile Include="../Js/Main/AsyncTests.fs" />
     <Compile Include="../Js/Main/CharTests.fs" />
     <Compile Include="../Js/Main/ComparisonTests.fs" />
+    <Compile Include="../Js/Main/ConditionalWeakTableTests.fs" />
     <Compile Include="../Js/Main/ConvertTests.fs" />
     <Compile Include="../Js/Main/CustomOperatorsTests.fs" />
     <Compile Include="../Js/Main/DateTimeOffsetTests.fs" />

--- a/tests/TypeScript/Main.fs
+++ b/tests/TypeScript/Main.fs
@@ -12,6 +12,7 @@ let allTests =
     Async.tests
     Chars.tests
     Comparison.tests
+    ConditionalWeakTable.tests
     Convert.tests
     CustomOperators.tests
     DateTimeOffset.tests


### PR DESCRIPTION
Adds an implementation of [ConditionalWeakTable](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.conditionalweaktable-2?view=net-7.0) for JS/TS using [WeakMap](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap).

Missing/different behavior to .NET:

- The [GetOrCreateValue](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.conditionalweaktable-2.getorcreatevalue?view=net-7.0) method is not implemented. It might be possible to invoke the default constructor of the value type if the type info for the generic argument is saved when the `ConditionalWeakTable` is constructed, but I did not implement that.
- It is not iterable. Though `WeakMap` is not enumerable, it may be possible to support this by keeping an array of `WeakRef`s in addition to the `WeakMap`. But this seems like a lot of overhead, especially since the .NET version only implements `IEnumerable` as an explicit implementation.
- You cannot use JS primitive types as keys, including strings. The workaround is to manually box them using, e.g. `new String(str)`

With this PR, any `WeakMap` obtained from JS should be usable in F# as a `ConditionalWeakTable`, but the `Clear` method will only work on `ConditionalWeakTable`s constructed from F#.

