### PR TITLE
[All] Remove unused `Fable.Core` copy types from internal module

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Removed
+
+* [All] Remove unused `Fable.Core` copy types from internal module (by @MangelMaxime)
+
 ## 5.0.0-alpha.12 - 2025-03-14
 
 ### Added

--- a/src/Fable.Compiler/CHANGELOG.md
+++ b/src/Fable.Compiler/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* [All] Remove unused `Fable.Core` copy types from internal module (by @MangelMaxime)
+
 ## 5.0.0-alpha.12 - 2025-03-14
 
 ### Added

--- a/src/Fable.Transforms/Global/Fable.Core.fs
+++ b/src/Fable.Transforms/Global/Fable.Core.fs
@@ -16,12 +16,3 @@ type CaseRules =
     | KebabCase = 4
     /// FooBar -> foobar
     | LowerAll = 5
-
-[<AttributeUsage(AttributeTargets.Class)>]
-type StringEnumAttribute() =
-    inherit Attribute()
-    new(caseRules: CaseRules) = StringEnumAttribute()
-
-[<AttributeUsage(AttributeTargets.Interface)>]
-type MangleAttribute() =
-    inherit Attribute()

--- a/src/Fable.Transforms/Global/Fable.Core.fs
+++ b/src/Fable.Transforms/Global/Fable.Core.fs
@@ -16,3 +16,8 @@ type CaseRules =
     | KebabCase = 4
     /// FooBar -> foobar
     | LowerAll = 5
+
+[<AttributeUsage(AttributeTargets.Class)>]
+type StringEnumAttribute() =
+    inherit Attribute()
+    new(caseRules: CaseRules) = StringEnumAttribute()


### PR DESCRIPTION
Fix #4081