### PR TITLE
Fable.Core have an implicit dependency on FSharp.Core 9

### DIFF
--- a/src/Fable.Core/CHANGELOG.md
+++ b/src/Fable.Core/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [JS/TS] Fix #3533: Add `emitJsTopDirectivePrologue` supports (by @MangelMaxime)
 * [JS/TS] Fix #3533: Add `emitJsDirectivePrologue` supports (by @MangelMaxime)
 
+### Changed
+
+* Enforce Fable.Core to dependes on FSharp.Core >= 4.7.2 (by @PierreYvesR)
+
 ## 4.5.0 - 2025-03-03
 
 ### Added

--- a/src/Fable.Core/Fable.Core.fsproj
+++ b/src/Fable.Core/Fable.Core.fsproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+    <DisableImplicitFSharpCoreReference>false</DisableImplicitFSharpCoreReference>
     <Description>Fable Core Library</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
When using `net48`, `Fable.Core` has an implicit dependency on `FSharp.Core` 9.

This triggers warning `MSB3277` during build:
```
warning MSB3277: Found conflicts between different versions of "FSharp.Core" that could not be resolved. [C:\git\fable-core-test\fablecore-fsharpcore-conflict\test-fablecore-fsharpcore\test-fablecore-fsharpcore.fsproj::TargetFramework=net48]
warning MSB3277: There was a conflict between "FSharp.Core, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" and "FSharp.Core, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a". [C:\git\fable-core-test\fablecore-fsharpcore-conflict\test-fablecore-fsharpcore\test-fablecore-fsharpcore.fsproj::TargetFramework=net48]
...
```

I have created a project that reproduces the issue (https://github.com/PierreYvesR/fablecore-fsharpcore-conflict).

This PR sets `DisableImplicitFSharpCoreReference` to false, this pins `FSharp.Core` to 4.7.2 (as referenced in `Fable.Core.fsproj`)
(see https://github.com/dotnet/fsharp/blob/main/docs/fsharp-core-notes.md#package-authors-should-pin-their-fsharpcore-reference).

Before:
- `Fable.Core` nuget package does **not** have a dependency on `FSharp.Core
- `Fable.Core.dll`'s manifest references `FSharp.Core` **9.0.0**  (see below)

After:
- `Fable.Core` nuget package  depends on `FSharp.Core` **4.7.2**
- `Fable.Core.dll`'s manifest references `FSharp.Core` **4.7.2**

---

The current `Fable.Core.dll`'s manifest in `ildasm`:
```
// Metadata version: v4.0.30319
.assembly extern netstandard
{
  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
  .ver 2:0:0:0
}
.assembly extern FSharp.Core
{
  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
  .ver 9:0:0:0
}
```

Wth `DisableImplicitFSharpCoreReference` set to false:
```
// Metadata version: v4.0.30319
.assembly extern netstandard
{
  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
  .ver 2:0:0:0
}
.assembly extern FSharp.Core
{
  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
  .ver 4:7:0:0
}
```
