### PR TITLE
[TS] Make `AsyncBuilder` returns a real type instead of `Any`

### DIFF
--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -757,6 +757,8 @@ module Annotation =
     // Move this to Replacements.tryEntity?
     let tryNativeOrFableLibraryInterface com ctx genArgs (ent: Fable.Entity) =
         match ent.FullName with
+        | "Microsoft.FSharp.Control.FSharpAsync`1" ->
+            makeFableLibImportTypeAnnotation com ctx genArgs "AsyncBuilder" "IAsync" |> Some
         | _ when not ent.IsInterface -> None
         | Types.icollection -> makeNativeTypeAnnotation com ctx genArgs "Iterable" |> Some
         // -> makeFableLibImportTypeAnnotation com ctx [Fable.Any] "Util" "ICollection"

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -3500,7 +3500,14 @@ let asyncBuilder (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Exp
         Helper.InstanceCall(x, "Using", t, [ arg; f ], i.SignatureArgTypes, genArgs = i.GenericArgs, ?loc = r)
         |> Some
     | Some x, meth, _ ->
-        Helper.InstanceCall(x, meth, t, args, i.SignatureArgTypes, genArgs = i.GenericArgs, ?loc = r)
+        let typ =
+            // Progressively add types to AsyncBuilder
+            // "Delay" is what is exposed to the end user, so for now we only care about it
+            match meth with
+            | "Delay" -> t
+            | _ -> Any
+
+        Helper.InstanceCall(x, meth, typ, args, i.SignatureArgTypes, genArgs = i.GenericArgs, ?loc = r)
         |> Some
     | None, meth, _ ->
         Helper.LibCall(

--- a/src/fable-library-ts/Async.ts
+++ b/src/fable-library-ts/Async.ts
@@ -9,9 +9,6 @@ import { protectedReturn } from "./AsyncBuilder.js";
 import { FSharpChoice$2_$union, Choice_makeChoice1Of2, Choice_makeChoice2Of2 } from "./Choice.js";
 import { TimeoutException } from "./SystemException.js";
 
-// Implemented just for type references
-export class Async<_T> { }
-
 function emptyContinuation<T>(_x: T) {
   // NOP
 }
@@ -203,5 +200,3 @@ export function startAsPromise<T>(computation: IAsync<T>, cancellationToken?: Ca
     startWithContinuations(computation, resolve, reject, reject,
       cancellationToken ? cancellationToken : defaultCancellationToken));
 }
-
-export default Async;


### PR DESCRIPTION
I was looking at fixing #3864, and it seems like my fix works for the code provided in the issue:

```fs
let doAsync =
    async {
        return "hi"
    }
```

However, it fails on more complex code and I don't understand why.

```text
Argument of type '(ctx: IAsyncContext<number | undefined>) => void' is not assignable to parameter of type 'IAsync<number>'.
  Types of parameters 'ctx' and 'x' are incompatible.
    Type 'IAsyncContext<number>' is not assignable to type 'IAsyncContext<number | undefined>'.
      Type 'number | undefined' is not assignable to type 'number'.
        Type 'undefined' is not assignable to type 'number'.ts(2345)
```

I don't understand where TypeScript infer the type to `XX | undefined` we never seems to use it inside of `AsyncBuilder`.

@ncave Do you have an idea?