### PR TITLE
[JS/TS] OrdinalIgnoreCase overload for .EndsWith

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,5 +2,3 @@
 
 dotnet tool restore
 dotnet run --project src/Fable.Build/Fable.Build.fsproj -- $@
-# dotnet run --project src/Fable.Build/Fable.Build.fsproj -- test javascript
-# dotnet run --project src/Fable.Build/Fable.Build.fsproj -- test typescript

--- a/build.sh
+++ b/build.sh
@@ -2,3 +2,5 @@
 
 dotnet tool restore
 dotnet run --project src/Fable.Build/Fable.Build.fsproj -- $@
+# dotnet run --project src/Fable.Build/Fable.Build.fsproj -- test javascript
+# dotnet run --project src/Fable.Build/Fable.Build.fsproj -- test typescript

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -1449,7 +1449,6 @@ let implementedStringFunctions =
         [|
             "Compare"
             "CompareTo"
-            "EndsWith"
             "Format"
             "IndexOfAny"
             "Insert"
@@ -1503,12 +1502,15 @@ let strings (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr opt
 
         let left = Helper.InstanceCall(c, "indexOf", Int32.Number, [ arg ])
         makeEqOp r left (makeIntConst 0) BinaryGreaterOrEqual |> Some
-    | "StartsWith", Some c, [ _str ] ->
-        let left = Helper.InstanceCall(c, "indexOf", Int32.Number, args)
-        makeEqOp r left (makeIntConst 0) BinaryEqual |> Some
+    | "StartsWith", Some c, [ _str ] -> Helper.InstanceCall(c, "startsWith", Boolean, args) |> Some
     | "StartsWith", Some c, [ _str; _comp ] ->
         Helper.LibCall(com, "String", "startsWith", t, args, i.SignatureArgTypes, thisArg = c, ?loc = r)
         |> Some
+    | "EndsWith", Some c, [ _str ] -> Helper.InstanceCall(c, "endsWith", Boolean, args) |> Some
+    | "EndsWith", Some c, [ _str; _comp ] ->
+        Helper.LibCall(com, "String", "endsWith", t, args, i.SignatureArgTypes, thisArg = c, ?loc = r)
+        |> Some
+
     | ReplaceName [ "ToUpper", "toLocaleUpperCase"
                     "ToUpperInvariant", "toUpperCase"
                     "ToLower", "toLocaleLowerCase"

--- a/src/fable-library-ts/String.ts
+++ b/src/fable-library-ts/String.ts
@@ -64,8 +64,21 @@ export function compareTo(x: string, y: string) {
 }
 
 export function startsWith(str: string, pattern: string, ic: number) {
+  if (ic=== StringComparison.Ordinal){ // to avoid substring allocation
+    return str.startsWith(pattern) ;
+  }
   if (str.length >= pattern.length) {
     return cmp(str.substr(0, pattern.length), pattern, ic) === 0;
+  }
+  return false;
+}
+
+export function endsWith(str: string, pattern: string, ic: number) {
+  if (ic=== StringComparison.Ordinal){ // to avoid substring allocation
+    return str.endsWith(pattern) ;
+  }
+  if (str.length >= pattern.length) {
+    return cmp(str.substr(str.length-pattern.length, pattern.length), pattern, ic) === 0;
   }
   return false;
 }
@@ -374,12 +387,6 @@ export function format(str: string | object, ...args: any[]) {
   });
 }
 
-export function endsWith(str: string, pattern: string, ic: number) {
-  if (str.length >= pattern.length) {
-    return cmp(str.substr(str.length-1-pattern.length, pattern.length), pattern, ic) === 0;
-  }
-  return false;
-}
 
 export function initialize(n: number, f: (i: number) => string) {
   if (n < 0) {

--- a/src/fable-library-ts/String.ts
+++ b/src/fable-library-ts/String.ts
@@ -374,9 +374,11 @@ export function format(str: string | object, ...args: any[]) {
   });
 }
 
-export function endsWith(str: string, search: string) {
-  const idx = str.lastIndexOf(search);
-  return idx >= 0 && idx === str.length - search.length;
+export function endsWith(str: string, pattern: string, ic: number) {
+  if (str.length >= pattern.length) {
+    return cmp(str.substr(str.length-1-pattern.length, pattern.length), pattern, ic) === 0;
+  }
+  return false;
 }
 
 export function initialize(n: number, f: (i: number) => string) {

--- a/tests/Js/Main/StringTests.fs
+++ b/tests/Js/Main/StringTests.fs
@@ -815,30 +815,28 @@ let tests = testList "Strings" [
         "abcdbcebc".IndexOfAny([|'c';'b'|]) |> equal 1
 
     testCase "String.StartsWith works" <| fun () ->
-        let args = [("ab", true); ("cd", false); ("abcdx", false)]
+        let args = [("ab", true); ("bc", false); ("cd", false); ("abcdx", false); ("abcd", true)]
         for arg in args do
                 "abcd".StartsWith(fst arg)
                 |> equal (snd arg)
 
-    testCase "String.StartsWith with StringComparison.OrdinalIgnoreCase works" <| fun () ->
-        let args = [("ab", true); ("AB", true); ("cd", false); ("abcd", false)]
+    testCase "String.StartsWith with OrdinalIgnoreCase works" <| fun () ->
+        let args = [("ab", true); ("AB", true); ("BC", false); ("cd", false); ("abcdx", false); ("abcd", true)]
         for arg in args do
                 "ABCD".StartsWith(fst arg, StringComparison.OrdinalIgnoreCase)
                 |> equal (snd arg)
 
-
     testCase "String.EndsWith works" <| fun () ->
-        let args = [("ab", false); ("cd", true); ("abcdx", false)]
+        let args = [("ab", false); ("cd", true);  ("bc", false); ("abcdx", false); ("abcd", true)]
         for arg in args do
                 "abcd".EndsWith(fst arg)
                 |> equal (snd arg)
-
-    testCase "String.EndsWith with StringComparison.OrdinalIgnoreCase works" <| fun () ->
-        let args = [("ab", false); ("CD", true); ("cd", true); ("abcd", false)]
+    
+    testCase "String.EndsWith with OrdinalIgnoreCase works" <| fun () ->
+        let args = [("ab", false); ("CD", true); ("cd", true); ("bc", false); ("xabcd", false); ("abcd", true)]
         for arg in args do
                 "ABCD".EndsWith(fst arg, StringComparison.OrdinalIgnoreCase)
-                |> equal (snd arg)
-                
+                |> equal (snd arg)                
 
     testCase "String.Trim works" <| fun () ->
         "   abc   ".Trim()

--- a/tests/Js/Main/StringTests.fs
+++ b/tests/Js/Main/StringTests.fs
@@ -820,8 +820,8 @@ let tests = testList "Strings" [
                 "abcd".StartsWith(fst arg)
                 |> equal (snd arg)
 
-    testCase "String.StartsWith with StringComparison works" <| fun () ->
-        let args = [("ab", true); ("cd", false); ("abcdx", false)]
+    testCase "String.StartsWith with StringComparison.OrdinalIgnoreCase works" <| fun () ->
+        let args = [("ab", true); ("AB", true); ("cd", false); ("abcd", false)]
         for arg in args do
                 "ABCD".StartsWith(fst arg, StringComparison.OrdinalIgnoreCase)
                 |> equal (snd arg)
@@ -832,6 +832,13 @@ let tests = testList "Strings" [
         for arg in args do
                 "abcd".EndsWith(fst arg)
                 |> equal (snd arg)
+
+    testCase "String.EndsWith with StringComparison.OrdinalIgnoreCase works" <| fun () ->
+        let args = [("ab", false); ("CD", true); ("cd", true); ("abcd", false)]
+        for arg in args do
+                "ABCD".EndsWith(fst arg, StringComparison.OrdinalIgnoreCase)
+                |> equal (snd arg)
+                
 
     testCase "String.Trim works" <| fun () ->
         "   abc   ".Trim()


### PR DESCRIPTION
Since[ `string.StartsWith`  supports a `StringComparison.OrdinalIgnoreCase` overload](https://github.com/fable-compiler/Fable/blob/9cf4849fa3da4e7f53138aa468622f1b6987a2ca/src/fable-library-ts/String.ts#L66), I think `.EndsWith` should too