### PR TITLE
[JS/TS] JSX : Alias `empty` CEs list to `null` when encountered in the `children` list

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [Python] Fable Library for Python is now partially written in Rust (by @dbrattli)
 
+### Fixed
+
+* [JS/TS] JSX : Alias `empty` CEs list to `null` when encountered in the `children` list (by @MangelMaxime)
+
 ## 5.0.0-alpha.13 - 2025-05-04
 
 ### Fixed

--- a/src/Fable.Compiler/CHANGELOG.md
+++ b/src/Fable.Compiler/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+* [Python] Fable Library for Python is now partially written in Rust (by @dbrattli)
+
+### Fixed
+
+* [JS/TS] JSX : Alias `empty` CEs list to `null` when encountered in the `children` list (by @MangelMaxime)
+
 ## 5.0.0-alpha.13 - 2025-05-04
 
 ### Fixed

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -2124,6 +2124,7 @@ but thanks to the optimisation done below we get
                                           _) -> exprs @ rest
                 | CalledExpression "append" exprs -> exprs @ rest
                 | CalledExpression "singleton" exprs -> exprs @ rest
+                | CalledExpression "empty" _ -> [ Expression.nullLiteral () ] @ rest
                 // Note: Should we guard this unwrapper by checking that all the elements in the array are JsxElements?
                 | ArrayExpression(UnrollerFromArray exprs, _) -> exprs @ rest
                 | ConditionalExpression(testExpr, UnrollerFromSingleton thenExprs, UnrollerFromSingleton elseExprs, loc) ->

--- a/tests/Integration/Integration/data/jsxListOptimisation/Components.fs
+++ b/tests/Integration/Integration/data/jsxListOptimisation/Components.fs
@@ -149,3 +149,11 @@ let divWithAttributes =
             Html.div "Test 1"
         ]
     ]
+
+let divWithConditionalWithoutElseBranchWorks show =
+    Html.div [
+        if show then
+            Html.div "I show sometimes!"
+
+        Html.div "I show always!"
+    ]

--- a/tests/Integration/Integration/data/jsxListOptimisation/Components.jsx.expected
+++ b/tests/Integration/Integration/data/jsxListOptimisation/Components.jsx.expected
@@ -1,7 +1,7 @@
 import * as react from "react";
-import { map, singleton, append, delay, toList } from "./fable_modules/fable-library-js.5.0.0-alpha.12/Seq.js";
-import { int32ToString } from "./fable_modules/fable-library-js.5.0.0-alpha.12/Util.js";
-import { rangeDouble } from "./fable_modules/fable-library-js.5.0.0-alpha.12/Range.js";
+import { empty, map, singleton, append, delay, toList } from "./fable_modules/fable-library-js.5.0.0-alpha.13/Seq.js";
+import { int32ToString } from "./fable_modules/fable-library-js.5.0.0-alpha.13/Util.js";
+import { rangeDouble } from "./fable_modules/fable-library-js.5.0.0-alpha.13/Range.js";
 
 export const React = react;
 
@@ -97,3 +97,14 @@ export const divWithAttributes = <div className="header">
         Test 1
     </div>
 </div>;
+
+export function divWithConditionalWithoutElseBranchWorks(show) {
+    return <div>
+        {show ? (<div>
+            I show sometimes!
+        </div>) : (null)}
+        <div>
+            I show always!
+        </div>
+    </div>;
+}

--- a/tests/React/__tests__/JSX_API.fs
+++ b/tests/React/__tests__/JSX_API.fs
@@ -73,4 +73,12 @@ Jest.describe("JSX API tests (using React)", fun () ->
     Jest.test("Elements can have attributes", fun () ->
         matchSnapshot Components.divWithAttributes
     )
+
+    Jest.test("Test that condition without else branch works if condition is True", fun () ->
+        matchSnapshot (Components.divWithConditionalWithoutElseBranchWorks true)
+    )
+
+    Jest.test("Test that condition without else branch works if condition is False", fun () ->
+        matchSnapshot (Components.divWithConditionalWithoutElseBranchWorks false)
+    )
 )

--- a/tests/React/__tests__/__snapshots__/JSX_API.fs.js.snap
+++ b/tests/React/__tests__/__snapshots__/JSX_API.fs.js.snap
@@ -109,6 +109,29 @@ exports[`JSX API tests (using React) Fragments are supported 1`] = `
 </div>
 `;
 
+exports[`JSX API tests (using React) Test that condition without else branch works if condition is False 1`] = `
+<div>
+  <div>
+    <div>
+      I show always!
+    </div>
+  </div>
+</div>
+`;
+
+exports[`JSX API tests (using React) Test that condition without else branch works if condition is True 1`] = `
+<div>
+  <div>
+    <div>
+      I show sometimes!
+    </div>
+    <div>
+      I show always!
+    </div>
+  </div>
+</div>
+`;
+
 exports[`JSX API tests (using React) Test that non optimised condition works 1`] = `
 <div>
   <div>


### PR DESCRIPTION


Fix #4113