### PR TITLE
[All] Add StringBuilder.Append char * int overload

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+* [All] Add `StringBuiler.Append(c: char, repeatCount: int)` overload (by @roboz0r)
+
 ## 5.0.0-alpha.5 - 2025-01-09
 
 ### Added

--- a/src/Fable.Compiler/CHANGELOG.md
+++ b/src/Fable.Compiler/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+* [All] Add `StringBuiler.Append(c: char, repeatCount: int)` overload (by @roboz0r)
+
 ## 5.0.0-alpha.5 - 2025-01-09
 
 ### Added

--- a/src/fable-library-dart/System.Text.fs
+++ b/src/fable-library-dart/System.Text.fs
@@ -23,6 +23,11 @@ type StringBuilder(value: string, capacity: int) =
         buf.Add(string<char> c)
         x
 
+    member x.Append(c: char, repeatCount: int) =
+        let s = String.replicate repeatCount (string<char> c)
+        buf.Add(s)
+        x
+
     member x.Append(o: int) =
         buf.Add(string<int> o)
         x

--- a/src/fable-library-rust/src/System.Text.fs
+++ b/src/fable-library-rust/src/System.Text.fs
@@ -19,6 +19,12 @@ type StringBuilder(value: string, capacity: int) =
 
     member x.Append(o: bool) = x.Append(string o)
     member x.Append(c: char) = x.Append(string c)
+
+    member x.Append(c: char, repeatCount: int) =
+        let s = String.replicate repeatCount (string<char> c)
+        buf.Add(s)
+        x
+
     member x.Append(o: int8) = x.Append(string o)
     member x.Append(o: byte) = x.Append(string o)
     member x.Append(o: int16) = x.Append(string o)

--- a/src/fable-library-ts/CHANGELOG.md
+++ b/src/fable-library-ts/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+* [JS/TS] Add `StringBuiler.Append(c: char, repeatCount: int)` overload (by @roboz0r)
+
 ## 1.9.0 - 2025-01-09
 
 ### Added

--- a/src/fable-library-ts/System.Text.fs
+++ b/src/fable-library-ts/System.Text.fs
@@ -23,6 +23,11 @@ type StringBuilder(value: string, capacity: int) =
         buf.Add(string<char> c)
         x
 
+    member x.Append(c: char, repeatCount: int) =
+        let s = String.replicate repeatCount (string<char> c)
+        buf.Add(s)
+        x
+
     member x.Append(o: int) =
         buf.Add(string<int> o)
         x

--- a/tests/Dart/src/StringTests.fs
+++ b/tests/Dart/src/StringTests.fs
@@ -128,8 +128,9 @@ let tests() =
                             .Append(true)
                             .Append(5.2)
                             .Append(34)
+                            .Append('x', 4)
         let actual = sb.ToString().Replace(",", ".").ToLower()
-        actual |> equal "aaabcd/true5.234"
+        actual |> equal "aaabcd/true5.234xxxx"
 
     // testCase "StringBuilder.AppendFormat works" <| fun () ->
     //     let sb = System.Text.StringBuilder()

--- a/tests/Js/Main/StringTests.fs
+++ b/tests/Js/Main/StringTests.fs
@@ -106,8 +106,9 @@ let tests = testList "Strings" [
                             .Append(true)
                             .Append(5.2)
                             .Append(34)
+                            .Append('x', 4)
         let actual = sb.ToString().Replace(",", ".").ToLower()
-        actual |> equal "aaabcd/true5.234"
+        actual |> equal "aaabcd/true5.234xxxx"
 
     testCase "StringBuilder.AppendFormat works" <| fun () ->
         let sb = System.Text.StringBuilder()

--- a/tests/Php/TestString.fs
+++ b/tests/Php/TestString.fs
@@ -199,7 +199,8 @@ let ``test StringBuilder.Append works with various overloads`` () =
                         .Append(true)
                         .Append(5.2)
                         .Append(34)
-    equal "aaabcd/true5.234" (sb.ToString().ToLower())
+                        .Append('x', 4)
+    equal "aaabcd/true5.234xxxx" (sb.ToString().ToLower())
 
 [<Fact>]
 let ``StringBuilder.AppendFormat works`` () =

--- a/tests/Python/TestString.fs
+++ b/tests/Python/TestString.fs
@@ -244,8 +244,9 @@ let ``test StringBuilder.Append works with various overloads`` () =
                         .Append(true)
                         .AppendFormat(CultureInfo.InvariantCulture, "{0}", 5.2)
                         .Append(34)
+                        .Append('x', 4)
     let actual = sb.ToString().ToLower()
-    actual |> equal "aaabcd/true5.234"
+    actual |> equal "aaabcd/true5.234xxxx"
 
 [<Fact>]
 let ``test StringBuilder.AppendFormat works`` () =

--- a/tests/Rust/tests/src/StringTests.fs
+++ b/tests/Rust/tests/src/StringTests.fs
@@ -115,8 +115,9 @@ let ``StringBuilder.Append works with various overloads`` () =
                         .Append(true)
                         .Append(5.2)
                         .Append(34)
+                        .Append('x', 4)
     let actual = sb.ToString().Replace(",", ".").ToLower()
-    actual |> equal "aaabcd/true5.234"
+    actual |> equal "aaabcd/true5.234xxxx"
 
 [<Fact>]
 let ``StringBuilder.AppendFormat works`` () =


### PR DESCRIPTION
- https://github.com/fable-compiler/Fable/issues/2636
- https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.append?view=net-8.0#system-text-stringbuilder-append(system-char-system-int32) 

Perhaps a lesser used overload but I was using it in some .NET code I'm working on making Fable compatible 