### PR TITLE
[Python] Import fixes

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* [Python] - Print root module and module function comments (by @alfonsogarciacaro)
+* [Python] Print root module and module function comments (by @alfonsogarciacaro)
 * [Rust] Add support for module comments (by @ncave)
 * [Rust] Add support for null strings (by @ncave)
 
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [JS/TS] - Fix anonymous record printing (#4029) (by @alfonsogarciacaro)
 * [Python] - Fix #3998: PhysicalEquality (by @alfonsogarciacaro)
+* [Python] Resolve relative paths for non-qualified imports (#3481) (by @alfonsogarciacaro)
+* [Python] `importSideEffects` shouldn't generate identifier (#3965) (by @alfonsogarciacaro)
 
 ## 5.0.0-alpha.9 - 2025-01-28
 

--- a/src/Fable.Cli/Pipeline.fs
+++ b/src/Fable.Cli/Pipeline.fs
@@ -252,10 +252,8 @@ module Python =
                         |> Array.choose (fun part ->
                             i <- i + 1
 
-                            if part = "." then
+                            if part = "." || part = ".." then
                                 None
-                            elif part = ".." then
-                                Some ""
                             elif i = parts.Length - 1 then
                                 Some(normalizeFileName part)
                             else

--- a/src/Fable.Compiler/CHANGELOG.md
+++ b/src/Fable.Compiler/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [JS/TS] - Fix anonymous record printing (#4029) (by @alfonsogarciacaro)
 * [Python] - Fix #3998: PhysicalEquality (by @alfonsogarciacaro)
+* [Python] Resolve relative paths for non-qualified imports (#3481) (by @alfonsogarciacaro)
+* [Python] `importSideEffects` shouldn't generate identifier (#3965) (by @alfonsogarciacaro)
 
 ## 5.0.0-alpha.9 - 2025-01-28
 

--- a/src/Fable.Transforms/Python/PythonPrinter.fs
+++ b/src/Fable.Transforms/Python/PythonPrinter.fs
@@ -873,6 +873,12 @@ let run writer (program: Module) : Async<unit> =
             | ImportFrom({ Module = Some(Identifier path) } as info) ->
                 let path = printer.MakeImportPath(path)
                 ImportFrom { info with Module = Some(Identifier path) }
+            | Import({ Names = names }) ->
+                let names =
+                    names
+                    |> List.map (fun n -> { n with Name = printer.MakeImportPath(n.Name.Name) |> Identifier })
+
+                Import { Names = names }
             | decl -> decl
             |> printDeclWithExtraLine false printer
 

--- a/tests/Python/more_native_code.py
+++ b/tests/Python/more_native_code.py
@@ -1,0 +1,2 @@
+def multiply3(x: int) -> int:
+    return x * 3

--- a/tests/Python/native_code.py
+++ b/tests/Python/native_code.py
@@ -1,0 +1,6 @@
+def add5(x: int) -> int:
+    return x + 5
+
+
+def add7(x: int) -> int:
+    return x + 7


### PR DESCRIPTION
Fix #3965: importSideEffects shouldn't generate identifier
Fix #3481: Resolve also paths for non-qualified imports

UPDATE:
Also, ignore backwards paths in relative imports as this is not allowed in python.
Added tests, ready for review/merge.