### PR TITLE
add null check to tryParse boolean

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [JS/TS] Fixed `DateTime.Add` for `DateTimeKind.Unspecified` (by @ncave)
 * [Rust] Fixed deprecated `NaiveDateTime` usage in `DateTime` (by @ncave)
+* [GH-3783](https://github.com/fable-compiler/Fable/pull/3783) [JS/TS] `Boolean.tryParse` should not crash on `null` string (@goswinr)
 
 ### Added
 

--- a/src/fable-library-ts/Boolean.ts
+++ b/src/fable-library-ts/Boolean.ts
@@ -1,10 +1,10 @@
 import { FSharpRef } from "./Types.js"
 
 export function tryParse(str: string, defValue: FSharpRef<boolean>): boolean {
-  if (str.match(/^\s*true\s*$/i)) {
+  if (str != null && str.match(/^\s*true\s*$/i)) {
     defValue.contents = true;
     return true;
-  } else if (str.match(/^\s*false\s*$/i)) {
+  } else if (str != null && str.match(/^\s*false\s*$/i)) {
     defValue.contents = false;
     return true;
   }

--- a/tests/Js/Main/ConvertTests.fs
+++ b/tests/Js/Main/ConvertTests.fs
@@ -18,13 +18,6 @@ let tryParse f initial (value: string) =
 #endif
     (success, !res)
 
-
-let tryParseBool f initial (value: string) =
-    let res = ref initial
-    let success = f(value, res)
-    (success, !res)
-
-
 let parse f (a: string) =
 #if FABLE_COMPILER
     f(a)
@@ -97,6 +90,7 @@ let tests =
         throwsAnyError (fun () -> Boolean.Parse "falsee")
 
     testCase "System.Boolean.TryParse works" <| fun () ->
+        // expect parse success
         Boolean.TryParse "true" |> equal (true, true)
         Boolean.TryParse "True" |> equal (true, true)
         Boolean.TryParse " true " |> equal (true, true)
@@ -104,8 +98,13 @@ let tests =
         Boolean.TryParse "False" |> equal (true, false)
         Boolean.TryParse " false " |> equal (true, false)
 
+        // expect parse failure
         Boolean.TryParse "tru" |> equal (false, false)
         Boolean.TryParse "falsee" |> equal (false, false)
+        Boolean.TryParse  "0"  |> equal (false, false)
+        Boolean.TryParse  ""   |> equal (false, false)
+        Boolean.TryParse  "1"  |> equal (false, false)
+        Boolean.TryParse  null |> equal (false, false)
 
     testCase "System.SByte.Parse works" <| fun () ->
         SByte.Parse("5") |> equal 5y
@@ -208,18 +207,6 @@ let tests =
     testCase "BigInt.TryParse works" <| fun () ->
         tryParse bigint.TryParse 0I "4234523548923954" |> equal (true, 4234523548923954I)
         tryParse bigint.TryParse 0I "9SayWhat12Huh" |> equal (false, 0I)
-
-    testCase "System.Boolean.TryParse works" <| fun () ->
-        // expect parse success
-        tryParseBool Boolean.TryParse false "True"  |> equal (true, true)
-        tryParseBool Boolean.TryParse false "true"  |> equal (true, true)
-        tryParseBool Boolean.TryParse false "false" |> equal (true, false)
-        tryParseBool Boolean.TryParse false "False" |> equal (true, false)
-        // expect parse failure
-        tryParseBool Boolean.TryParse true "0"  |> equal (false, true)
-        tryParseBool Boolean.TryParse true ""   |> equal (false, true)
-        tryParseBool Boolean.TryParse true "1"  |> equal (false, true)
-        tryParseBool Boolean.TryParse true null |> equal (false, true)
 
     testCase "System.Int32.ToString works" <| fun () ->
         (5592405).ToString() |> equal "5592405"

--- a/tests/Js/Main/ConvertTests.fs
+++ b/tests/Js/Main/ConvertTests.fs
@@ -18,6 +18,13 @@ let tryParse f initial (value: string) =
 #endif
     (success, !res)
 
+
+let tryParseBool f initial (value: string) =
+    let res = ref initial
+    let success = f(value, res)
+    (success, !res)
+
+
 let parse f (a: string) =
 #if FABLE_COMPILER
     f(a)
@@ -201,6 +208,18 @@ let tests =
     testCase "BigInt.TryParse works" <| fun () ->
         tryParse bigint.TryParse 0I "4234523548923954" |> equal (true, 4234523548923954I)
         tryParse bigint.TryParse 0I "9SayWhat12Huh" |> equal (false, 0I)
+
+    testCase "System.Boolean.TryParse works" <| fun () ->
+        // expect parse success
+        tryParseBool Boolean.TryParse false "True"  |> equal (true, true)
+        tryParseBool Boolean.TryParse false "true"  |> equal (true, true)
+        tryParseBool Boolean.TryParse false "false" |> equal (true, false)
+        tryParseBool Boolean.TryParse false "False" |> equal (true, false)
+        // expect parse failure
+        tryParseBool Boolean.TryParse true "0"  |> equal (false, true)
+        tryParseBool Boolean.TryParse true ""   |> equal (false, true)
+        tryParseBool Boolean.TryParse true "1"  |> equal (false, true)
+        tryParseBool Boolean.TryParse true null |> equal (false, true)
 
     testCase "System.Int32.ToString works" <| fun () ->
         (5592405).ToString() |> equal "5592405"


### PR DESCRIPTION
`bool.TryParse` should not fail on null string.
I added tests too. 

with Fable 4.14: it does:
![image](https://github.com/fable-compiler/Fable/assets/884885/2b33d2b6-11cc-4804-82a6-ea0e0a33f68a)
