### PR TITLE
[JS/TS] add tests for nullness supports

### DIFF
--- a/.fantomasignore
+++ b/.fantomasignore
@@ -1,3 +1,5 @@
 src/fcs-fable
 tests/**
 tests_external/**
+
+!tests/Js/Main/Nullness.fs

--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * [Python] Add support for `nullArgCheck`(by @MangelMaxime)
+* [All] Add support for F# `nullness` (by @MangelMaxime)
 
 ### Fixed
 

--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [Python] Add support for `nullArgCheck`(by @MangelMaxime)
 * [All] Add support for F# `nullness` (by @MangelMaxime)
+* [JS/TS] Add support for `Unchecked.nonNull` (by @MangelMaxime)
 
 ### Fixed
 

--- a/src/Fable.Compiler/CHANGELOG.md
+++ b/src/Fable.Compiler/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * [Python] Add support for `nullArgCheck`(by @MangelMaxime)
+* [All] Add support for F# `nullness` (by @MangelMaxime)
 
 ### Fixed
 

--- a/src/Fable.Compiler/CHANGELOG.md
+++ b/src/Fable.Compiler/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [Python] Add support for `nullArgCheck`(by @MangelMaxime)
 * [All] Add support for F# `nullness` (by @MangelMaxime)
+* [JS/TS] Add support for `Unchecked.nonNull` (by @MangelMaxime)
 
 ### Fixed
 

--- a/src/Fable.Compiler/ProjectCracker.fs
+++ b/src/Fable.Compiler/ProjectCracker.fs
@@ -427,10 +427,12 @@ let private extractUsefulOptionsAndSources
                 accSources, line :: accOptions
             else
                 accSources, accOptions
+        // Only forward the nullness flag if it is coming from the main project
+        elif line.StartsWith("--checknulls+", StringComparison.Ordinal) && isMainProj then
+            accSources, line :: accOptions
         elif
             line.StartsWith("--nowarn", StringComparison.Ordinal)
             || line.StartsWith("--warnon", StringComparison.Ordinal)
-            || line.StartsWith("--checknulls+", StringComparison.Ordinal)
         then
             accSources, line :: accOptions
         elif line.StartsWith("--define:", StringComparison.Ordinal) then

--- a/src/Fable.Compiler/ProjectCracker.fs
+++ b/src/Fable.Compiler/ProjectCracker.fs
@@ -430,6 +430,7 @@ let private extractUsefulOptionsAndSources
         elif
             line.StartsWith("--nowarn", StringComparison.Ordinal)
             || line.StartsWith("--warnon", StringComparison.Ordinal)
+            || line.StartsWith("--checknulls+", StringComparison.Ordinal)
         then
             accSources, line :: accOptions
         elif line.StartsWith("--define:", StringComparison.Ordinal) then

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -2979,6 +2979,7 @@ let unchecked (com: ICompiler) (ctx: Context) r t (i: CallInfo) (_: Expr option)
     | "Hash", [ arg ] -> structuralHash com r arg |> Some
     | "Equals", [ arg1; arg2 ] -> equals com ctx r true arg1 arg2 |> Some
     | "Compare", [ arg1; arg2 ] -> compare com ctx r arg1 arg2 |> Some
+    | "NonNull", [ arg ] -> arg |> Some
     | _ -> None
 
 let enums (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr option) (args: Expr list) =

--- a/tests/Js/Main/Fable.Tests.fsproj
+++ b/tests/Js/Main/Fable.Tests.fsproj
@@ -81,6 +81,7 @@
     <Compile Include="TimeOnlyTests.fs" />
     <Compile Include="TimeSpanTests.fs" />
     <Compile Include="ListCollectorTests.fs" />
+    <Compile Include="Nullness.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
 

--- a/tests/Js/Main/Nullness.fs
+++ b/tests/Js/Main/Nullness.fs
@@ -1,0 +1,90 @@
+module Fable.Tests.Nullness
+
+open Util.Testing
+open Fable.Core.JsInterop
+
+type ABNull =
+    | A
+    | B of (string | null)
+
+let tests =
+    testList
+        "Nullness"
+        [
+            testCase
+                "nullArgCheck"
+                (fun () ->
+                    let ex =
+                        try
+                            nullArgCheck "arg" null
+                        with e ->
+                            e
+
+                    equal "Value cannot be null. (Parameter 'arg')" ex.Message
+                )
+
+            testCase "Null active pattern works"
+            <| fun () ->
+                let getLength abnull =
+                    match abnull with
+                    | A -> 0
+                    | B Null -> 0
+                    | B(NonNull s) -> s.Length // `s` is derived to be `string`
+
+                equal (getLength A) 0
+                equal (getLength (B null)) 0
+
+            testCase "NonNull active pattern works"
+            <| fun () ->
+                let getLength abnull =
+                    match abnull with
+                    | A -> 0
+                    | B Null -> 0
+                    | B(NonNull s) -> s.Length // `s` is derived to be `string`
+
+                equal (getLength (B "hello")) 5
+
+            testCase "works with generics"
+            <| fun _ ->
+                // Generic code, note 'T must be constrained to be a reference type
+                let findOrNull (index: int) (list: 'T list) : 'T | null when 'T: not struct =
+                    match List.tryItem index list with
+                    | Some item -> item
+                    | None -> null
+
+                equal (findOrNull 1 [ "a"; "b"; "c" ]) "b"
+                equal (findOrNull 3 [ "a"; "b"; "c" ]) null
+
+#if FABLE_COMPILER
+            testCase "works for interop with undefined"
+            <| fun () ->
+                let maybeUndefined (value: string) : (string | null) = importMember "./js/nullness.js"
+
+                match maybeUndefined "ok" with
+                | NonNull _ -> equal true true
+                | Null -> equal true false
+
+                match maybeUndefined "foo" with
+                | NonNull _ -> equal true false
+                | Null -> equal true true
+
+            testCase "works for interop with null"
+            <| fun () ->
+                let maybeNull (value: string) : (string | null) = importMember "./js/nullness.js"
+
+                match maybeNull "ok" with
+                | NonNull _ -> equal true true
+                | Null -> equal true false
+
+                match maybeNull "foo" with
+                | NonNull _ -> equal true false
+                | Null -> equal true true
+#endif
+
+            testCase "Unchecked.nonNull works"
+            <| fun () ->
+                let toUpper (text: string | null) =
+                    (Unchecked.nonNull text).ToUpperInvariant()
+
+                equal (toUpper "hello") "HELLO"
+        ]

--- a/tests/Js/Main/js/nullness.js
+++ b/tests/Js/Main/js/nullness.js
@@ -1,0 +1,17 @@
+export function maybeUndefined(value) {
+    if (value === "ok") {
+        return value;
+    }
+    else {
+        return undefined;
+    }
+}
+
+export function maybeNull(value) {
+    if (value === "ok") {
+        return value;
+    }
+    else {
+        return null;
+    }
+}


### PR DESCRIPTION
Fix #3887
Fix #3991

@kerams

It seems like Fable already supports "nullness" and its new API thanks to @ncave adding the new `NonNull`, `Null`, APIs.

I tried to create some tests suites to check if "nullness" is working but I think that right now this is more testing if `T | null` and related APIs works with Fable.

I am not sure if we want to enable on the test project `<Nullable>enable</Nullable>`, this generates several new warnings and I am not sure if this adds value for this specific project.

Example of places with warnings:

![image](https://github.com/user-attachments/assets/63e31ce5-2b5e-45bc-b763-6a6a24d8fc7a)

![image](https://github.com/user-attachments/assets/cc3c864c-0577-4db4-a2a3-f8ecbdd17fec)

![image](https://github.com/user-attachments/assets/498108c5-8aeb-4b52-9016-ae615a1684ef)

If we thinks that enabling nullable make sense, I can give a try to fix them.

I am not familiar with nullness API, @kerams do you see a common case that is not covered and you would like to be covered? I tried to look at F# repository for tests regarding but it seems like most of them are related to testing compiler warning.