### PR TITLE
Renamed IAsync to Async

### DIFF
--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -757,8 +757,9 @@ module Annotation =
     // Move this to Replacements.tryEntity?
     let tryNativeOrFableLibraryInterface com ctx genArgs (ent: Fable.Entity) =
         match ent.FullName with
-        | Types.fsharpAsyncGeneric -> makeFableLibImportTypeAnnotation com ctx genArgs "AsyncBuilder" "IAsync" |> Some
+        | Types.fsharpAsyncGeneric -> makeFableLibImportTypeAnnotation com ctx genArgs "AsyncBuilder" "Async" |> Some
         | _ when not ent.IsInterface -> None
+        // everything below is an interface
         | Types.icollection -> makeNativeTypeAnnotation com ctx genArgs "Iterable" |> Some
         // -> makeFableLibImportTypeAnnotation com ctx [Fable.Any] "Util" "ICollection"
         | Types.icollectionGeneric -> makeNativeTypeAnnotation com ctx genArgs "Iterable" |> Some

--- a/src/fable-library-py/fable_library/Async.fs
+++ b/src/fable-library-py/fable_library/Async.fs
@@ -14,7 +14,7 @@ let defaultCancellationToken = new CancellationToken()
 [<Erase>]
 type Async =
     static member StartWithContinuations
-        (computation: IAsync<'T>, continuation, exceptionContinuation, cancellationContinuation, ?cancellationToken)
+        (computation: Async<'T>, continuation, exceptionContinuation, cancellationContinuation, ?cancellationToken)
         : unit
         =
         let trampoline = Trampoline()
@@ -31,7 +31,7 @@ type Async =
             }
         )
 
-    static member StartWithContinuations(computation: IAsync<'T>, ?cancellationToken) : unit =
+    static member StartWithContinuations(computation: Async<'T>, ?cancellationToken) : unit =
         Async.StartWithContinuations(
             computation,
             emptyContinuation,
@@ -44,8 +44,8 @@ type Async =
         Async.StartWithContinuations(computation, ?cancellationToken = cancellationToken)
 
 
-    static member StartImmediate(computation: IAsync<'T>, ?cancellationToken) =
+    static member StartImmediate(computation: Async<'T>, ?cancellationToken) =
         Async.Start(computation, ?cancellationToken = cancellationToken)
 
-let startImmediate (computation: IAsync<'T>) =
+let startImmediate (computation: Async<'T>) =
     Async.StartImmediate(computation, ?cancellationToken = None)

--- a/src/fable-library-py/fable_library/AsyncBuilder.fs
+++ b/src/fable-library-py/fable_library/AsyncBuilder.fs
@@ -74,9 +74,9 @@ type IAsyncContext<'T> =
     abstract member cancelToken: CancellationToken
     abstract member trampoline: Trampoline
 
-type IAsync<'T> = IAsyncContext<'T> -> unit
+type Async<'T> = IAsyncContext<'T> -> unit
 
-let protectedCont<'T> (f: IAsync<'T>) =
+let protectedCont<'T> (f: Async<'T>) =
     fun (ctx: IAsyncContext<'T>) ->
         if ctx.cancelToken.IsCancelled then
             ctx.onCancel (new OperationCanceledError())
@@ -93,7 +93,7 @@ let protectedCont<'T> (f: IAsync<'T>) =
             with err ->
                 ctx.onError (err)
 
-let protectedBind<'T, 'U> (computation: IAsync<'T>, binder: 'T -> IAsync<'U>) =
+let protectedBind<'T, 'U> (computation: Async<'T>, binder: 'T -> Async<'U>) =
     protectedCont (fun (ctx: IAsyncContext<'U>) ->
         computation (
             { new IAsyncContext<'T> with
@@ -116,34 +116,32 @@ let protectedReturn<'T> (value: 'T) =
     protectedCont (fun (ctx: IAsyncContext<'T>) -> ctx.onSuccess (value))
 
 type IAsyncBuilder =
-    abstract member Bind<'T, 'U> : IAsync<'T> * ('T -> IAsync<'U>) -> IAsync<'U>
+    abstract member Bind<'T, 'U> : Async<'T> * ('T -> Async<'U>) -> Async<'U>
 
-    abstract member Combine<'T> : IAsync<unit> * IAsync<'T> -> IAsync<'T>
+    abstract member Combine<'T> : Async<unit> * Async<'T> -> Async<'T>
 
-    abstract member Delay<'T> : (unit -> IAsync<'T>) -> IAsync<'T>
+    abstract member Delay<'T> : (unit -> Async<'T>) -> Async<'T>
 
-    //abstract member Return<'T> : [<ParamArray>] values: 'T [] -> IAsync<'T>
-    abstract member Return<'T> : value: 'T -> IAsync<'T>
+    //abstract member Return<'T> : [<ParamArray>] values: 'T [] -> Async<'T>
+    abstract member Return<'T> : value: 'T -> Async<'T>
 
-    abstract member While: (unit -> bool) * IAsync<unit> -> IAsync<unit>
-    abstract member Zero: unit -> IAsync<unit>
+    abstract member While: (unit -> bool) * Async<unit> -> Async<unit>
+    abstract member Zero: unit -> Async<unit>
 
 
 type AsyncBuilder() =
     interface IAsyncBuilder with
 
-        member this.Bind<'T, 'U>(computation: IAsync<'T>, binder: 'T -> IAsync<'U>) =
-            protectedBind (computation, binder)
+        member this.Bind<'T, 'U>(computation: Async<'T>, binder: 'T -> Async<'U>) = protectedBind (computation, binder)
 
-        member this.Combine<'T>(computation1: IAsync<unit>, computation2: IAsync<'T>) =
+        member this.Combine<'T>(computation1: Async<unit>, computation2: Async<'T>) =
             let self = this :> IAsyncBuilder
             self.Bind(computation1, (fun () -> computation2))
 
-        member x.Delay<'T>(generator: unit -> IAsync<'T>) =
+        member x.Delay<'T>(generator: unit -> Async<'T>) =
             protectedCont (fun (ctx: IAsyncContext<'T>) -> generator () (ctx))
 
-
-        //   public For<T>(sequence: Iterable<T>, body: (x: T) => IAsync<void>) {
+        //   public For<T>(sequence: Iterable<T>, body: (x: T) => Async<void>) {
         //     const iter = sequence[Symbol.iterator]();
         //     let cur = iter.next();
         //     return this.While(() => !cur.done, this.Delay(() => {
@@ -153,19 +151,19 @@ type AsyncBuilder() =
         //     }));
         //   }
 
-        member this.Return<'T>(value: 'T) : IAsync<'T> = protectedReturn (unbox value)
-        // member this.Return<'T>([<ParamArray>] value: 'T []) : IAsync<'T> =
+        member this.Return<'T>(value: 'T) : Async<'T> = protectedReturn (unbox value)
+        // member this.Return<'T>([<ParamArray>] value: 'T []) : Async<'T> =
         //     match value with
         //     | [||] -> protectedReturn (unbox null)
         //     | [| value |] -> protectedReturn value
         //     | _ -> failwith "Return takes zero or one argument."
 
 
-        //   public ReturnFrom<T>(computation: IAsync<T>) {
+        //   public ReturnFrom<T>(computation: Async<T>) {
         //     return computation;
         //   }
 
-        //   public TryFinally<T>(computation: IAsync<T>, compensation: () => void) {
+        //   public TryFinally<T>(computation: Async<T>, compensation: () => void) {
         //     return protectedCont((ctx: IAsyncContext<T>) => {
         //       computation({
         //         onSuccess: (x: T) => {
@@ -186,7 +184,7 @@ type AsyncBuilder() =
         //     });
         //   }
 
-        //   public TryWith<T>(computation: IAsync<T>, catchHandler: (e: any) => IAsync<T>) {
+        //   public TryWith<T>(computation: Async<T>, catchHandler: (e: any) => Async<T>) {
         //     return protectedCont((ctx: IAsyncContext<T>) => {
         //       computation({
         //         onSuccess: ctx.onSuccess,
@@ -204,11 +202,11 @@ type AsyncBuilder() =
         //     });
         //   }
 
-        //   public Using<T extends IDisposable, U>(resource: T, binder: (x: T) => IAsync<U>) {
+        //   public Using<T extends IDisposable, U>(resource: T, binder: (x: T) => Async<U>) {
         //     return this.TryFinally(binder(resource), () => resource.Dispose());
         //   }
 
-        member this.While(guard: unit -> bool, computation: IAsync<unit>) : IAsync<unit> =
+        member this.While(guard: unit -> bool, computation: Async<unit>) : Async<unit> =
             let self = this :> IAsyncBuilder
 
             if guard () then
@@ -216,8 +214,8 @@ type AsyncBuilder() =
             else
                 self.Return()
 
-        //    member this.Bind<'T, 'U>(computation: IAsync<'T>, binder: 'T -> IAsync<'U>) = (this :> IAsyncBuilder).Bind(computation, binder)
-        member this.Zero() : IAsync<unit> =
+        //    member this.Bind<'T, 'U>(computation: Async<'T>, binder: 'T -> Async<'U>) = (this :> IAsyncBuilder).Bind(computation, binder)
+        member this.Zero() : Async<unit> =
             protectedCont (fun (ctx: IAsyncContext<unit>) -> ctx.onSuccess (()))
 
 // }

--- a/src/fable-library-ts/AsyncBuilder.ts
+++ b/src/fable-library-ts/AsyncBuilder.ts
@@ -86,9 +86,9 @@ export interface IAsyncContext<T> {
   trampoline: Trampoline;
 }
 
-export type IAsync<T> = (x: IAsyncContext<T>) => void;
+export type Async<T> = (x: IAsyncContext<T>) => void;
 
-export function protectedCont<T>(f: IAsync<T>) {
+export function protectedCont<T>(f: Async<T>) {
   return (ctx: IAsyncContext<T>) => {
     if (ctx.cancelToken.isCancelled) {
       ctx.onCancel(new OperationCanceledError());
@@ -110,7 +110,7 @@ export function protectedCont<T>(f: IAsync<T>) {
   };
 }
 
-export function protectedBind<T, U>(computation: IAsync<T>, binder: (x: T) => IAsync<U>) {
+export function protectedBind<T, U>(computation: Async<T>, binder: (x: T) => Async<U>) {
   return protectedCont((ctx: IAsyncContext<U>) => {
     computation({
       onSuccess: (x: T) => {
@@ -133,19 +133,19 @@ export function protectedReturn<T>(value: T) {
 }
 
 export class AsyncBuilder {
-  public Bind<T, U>(computation: IAsync<T>, binder: (x: T) => IAsync<U>) {
+  public Bind<T, U>(computation: Async<T>, binder: (x: T) => Async<U>) {
     return protectedBind(computation, binder);
   }
 
-  public Combine<T>(computation1: IAsync<void>, computation2: IAsync<T>) {
+  public Combine<T>(computation1: Async<void>, computation2: Async<T>) {
     return this.Bind(computation1, () => computation2);
   }
 
-  public Delay<T>(generator: () => IAsync<T>) {
+  public Delay<T>(generator: () => Async<T>) {
     return protectedCont((ctx: IAsyncContext<T>) => generator()(ctx));
   }
 
-  public For<T>(sequence: Iterable<T>, body: (x: T) => IAsync<void>) {
+  public For<T>(sequence: Iterable<T>, body: (x: T) => Async<void>) {
     const iter = sequence[Symbol.iterator]();
     let cur = iter.next();
     return this.While(() => !cur.done, this.Delay(() => {
@@ -159,11 +159,11 @@ export class AsyncBuilder {
     return protectedReturn(value);
   }
 
-  public ReturnFrom<T>(computation: IAsync<T>) {
+  public ReturnFrom<T>(computation: Async<T>) {
     return computation;
   }
 
-  public TryFinally<T>(computation: IAsync<T>, compensation: () => void) {
+  public TryFinally<T>(computation: Async<T>, compensation: () => void) {
     return protectedCont((ctx: IAsyncContext<T>) => {
       computation({
         onSuccess: (x: T) => {
@@ -184,7 +184,7 @@ export class AsyncBuilder {
     });
   }
 
-  public TryWith<T>(computation: IAsync<T>, catchHandler: (e: any) => IAsync<T>) {
+  public TryWith<T>(computation: Async<T>, catchHandler: (e: any) => Async<T>) {
     return protectedCont((ctx: IAsyncContext<T>) => {
       computation({
         onSuccess: ctx.onSuccess,
@@ -202,11 +202,11 @@ export class AsyncBuilder {
     });
   }
 
-  public Using<T extends IDisposable, U>(resource: T, binder: (x: T) => IAsync<U>) {
+  public Using<T extends IDisposable, U>(resource: T, binder: (x: T) => Async<U>) {
     return this.TryFinally(binder(resource), () => resource.Dispose());
   }
 
-  public While(guard: () => boolean, computation: IAsync<void>): IAsync<void> {
+  public While(guard: () => boolean, computation: Async<void>): Async<void> {
     if (guard()) {
       return this.Bind(computation, () => this.While(guard, computation));
     } else {

--- a/src/fable-library-ts/MailboxProcessor.ts
+++ b/src/fable-library-ts/MailboxProcessor.ts
@@ -1,7 +1,7 @@
 import { defaultCancellationToken } from "./Async.js";
 import { fromContinuations } from "./Async.js";
 import { startImmediate } from "./Async.js";
-import { IAsync } from "./AsyncBuilder.js";
+import { Async } from "./AsyncBuilder.js";
 import { Continuation, Continuations } from "./AsyncBuilder.js";
 import { CancellationToken } from "./AsyncBuilder.js";
 
@@ -41,7 +41,7 @@ class MailboxQueue<Msg> {
   }
 }
 
-export type MailboxBody<Msg> = (m: MailboxProcessor<Msg>) => IAsync<void>;
+export type MailboxBody<Msg> = (m: MailboxProcessor<Msg>) => Async<void>;
 
 export interface AsyncReplyChannel<Reply> {
   reply: (r: Reply) => void;


### PR DESCRIPTION
- Renamed `IAsync<T>` to `Async<T>` as it's not an interface.

(Note: This change doesn't seem to impact the Python generated code in any way).