### PR TITLE
remove extraneous dollar sign in py format string

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+* [Python] Remove `$` sign when reporting an error from `assert_equal` and `assert_not_equal` (#3878) (by @joprice)
+
 ## 4.20.0 - 2024-09-04
 
 ### Added

--- a/src/fable-library-py/fable_library/reflection.py
+++ b/src/fable-library-py/fable_library/reflection.py
@@ -305,7 +305,7 @@ def get_enum_case(t: TypeInfo, v: int | str) -> EnumCase:
             if kv[0] == v:
                 return kv
 
-        raise ValueError(f"{v}' was not found in ${t.fullname}")
+        raise ValueError(f"{v}' was not found in {t.fullname}")
 
     for kv in t.enum_cases:
         if kv[1] == v:

--- a/src/fable-library-py/fable_library/util.py
+++ b/src/fable-library-py/fable_library/util.py
@@ -355,12 +355,12 @@ def clamp(comparer: Callable[[_T, _T], int], value: _T, min: _T, max: _T):
 
 def assert_equal(actual: Any, expected: Any, msg: str | None = None) -> None:
     if not equals(actual, expected):
-        raise Exception(msg or f"Expected: ${expected} - Actual: ${actual}")
+        raise Exception(msg or f"Expected: {expected} - Actual: {actual}")
 
 
 def assert_not_equal(actual: _T, expected: _T, msg: str | None = None) -> None:
     if equals(actual, expected):
-        raise Exception(msg or f"Expected: ${expected} - Actual: ${actual}")
+        raise Exception(msg or f"Expected: {expected} - Actual: {actual}")
 
 
 MAX_LOCKS = 1024


### PR DESCRIPTION
Calling `Assert.AreEqual(1, 2)` results in an exception like `Exception: Expected: $2 - Actual: $1`, where an extra `$` appears before the value. Similarly, when calling `System.Enum.Parse`, an extra dollar sign prefixes the type name.