### PR TITLE
Allow Fable 5 to be used with Fable 4 plugins

### DIFF
--- a/src/Fable.Transforms/Global/Compiler.fs
+++ b/src/Fable.Transforms/Global/Compiler.fs
@@ -99,7 +99,7 @@ type InlineExprLazy(f: Compiler -> InlineExpr) =
 
 [<AutoOpen>]
 module CompilerExt =
-    let private expectedVersionMatchesActual (expected: string) (actual: string) =
+    let expectedVersionMatchesActual (expected: string) (actual: string) =
         try
             let r = System.Text.RegularExpressions.Regex(@"^(\d+)\.(\d+)(?:\.(\d+))?")
 

--- a/src/Fable.Transforms/Global/Compiler.fs
+++ b/src/Fable.Transforms/Global/Compiler.fs
@@ -119,7 +119,7 @@ module CompilerExt =
             actualMajor > expectedMajor
             || (actualMajor = expectedMajor
                 && (actualMinor > expectedMinor
-                    || actualMinor = expectedMinor && actualPatch >= expectedPatch))
+                    || (actualMinor = expectedMinor && actualPatch >= expectedPatch)))
         with _ ->
             false
 

--- a/src/Fable.Transforms/Global/Compiler.fs
+++ b/src/Fable.Transforms/Global/Compiler.fs
@@ -116,10 +116,10 @@ module CompilerExt =
             let actualMajor, actualMinor, actualPatch = parse actual
             let expectedMajor, expectedMinor, expectedPatch = parse expected
 
-            // Fail also if actual major is bigger than expected major version
-            actualMajor = expectedMajor
-            && (actualMinor > expectedMinor
-                || (actualMinor = expectedMinor && actualPatch >= expectedPatch))
+            actualMajor > expectedMajor
+            || (actualMajor = expectedMajor
+                && (actualMinor > expectedMinor
+                    || actualMinor = expectedMinor && actualPatch >= expectedPatch))
         with _ ->
             false
 

--- a/tests/Integration/Compiler/CompilerHelpersTests.fs
+++ b/tests/Integration/Compiler/CompilerHelpersTests.fs
@@ -12,12 +12,12 @@ let tests =
             Fable.CompilerExt.expectedVersionMatchesActual "5.0.1" "5.0.0" |> equal true
             Fable.CompilerExt.expectedVersionMatchesActual "5.1.0" "5.0.0" |> equal true
 
-        testCase "expectedVersionMatchesActual works if actual version is highter than expected version" <| fun _ ->
+        testCase "expectedVersionMatchesActual works if actual version is higher than expected version" <| fun _ ->
             Fable.CompilerExt.expectedVersionMatchesActual "4.0.0" "5.0.0" |> equal true
             Fable.CompilerExt.expectedVersionMatchesActual "4.0.1" "5.0.0" |> equal true
             Fable.CompilerExt.expectedVersionMatchesActual "4.1.0" "5.0.0" |> equal true
 
-        testCase "expectedVersionMatchesActual reject if actual version is highter than expected version" <| fun _ ->
+        testCase "expectedVersionMatchesActual reject if actual version is lower than expected version" <| fun _ ->
             Fable.CompilerExt.expectedVersionMatchesActual "4.0.0" "3.0.0" |> equal false
             Fable.CompilerExt.expectedVersionMatchesActual "4.0.1" "3.0.0" |> equal false
             Fable.CompilerExt.expectedVersionMatchesActual "4.1.0" "3.0.0" |> equal false

--- a/tests/Integration/Compiler/CompilerHelpersTests.fs
+++ b/tests/Integration/Compiler/CompilerHelpersTests.fs
@@ -1,0 +1,24 @@
+module Fable.Tests.Compiler.CompilerHelpers
+
+open Fable.Core
+open Util.Testing
+open Fable.Tests.Compiler.Util
+open Fable.Tests.Compiler.Util.Compiler
+
+let tests =
+    testList "Compiler Helpers" [
+        testCase "expectedVersionMatchesActual works for same major version" <| fun _ ->
+            Fable.CompilerExt.expectedVersionMatchesActual "5.0.0" "5.0.0" |> equal true
+            Fable.CompilerExt.expectedVersionMatchesActual "5.0.1" "5.0.0" |> equal true
+            Fable.CompilerExt.expectedVersionMatchesActual "5.1.0" "5.0.0" |> equal true
+
+        testCase "expectedVersionMatchesActual works if actual version is highter than expected version" <| fun _ ->
+            Fable.CompilerExt.expectedVersionMatchesActual "4.0.0" "5.0.0" |> equal true
+            Fable.CompilerExt.expectedVersionMatchesActual "4.0.1" "5.0.0" |> equal true
+            Fable.CompilerExt.expectedVersionMatchesActual "4.1.0" "5.0.0" |> equal true
+
+        testCase "expectedVersionMatchesActual reject if actual version is highter than expected version" <| fun _ ->
+            Fable.CompilerExt.expectedVersionMatchesActual "4.0.0" "3.0.0" |> equal true
+            Fable.CompilerExt.expectedVersionMatchesActual "4.0.1" "3.0.0" |> equal true
+            Fable.CompilerExt.expectedVersionMatchesActual "4.1.0" "3.0.0" |> equal true
+    ]

--- a/tests/Integration/Compiler/CompilerHelpersTests.fs
+++ b/tests/Integration/Compiler/CompilerHelpersTests.fs
@@ -18,7 +18,7 @@ let tests =
             Fable.CompilerExt.expectedVersionMatchesActual "4.1.0" "5.0.0" |> equal true
 
         testCase "expectedVersionMatchesActual reject if actual version is highter than expected version" <| fun _ ->
-            Fable.CompilerExt.expectedVersionMatchesActual "4.0.0" "3.0.0" |> equal true
-            Fable.CompilerExt.expectedVersionMatchesActual "4.0.1" "3.0.0" |> equal true
-            Fable.CompilerExt.expectedVersionMatchesActual "4.1.0" "3.0.0" |> equal true
+            Fable.CompilerExt.expectedVersionMatchesActual "4.0.0" "3.0.0" |> equal false
+            Fable.CompilerExt.expectedVersionMatchesActual "4.0.1" "3.0.0" |> equal false
+            Fable.CompilerExt.expectedVersionMatchesActual "4.1.0" "3.0.0" |> equal false
     ]

--- a/tests/Integration/Compiler/CompilerHelpersTests.fs
+++ b/tests/Integration/Compiler/CompilerHelpersTests.fs
@@ -9,13 +9,13 @@ let tests =
     testList "Compiler Helpers" [
         testCase "expectedVersionMatchesActual works for same major version" <| fun _ ->
             Fable.CompilerExt.expectedVersionMatchesActual "5.0.0" "5.0.0" |> equal true
-            Fable.CompilerExt.expectedVersionMatchesActual "5.0.1" "5.0.0" |> equal true
-            Fable.CompilerExt.expectedVersionMatchesActual "5.1.0" "5.0.0" |> equal true
+            Fable.CompilerExt.expectedVersionMatchesActual "5.0.0" "5.0.1" |> equal true
+            Fable.CompilerExt.expectedVersionMatchesActual "5.1.0" "5.1.0" |> equal true
 
         testCase "expectedVersionMatchesActual works if actual version is higher than expected version" <| fun _ ->
             Fable.CompilerExt.expectedVersionMatchesActual "4.0.0" "5.0.0" |> equal true
-            Fable.CompilerExt.expectedVersionMatchesActual "4.0.1" "5.0.0" |> equal true
-            Fable.CompilerExt.expectedVersionMatchesActual "4.1.0" "5.0.0" |> equal true
+            Fable.CompilerExt.expectedVersionMatchesActual "4.0.0" "5.0.1" |> equal true
+            Fable.CompilerExt.expectedVersionMatchesActual "4.0.0" "5.1.0" |> equal true
 
         testCase "expectedVersionMatchesActual reject if actual version is lower than expected version" <| fun _ ->
             Fable.CompilerExt.expectedVersionMatchesActual "4.0.0" "3.0.0" |> equal false

--- a/tests/Integration/Compiler/Fable.Tests.Compiler.fsproj
+++ b/tests/Integration/Compiler/Fable.Tests.Compiler.fsproj
@@ -22,6 +22,7 @@
     <Compile Include="Util/Compiler.fs" />
     <Compile Include="CompilerMessagesTests.fs" />
     <Compile Include="AnonRecordInInterfaceTests.fs" />
+    <Compile Include="CompilerHelpersTests.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
 </Project>

--- a/tests/Integration/Compiler/Main.fs
+++ b/tests/Integration/Compiler/Main.fs
@@ -7,6 +7,7 @@ let allTests =
     [
         CompilerMessages.tests
         AnonRecordInInterface.tests
+        CompilerHelpers.tests
     ]
 
 

--- a/tests/Integration/Integration/CompilationTests.fs
+++ b/tests/Integration/Integration/CompilationTests.fs
@@ -25,7 +25,7 @@ let tests =
                 Expect.equal exitCode 0 "Expected exit code to be 0"
 
                 let normalize content =
-                    Regex.Replace(content, @"(/fable-library-js)[.0-9]+", "$1")
+                    Regex.Replace(content, @"(/fable-library-js)[^/]+", "$1")
                     |> _.ReplaceLineEndings()
                     |> _.Trim()
 


### PR DESCRIPTION
- Fixes #3962