### PR TITLE
use case insensitive comparison when searching for dependencies between fable packages

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * [TS] Fixed interface indexers (#3830) (by @ncave)
+* [GH-3835](https://github.com/fable-compiler/Fable/pull/3835) [All] Use case insensitive comparison when searching for dependencies between fable packages (by @ThisFunctionalTom)
 
 ## 4.18.0 - 2024-05-23
 

--- a/src/Fable.Compiler/ProjectCracker.fs
+++ b/src/Fable.Compiler/ProjectCracker.fs
@@ -303,7 +303,11 @@ let tryGetFablePackage (opts: CrackerOptions) (dllPath: string) =
 let sortFablePackages (pkgs: FablePackage list) =
     ([], pkgs)
     ||> List.fold (fun acc pkg ->
-        match List.tryFindIndexBack (fun (x: FablePackage) -> pkg.Dependencies.Contains(x.Id)) acc with
+        let isPkgDependency (dependency: FablePackage) =
+            pkg.Dependencies
+            |> Set.exists (fun dep -> dep.ToLowerInvariant() = dependency.Id.ToLowerInvariant())
+
+        match List.tryFindIndexBack isPkgDependency acc with
         | None -> pkg :: acc
         | Some targetIdx ->
             let rec insertAfter x targetIdx i before after =

--- a/src/fable-compiler-js/CHANGELOG.md
+++ b/src/fable-compiler-js/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+* [GH-3835](https://github.com/fable-compiler/Fable/pull/3835) [All] Use case insensitive comparison when searching for dependencies between fable packages (by @ThisFunctionalTom)
+
 ## 1.2.2 - 2024-05-24
 
 ### Fixed


### PR DESCRIPTION
This should fix the [Issue 3833](https://github.com/fable-compiler/Fable/issues/3833)