### PR TITLE
[All] Add support for `TreatWarningsAsErrors`

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [Python] Add support for `nullArgCheck`(by @MangelMaxime)
 * [All] Add support for F# `nullness` (by @MangelMaxime)
 * [JS/TS] Add support for `Unchecked.nonNull` (by @MangelMaxime)
+* [All] Add support for `TreatWarningsAsErrors` (by @MangelMaxime)
 
 ### Fixed
 

--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -1354,7 +1354,7 @@ let startCompilationAsync state =
 
             match compilationResult.ExitCode with
             | 0 -> return Ok(state, logs)
-            | _ -> return Error("Compilation failed", [||])
+            | _ -> return Error("Compilation failed", logs)
 
         with
         | Fable.FableError e -> return Error(e, [||])

--- a/src/Fable.Compiler/CHANGELOG.md
+++ b/src/Fable.Compiler/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [Python] Add support for `nullArgCheck`(by @MangelMaxime)
 * [All] Add support for F# `nullness` (by @MangelMaxime)
 * [JS/TS] Add support for `Unchecked.nonNull` (by @MangelMaxime)
+* [All] Add support for `TreatWarningsAsErrors` (by @MangelMaxime)
 
 ### Fixed
 

--- a/src/Fable.Compiler/ProjectCracker.fsi
+++ b/src/Fable.Compiler/ProjectCracker.fsi
@@ -23,6 +23,7 @@ type CacheInfo =
         Exclude: string list
         SourceMaps: bool
         SourceMapsRoot: string option
+        TreatWarningsAsErrors: bool
     }
 
 type CrackerOptions =
@@ -54,6 +55,7 @@ type CrackerResponse =
         TargetFramework: string option
         PrecompiledInfo: PrecompiledInfoImpl option
         CanReuseCompiledFiles: bool
+        TreatWarningsAsErrors: bool
     }
 
 type ProjectOptionsResponse =


### PR DESCRIPTION
This PR tries to re-enable `TreatWarningsAsErrors`, this is really handy feature and becoming even more important with nullness supports to make nullness really strict.

We mimic the behavior at Fable level, because we can pass the option to FCS otherwise it will also report errors from libraries/packages code which the user have no control over.

https://github.com/fable-compiler/Fable/issues/2521
