### PR TITLE
[Python] Do not return None | None for optional unit types

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* [Python] Do not return None | None for optional unit types (#4127) (by @dbrattli)
+
 ### Changed
 
 * [Python] Use [uv](https://docs.astral.sh/uv/) instead of Poetry for package management (by @dbrattli)

--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-* [Python] Do not return None | None for optional unit types (#4127) (by @dbrattli)
-
 ### Changed
 
 * [Python] Use [uv](https://docs.astral.sh/uv/) instead of Poetry for package management (by @dbrattli)
@@ -16,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* [Python] Do not return None | None for optional unit types (#4127) (by @dbrattli)
 * [JS/TS] JSX : Alias `empty` CEs list to `null` when encountered in the `children` list (by @MangelMaxime)
 * [JS/TS] JSX : Allow usage of `unbox` when definining properties for `JSX.create` (by @MangelMaxime)
 

--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -734,6 +734,9 @@ module Annotation =
             stdlibModuleTypeHint com ctx "collections.abc" "Callable" (argTypes @ [ returnType ])
         | Fable.DelegateType(argTypes, returnType) ->
             stdlibModuleTypeHint com ctx "collections.abc" "Callable" (argTypes @ [ returnType ])
+        | Fable.Option(Fable.Unit, _) ->
+            // unit option -> just None instead of None | None
+            Expression.none, []
         | Fable.Option(genArg, _) ->
             let resolved, stmts = resolveGenerics com ctx [ genArg ] repeatedGenerics
 

--- a/tests/Python/TestNonRegression.fs
+++ b/tests/Python/TestNonRegression.fs
@@ -204,3 +204,12 @@ module Issue3986 =
     // interpreted.
     type FieldFnCreator<'b, 'c> =
         abstract eval<'a> : string -> ('c -> 'a)
+
+module Issue4125 =
+    let none () : unit option =
+        None
+
+[<Fact>]
+let ``test issue 4125`` () =
+    let x = Issue4125.none ()
+    equal None x


### PR DESCRIPTION
Fixes #4125

@MangelMaxime Should we backport this to Fable 4?