### PR TITLE
[RFC] inline op_Implicit for Erased Unions

### DIFF
--- a/src/Fable.Core/Fable.Core.Types.fs
+++ b/src/Fable.Core/Fable.Core.Types.fs
@@ -125,8 +125,28 @@ type NamedParamsAttribute = ParamObjectAttribute
 type InjectAttribute() =
     inherit Attribute()
 
-/// Erased union type to represent one of two possible values.
-/// More info: https://fable.io/docs/communicate/js-from-fable.html#erase-attribute
+/// <summary>
+/// Erased union type to represent one of two possible value types mainly intended for typing the signature of imported
+/// JS functions.
+/// </summary>
+/// <remarks>
+/// Pattern matching is possible, but should consider the implications of the Erased union and JS type testing (see the
+/// docs for details).
+/// <br/>
+/// Member concrete types will be implicitly cast into the union, and will provide a warning to this effect. Usage of
+/// the explicit cast operator <c>!^</c> available in <c>Fable.Core.JsInterop</c> will remove this warning.
+/// <a href="https://github.com/fable-compiler/Fable/pull/4143">Collection types, can provide an error</a> that will
+/// only be resolved with the explicit operator. <a href="https://github.com/glutinum-org/cli/issues/80">Anonymous
+/// records have other considerations that may be relevant if you are encountering issues.</a>
+/// <code lang="fsharp">
+/// let test(arg: U3&lt;string, int, float[]>) =
+///     match arg with
+///     | U3.Case1 x -> printfn "A string %s" x
+///     | U3.Case2 x -> printfn "An int %i" x
+///     | U3.Case3 xs -> Array.sum xs |> printfn "An array with sum %f"
+/// </code>
+/// </remarks>
+/// <seealso href="https://fable.io/docs/communicate/js-from-fable.html#erase-attribute"/>
 [<Erase>]
 type U2<'a, 'b> =
     | Case1 of 'a
@@ -137,8 +157,29 @@ type U2<'a, 'b> =
     static member inline op_Implicit(x: 'a) : U2<'a, 'b> = Case1 x
     static member inline op_Implicit(x: 'b) : U2<'a, 'b> = Case2 x
 
-/// Erased union type to represent one of three possible values.
-/// More info: https://fable.io/docs/communicate/js-from-fable.html#erase-attribute
+/// <summary>
+/// Erased union type to represent one of three possible value types mainly intended for typing the signature of imported
+/// JS functions.
+/// </summary>
+/// <remarks>
+/// Pattern matching is possible, but should consider the implications of the Erased union and JS type testing (see the
+/// docs for details).
+/// <br/>
+/// Member concrete types will be implicitly cast into the union, and will provide a warning to this effect. Usage of
+/// the explicit cast operator <c>!^</c> available in <c>Fable.Core.JsInterop</c> will remove this warning.
+/// <a href="https://github.com/fable-compiler/Fable/pull/4143">Collection types, can provide an error</a> that will
+/// only be resolved with the explicit operator. <a href="https://github.com/glutinum-org/cli/issues/80">Anonymous
+/// records have other considerations that may be relevant if you are encountering issues.</a>
+/// <code lang="fsharp">
+/// let test(arg: U3&lt;string, int, float[]>) =
+///     match arg with
+///     | U3.Case1 x -> printfn "A string %s" x
+///     | U3.Case2 x -> printfn "An int %i" x
+///     | U3.Case3 xs -> Array.sum xs |> printfn "An array with sum %f"
+/// </code>
+/// </remarks>
+/// <seealso href="https://fable.io/docs/communicate/js-from-fable.html#erase-attribute"/>
+
 [<Erase>]
 type U3<'a, 'b, 'c> =
     | Case1 of 'a
@@ -152,8 +193,28 @@ type U3<'a, 'b, 'c> =
     static member inline op_Implicit(x: 'b) : U3<'a, 'b, 'c> = Case2 x
     static member inline op_Implicit(x: 'c) : U3<'a, 'b, 'c> = Case3 x
 
-/// Erased union type to represent one of four possible values.
-/// More info: https://fable.io/docs/communicate/js-from-fable.html#erase-attribute
+/// <summary>
+/// Erased union type to represent one of four possible value types mainly intended for typing the signature of imported
+/// JS functions.
+/// </summary>
+/// <remarks>
+/// Pattern matching is possible, but should consider the implications of the Erased union and JS type testing (see the
+/// docs for details).
+/// <br/>
+/// Member concrete types will be implicitly cast into the union, and will provide a warning to this effect. Usage of
+/// the explicit cast operator <c>!^</c> available in <c>Fable.Core.JsInterop</c> will remove this warning.
+/// <a href="https://github.com/fable-compiler/Fable/pull/4143">Collection types, can provide an error</a> that will
+/// only be resolved with the explicit operator. <a href="https://github.com/glutinum-org/cli/issues/80">Anonymous
+/// records have other considerations that may be relevant if you are encountering issues.</a>
+/// <code lang="fsharp">
+/// let test(arg: U3&lt;string, int, float[]>) =
+///     match arg with
+///     | U3.Case1 x -> printfn "A string %s" x
+///     | U3.Case2 x -> printfn "An int %i" x
+///     | U3.Case3 xs -> Array.sum xs |> printfn "An array with sum %f"
+/// </code>
+/// </remarks>
+/// <seealso href="https://fable.io/docs/communicate/js-from-fable.html#erase-attribute"/>
 [<Erase>]
 type U4<'a, 'b, 'c, 'd> =
     | Case1 of 'a
@@ -170,8 +231,28 @@ type U4<'a, 'b, 'c, 'd> =
     static member inline op_Implicit(x: 'c) : U4<'a, 'b, 'c, 'd> = Case3 x
     static member inline op_Implicit(x: 'd) : U4<'a, 'b, 'c, 'd> = Case4 x
 
-/// Erased union type to represent one of five possible values.
-/// More info: https://fable.io/docs/communicate/js-from-fable.html#erase-attribute
+/// <summary>
+/// Erased union type to represent one of five possible value types mainly intended for typing the signature of imported
+/// JS functions.
+/// </summary>
+/// <remarks>
+/// Pattern matching is possible, but should consider the implications of the Erased union and JS type testing (see the
+/// docs for details).
+/// <br/>
+/// Member concrete types will be implicitly cast into the union, and will provide a warning to this effect. Usage of
+/// the explicit cast operator <c>!^</c> available in <c>Fable.Core.JsInterop</c> will remove this warning.
+/// <a href="https://github.com/fable-compiler/Fable/pull/4143">Collection types, can provide an error</a> that will
+/// only be resolved with the explicit operator. <a href="https://github.com/glutinum-org/cli/issues/80">Anonymous
+/// records have other considerations that may be relevant if you are encountering issues.</a>
+/// <code lang="fsharp">
+/// let test(arg: U3&lt;string, int, float[]>) =
+///     match arg with
+///     | U3.Case1 x -> printfn "A string %s" x
+///     | U3.Case2 x -> printfn "An int %i" x
+///     | U3.Case3 xs -> Array.sum xs |> printfn "An array with sum %f"
+/// </code>
+/// </remarks>
+/// <seealso href="https://fable.io/docs/communicate/js-from-fable.html#erase-attribute"/>
 [<Erase>]
 type U5<'a, 'b, 'c, 'd, 'e> =
     | Case1 of 'a
@@ -191,8 +272,28 @@ type U5<'a, 'b, 'c, 'd, 'e> =
     static member inline op_Implicit(x: 'd) : U5<'a, 'b, 'c, 'd, 'e> = Case4 x
     static member inline op_Implicit(x: 'e) : U5<'a, 'b, 'c, 'd, 'e> = Case5 x
 
-/// Erased union type to represent one of six possible values.
-/// More info: https://fable.io/docs/communicate/js-from-fable.html#erase-attribute
+/// <summary>
+/// Erased union type to represent one of six possible value types mainly intended for typing the signature of imported
+/// JS functions.
+/// </summary>
+/// <remarks>
+/// Pattern matching is possible, but should consider the implications of the Erased union and JS type testing (see the
+/// docs for details).
+/// <br/>
+/// Member concrete types will be implicitly cast into the union, and will provide a warning to this effect. Usage of
+/// the explicit cast operator <c>!^</c> available in <c>Fable.Core.JsInterop</c> will remove this warning.
+/// <a href="https://github.com/fable-compiler/Fable/pull/4143">Collection types, can provide an error</a> that will
+/// only be resolved with the explicit operator. <a href="https://github.com/glutinum-org/cli/issues/80">Anonymous
+/// records have other considerations that may be relevant if you are encountering issues.</a>
+/// <code lang="fsharp">
+/// let test(arg: U3&lt;string, int, float[]>) =
+///     match arg with
+///     | U3.Case1 x -> printfn "A string %s" x
+///     | U3.Case2 x -> printfn "An int %i" x
+///     | U3.Case3 xs -> Array.sum xs |> printfn "An array with sum %f"
+/// </code>
+/// </remarks>
+/// <seealso href="https://fable.io/docs/communicate/js-from-fable.html#erase-attribute"/>
 [<Erase>]
 type U6<'a, 'b, 'c, 'd, 'e, 'f> =
     | Case1 of 'a
@@ -215,8 +316,28 @@ type U6<'a, 'b, 'c, 'd, 'e, 'f> =
     static member inline op_Implicit(x: 'e) : U6<'a, 'b, 'c, 'd, 'e, 'f> = Case5 x
     static member inline op_Implicit(x: 'f) : U6<'a, 'b, 'c, 'd, 'e, 'f> = Case6 x
 
-/// Erased union type to represent one of seven possible values.
-/// More info: https://fable.io/docs/communicate/js-from-fable.html#erase-attribute
+/// <summary>
+/// Erased union type to represent one of seven possible value types mainly intended for typing the signature of imported
+/// JS functions.
+/// </summary>
+/// <remarks>
+/// Pattern matching is possible, but should consider the implications of the Erased union and JS type testing (see the
+/// docs for details).
+/// <br/>
+/// Member concrete types will be implicitly cast into the union, and will provide a warning to this effect. Usage of
+/// the explicit cast operator <c>!^</c> available in <c>Fable.Core.JsInterop</c> will remove this warning.
+/// <a href="https://github.com/fable-compiler/Fable/pull/4143">Collection types, can provide an error</a> that will
+/// only be resolved with the explicit operator. <a href="https://github.com/glutinum-org/cli/issues/80">Anonymous
+/// records have other considerations that may be relevant if you are encountering issues.</a>
+/// <code lang="fsharp">
+/// let test(arg: U3&lt;string, int, float[]>) =
+///     match arg with
+///     | U3.Case1 x -> printfn "A string %s" x
+///     | U3.Case2 x -> printfn "An int %i" x
+///     | U3.Case3 xs -> Array.sum xs |> printfn "An array with sum %f"
+/// </code>
+/// </remarks>
+/// <seealso href="https://fable.io/docs/communicate/js-from-fable.html#erase-attribute"/>
 [<Erase>]
 type U7<'a, 'b, 'c, 'd, 'e, 'f, 'g> =
     | Case1 of 'a
@@ -242,8 +363,28 @@ type U7<'a, 'b, 'c, 'd, 'e, 'f, 'g> =
     static member inline op_Implicit(x: 'f) : U7<'a, 'b, 'c, 'd, 'e, 'f, 'g> = Case6 x
     static member inline op_Implicit(x: 'g) : U7<'a, 'b, 'c, 'd, 'e, 'f, 'g> = Case7 x
 
-/// Erased union type to represent one of eight possible values.
-/// More info: https://fable.io/docs/communicate/js-from-fable.html#erase-attribute
+/// <summary>
+/// Erased union type to represent one of eight possible value types mainly intended for typing the signature of imported
+/// JS functions.
+/// </summary>
+/// <remarks>
+/// Pattern matching is possible, but should consider the implications of the Erased union and JS type testing (see the
+/// docs for details).
+/// <br/>
+/// Member concrete types will be implicitly cast into the union, and will provide a warning to this effect. Usage of
+/// the explicit cast operator <c>!^</c> available in <c>Fable.Core.JsInterop</c> will remove this warning.
+/// <a href="https://github.com/fable-compiler/Fable/pull/4143">Collection types, can provide an error</a> that will
+/// only be resolved with the explicit operator. <a href="https://github.com/glutinum-org/cli/issues/80">Anonymous
+/// records have other considerations that may be relevant if you are encountering issues.</a>
+/// <code lang="fsharp">
+/// let test(arg: U3&lt;string, int, float[]>) =
+///     match arg with
+///     | U3.Case1 x -> printfn "A string %s" x
+///     | U3.Case2 x -> printfn "An int %i" x
+///     | U3.Case3 xs -> Array.sum xs |> printfn "An array with sum %f"
+/// </code>
+/// </remarks>
+/// <seealso href="https://fable.io/docs/communicate/js-from-fable.html#erase-attribute"/>
 [<Erase>]
 type U8<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h> =
     | Case1 of 'a
@@ -272,8 +413,28 @@ type U8<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h> =
     static member inline op_Implicit(x: 'g) : U8<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h> = Case7 x
     static member inline op_Implicit(x: 'h) : U8<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h> = Case8 x
 
-/// Erased union type to represent one of nine or more possible values.
-/// More info: https://fable.io/docs/communicate/js-from-fable.html#erase-attribute
+/// <summary>
+/// Erased union type to represent one of nine possible value types mainly intended for typing the signature of imported
+/// JS functions.
+/// </summary>
+/// <remarks>
+/// Pattern matching is possible, but should consider the implications of the Erased union and JS type testing (see the
+/// docs for details).
+/// <br/>
+/// Member concrete types will be implicitly cast into the union, and will provide a warning to this effect. Usage of
+/// the explicit cast operator <c>!^</c> available in <c>Fable.Core.JsInterop</c> will remove this warning.
+/// <a href="https://github.com/fable-compiler/Fable/pull/4143">Collection types, can provide an error</a> that will
+/// only be resolved with the explicit operator. <a href="https://github.com/glutinum-org/cli/issues/80">Anonymous
+/// records have other considerations that may be relevant if you are encountering issues.</a>
+/// <code lang="fsharp">
+/// let test(arg: U3&lt;string, int, float[]>) =
+///     match arg with
+///     | U3.Case1 x -> printfn "A string %s" x
+///     | U3.Case2 x -> printfn "An int %i" x
+///     | U3.Case3 xs -> Array.sum xs |> printfn "An array with sum %f"
+/// </code>
+/// </remarks>
+/// <seealso href="https://fable.io/docs/communicate/js-from-fable.html#erase-attribute"/>
 [<Erase>]
 type U9<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i> =
     | Case1 of 'a

--- a/src/Fable.Core/Fable.Core.Types.fs
+++ b/src/Fable.Core/Fable.Core.Types.fs
@@ -134,6 +134,8 @@ type U2<'a, 'b> =
 
     static member op_ErasedCast(x: 'a) = Case1 x
     static member op_ErasedCast(x: 'b) = Case2 x
+    static member inline op_Implicit(x: 'a) : U2<'a, 'b> = Case1 x
+    static member inline op_Implicit(x: 'b) : U2<'a, 'b> = Case2 x
 
 /// Erased union type to represent one of three possible values.
 /// More info: https://fable.io/docs/communicate/js-from-fable.html#erase-attribute
@@ -146,6 +148,9 @@ type U3<'a, 'b, 'c> =
     static member op_ErasedCast(x: 'a) = Case1 x
     static member op_ErasedCast(x: 'b) = Case2 x
     static member op_ErasedCast(x: 'c) = Case3 x
+    static member inline op_Implicit(x: 'a) : U3<'a, 'b, 'c> = Case1 x
+    static member inline op_Implicit(x: 'b) : U3<'a, 'b, 'c> = Case2 x
+    static member inline op_Implicit(x: 'c) : U3<'a, 'b, 'c> = Case3 x
 
 /// Erased union type to represent one of four possible values.
 /// More info: https://fable.io/docs/communicate/js-from-fable.html#erase-attribute
@@ -160,6 +165,10 @@ type U4<'a, 'b, 'c, 'd> =
     static member op_ErasedCast(x: 'b) = Case2 x
     static member op_ErasedCast(x: 'c) = Case3 x
     static member op_ErasedCast(x: 'd) = Case4 x
+    static member inline op_Implicit(x: 'a) : U4<'a, 'b, 'c, 'd> = Case1 x
+    static member inline op_Implicit(x: 'b) : U4<'a, 'b, 'c, 'd> = Case2 x
+    static member inline op_Implicit(x: 'c) : U4<'a, 'b, 'c, 'd> = Case3 x
+    static member inline op_Implicit(x: 'd) : U4<'a, 'b, 'c, 'd> = Case4 x
 
 /// Erased union type to represent one of five possible values.
 /// More info: https://fable.io/docs/communicate/js-from-fable.html#erase-attribute
@@ -176,6 +185,11 @@ type U5<'a, 'b, 'c, 'd, 'e> =
     static member op_ErasedCast(x: 'c) = Case3 x
     static member op_ErasedCast(x: 'd) = Case4 x
     static member op_ErasedCast(x: 'e) = Case5 x
+    static member inline op_Implicit(x: 'a) : U5<'a, 'b, 'c, 'd, 'e> = Case1 x
+    static member inline op_Implicit(x: 'b) : U5<'a, 'b, 'c, 'd, 'e> = Case2 x
+    static member inline op_Implicit(x: 'c) : U5<'a, 'b, 'c, 'd, 'e> = Case3 x
+    static member inline op_Implicit(x: 'd) : U5<'a, 'b, 'c, 'd, 'e> = Case4 x
+    static member inline op_Implicit(x: 'e) : U5<'a, 'b, 'c, 'd, 'e> = Case5 x
 
 /// Erased union type to represent one of six possible values.
 /// More info: https://fable.io/docs/communicate/js-from-fable.html#erase-attribute
@@ -194,6 +208,12 @@ type U6<'a, 'b, 'c, 'd, 'e, 'f> =
     static member op_ErasedCast(x: 'd) = Case4 x
     static member op_ErasedCast(x: 'e) = Case5 x
     static member op_ErasedCast(x: 'f) = Case6 x
+    static member inline op_Implicit(x: 'a) : U6<'a, 'b, 'c, 'd, 'e, 'f> = Case1 x
+    static member inline op_Implicit(x: 'b) : U6<'a, 'b, 'c, 'd, 'e, 'f> = Case2 x
+    static member inline op_Implicit(x: 'c) : U6<'a, 'b, 'c, 'd, 'e, 'f> = Case3 x
+    static member inline op_Implicit(x: 'd) : U6<'a, 'b, 'c, 'd, 'e, 'f> = Case4 x
+    static member inline op_Implicit(x: 'e) : U6<'a, 'b, 'c, 'd, 'e, 'f> = Case5 x
+    static member inline op_Implicit(x: 'f) : U6<'a, 'b, 'c, 'd, 'e, 'f> = Case6 x
 
 /// Erased union type to represent one of seven possible values.
 /// More info: https://fable.io/docs/communicate/js-from-fable.html#erase-attribute
@@ -214,6 +234,13 @@ type U7<'a, 'b, 'c, 'd, 'e, 'f, 'g> =
     static member op_ErasedCast(x: 'e) = Case5 x
     static member op_ErasedCast(x: 'f) = Case6 x
     static member op_ErasedCast(x: 'g) = Case7 x
+    static member inline op_Implicit(x: 'a) : U7<'a, 'b, 'c, 'd, 'e, 'f, 'g> = Case1 x
+    static member inline op_Implicit(x: 'b) : U7<'a, 'b, 'c, 'd, 'e, 'f, 'g> = Case2 x
+    static member inline op_Implicit(x: 'c) : U7<'a, 'b, 'c, 'd, 'e, 'f, 'g> = Case3 x
+    static member inline op_Implicit(x: 'd) : U7<'a, 'b, 'c, 'd, 'e, 'f, 'g> = Case4 x
+    static member inline op_Implicit(x: 'e) : U7<'a, 'b, 'c, 'd, 'e, 'f, 'g> = Case5 x
+    static member inline op_Implicit(x: 'f) : U7<'a, 'b, 'c, 'd, 'e, 'f, 'g> = Case6 x
+    static member inline op_Implicit(x: 'g) : U7<'a, 'b, 'c, 'd, 'e, 'f, 'g> = Case7 x
 
 /// Erased union type to represent one of eight possible values.
 /// More info: https://fable.io/docs/communicate/js-from-fable.html#erase-attribute
@@ -236,6 +263,14 @@ type U8<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h> =
     static member op_ErasedCast(x: 'f) = Case6 x
     static member op_ErasedCast(x: 'g) = Case7 x
     static member op_ErasedCast(x: 'h) = Case8 x
+    static member inline op_Implicit(x: 'a) : U8<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h> = Case1 x
+    static member inline op_Implicit(x: 'b) : U8<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h> = Case2 x
+    static member inline op_Implicit(x: 'c) : U8<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h> = Case3 x
+    static member inline op_Implicit(x: 'd) : U8<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h> = Case4 x
+    static member inline op_Implicit(x: 'e) : U8<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h> = Case5 x
+    static member inline op_Implicit(x: 'f) : U8<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h> = Case6 x
+    static member inline op_Implicit(x: 'g) : U8<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h> = Case7 x
+    static member inline op_Implicit(x: 'h) : U8<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h> = Case8 x
 
 /// Erased union type to represent one of nine or more possible values.
 /// More info: https://fable.io/docs/communicate/js-from-fable.html#erase-attribute
@@ -260,6 +295,15 @@ type U9<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i> =
     static member op_ErasedCast(x: 'g) = Case7 x
     static member op_ErasedCast(x: 'h) = Case8 x
     static member op_ErasedCast(x: 'i) = Case9 x
+    static member inline op_Implicit(x: 'a) : U9<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i> = Case1 x
+    static member inline op_Implicit(x: 'b) : U9<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i> = Case2 x
+    static member inline op_Implicit(x: 'c) : U9<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i> = Case3 x
+    static member inline op_Implicit(x: 'd) : U9<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i> = Case4 x
+    static member inline op_Implicit(x: 'e) : U9<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i> = Case5 x
+    static member inline op_Implicit(x: 'f) : U9<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i> = Case6 x
+    static member inline op_Implicit(x: 'g) : U9<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i> = Case7 x
+    static member inline op_Implicit(x: 'h) : U9<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i> = Case8 x
+    static member inline op_Implicit(x: 'i) : U9<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i> = Case9 x
 
     static member inline op_ErasedCast(x: 't) : U9<_, _, _, _, _, _, _, _, ^U> =
         Case9(^U: (static member op_ErasedCast: 't -> ^U) x)


### PR DESCRIPTION
# op_Implicit for Erased Unions

![Animation3](https://github.com/user-attachments/assets/f0f17b8e-42c5-424e-8bf7-ad6936058171)

The suggested change is to provide inlined implicit casting into the erased union.

This would allow method/other calls to accept arguments of the type implicitly in situations where the inferred type is concrete. It will provide an error with generic type parameters and still error unless `!^` explicitly cast which is fine. See above.

This would not concretely change anything fundamental about the usage or behaviour of these erased unions in implementation. The advantage here is that the erased union would provide a *warning* (from the implicit cast) rather than an *error*, which better 
suits the use case of the discriminated union as an interface for F# to dynamic languages when interop-ing.

In this situation, workflow would ideally not be broken when providing an input to bindings that accept multiple types. Especially since the erased operator is defined in the JsInterop module.
I would argue appropriate highlighting of a potential issue that can be adjusted afterwards and made explicit instead of outright being invalid would align with the majority use case of these erased unions.

*I've had this implemented in my own libraries for a while as I find it to be a great DX improvement without cost*