### PR TITLE
[JS/TS] Fix #4029: print formatting with anonymous records

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * [Python] - Print root module and module function comments (by @alfonsogarciacaro)
+* [JS/TS] - Fix anonymous record printing (#4029) (by @alfonsogarciacaro)
 
 ## 5.0.0-alpha.9 - 2025-01-28
 

--- a/src/Fable.Compiler/CHANGELOG.md
+++ b/src/Fable.Compiler/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * [Python] - Print root module and module function comments (by @alfonsogarciacaro)
+* [JS/TS] - Fix anonymous record printing (#4029) (by @alfonsogarciacaro)
 
 ## 5.0.0-alpha.9 - 2025-01-28
 

--- a/src/fable-library-ts/Types.ts
+++ b/src/fable-library-ts/Types.ts
@@ -23,7 +23,7 @@ export function seqToString<T>(self: Iterable<T>): string {
 
 export function toString(x: any, callStack = 0): string {
   if (x != null && typeof x === "object") {
-    if (typeof x.toString === "function") {
+    if (typeof x.toString === "function" && x.toString !== Object.prototype.toString) {
       return x.toString();
     } else if (Symbol.iterator in x) {
       return seqToString(x);

--- a/tests/Js/Main/StringTests.fs
+++ b/tests/Js/Main/StringTests.fs
@@ -308,6 +308,12 @@ let tests = testList "Strings" [
         $"Hi! My name is %s{person.Name} %s{person.Surname.ToUpper()}. I'm %i{person.Age} years old and I'm from %s{person.Country}!"
         |> equal "Hi! My name is John DOE. I'm 32 years old and I'm from The United Kingdom!"
 
+    testCase "Printf %A works with anonymous records" <| fun () -> // See #4029
+        let person  = {| FirstName = "John"; LastName = "Doe" |}
+        let s = sprintf "%A" person
+        System.Text.RegularExpressions.Regex.Replace(s.Replace("\"", ""), @"\s+", " ")
+        |> equal """{ FirstName = John LastName = Doe }"""
+
     testCase "Interpolated strings keep empty lines" <| fun () ->
         let s1 = $"""1
 


### PR DESCRIPTION
Fix #4029

Don't use the default `Object.prototype.toString` method when format printing.