### PR TITLE
[Python] Fix #3998: PhysicalEquality

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Fixed
-
-* [Python] - Fix #3998: PhysicalEquality (by @alfonsogarciacaro)
-
 ### Added
 
 * [Python] - Print root module and module function comments (by @alfonsogarciacaro)
@@ -20,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * [JS/TS] - Fix anonymous record printing (#4029) (by @alfonsogarciacaro)
+* [Python] - Fix #3998: PhysicalEquality (by @alfonsogarciacaro)
 
 ## 5.0.0-alpha.9 - 2025-01-28
 

--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+* [Python] - Fix #3998: PhysicalEquality (by @alfonsogarciacaro)
+
 ### Added
 
 * [Python] - Print root module and module function comments (by @alfonsogarciacaro)

--- a/src/Fable.Compiler/CHANGELOG.md
+++ b/src/Fable.Compiler/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Fixed
-
-* [Python] - Fix #3998: PhysicalEquality (by @alfonsogarciacaro)
-
 ### Added
 
 * [Python] - Print root module and module function comments (by @alfonsogarciacaro)
@@ -20,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * [JS/TS] - Fix anonymous record printing (#4029) (by @alfonsogarciacaro)
+* [Python] - Fix #3998: PhysicalEquality (by @alfonsogarciacaro)
 
 ## 5.0.0-alpha.9 - 2025-01-28
 

--- a/src/Fable.Compiler/CHANGELOG.md
+++ b/src/Fable.Compiler/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+* [Python] - Fix #3998: PhysicalEquality (by @alfonsogarciacaro)
+
 ### Added
 
 * [Python] - Print root module and module function comments (by @alfonsogarciacaro)

--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -2269,7 +2269,8 @@ let languagePrimitives (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisAr
       [ comp; left; right ] ->
         Helper.InstanceCall(comp, "Equals", t, [ left; right ], i.SignatureArgTypes, ?loc = r)
         |> Some
-    | ("PhysicalEquality" | "PhysicalEqualityIntrinsic"), [ left; right ] -> makeEqOp r left right BinaryEqual |> Some
+    | ("PhysicalEquality" | "PhysicalEqualityIntrinsic"), [ left; right ] ->
+        makeEqOpStrict r left right BinaryEqual |> Some
     | ("PhysicalHash" | "PhysicalHashIntrinsic"), [ arg ] ->
         Helper.LibCall(com, "util", "physicalHash", Int32.Number, [ arg ], ?loc = r)
         |> Some

--- a/src/Fable.Transforms/Replacements.Util.fs
+++ b/src/Fable.Transforms/Replacements.Util.fs
@@ -179,6 +179,7 @@ let withTag tag =
     function
     | Call(e, i, t, r) -> Call(e, { i with Tags = tag :: i.Tags }, t, r)
     | Get(e, FieldGet i, t, r) -> Get(e, FieldGet { i with Tags = tag :: i.Tags }, t, r)
+    | Operation(op, tags, t, r) -> Operation(op, tag :: tags, t, r)
     | e -> e
 
 let getTags =

--- a/tests/Python/TestComparison.fs
+++ b/tests/Python/TestComparison.fs
@@ -70,6 +70,16 @@ type MyClass(v) =
     member val Value: int = v with get, set
 
 [<Fact>]
+let ``test PhysicalEquality works`` () = // See #3998
+    let r1 = ResizeArray([1; 2])
+    let r2 = ResizeArray([1; 2])
+    let r3 = r1
+
+    LanguagePrimitives.PhysicalEquality r1 r2 |> equal false
+    LanguagePrimitives.PhysicalEquality r2 r2 |> equal true
+    LanguagePrimitives.PhysicalEquality r3 r1 |> equal true
+
+[<Fact>]
 let ``test Typed array equality works`` () =
     let xs1 = [| 1; 2; 3 |]
     let xs2 = [| 1; 2; 3 |]


### PR DESCRIPTION
As advised in #3998, use `is` operator for reference equality when translating `PhysicalEquality`