### PR TITLE
[Python] Fixed resource managers with empty body

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* [Python] Fixed resource managers with empty body (#3912) (by @dbrattli)
 * [Python] Fixed `Async.Sleep`to handle TimeSpan correctly (#4137) (by @dbrattli)
 * [Python] Make sure snake-cased Record do not conflict (by @dbrattli)
 * [Python] Do not return None | None for optional unit types (#4127) (by @dbrattli)

--- a/tests/Python/TestNonRegression.fs
+++ b/tests/Python/TestNonRegression.fs
@@ -213,3 +213,22 @@ module Issue4125 =
 let ``test issue 4125`` () =
     let x = Issue4125.none ()
     equal None x
+
+module Issue3912 =
+    type X() =
+        let mutable _disposed = false
+
+        member this.IsDisposed = _disposed
+
+        interface System.IDisposable with
+            member this.Dispose() =
+                _disposed <- true
+
+[<Fact>]
+let ``test issue 3912`` () =
+    let x = new Issue3912.X()
+
+    let () =
+        use x = x
+        ()
+    equal x.IsDisposed true


### PR DESCRIPTION
Fixes issue with resource managers in Python having empty body. Instead of adding an invalid `Return None` it will now only do `Pass`.

Fixes #3912 