### PR TITLE
Keep comments for ts interface generation :sparkles:

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+* [TS] Include XML Doc comment on interface properties (by @Freymaurer)
+
 ## 5.0.0-alpha.7 - 2025-01-23
 
 ### Fixed

--- a/src/Fable.Compiler/CHANGELOG.md
+++ b/src/Fable.Compiler/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+* [TS] Include XML Doc comment on interface properties (by @Freymaurer)
+
 ## 5.0.0-alpha.7 - 2025-01-23
 
 ### Fixed

--- a/src/Fable.Transforms/BabelPrinter.fs
+++ b/src/Fable.Transforms/BabelPrinter.fs
@@ -664,7 +664,7 @@ module PrinterExtensions =
                 printer.PrintFunction(Some id, parameters, body, typeParameters, returnType, loc, isDeclaration = true)
 
                 printer.PrintNewLine()
-            | InterfaceDeclaration(id, body, extends, typeParameters) ->
+            | InterfaceDeclaration(id, body, extends, typeParameters, _) ->
                 printer.PrintInterfaceDeclaration(id, body, extends, typeParameters)
             | EnumDeclaration(name, cases, isConst) ->
                 if isConst then

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -3788,9 +3788,6 @@ module Util =
         (classDecl: Fable.ClassDecl)
         (ent: Fable.Entity)
         =
-        printfn "[classDecl] %A" classDecl
-        printfn "[ent] %A" ent
-        printfn "[ctx] %A" ctx
 
         let members =
             ent.MembersFunctionsAndValues

--- a/src/Fable.Transforms/Global/Babel.fs
+++ b/src/Fable.Transforms/Global/Babel.fs
@@ -188,14 +188,16 @@ type Declaration =
         id: Identifier *
         members: AbstractMember array *
         extends: TypeAnnotation array *
-        typeParameters: TypeParameter array
+        typeParameters: TypeParameter array *
+        doc: string option
     | EnumDeclaration of name: string * cases: (string * Expression) array * isConst: bool
     | TypeAliasDeclaration of name: string * typeParameters: TypeParameter array * alias: TypeAnnotation
 
     member this.JsDoc =
         match this with
         | ClassDeclaration(_, _, _, _, _, _, doc)
-        | FunctionDeclaration(_, _, _, _, _, _, doc) -> doc
+        | FunctionDeclaration(_, _, _, _, _, _, doc)
+        | InterfaceDeclaration(_, _, _, _, doc) -> doc
         | _ -> None
 
 /// A module import or export declaration.
@@ -779,8 +781,8 @@ module Helpers =
         static member classDeclaration(body, ?id, ?superClass, ?typeParameters, ?implements, ?loc, ?doc) =
             ClassDeclaration(body, id, superClass, defaultArg implements [||], defaultArg typeParameters [||], loc, doc)
 
-        static member interfaceDeclaration(id, body, ?extends, ?typeParameters) : Declaration = // ?mixins_,
-            InterfaceDeclaration(id, body, defaultArg extends [||], defaultArg typeParameters [||])
+        static member interfaceDeclaration(id, body, ?extends, ?typeParameters, ?doc) : Declaration = // ?mixins_,
+            InterfaceDeclaration(id, body, defaultArg extends [||], defaultArg typeParameters [||], doc)
 
         static member enumDeclaration(name, cases, ?isConst) =
             EnumDeclaration(name, cases, defaultArg isConst false)

--- a/src/quicktest/QuickTest.fs
+++ b/src/quicktest/QuickTest.fs
@@ -94,7 +94,23 @@ let measureTime (f: unit -> unit) : unit =
 
 printfn "Running quick tests..."
 
+
+/// This is a user, a very strange individium which will find each and every edge case existing.
+[<AllowNullLiteral>]
+[<Global>]
+type User [<ParamObjectAttribute; Emit("$0")>] (id: int, ?name: string, ?age: int) =
+    /// Id used for id stuff
+    member val id = id with get, set
+    /// name used for naming conventions
+    member val name: string option = jsNative with get, set
+    /// age because you never tell age
+    member val age: int option = jsNative with get, set
+
+let term = User(1, "test")
+
+printfn "%A" term.id
+
+
 // Write here your unit test, you can later move it
 // to Fable.Tests project. For example:
-// testCase "Addition works" <| fun () ->
-//     2 + 2 |> equal 4
+testCase "Addition works" <| fun () -> 2 + 2 |> equal 5

--- a/src/quicktest/QuickTest.fs
+++ b/src/quicktest/QuickTest.fs
@@ -95,7 +95,7 @@ let measureTime (f: unit -> unit) : unit =
 printfn "Running quick tests..."
 
 
-/// This is a user, a very strange individium which will find each and every edge case existing.
+/// This is a user, a very strange individual which will find each and every edge case existing.
 [<AllowNullLiteral>]
 [<Global>]
 type User [<ParamObjectAttribute; Emit("$0")>] (id: int, ?name: string, ?age: int) =


### PR DESCRIPTION
I updated ts interface generation to keep xmlDoc comments from f# code. I tried to uphold existing patterns, but please check if everything is fine with you:

The changes transpile the following f# code:

```fsharp
/// This is a user, a very strange individium which will find each and every edge case existing.
[<AllowNullLiteral>]
[<Global>]
type User [<ParamObjectAttribute; Emit("$0")>] (id: int, ?name: string, ?age: int) =
    /// Id used for id stuff
    member val id = id with get, set
    /// name used for naming conventions
    member val name: string option = jsNative with get, set
    /// age because you never tell age
    member val age: int option = jsNative with get, set
```

to:

```ts
/**
 * This is a user, a very strange individium which will find each and every edge case existing.
 */
export interface User {
    /**
     * Id used for id stuff
     */
    id: int32,
    /**
     * name used for naming conventions
     */
    name?: string,
    /**
     * age because you never tell age
     */
    age?: int32
}
```

I kept the example in `src/quicktest/QuickTest.fs`.