### PR TITLE
[Python] Make sure record fields do not conflict

### DIFF
--- a/src/Fable.Transforms/Python/Prelude.fs
+++ b/src/Fable.Transforms/Python/Prelude.fs
@@ -28,6 +28,17 @@ module Naming =
     let toSnakeCase (name: string) =
         Naming.applyCaseRule CaseRules.SnakeCase name
 
+    /// Convert F# record field name to snake_case with special handling for camelCase/PascalCase conflicts.
+    /// - If the name is PascalCase, convert to snake_case without suffix.
+    /// - If the name is camelCase, convert to snake_case and add '_' suffix to avoid conflict with PascalCase.
+    let toRecordFieldSnakeCase (name: string) =
+        let snakeCase = Naming.applyCaseRule CaseRules.SnakeCase name
+
+        if name.Length > 0 && Char.IsLower(name.[0]) then
+            snakeCase + "_"
+        else
+            snakeCase
+
     let toPascalCase (name: string) = upperFirst name
 
     /// Convert name to Python naming convention.

--- a/tests/Python/TestRecordType.fs
+++ b/tests/Python/TestRecordType.fs
@@ -182,3 +182,12 @@ let ``test Record equality when it has optional field`` () =
     equal true (a = b)
     equal false (a = c)
     equal false (c = b)
+
+type CasingRecord =
+    { firstName: string; FirstName: string }
+
+[<Fact>]
+let ``test Record with both camel-case and pascal-case fields don't conflict`` () =
+    let x = { firstName = "John"; FirstName = "Jane" }
+    equal "John" x.firstName
+    equal "Jane" x.FirstName


### PR DESCRIPTION
Make sure record fields with mixed camel-case and pascal-case to do conflict with each other when converted to snake-case, e.g:

```fs
[<Fact>]
let ``test Record with both camel-case and pascal-case fields don't conflict`` () =
    let x = { firstName = "John"; FirstName = "Jane" }
    equal "John" x.firstName
    equal "Jane" x.FirstName
```