### PR TITLE
[Python] Fix python reflection info casing issues

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [JS/TS] Fixed TimeSpan.FromMilliseconds (#3815) (by @ncave)
 * [Python] Fixed quotation for union string cases (by @dbrattli)
-* [Python] Fixed casing issues with identifiers and reflection info (by @dbrattli)
+* [Python] Fixed casing issues with identifiers and reflection info (#3811) (by @dbrattli)
 
 ## 4.17.0 - 2024-04-23
 

--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [JS/TS] Fixed TimeSpan.FromMilliseconds (#3815) (by @ncave)
 * [Python] Fixed quotation for union string cases (by @dbrattli)
+* [Python] Fixed casing issues with identifiers and reflection info (by @dbrattli)
 
 ## 4.17.0 - 2024-04-23
 

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -4173,7 +4173,7 @@ module Util =
                 let decls =
                     if info.IsValue then
                         let value, stmts = transformAsExpr com ctx decl.Body
-                        let name = com.GetIdentifier(ctx, decl.Name)
+                        let name = com.GetIdentifier(ctx, Naming.toSnakeCase decl.Name)
                         let ta, _ = typeAnnotation com ctx None decl.Body.Type
 
                         stmts @ declareModuleMember com ctx info.IsPublic name (Some ta) value

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -2445,7 +2445,7 @@ module Util =
             stmts @ [ decl ] @ body
         else
             let value, stmts = transformBindingExprBody com ctx var value
-            let varName = com.GetIdentifierAsExpr(ctx, var.Name)
+            let varName = com.GetIdentifierAsExpr(ctx, Naming.toSnakeCase var.Name)
             let ta, stmts' = typeAnnotation com ctx None var.Type
             let decl = varDeclaration ctx varName (Some ta) value
             stmts @ stmts' @ decl

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -383,6 +383,8 @@ module Reflection =
                     | [] -> yield Util.undefined None, []
                     | generics -> yield Expression.list generics, []
                     match tryPyConstructor com ctx ent with
+                    | Some(Expression.Name { Id = name }, stmts) ->
+                        yield Expression.name (name.Name |> Naming.toSnakeCase), stmts
                     | Some(cons, stmts) -> yield cons, stmts
                     | None -> ()
                     match ent.BaseType with

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -156,7 +156,7 @@ module Reflection =
 
                 let name = fi.Name |> Naming.toSnakeCase |> Helpers.clean
 
-                (Expression.tuple [ Expression.stringConstant (name); typeInfo ]), stmts
+                (Expression.tuple [ Expression.stringConstant name; typeInfo ]), stmts
             )
             |> Seq.toList
             |> Helpers.unzipArgs
@@ -1129,7 +1129,8 @@ module Util =
 
     let ident (com: IPythonCompiler) (ctx: Context) (id: Fable.Ident) = com.GetIdentifier(ctx, id.Name)
 
-    let identAsExpr (com: IPythonCompiler) (ctx: Context) (id: Fable.Ident) = com.GetIdentifierAsExpr(ctx, id.Name)
+    let identAsExpr (com: IPythonCompiler) (ctx: Context) (id: Fable.Ident) =
+        com.GetIdentifierAsExpr(ctx, Naming.toSnakeCase id.Name)
 
     let thisExpr = Expression.name "self"
 
@@ -3743,7 +3744,8 @@ module Util =
 
             let expr, stmts' = makeFunctionExpression com ctx None (args, body, [], ta)
 
-            let name = com.GetIdentifier(ctx, entName + Naming.reflectionSuffix)
+            let name =
+                com.GetIdentifier(ctx, Naming.toSnakeCase entName + Naming.reflectionSuffix)
 
             expr |> declareModuleMember com ctx ent.IsPublic name None, stmts @ stmts'
 

--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -805,7 +805,7 @@ let tryEntityIdent (com: Compiler) entFullName =
 
 let tryConstructor com (ent: Entity) =
     if FSharp2Fable.Util.isReplacementCandidate ent.Ref then
-        tryEntityIdent com ent.FullName
+        tryEntityIdent com (ent.FullName |> Naming.toSnakeCase)
     else
         FSharp2Fable.Util.tryEntityIdentMaybeGlobalOrImported com ent
 

--- a/tests/Python/TestNonRegression.fs
+++ b/tests/Python/TestNonRegression.fs
@@ -1,5 +1,6 @@
 module Fable.Tests.NonRegression
 
+open Fable.Core
 open Util.Testing
 
 module Issue3496 =
@@ -47,6 +48,17 @@ module Issue3674 =
 
     type Y = | X of X
 
+module Issue3811 =
+    type FlowchartDirection =
+    | TB
+    | TD
+
+    [<AttachMembers>]
+    type flowchartDirection =
+        static member tb = FlowchartDirection.TB
+        static member td = FlowchartDirection.TD
+        static member tb' () =
+            flowchartDirection.tb
 
 [<Fact>]
 let ``test hashcodes are unique`` () =
@@ -68,6 +80,7 @@ let ``test hashcodes are unique`` () =
     xHash <> 0 |> equal true
     yHash <> 0 |> equal true
 
+[<Fact>]
 let ``test record hashcodes are unique`` () =
     let x =
         {
@@ -96,7 +109,7 @@ let ``test record hashcodes are unique`` () =
     xHash <> 0 |> equal true
     yHash <> 0 |> equal true
 
-
+[<Fact>]
 let ``test Nested type with Custom Hashcode works`` () =
     let x =
         {
@@ -128,6 +141,7 @@ module Issue3717 =
     type Y =
         {X : X}
 
+[<Fact>]
 let ``test nested type with custom equality works`` () =
 
     // Should be equal according to custom equality
@@ -156,7 +170,13 @@ type MyRecord =
     override this.GetHashCode() =
         this.Age
 
+[<Fact>]
 let ``test custom equality and hashcode works`` () =
     let p1 = {Name = "John"; Age = 30}
 
     equal 30 (p1.GetHashCode())
+
+[<Fact>]
+let ``test class name casing`` () =
+    let x = Issue3811.flowchartDirection.tb' ()
+    equal Issue3811.FlowchartDirection.TB x


### PR DESCRIPTION
- Fix casing of `matchValue`
- Fix casing of identifiers and reflection info

Fixes #3811 