### PR TITLE
[Python] Typematching against an Interface leads to incorrect pattern matches

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* [Python] Fixed testing with interfaces leads to incorrect pattern match (#3972) (by @dbrattli)
 * [Python] Fixed import path handling for libraries (#4088) (by @dbrattli)
 * [Python] Reenable type aliasing for imports with name "*" (by @freymauer)
 

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -2306,7 +2306,14 @@ module Util =
         let expr, stmts = com.TransformAsExpr(ctx, guardExpr)
 
         match expr with
-        | Constant(value = BoolLiteral value) -> stmts @ com.TransformAsStatements(ctx, ret, thenStmnt)
+        | Constant(value = BoolLiteral value) ->
+            let e =
+                if value then
+                    thenStmnt
+                else
+                    elseStmnt
+
+            stmts @ com.TransformAsStatements(ctx, ret, e)
         | guardExpr ->
             let thenStmnt, stmts' =
                 transformBlock com ctx ret thenStmnt

--- a/tests/Python/TestNonRegression.fs
+++ b/tests/Python/TestNonRegression.fs
@@ -180,3 +180,20 @@ let ``test custom equality and hashcode works`` () =
 let ``test class name casing`` () =
     let x = Issue3811.flowchartDirection.tb' ()
     equal Issue3811.FlowchartDirection.TB x
+
+module Issue3972 =
+    type IInterface =
+        abstract member LOL : int
+
+[<Fact>]
+let ``test with interfaces does not not lead to incorrect pattern matching`` () =
+    let sideEffect () = ()
+    let typeMatchSomeBoxedObject (o:obj) =
+        match o with
+        | :? int -> 1
+        | :? Issue3972.IInterface ->
+            sideEffect () // To avoid any code optimizations
+            2
+        | _ -> 3
+
+    equal (typeMatchSomeBoxedObject "lol") 3


### PR DESCRIPTION
## Why

- Typematching against an Interface leads to incorrect pattern matches

Note: This PR does not allow you to correctly type test against interfaces. This still produces a warning (as with JS), and may be fixed in some future PR.

Fixes #3972

## How

- Else-branch was skipped in some cases when transforming if-statement. Fixed by aligning code with `Fable2Babel`.
