### PR TITLE
[JS/TS] Don't generate the setter code if a property is decorated with `[<Erase>]`

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [TS] Make discriminated union `.Is*` properties works (@MangelMaxime)
 * [JS/TS/Python] Fix `h` in `DateTime.ToString` (@MangelMaxime)
 * [JS/TS] Fix `hh` in `DateTime.ToString` (@MangelMaxime)
+* [JS/TS] Don't generate the setter code if a property is decorated with `[<Erase>]` (@MangelMaxime)
 
 ## 5.0.0-alpha.3 - 2024-12-18
 

--- a/tests/Integration/Integration/data/eraseAttribute/ErasedProperty.fs
+++ b/tests/Integration/Integration/data/eraseAttribute/ErasedProperty.fs
@@ -1,0 +1,12 @@
+module ErasedProperty
+
+open Fable.Core
+
+
+// This test is to make sure that we are retrieving the Erase attribute from the erased property
+// and not the declaring type
+
+type internal LanguageInjectionAttribute() =
+
+    [<Erase>]
+    member val Prefix = "" with get, set

--- a/tests/Integration/Integration/data/eraseAttribute/ErasedProperty.js.expected
+++ b/tests/Integration/Integration/data/eraseAttribute/ErasedProperty.js.expected
@@ -1,0 +1,16 @@
+import { class_type } from "./fable_modules/fable-library-js.5.0.0-alpha.3/Reflection.js";
+
+export class LanguageInjectionAttribute {
+    constructor() {
+        this["Prefix@"] = "";
+    }
+}
+
+export function LanguageInjectionAttribute_$reflection() {
+    return class_type("ErasedProperty.LanguageInjectionAttribute", undefined, LanguageInjectionAttribute);
+}
+
+export function LanguageInjectionAttribute_$ctor() {
+    return new LanguageInjectionAttribute();
+}
+

--- a/tests/Integration/Integration/data/eraseAttribute/ErasedTypeWithProperty.fs
+++ b/tests/Integration/Integration/data/eraseAttribute/ErasedTypeWithProperty.fs
@@ -1,0 +1,12 @@
+module ErasedTypeWithProperty
+
+open Fable.Core
+
+[<Erase>]
+type internal LanguageInjectionAttribute() =
+
+    [<Erase>]
+    member val Prefix = "" with get, set
+
+// Force Fable to generate a file, otherwise because everything is erased, it will not generate anything
+let a = 0

--- a/tests/Integration/Integration/data/eraseAttribute/ErasedTypeWithProperty.js.expected
+++ b/tests/Integration/Integration/data/eraseAttribute/ErasedTypeWithProperty.js.expected
@@ -1,0 +1,3 @@
+
+export const a = 0;
+

--- a/tests/Integration/Integration/data/eraseAttribute/eraseAttribute.fsproj
+++ b/tests/Integration/Integration/data/eraseAttribute/eraseAttribute.fsproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <Compile Include="Members.fs" />
+    <Compile Include="ErasedTypeWithProperty.fs" />
+    <Compile Include="ErasedProperty.fs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix #3948

This implementation is actually invalid `DeclaringEntity` is the type so `LanguageInjectionAttribute` and not the original symbol of `Prefix`
