### PR TITLE
[TS] Make discriminated union `.Is*` properties works

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [Python] Fix type testing against `uint8`, `uint32`, `uint64`, `decimal` (@MangelMaxime)
 * [JS/TS] Workaround source map generation bug (deteriorate them a little) (@MangelMaxime)
+* [TS] Make discriminated union `.Is*` properties works (@MangelMaxime)
 
 ## 5.0.0-alpha.2 - 2024-11-25
 

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -2438,7 +2438,17 @@ module Util =
                 expr
         | Fable.UnionCaseTest tag ->
             let expected = transformUnionCaseTag com range expr.Type tag
-            let actual = getUnionExprTag com ctx None expr
+
+            let unionExprTag = getUnionExprTag com ctx None expr
+
+            let actual =
+                if com.IsTypeScript then
+                    // In TypeScript, we need to cast the union case tag to a number
+                    // otherwise TypeScript compiler is too smart and test against the literal value (0, 1, 2, etc.)
+                    let number = Fable.Number(Int32, Fable.NumberInfo.Empty)
+                    (AsExpression(unionExprTag, makeTypeAnnotation com ctx number))
+                else
+                    unionExprTag
 
             Expression.binaryExpression (BinaryEqual, actual, expected, ?loc = range)
 


### PR DESCRIPTION
I am not sure why but casting the `tag` to `number` make some others scenarios fails:

```fs
type Test<'T> =
    | A
    | Value of 'T

let testResult = Value "test"

printfn "%A" testResult.IsA
printfn "%A" testResult.IsValue

let apply (f: 'A -> 'B) (value : Test<'A>) : Test<'B> =
    match value with
    | A -> A
    | Value v -> Value (f v)
```

```ts
(function () {
    const arg: boolean = testResult.tag === (/* A */ 0 as int32);
    toConsole(printf("%A"))(arg);
})();

(function () {
    const arg: boolean = testResult.tag === (/* Value */ 1 as int32);
    toConsole(printf("%A"))(arg);
})();

export function apply<A, B>(f: ((arg0: A) => B), value: Test$1_$union<A>): Test$1_$union<B> {
    if (value.tag === (/* Value */ 1 as int32)) {
        const v: A = value.fields[0]; // <===================== Error here
        return Test$1_Value<B>(f(v));
    }
    else {
        return Test$1_A<B>();
    }
}
```

```
Type 'A | undefined' is not assignable to type 'A'.
```

But without the cast then in some scenario `Is*` don't works with TypeScript is able to compare the literal value directly.