### PR TITLE
[<>TS] File declaration for POJOs not required outside of TS

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [JS/TS] Make `nullArgCheck` report the same error message as on .NET (by @MangelMaxime)
 * [TS] Sanitize DUs case names when generating constructor function (by @MangelMaxime)
 * [All] Don't print help message on failed compilation (by @MangelMaxime)
+* [JS] Don't generate an import statement for pojos defined in another file (by @shayanhabibi)
 
 ## 5.0.0-alpha.11 - 2025-03-03
 

--- a/src/Fable.Compiler/CHANGELOG.md
+++ b/src/Fable.Compiler/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [All] Add support for F# `nullness` (by @MangelMaxime)
 * [JS/TS] Add support for `Unchecked.nonNull` (by @MangelMaxime)
 * [All] Add support for `TreatWarningsAsErrors` (by @MangelMaxime)
+* [JS] Don't generate an import statement for pojos defined in another file (by @shayanhabibi)
 
 ### Fixed
 

--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -1967,6 +1967,11 @@ module Util =
         atts
         |> Seq.tryPick (
             function
+            // treat pojo as global outside of TypeScript and other exceptions where interface gen is required
+            | AttFullName(Atts.pojoDefinedByConsArgs, att) when Compiler.Language <> TypeScript ->
+                match att.ConstructorArgs with
+                | [ :? string as customName ] -> GlobalAtt(Some customName) |> Some
+                | _ -> GlobalAtt(None) |> Some
             | AttFullName(Atts.global_, att) ->
                 match att.ConstructorArgs with
                 | [ :? string as customName ] -> GlobalAtt(Some customName) |> Some
@@ -2070,6 +2075,7 @@ module Util =
         |> Seq.exists (fun att ->
             match att.Entity.FullName with
             | Atts.global_
+            | Atts.pojoDefinedByConsArgs
             | Naming.StartsWith Atts.import _ -> true
             | _ -> false
         )
@@ -2078,7 +2084,7 @@ module Util =
         ent.Attributes
         |> Seq.exists (fun att ->
             match (nonAbbreviatedDefinition att.AttributeType).TryFullName with
-            | Some(Atts.global_ | Naming.StartsWith Atts.import _) -> true
+            | Some(Atts.pojoDefinedByConsArgs | Atts.global_ | Naming.StartsWith Atts.import _) -> true
             | _ -> false
         )
 

--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -2075,7 +2075,6 @@ module Util =
         |> Seq.exists (fun att ->
             match att.Entity.FullName with
             | Atts.global_
-            | Atts.pojoDefinedByConsArgs
             | Naming.StartsWith Atts.import _ -> true
             | _ -> false
         )
@@ -2084,7 +2083,7 @@ module Util =
         ent.Attributes
         |> Seq.exists (fun att ->
             match (nonAbbreviatedDefinition att.AttributeType).TryFullName with
-            | Some(Atts.pojoDefinedByConsArgs | Atts.global_ | Naming.StartsWith Atts.import _) -> true
+            | Some(Atts.global_ | Naming.StartsWith Atts.import _) -> true
             | _ -> false
         )
 

--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -1967,7 +1967,8 @@ module Util =
         atts
         |> Seq.tryPick (
             function
-            // treat pojo as global outside of TypeScript and other exceptions where interface gen is required
+            // Disable import of the type decorated by Pojo Attribute unless we are targeting TypeScript
+            // See https://github.com/fable-compiler/Fable/issues/4075
             | AttFullName(Atts.pojoDefinedByConsArgs, att) when Compiler.Language <> TypeScript ->
                 match att.ConstructorArgs with
                 | [ :? string as customName ] -> GlobalAtt(Some customName) |> Some

--- a/src/Fable.Transforms/FSharp2Fable.fs
+++ b/src/Fable.Transforms/FSharp2Fable.fs
@@ -2045,8 +2045,6 @@ let rec private transformDeclarations (com: FableCompiler) ctx fsDecls =
                 if
                     (isErasedOrStringEnumEntity ent && Compiler.Language <> TypeScript)
                     || isGlobalOrImportedEntity ent
-                    // No ref to decl file required for POJO if not TypeScript
-                    || (isPojoDefinedByConsArgsEntity ent && Compiler.Language <> TypeScript)
                 then
                     []
                 else

--- a/src/Fable.Transforms/FSharp2Fable.fs
+++ b/src/Fable.Transforms/FSharp2Fable.fs
@@ -2045,6 +2045,8 @@ let rec private transformDeclarations (com: FableCompiler) ctx fsDecls =
                 if
                     (isErasedOrStringEnumEntity ent && Compiler.Language <> TypeScript)
                     || isGlobalOrImportedEntity ent
+                    // No ref to decl file required for POJO if not TypeScript
+                    || (isPojoDefinedByConsArgsEntity ent && Compiler.Language <> TypeScript)
                 then
                     []
                 else

--- a/tests/Js/Main/Fable.Tests.fsproj
+++ b/tests/Js/Main/Fable.Tests.fsproj
@@ -34,6 +34,7 @@
     <Compile Include="Util/Util3.fs" />
     <Compile Include="../../../tests_external/Util3.fs" />
     <Compile Include="Util/UtilTests.fs" />
+    <Compile Include="Global.fs" />
     <Compile Include="ApplicativeTests.fs" />
     <Compile Include="ArithmeticTests.fs" />
     <Compile Include="ArrayTests.fs" />

--- a/tests/Js/Main/Global.fs
+++ b/tests/Js/Main/Global.fs
@@ -1,0 +1,13 @@
+module Fable.Tests.Global
+
+open Fable.Core
+open Fable.Core.JS
+
+[<Pojo>]
+type Toast
+    (
+        id : string,
+        title : string
+    ) =
+    member val id : string = jsNative with get, set
+    member val title : string = jsNative with get, set

--- a/tests/Js/Main/JsInteropTests.fs
+++ b/tests/Js/Main/JsInteropTests.fs
@@ -419,6 +419,12 @@ module PojoDefinedByConsArgs =
                 FSharp.Reflection.FSharpType.GetRecordFields typeof<{| Leader: User |}>
                 |> Array.map (fun f -> f.PropertyType.FullName)
                 |> equal expected
+
+            testCase "PojoDefinedByConsArgs works with types defined in another file" <| fun _ ->
+                let toast = Global.Toast("1", "Hello")
+
+                toast.id |> equal "1"
+                toast.title |> equal "Hello"
         ]
 #endif
 


### PR DESCRIPTION
@MangelMaxime This works locally, but it's a very blanketed solution. I couldn't get any targeted approaches to work (in trying to treat pojos outside of TypeScript like globals in select transformers). I'm sure alf might have a better idea though of where to target

#4075 