### PR TITLE
[Python] Fixes for string compare

### DIFF
--- a/src/fable-library-py/fable_library/string_.py
+++ b/src/fable-library-py/fable_library/string_.py
@@ -475,7 +475,12 @@ def cmp(x: str, y: str, ic: bool | StringComparison) -> int:
         x = x.lower()
         y = y.lower()
 
-    return locale.strcoll(x, y) if use_strcoll else (0 if x == y else -1 if x < y else 1)
+    if use_strcoll:
+        result = locale.strcoll(x, y)
+        # Normalize result to -1, 0, 1
+        return -1 if result < 0 else (1 if result > 0 else 0)
+    else:
+        return -1 if x < y else (1 if x > y else 0)
 
 
 @overload

--- a/src/fable-library-py/fable_library/string_.py
+++ b/src/fable-library-py/fable_library/string_.py
@@ -440,14 +440,6 @@ class StringComparison(IntEnum):
     OrdinalIgnoreCase = 5
 
 
-# Determine the comparison strategy once at module level
-try:
-    current_locale = locale.getlocale(locale.LC_COLLATE)
-    use_strcoll = current_locale[0] is not None
-except (locale.Error, TypeError):
-    use_strcoll = False
-
-
 def cmp(x: str, y: str, ic: bool | StringComparison) -> int:
     def is_ignore_case(i: bool | StringComparison) -> bool:
         return (
@@ -475,12 +467,10 @@ def cmp(x: str, y: str, ic: bool | StringComparison) -> int:
         x = x.lower()
         y = y.lower()
 
-    if use_strcoll:
-        result = locale.strcoll(x, y)
-        # Normalize result to -1, 0, 1
-        return -1 if result < 0 else (1 if result > 0 else 0)
-    else:
-        return -1 if x < y else (1 if x > y else 0)
+    result = locale.strcoll(x, y)
+
+    # Normalize result to -1, 0, 1
+    return -1 if result < 0 else (1 if result > 0 else 0)
 
 
 @overload

--- a/src/fable-library-py/fable_library/string_.py
+++ b/src/fable-library-py/fable_library/string_.py
@@ -440,6 +440,14 @@ class StringComparison(IntEnum):
     OrdinalIgnoreCase = 5
 
 
+# Determine the comparison strategy once at module level
+try:
+    current_locale = locale.getlocale(locale.LC_COLLATE)
+    use_strcoll = current_locale[0] is not None
+except (locale.Error, TypeError):
+    use_strcoll = False
+
+
 def cmp(x: str, y: str, ic: bool | StringComparison) -> int:
     def is_ignore_case(i: bool | StringComparison) -> bool:
         return (
@@ -467,7 +475,7 @@ def cmp(x: str, y: str, ic: bool | StringComparison) -> int:
         x = x.lower()
         y = y.lower()
 
-    return locale.strcoll(x, y)
+    return locale.strcoll(x, y) if use_strcoll else (0 if x == y else -1 if x < y else 1)
 
 
 @overload


### PR DESCRIPTION
## Why

Flaky test:

```py
    def test_string_compare_works(__unit: None=None) -> None:
        Testing_equal(0, compare("abc", "abc"))
>       Testing_equal(-1, compare("abc", "abd"))
```

Exception: Expected: -1 - Actual: -4

## How

Normalize the return value from `strcoll` to -1, 0 or 1.