### PR TITLE
Fix directory delete when building Fable.Libaray

### DIFF
--- a/src/Fable.Build/FableLibrary/Core.fs
+++ b/src/Fable.Build/FableLibrary/Core.fs
@@ -48,7 +48,8 @@ type BuildFableLibrary
     default _.CopyStage() = ()
 
     /// <summary>
-    /// Robustly delete a directory, handling macOS file system timing issues
+    /// Robustly delete a directory, handling file system issues on MacOS and Windows.
+    /// Ref: https://stackoverflow.com/questions/329355/cannot-delete-directory-with-directory-deletepath-true
     /// </summary>
     member private this.deleteDirectoryRobust(path: string) =
         if Directory.Exists path then
@@ -56,7 +57,7 @@ type BuildFableLibrary
                 try
                     Directory.Delete(path, true)
                 with :? IOException when retries > 0 ->
-                    System.Threading.Thread.Sleep(50)
+                    System.Threading.Thread.Sleep 50
                     tryDelete (retries - 1)
 
             tryDelete 3

--- a/src/Fable.Build/FableLibrary/Core.fs
+++ b/src/Fable.Build/FableLibrary/Core.fs
@@ -47,6 +47,20 @@ type BuildFableLibrary
     abstract member CopyStage: unit -> unit
     default _.CopyStage() = ()
 
+    /// <summary>
+    /// Robustly delete a directory, handling macOS file system timing issues
+    /// </summary>
+    member private this.deleteDirectoryRobust(path: string) =
+        if Directory.Exists path then
+            let rec tryDelete retries =
+                try
+                    Directory.Delete(path, true)
+                with :? IOException when retries > 0 ->
+                    System.Threading.Thread.Sleep(50)
+                    tryDelete (retries - 1)
+
+            tryDelete 3
+
     member this.Run(?skipIfExist: bool) =
         let toConsole (s: string) = System.Console.WriteLine(s)
 
@@ -59,8 +73,7 @@ type BuildFableLibrary
 
             "Cleaning build directory" |> toConsole
 
-            if Directory.Exists buildDir then
-                Directory.Delete(buildDir, true)
+            this.deleteDirectoryRobust buildDir
 
             "Building Fable.Library" |> toConsole
 


### PR DESCRIPTION
Fixes error that happens on every other build on MacOS. Trying to build again always works, so there's some timing issue or something that happens when trying to delete the build directory.

```
Cleaning build directory
System.IO.IOException: Directory not empty : '/Users/dbrattli/Developer/Fable-pyo3/temp/fable-library-py'
   at System.IO.FileSystem.RemoveEmptyDirectory(String fullPath, Boolean topLevel, Boolean throwWhenNotEmpty)
   at System.IO.FileSystem.RemoveDirectoryRecursive(String fullPath)
   at Build.FableLibrary.BuildFableLibrary.Run(FSharpOption`1 skipIfExist) in /Users/dbrattli/Developer/Fable-pyo3/src/Fable.Build/FableLibrary/Core.fs:line 63
   at Build.Test.Python.handle(FSharpList`1 args) in /Users/dbrattli/Developer/Fable-pyo3/src/Fable.Build/Test/Python.fs:line 17
   at Build.Main.main(String[] argv) in /Users/dbrattli/Developer/Fable-pyo3/src/Fable.Build/Main.fs:line 126
```

FYI: @MangelMaxime 