### PR TITLE
[TS] Support `[<Mangle>]` on interface

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [All/Rust] Removed Regex.Replace from hot paths (by @ncave)
 * [JS] Fix regression, generate `let` variable when using `import` on a private mutable variable (by @MangelMaxime)
 * [TS] Prevent generics to be duplicated (by @MangelMaxime)
+* [TS] Fix interface generation when decorated with `Mangle` (by @MangelMaxime)
 
 ## 4.22.0 - 2024-10-02
 

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -3858,7 +3858,11 @@ module Util =
         let methods =
             methods
             |> Array.map (fun info ->
-                let prop, isComputed = memberFromName info.CompiledName
+                let prop, isComputed =
+                    if ent.Attributes |> hasAttribute Atts.mangle then
+                        memberFromName info.FullName
+                    else
+                        memberFromName info.CompiledName
 
                 let args =
                     info.CurriedParameterGroups

--- a/tests/Js/Main/TypeTests.fs
+++ b/tests/Js/Main/TypeTests.fs
@@ -351,6 +351,16 @@ type InfoB = {
     Bar: string
 }
 
+[<Mangle>]
+type IUpperMangledInterface =
+    abstract Upper: string -> string
+    abstract Ping: unit -> string
+
+type UpperMangledClass() =
+    interface IUpperMangledInterface with
+        member _.Upper s = s.ToUpper()
+        member _.Ping () = "pong"
+
 #if !FABLE_COMPILER_TYPESCRIPT
 [<AbstractClass>]
 type InfoAClass(info: InfoA) =
@@ -370,7 +380,7 @@ type FooInterface =
     abstract Item: int -> char with get, set
     abstract Sum: [<ParamArray>] items: string[] -> string
 
-[<Fable.Core.Mangle>]
+[<Mangle>]
 type BarInterface =
     abstract Bar: string with get, set
     abstract DoSomething: f: (float -> float -> float) * v: float -> float
@@ -1322,4 +1332,9 @@ let tests =
         let mutable arr = [| 1; 2; 3 |]
         let result = genericByrefFunc &arr
         result |> equal 3
+
+    testCase "mangled method on interface works" <| fun () ->
+        let upper = UpperMangledClass()
+        (upper :> IUpperMangledInterface).Upper("hello") |> equal "HELLO"
+        (upper :> IUpperMangledInterface).Ping() |> equal "pong"
   ]


### PR DESCRIPTION
Fix #3863

@ncave I was looking into fixing #3863 and manage to fix that specific case however, if the members as an argument different than `unit` then it doesn't work because that member should me mangled.

The difficulty is `Mangle` name computation happens during `FSharp2Fable` transformation, but for interfaces we don't do it.

How should we approach this problem? Should we try to add `Mangle` information for interface too which means making a changes to `Fable.AST` or can we recompute the `Mangle` / `HashSuffix` using FableEntity instead of FSharpEntity?