### PR TITLE
Save nullness information in the AST

### DIFF
--- a/src/Fable.AST/Fable.fs
+++ b/src/Fable.AST/Fable.fs
@@ -200,6 +200,7 @@ type Type =
     | GenericParam of name: string * isMeasure: bool * constraints: Constraint list
     | DeclaredType of ref: EntityRef * genericArgs: Type list
     | AnonymousRecordType of fieldNames: string[] * genericArgs: Type list * isStruct: bool
+    | Nullable of Type
 
     member this.Generics =
         match this with
@@ -211,6 +212,7 @@ type Type =
         | Tuple(gen, _) -> gen
         | DeclaredType(_, gen) -> gen
         | AnonymousRecordType(_, gen, _) -> gen
+        | Nullable typ -> typ.Generics
         // TODO: Check numbers with measure?
         | MetaType
         | Any
@@ -233,6 +235,7 @@ type Type =
         | Tuple(gen, isStruct) -> Tuple(List.map f gen, isStruct)
         | DeclaredType(e, gen) -> DeclaredType(e, List.map f gen)
         | AnonymousRecordType(e, gen, isStruct) -> AnonymousRecordType(e, List.map f gen, isStruct)
+        | Nullable typ -> Nullable(f typ)
         | MetaType
         | Any
         | Unit

--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -1633,11 +1633,11 @@ module TypeHelpers =
                 Fable.Any // failwithf "Unexpected non-declared F# type: %A" t
 
         // TODO:
-        // if not t.IsGenericParameter && t.HasNullAnnotation // || t.IsNullAmbivalent
-        // then
-        //     makeRuntimeType [ typ ] Types.nullable // represent it as Nullable<T>
-        // else typ
-        typ
+        if not t.IsGenericParameter && t.HasNullAnnotation // || t.IsNullAmbivalent
+        then
+            Fable.Nullable typ
+            // makeRuntimeType [ typ ] Types.nullable // represent it as Nullable<T>
+        else typ
 
     let makeType (ctxTypeArgs: Map<string, Fable.Type>) t =
         makeTypeWithConstraints true ctxTypeArgs t

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -341,6 +341,7 @@ module Reflection =
             List.zip (fieldNames |> Array.toList) genArgs
             |> List.map (fun (k, t) -> Expression.arrayExpression [| Expression.stringLiteral (k); t |])
             |> libReflectionCall com ctx None "anonRecord"
+        | Fable.Nullable typ -> transformTypeInfoFor purpose com ctx r genMap typ
         | Fable.DeclaredType(entRef, genArgs) ->
             let fullName = entRef.FullName
 
@@ -491,6 +492,7 @@ module Reflection =
         | Fable.MetaType -> jsInstanceof (libValue com ctx "Reflection" "TypeInfo") expr
         | Fable.Option _ -> warnAndEvalToFalse "options" // TODO
         | Fable.GenericParam _ -> warnAndEvalToFalse "generic parameters"
+        | Fable.Nullable typ -> transformTypeTest com ctx range expr typ
         | Fable.DeclaredType(ent, genArgs) ->
             match ent.FullName with
             | Types.idisposable ->
@@ -614,6 +616,7 @@ module Annotation =
         | Fable.DelegateType(argTypes, returnType) -> makeFunctionTypeAnnotation com ctx typ argTypes returnType
         | Fable.AnonymousRecordType(fieldNames, fieldTypes, _isStruct) ->
             makeAnonymousRecordTypeAnnotation com ctx fieldNames fieldTypes
+        | Fable.Nullable typ -> makeNullableTypeAnnotation com ctx typ
         | Replacements.Util.Builtin kind -> makeBuiltinTypeAnnotation com ctx typ kind
         | Fable.DeclaredType(entRef, genArgs) -> com.GetEntity(entRef) |> makeEntityTypeAnnotation com ctx genArgs
 
@@ -688,7 +691,7 @@ module Annotation =
         let typeName = getNumberKindName kind
         makeFableLibImportTypeAnnotation com ctx [] moduleName typeName
 
-    let makeNullableTypeAnnotation com ctx genArg =
+    let makeNullableTypeAnnotation com ctx (genArg: Fable.Type) =
         makeFableLibImportTypeAnnotation com ctx [ genArg ] "Option" "Nullable"
 
     let makeOptionTypeAnnotation com ctx genArg =

--- a/src/Fable.Transforms/Global/Babel.fs
+++ b/src/Fable.Transforms/Global/Babel.fs
@@ -517,6 +517,7 @@ type TypeAnnotation =
     | TypeofTypeAnnotation of Expression
     | IndexedTypeAnnotation of typ: TypeAnnotation * prop: TypeAnnotation
     | LiteralTypeAnnotation of Literal
+    // | NullableTypeAnnotation of TypeAnnotation
 
 type TypeParameter = | TypeParameter of name: string * bound: TypeAnnotation option * ``default``: TypeAnnotation option
 

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -989,6 +989,7 @@ let rec defaultof (com: ICompiler) (ctx: Context) r t =
             // Null t |> makeValue None
             Helper.LibCall(com, "Util", "defaultOf", t, [], ?loc = r)
         )
+    | Nullable _ -> Value(Null Any, None) // null
     // TODO: Fail (or raise warning) if this is an unresolved generic parameter?
     | _ ->
         // Null t |> makeValue None

--- a/src/Fable.Transforms/Rust/Replacements.fs
+++ b/src/Fable.Transforms/Rust/Replacements.fs
@@ -2877,6 +2877,7 @@ let getArgsSuffix (thisArg: Expr option) (args: Expr list) =
                 | GenericParam _ -> 'g'
                 | DeclaredType _ -> '_'
                 | AnonymousRecordType _ -> '_'
+                | Nullable _ -> '_'
         |]
 
     System.String(chars)

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -1351,6 +1351,7 @@ module AST =
             && listEquals (typeEquals strict) gen1 gen2
             && isStruct1 = isStruct2
         | Measure _, Measure _ -> true
+        | Nullable typ1, Nullable typ2 -> typeEquals strict typ1 typ2
         | _ -> false
 
     let rec getEntityFullName prettify (entRef: EntityRef) gen =


### PR DESCRIPTION
I am only working on JS/TS code for now, which explains why others target fails in the CI.

With the nullable information we have trouble with TypeScript compiler type inference:

```fs
let length (s: string | null) =
    match s with
    | null -> 0
    | s -> s.Length
```

compiles to

```ts
export function length(s: Nullable<string>): int32 {
    if (equals(s, defaultOf())) {
        return 0;
    }
    else {
        const s_1: string = s;
        return s_1.length | 0;
    }
}
```

But TS compiler generated an error on `const s_1: string = s;` because of `Type 'Nullable<string>' is not assignable to type 'string'.`

I think what we would like to do is, detect `match`/`if` operation against null and there the check for `null` inline directly or using a dedicated helpers function to make TypeScript understand that we check the `null | undefined` case.

Here we are defaulting to the default equality which works but don't gives enough information to TypeScript
