### PR TITLE
[TS] Emit `interface` declaration when encountering a `ParamObject` pattern

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+* [TS] Include XML Doc comment on interface properties (by @Freymaurer)
+
 ## 5.0.0-alpha.7 - 2025-01-23
 
 ### Fixed

--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * [TS] Include XML Doc comment on interface properties (by @Freymaurer)
+* [TS] Generate `interface` type when using the "ParamObject" class pattern (by @MangelMaxime)
 
 ## 5.0.0-alpha.7 - 2025-01-23
 

--- a/src/Fable.Compiler/CHANGELOG.md
+++ b/src/Fable.Compiler/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+* [TS] Include XML Doc comment on interface properties (by @Freymaurer)
+
 ## 5.0.0-alpha.7 - 2025-01-23
 
 ### Fixed

--- a/src/Fable.Compiler/CHANGELOG.md
+++ b/src/Fable.Compiler/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * [TS] Include XML Doc comment on interface properties (by @Freymaurer)
+* [TS] Generate `interface` type when using the "ParamObject" class pattern (by @MangelMaxime)
 
 ## 5.0.0-alpha.7 - 2025-01-23
 

--- a/src/Fable.Transforms/BabelPrinter.fs
+++ b/src/Fable.Transforms/BabelPrinter.fs
@@ -664,7 +664,7 @@ module PrinterExtensions =
                 printer.PrintFunction(Some id, parameters, body, typeParameters, returnType, loc, isDeclaration = true)
 
                 printer.PrintNewLine()
-            | InterfaceDeclaration(id, body, extends, typeParameters) ->
+            | InterfaceDeclaration(id, body, extends, typeParameters, _) ->
                 printer.PrintInterfaceDeclaration(id, body, extends, typeParameters)
             | EnumDeclaration(name, cases, isConst) ->
                 if isConst then

--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -817,6 +817,35 @@ module Helpers =
             | None -> false
         )
 
+    // When compiling to TypeScript, we want to captuer classes that use the
+    // [<Global>] attribute on the type and[<ParamObject>] on the constructors
+    // so we can transform it into an interface
+
+    /// <summary>
+    /// Check if the entity is decorated with the <code>Global</code> attribute
+    /// and all its constructors are decorated with <code>ParamObject</code> attribute.
+    ///
+    /// This is used to identify classes that should be transformed into interfaces.
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <returns>
+    /// <code>true</code> if the entity is a global type with all constructors as param objects,
+    /// <code>false</code> otherwise.
+    /// </returns>
+    let isParamObjectClassPattern (entity: Fable.Entity) =
+        let isGlobalType =
+            entity.Attributes |> Seq.exists (fun att -> att.Entity.FullName = Atts.global_)
+
+        let areAllConstructorsParamObject =
+            entity.MembersFunctionsAndValues
+            |> Seq.filter _.IsConstructor
+            |> Seq.forall (fun memb ->
+                memb.Attributes
+                |> Seq.exists (fun att -> att.Entity.FullName = Atts.paramObject)
+            )
+
+        isGlobalType && areAllConstructorsParamObject
+
     let tryPickAttrib attFullNames (attributes: FSharpAttribute seq) =
         let attFullNames = Map attFullNames
 

--- a/src/Fable.Transforms/FSharp2Fable.fs
+++ b/src/Fable.Transforms/FSharp2Fable.fs
@@ -2044,7 +2044,8 @@ let rec private transformDeclarations (com: FableCompiler) ctx fsDecls =
 
                 if
                     (isErasedOrStringEnumEntity ent && Compiler.Language <> TypeScript)
-                    || isGlobalOrImportedEntity ent
+                    || (isGlobalOrImportedEntity ent
+                        && (Compiler.Language = TypeScript && not (isParamObjectClassPattern ent)))
                 then
                     []
                 else

--- a/src/Fable.Transforms/FSharp2Fable.fs
+++ b/src/Fable.Transforms/FSharp2Fable.fs
@@ -2045,7 +2045,7 @@ let rec private transformDeclarations (com: FableCompiler) ctx fsDecls =
                 if
                     (isErasedOrStringEnumEntity ent && Compiler.Language <> TypeScript)
                     || (isGlobalOrImportedEntity ent
-                        && (Compiler.Language = TypeScript && not (isParamObjectClassPattern ent)))
+                        && (not (Compiler.Language = TypeScript && isParamObjectClassPattern ent)))
                 then
                     []
                 else

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -3788,6 +3788,7 @@ module Util =
         (classDecl: Fable.ClassDecl)
         (ent: Fable.Entity)
         =
+
         let members =
             ent.MembersFunctionsAndValues
             |> Seq.filter _.IsConstructor
@@ -3796,6 +3797,12 @@ module Util =
                 |> List.concat
                 |> List.mapi (fun index arg ->
                     let name = defaultArg arg.Name $"arg{index}"
+
+                    /// Try to find getter/setter in f# syntax for POJOs. If found propagate its xml doc to interface.
+                    let tryXmlDoc =
+                        ent.MembersFunctionsAndValues
+                        |> Seq.tryFind (fun s -> s.DisplayName = name)
+                        |> Option.bind (fun tgs -> tgs.XmlDoc)
 
                     let typeAnnotation =
                         if arg.IsOptional then
@@ -3808,7 +3815,8 @@ module Util =
                     AbstractMember.abstractProperty (
                         name |> Identifier.identifier |> Expression.Identifier,
                         typeAnnotation,
-                        isOptional = arg.IsOptional
+                        isOptional = arg.IsOptional,
+                        ?doc = tryXmlDoc
                     )
                 )
             )
@@ -3821,7 +3829,13 @@ module Util =
             |> List.map (fun g -> Fable.GenericParam(g.Name, g.IsMeasure, g.Constraints))
             |> makeTypeParamDecl com ctx
 
-        Declaration.interfaceDeclaration (Identifier.identifier classDecl.Name, members, [||], typeParameters)
+        Declaration.interfaceDeclaration (
+            Identifier.identifier classDecl.Name,
+            members,
+            [||],
+            typeParameters,
+            ?doc = classDecl.XmlDoc
+        )
         |> asModuleDeclaration ent.IsPublic
         |> List.singleton
 

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -3815,7 +3815,13 @@ module Util =
             |> Seq.concat
             |> Seq.toArray
 
-        Declaration.interfaceDeclaration (Identifier.identifier classDecl.Name, members, [||])
+
+        let typeParameters =
+            ent.GenericParameters
+            |> List.map (fun g -> Fable.GenericParam(g.Name, g.IsMeasure, g.Constraints))
+            |> makeTypeParamDecl com ctx
+
+        Declaration.interfaceDeclaration (Identifier.identifier classDecl.Name, members, [||], typeParameters)
         |> asModuleDeclaration ent.IsPublic
         |> List.singleton
 

--- a/src/Fable.Transforms/Global/Babel.fs
+++ b/src/Fable.Transforms/Global/Babel.fs
@@ -188,14 +188,16 @@ type Declaration =
         id: Identifier *
         members: AbstractMember array *
         extends: TypeAnnotation array *
-        typeParameters: TypeParameter array
+        typeParameters: TypeParameter array *
+        doc: string option
     | EnumDeclaration of name: string * cases: (string * Expression) array * isConst: bool
     | TypeAliasDeclaration of name: string * typeParameters: TypeParameter array * alias: TypeAnnotation
 
     member this.JsDoc =
         match this with
         | ClassDeclaration(_, _, _, _, _, _, doc)
-        | FunctionDeclaration(_, _, _, _, _, _, doc) -> doc
+        | FunctionDeclaration(_, _, _, _, _, _, doc)
+        | InterfaceDeclaration(_, _, _, _, doc) -> doc
         | _ -> None
 
 /// A module import or export declaration.
@@ -779,8 +781,8 @@ module Helpers =
         static member classDeclaration(body, ?id, ?superClass, ?typeParameters, ?implements, ?loc, ?doc) =
             ClassDeclaration(body, id, superClass, defaultArg implements [||], defaultArg typeParameters [||], loc, doc)
 
-        static member interfaceDeclaration(id, body, ?extends, ?typeParameters) : Declaration = // ?mixins_,
-            InterfaceDeclaration(id, body, defaultArg extends [||], defaultArg typeParameters [||])
+        static member interfaceDeclaration(id, body, ?extends, ?typeParameters, ?doc) : Declaration = // ?mixins_,
+            InterfaceDeclaration(id, body, defaultArg extends [||], defaultArg typeParameters [||], doc)
 
         static member enumDeclaration(name, cases, ?isConst) =
             EnumDeclaration(name, cases, defaultArg isConst false)

--- a/src/quicktest/QuickTest.fs
+++ b/src/quicktest/QuickTest.fs
@@ -94,23 +94,7 @@ let measureTime (f: unit -> unit) : unit =
 
 printfn "Running quick tests..."
 
-
-/// This is a user, a very strange individual which will find each and every edge case existing.
-[<AllowNullLiteral>]
-[<Global>]
-type User [<ParamObjectAttribute; Emit("$0")>] (id: int, ?name: string, ?age: int) =
-    /// Id used for id stuff
-    member val id = id with get, set
-    /// name used for naming conventions
-    member val name: string option = jsNative with get, set
-    /// age because you never tell age
-    member val age: int option = jsNative with get, set
-
-let term = User(1, "test")
-
-printfn "%A" term.id
-
-
 // Write here your unit test, you can later move it
 // to Fable.Tests project. For example:
-testCase "Addition works" <| fun () -> 2 + 2 |> equal 5
+// testCase "Addition works" <| fun () ->
+//     2 + 2 |> equal 4

--- a/src/quicktest/QuickTest.fs
+++ b/src/quicktest/QuickTest.fs
@@ -94,7 +94,23 @@ let measureTime (f: unit -> unit) : unit =
 
 printfn "Running quick tests..."
 
+
+/// This is a user, a very strange individual which will find each and every edge case existing.
+[<AllowNullLiteral>]
+[<Global>]
+type User [<ParamObjectAttribute; Emit("$0")>] (id: int, ?name: string, ?age: int) =
+    /// Id used for id stuff
+    member val id = id with get, set
+    /// name used for naming conventions
+    member val name: string option = jsNative with get, set
+    /// age because you never tell age
+    member val age: int option = jsNative with get, set
+
+let term = User(1, "test")
+
+printfn "%A" term.id
+
+
 // Write here your unit test, you can later move it
 // to Fable.Tests project. For example:
-// testCase "Addition works" <| fun () ->
-//     2 + 2 |> equal 4
+testCase "Addition works" <| fun () -> 2 + 2 |> equal 5


### PR DESCRIPTION
Fix #4003 

```fs
[<AllowNullLiteral>]
[<Global>]
type User
    [<ParamObjectAttribute; Emit("$0")>]
    (id : int, ?name : string, ?age: int) =
    member val name: string option = jsNative with get, set

let term =
    User(1, "test")
````

transpile to

```ts
export interface User {
    id: int32,
    name?: string,
    age?: int32
}

export const term: User = {
    id: 1,
    name: "test",
};
```

Still need to add integration tests,  supports generics, inheritance.