### PR TITLE
WIP: Fixing fable-compiler-js when run from NPM

### DIFF
--- a/src/fable-compiler-js/CHANGELOG.md
+++ b/src/fable-compiler-js/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+* Use `@fable-org/fable-metadata` package instead of `fable-metadata` (by @MangelMaxime)
+* Use `@fable-org/fable-standalone` package instead of `fable-standalone` (by @MangelMaxime)
+* Make `GetDirectoryName` return `"."` instead of `""` if the path doesn't contain any directory (by @MangelMaxime)
+
+### Fixed
+
+* Fix initialization of `fable-standalone` with the new package format (by @MangelMaxime)
+
 ## 1.1.0 - 2024-02-20
 
 * Add `NPM_PACKAGE_FABLE_COMPILER_JAVASCRIPT` compiler directive (by @MangelMaxime)

--- a/src/fable-compiler-js/package-lock.json
+++ b/src/fable-compiler-js/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "fable-metadata": "^2.0.0",
-        "fable-standalone": "^3.0.0"
+        "@fable-org/fable-metadata": "^1.0.0",
+        "@fable-org/fable-standalone": "^1.4.0"
       },
       "bin": {
         "fable": "index.js"
@@ -372,6 +372,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/@fable-org/fable-metadata": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@fable-org/fable-metadata/-/fable-metadata-1.0.0.tgz",
+      "integrity": "sha512-O6xT43XenR1SjtaHtEFDL3DLPn8/JjVWyOYG1BFNBM30sF/mknIuIer1oy+iwNG2MJQiu8BtLrB0OMkGnt/2JQ=="
+    },
+    "node_modules/@fable-org/fable-standalone": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@fable-org/fable-standalone/-/fable-standalone-1.4.0.tgz",
+      "integrity": "sha512-CH1qg/1DxRQ0HF/mvzFN/19+5txRSfI6HL+MqA1S+ZQk7NKVLChHRXJdWLfqg9d//lzLI4Vh24X/598iX6E1Xg=="
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.2.0.tgz",
@@ -564,16 +574,6 @@
         "@esbuild/win32-ia32": "0.19.5",
         "@esbuild/win32-x64": "0.19.5"
       }
-    },
-    "node_modules/fable-metadata": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fable-metadata/-/fable-metadata-2.0.0.tgz",
-      "integrity": "sha512-lCXoctKzvHnkKJAO/TKPV20IRJ4OHM/Zn0ADucA0yMJdK1BVILmslhUTgCp3LIRLXk1S1UQ3Pmmo6ZsFznFYRw=="
-    },
-    "node_modules/fable-standalone": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fable-standalone/-/fable-standalone-3.2.11.tgz",
-      "integrity": "sha512-RVwJX/kDcYgyp4ZhrPxvECLJN0HszxAKjW8CXW+tuP+Sh87MZBjRHAbzUwqSa8BNHYAHNPJIcqOYvI2VEzpVAg=="
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -773,6 +773,16 @@
       "dev": true,
       "optional": true
     },
+    "@fable-org/fable-metadata": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@fable-org/fable-metadata/-/fable-metadata-1.0.0.tgz",
+      "integrity": "sha512-O6xT43XenR1SjtaHtEFDL3DLPn8/JjVWyOYG1BFNBM30sF/mknIuIer1oy+iwNG2MJQiu8BtLrB0OMkGnt/2JQ=="
+    },
+    "@fable-org/fable-standalone": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@fable-org/fable-standalone/-/fable-standalone-1.4.0.tgz",
+      "integrity": "sha512-CH1qg/1DxRQ0HF/mvzFN/19+5txRSfI6HL+MqA1S+ZQk7NKVLChHRXJdWLfqg9d//lzLI4Vh24X/598iX6E1Xg=="
+    },
     "@rollup/rollup-android-arm-eabi": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.2.0.tgz",
@@ -886,16 +896,6 @@
         "@esbuild/win32-ia32": "0.19.5",
         "@esbuild/win32-x64": "0.19.5"
       }
-    },
-    "fable-metadata": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fable-metadata/-/fable-metadata-2.0.0.tgz",
-      "integrity": "sha512-lCXoctKzvHnkKJAO/TKPV20IRJ4OHM/Zn0ADucA0yMJdK1BVILmslhUTgCp3LIRLXk1S1UQ3Pmmo6ZsFznFYRw=="
-    },
-    "fable-standalone": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fable-standalone/-/fable-standalone-3.2.11.tgz",
-      "integrity": "sha512-RVwJX/kDcYgyp4ZhrPxvECLJN0HszxAKjW8CXW+tuP+Sh87MZBjRHAbzUwqSa8BNHYAHNPJIcqOYvI2VEzpVAg=="
     },
     "fsevents": {
       "version": "2.3.3",

--- a/src/fable-compiler-js/package.json
+++ b/src/fable-compiler-js/package.json
@@ -24,8 +24,8 @@
   },
   "homepage": "https://github.com/fable-compiler/Fable#readme",
   "dependencies": {
-    "fable-metadata": "^2.0.0",
-    "fable-standalone": "^3.0.0"
+    "@fable-org/fable-metadata": "^1.0.0",
+    "@fable-org/fable-standalone": "^1.4.0"
   },
   "devDependencies": {
     "esbuild": "^0.19.5",

--- a/src/fable-compiler-js/src/Platform.fs
+++ b/src/fable-compiler-js/src/Platform.fs
@@ -143,6 +143,6 @@ module Path =
         let i = normPath.LastIndexOf('/')
 
         if i < 0 then
-            ""
+            "."
         else
             normPath.Substring(0, i)

--- a/src/fable-compiler-js/src/app.fs
+++ b/src/fable-compiler-js/src/app.fs
@@ -33,8 +33,16 @@ let getMetadataDir () : string =
 let getFableLibDir () : string = importMember "./util.js"
 let getVersion () : string = importMember "./util.js"
 
-let initFable () : Fable.Standalone.IFableManager =
-    import "init" "@fable-org/fable-standalone"
+type IFableInit =
+    abstract member init: unit -> Fable.Standalone.IFableManager
+
+// Make __FABLE_STANDALONE__ available in the global scope
+importSideEffects "@fable-org/fable-standalone"
+
+[<Global("__FABLE_STANDALONE__")>]
+let FableInit: IFableInit = jsNative
+
+let initFable () : Fable.Standalone.IFableManager = FableInit.init ()
 #endif
 
 let references = Fable.Metadata.coreAssemblies

--- a/src/fable-metadata/CHANGELOG.md
+++ b/src/fable-metadata/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+* Make `dirname-filename-esm` a `dependency` instead of a `devDependency`
+
 ## 1.0.0 - 2024-02-12
 
 * Release stable version

--- a/src/fable-metadata/package-lock.json
+++ b/src/fable-metadata/package-lock.json
@@ -1,30 +1,28 @@
 {
-  "name": "fable-metadata",
-  "version": "2.0.0",
+  "name": "@fable-org/fable-metadata",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "fable-metadata",
-      "version": "2.0.0",
+      "name": "@fable-org/fable-metadata",
+      "version": "1.0.0",
       "license": "MIT",
-      "devDependencies": {
+      "dependencies": {
         "dirname-filename-esm": "^1.1.1"
       }
     },
     "node_modules/dirname-filename-esm": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/dirname-filename-esm/-/dirname-filename-esm-1.1.1.tgz",
-      "integrity": "sha512-BWBkv157Cf/z7Hjod2v2JS7vyC36Dk1QQolAtuLjpl8RBlv7Z92X7+Ufc2cjfR/B3iJUiK0QmGZkgtsmmLz0Tw==",
-      "dev": true
+      "integrity": "sha512-BWBkv157Cf/z7Hjod2v2JS7vyC36Dk1QQolAtuLjpl8RBlv7Z92X7+Ufc2cjfR/B3iJUiK0QmGZkgtsmmLz0Tw=="
     }
   },
   "dependencies": {
     "dirname-filename-esm": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/dirname-filename-esm/-/dirname-filename-esm-1.1.1.tgz",
-      "integrity": "sha512-BWBkv157Cf/z7Hjod2v2JS7vyC36Dk1QQolAtuLjpl8RBlv7Z92X7+Ufc2cjfR/B3iJUiK0QmGZkgtsmmLz0Tw==",
-      "dev": true
+      "integrity": "sha512-BWBkv157Cf/z7Hjod2v2JS7vyC36Dk1QQolAtuLjpl8RBlv7Z92X7+Ufc2cjfR/B3iJUiK0QmGZkgtsmmLz0Tw=="
     }
   }
 }

--- a/src/fable-metadata/package.json
+++ b/src/fable-metadata/package.json
@@ -18,7 +18,7 @@
   ],
   "author": ".NET Foundation and Contributors",
   "license": "MIT",
-  "devDependencies": {
+  "dependencies": {
     "dirname-filename-esm": "^1.1.1"
   }
 }

--- a/src/fable-standalone/CHANGELOG.md
+++ b/src/fable-standalone/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+* Make `dirname-filename-esm` a `dependency` instead of a `devDependency`
+
 ## 1.5.0 - 2024-03-20
 
 ### Changed


### PR DESCRIPTION
#3794 #3793 

How to run:

1. `./build.sh compiler-js`
2. `cd src/fable-compiler-js`
3. `npm link @fable-org/fable-metadata ../fable-metadata`
4. `node index.js`

`node index.js --version` works but `node index.js test.fsx` fails ATM

To avoid the problem with having it working locally but not when packaged, we should probably remove the compiler directives and make use of `npm link` so it behave the same locally as if published.