### PR TITLE
Fixed `fable-compiler-js` includes

### DIFF
--- a/src/fable-compiler-js/src/util.js
+++ b/src/fable-compiler-js/src/util.js
@@ -11,7 +11,7 @@ export function getVersion() {
 
 export function getFableLibDir() {
   const require = createRequire(import.meta.url);
-  return Path.join(Path.dirname(require.resolve("@fable-org/fable-standalone")), "fable-library-ts");
+  return Path.join(Path.dirname(require.resolve("@fable-org/fable-compiler-js")), "fable-library-js");
 }
 
 export function getDirFiles(dir) {


### PR DESCRIPTION
- Fixed `fable-compiler-js` includes.

@MangelMaxime This fixes the incorrect `fable-compiler-js` includes.
Can you please push a new `fable-compiler-js` version with this fix, if you agree with it? Thanks!