### PR TITLE
[Python] Fix error with multiple generic type parameters

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* [Python] Fixed error when type contains multiple generic type parameters (#3986) (by @dbrattli)
 * [Python] Fixed import path handling for libraries (#4088) (by @dbrattli)
 * [Python] Reenable type aliasing for imports with name "*" (by @freymauer)
 

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -4146,8 +4146,14 @@ module Util =
                 if List.isEmpty interfaces then
                     com.GetImportExpr(ctx, "typing", "Protocol")
 
-                for gen in classEnt.GenericParameters do
-                    Expression.subscript (com.GetImportExpr(ctx, "typing", "Generic"), com.AddTypeVar(ctx, gen.Name))
+                // Collect all generic type variables and create a single `Generic` base
+                let genericTypeVars =
+                    classEnt.GenericParameters
+                    |> Seq.map (fun gen -> com.AddTypeVar(ctx, gen.Name))
+                    |> Seq.toList
+
+                if not (List.isEmpty genericTypeVars) then
+                    Expression.subscript (com.GetImportExpr(ctx, "typing", "Generic"), Expression.tuple genericTypeVars)
             ]
 
         [ Statement.classDef (classIdent, body = classMembers, bases = bases) ]

--- a/tests/Python/TestNonRegression.fs
+++ b/tests/Python/TestNonRegression.fs
@@ -180,3 +180,10 @@ let ``test custom equality and hashcode works`` () =
 let ``test class name casing`` () =
     let x = Issue3811.flowchartDirection.tb' ()
     equal Issue3811.FlowchartDirection.TB x
+
+module Issue3986 =
+    // We don't need a test for this, just that the generated
+    // Python code is valid and doesn't throw an error when
+    // interpreted.
+    type FieldFnCreator<'b, 'c> =
+        abstract eval<'a> : string -> ('c -> 'a)


### PR DESCRIPTION
Fixes issue when a type has multiple generic type parameters. Fixes #3986 