### PR TITLE
[Python] Fix async sleep

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* [Python] Fixed `Async.Sleep`to handle TimeSpan correctly (#4137) (by @dbrattli)
 * [Python] Do not return None | None for optional unit types (#4127) (by @dbrattli)
 * [JS/TS] JSX : Alias `empty` CEs list to `null` when encountered in the `children` list (by @MangelMaxime)
 * [JS/TS] JSX : Allow usage of `unbox` when definining properties for `JSX.create` (by @MangelMaxime)

--- a/src/fable-library-py/fable_library/time_span.py
+++ b/src/fable-library-py/fable_library/time_span.py
@@ -269,6 +269,14 @@ def try_parse(
     return True
 
 
+def to_milliseconds(value: int | TimeSpan) -> float:
+    """Convert either an int (milliseconds) or TimeSpan to milliseconds as float."""
+    if isinstance(value, TimeSpan):
+        return float(total_milliseconds(value))
+    else:
+        return float(value)
+
+
 __all__ = [
     "add",
     "create",
@@ -284,6 +292,7 @@ __all__ = [
     "negate",
     "parse",
     "subtract",
+    "to_milliseconds",
     "total_days",
     "total_days",
     "total_hours",


### PR DESCRIPTION
Make `Async.Sleep` to handle `millisecond_duetime` as `TimeSpan` input correctly, in addition to `int`. 

Fixes #4137 