### PR TITLE
[JS/TS] Add support for directive prologue

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+* [JS/TS] Fix #3533: Add directives prologues supports (by @MangelMaxime)
+
 ### Changed
 
 * [Python] Use Python 3.12 type parameter syntax. Deprecate Python 3.10 and 3.11 (by @dbrattli)

--- a/src/Fable.Compiler/CHANGELOG.md
+++ b/src/Fable.Compiler/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+* [JS/TS] Fix #3533: Add directives prologues supports (by @MangelMaxime)
+
 ### Changed
 
 * [Python] Fable Library for Python is now partially written in Rust (by @dbrattli)

--- a/src/Fable.Core/CHANGELOG.md
+++ b/src/Fable.Core/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* [JS/TS] Fix #3533: Add `emitTopDirectivePrologue` supports (by @MangelMaxime)
-* [JS/TS] Fix #3533: Add `emitDirectivePrologue` supports (by @MangelMaxime)
+* [JS/TS] Fix #3533: Add `emitJsTopDirectivePrologue` supports (by @MangelMaxime)
+* [JS/TS] Fix #3533: Add `emitJsDirectivePrologue` supports (by @MangelMaxime)
 
 ## 4.5.0 - 2025-03-03
 

--- a/src/Fable.Core/CHANGELOG.md
+++ b/src/Fable.Core/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+* [JS/TS] Fix #3533: Add `emitTopDirectivePrologue` supports (by @MangelMaxime)
+* [JS/TS] Fix #3533: Add `emitDirectivePrologue` supports (by @MangelMaxime)
+
 ## 4.5.0 - 2025-03-03
 
 ### Added

--- a/src/Fable.Core/Fable.Core.JsInterop.fs
+++ b/src/Fable.Core/Fable.Core.JsInterop.fs
@@ -47,7 +47,6 @@ let emitJsExpr<'T> (args: obj) (jsCode: string) : 'T = nativeOnly
 /// E.g. `emitJsStatement aValue "while($0 < 5) doSomething()"`
 let emitJsStatement<'T> (args: obj) (jsCode: string) : 'T = nativeOnly
 
-
 /// <summary>
 /// Emit a directive prologue at the top of the file (before the imports)
 ///

--- a/src/Fable.Core/Fable.Core.JsInterop.fs
+++ b/src/Fable.Core/Fable.Core.JsInterop.fs
@@ -47,6 +47,25 @@ let emitJsExpr<'T> (args: obj) (jsCode: string) : 'T = nativeOnly
 /// E.g. `emitJsStatement aValue "while($0 < 5) doSomething()"`
 let emitJsStatement<'T> (args: obj) (jsCode: string) : 'T = nativeOnly
 
+
+/// <summary>
+/// Emit a directive prologue at the top of the file (before the imports)
+///
+/// This is useful when working with Next.js or other frameworks that require
+/// a specific directive at the top of the file, such as "use client" or "use server".
+/// </summary>
+/// <param name="text">Directive text</param>
+let emitTopDirectivePrologue (text: string) : unit = nativeOnly
+
+/// <summary>
+/// Emit a directive prologue at the calling position.
+///
+/// This is useful when you need to emit a directive prologue for a specific part of the code,
+/// such as "use client" or "use server".
+/// </summary>
+/// <param name="text">Directive text</param>
+let emitDirectivePrologue (text: string) : unit = nativeOnly
+
 /// Create a literal JS object from a collection of key-value tuples.
 /// E.g. `createObj [ "a" ==> 5 ]` in JS becomes `{ a: 5 }`
 let createObj (fields: #seq<string * obj>) : obj = nativeOnly

--- a/src/Fable.Core/Fable.Core.JsInterop.fs
+++ b/src/Fable.Core/Fable.Core.JsInterop.fs
@@ -54,7 +54,7 @@ let emitJsStatement<'T> (args: obj) (jsCode: string) : 'T = nativeOnly
 /// a specific directive at the top of the file, such as "use client" or "use server".
 /// </summary>
 /// <param name="text">Directive text</param>
-let emitTopDirectivePrologue (text: string) : unit = nativeOnly
+let emitJsTopDirectivePrologue (text: string) : unit = nativeOnly
 
 /// <summary>
 /// Emit a directive prologue at the calling position.
@@ -63,7 +63,7 @@ let emitTopDirectivePrologue (text: string) : unit = nativeOnly
 /// such as "use client" or "use server".
 /// </summary>
 /// <param name="text">Directive text</param>
-let emitDirectivePrologue (text: string) : unit = nativeOnly
+let emitJsDirectivePrologue (text: string) : unit = nativeOnly
 
 /// Create a literal JS object from a collection of key-value tuples.
 /// E.g. `createObj [ "a" ==> 5 ]` in JS becomes `{ a: 5 }`

--- a/src/Fable.Transforms/BabelPrinter.fs
+++ b/src/Fable.Transforms/BabelPrinter.fs
@@ -527,27 +527,28 @@ module PrinterExtensions =
                 printer.PrintMemberExpression(object, property, isComputed, loc)
             | LogicalExpression(left, operator, right, loc) -> printer.PrintOperation(left, operator, right, loc)
             | SequenceExpression(expressions, loc) ->
-                // A comma-separated sequence of expressions.
-                printer.AddLocation(loc)
-                let last = expressions.Length - 1
-
-                let expressions =
-                    expressions |> Array.filteri (fun i e -> i = last || hasSideEffects e)
-
-                if expressions.Length = 1 then
-                    printer.Print(expressions[0])
-                else
+                if expressions.Length > 0 then
+                    // A comma-separated sequence of expressions.
+                    printer.AddLocation(loc)
                     let last = expressions.Length - 1
-                    printer.Print("(")
 
-                    for i = 0 to last do
-                        let e = expressions[i]
-                        printer.Print(e)
+                    let expressions =
+                        expressions |> Array.filteri (fun i e -> i = last || hasSideEffects e)
 
-                        if i < last then
-                            printer.Print(", ")
+                    if expressions.Length = 1 then
+                        printer.Print(expressions[0])
+                    else
+                        let last = expressions.Length - 1
+                        printer.Print("(")
 
-                    printer.Print(")")
+                        for i = 0 to last do
+                            let e = expressions[i]
+                            printer.Print(e)
+
+                            if i < last then
+                                printer.Print(", ")
+
+                        printer.Print(")")
             | AssignmentExpression(left, right, operator, loc) -> printer.PrintOperation(left, operator, right, loc)
             | ConditionalExpression(test, consequent, alternate, loc) ->
                 printer.PrintConditionalExpression(test, consequent, alternate, loc)
@@ -559,6 +560,8 @@ module PrinterExtensions =
                 printer.Print(expression)
                 printer.Print(" as ")
                 printer.Print(typeAnnotation)
+
+        member printer.PrintDirectivePrologue(DirectivePrologue text: DirectivePrologue) = printer.Print(text)
 
         member printer.PrintLiteral(literal: Literal) =
             match literal with
@@ -743,6 +746,7 @@ module PrinterExtensions =
                 match declaration with
                 | Choice1Of2 x -> printer.PrintDeclaration(x)
                 | Choice2Of2 x -> printer.Print(x)
+            | DirectivePrologueDeclaration directive -> printer.PrintDirectivePrologue(directive)
 
         member printer.PrintEmitExpression(value, args, loc) =
             printer.AddLocation(loc)
@@ -1563,22 +1567,36 @@ let run writer (program: Program) : Async<unit> =
         if extraLine then
             printer.PrintNewLine()
 
+    let writeTopLevelDeclarations declarations (printer: PrinterImpl) =
+        async {
+            for decl in declarations do
+                printDeclWithExtraLine false printer decl
+
+                (printer :> Printer).PrintNewLine()
+                do! printer.Flush()
+        }
+
     async {
         use printer = new PrinterImpl(writer)
 
-        let imports, restDecls =
+        let topDirectiveProloge, restDecls =
             program.Body
+            |> Array.splitWhile (
+                function
+                | DirectivePrologueDeclaration _ -> true
+                | _ -> false
+            )
+
+        let imports, restDecls =
+            restDecls
             |> Array.splitWhile (
                 function
                 | ImportDeclaration(_) -> true
                 | _ -> false
             )
 
-        for decl in imports do
-            printDeclWithExtraLine false printer decl
-
-        (printer :> Printer).PrintNewLine()
-        do! printer.Flush()
+        do! writeTopLevelDeclarations topDirectiveProloge printer
+        do! writeTopLevelDeclarations imports printer
 
         for decl in restDecls do
             printDeclWithExtraLine true printer decl

--- a/src/Fable.Transforms/BabelPrinter.fs
+++ b/src/Fable.Transforms/BabelPrinter.fs
@@ -1572,8 +1572,8 @@ let run writer (program: Program) : Async<unit> =
             for decl in declarations do
                 printDeclWithExtraLine false printer decl
 
-                (printer :> Printer).PrintNewLine()
-                do! printer.Flush()
+            (printer :> Printer).PrintNewLine()
+            do! printer.Flush()
         }
 
     async {

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -2231,9 +2231,6 @@ but thanks to the optimisation done below we get
             "Expecting a static list or array literal (no generator) for JSX props"
             |> addErrorAndReturnNull com range
             |> Some
-        // | Fable.Tags.Contains "topDirectiveProloge", _ ->
-        //     Expression.sequenceExpression([||])
-        //     |> Some
         | Fable.Tags.Contains "jsx-template", args ->
             match args with
             | StringConst template :: _ ->

--- a/src/Fable.Transforms/Global/Babel.fs
+++ b/src/Fable.Transforms/Global/Babel.fs
@@ -200,6 +200,10 @@ type Declaration =
         | InterfaceDeclaration(_, _, _, _, doc) -> doc
         | _ -> None
 
+/// A directive prologue as defined in ECMA specification
+/// https://tc39.es/ecma262/#sec-directive-prologues-and-the-use-strict-directive
+type DirectivePrologue = | DirectivePrologue of text: string
+
 /// A module import or export declaration.
 type ModuleDeclaration =
     | PrivateModuleDeclaration of statement: Statement
@@ -211,6 +215,7 @@ type ModuleDeclaration =
     | ExportDefaultDeclaration of declaration: Choice<Declaration, Expression>
     | ImportDeclaration of specifiers: ImportSpecifier array * source: StringLiteral
     | ExportNamedReferences of specifiers: ExportSpecifier array * source: StringLiteral option
+    | DirectivePrologueDeclaration of directiveText: DirectivePrologue
 
 //    /// An export batch declaration, e.g., export * from "mod";.
 // Template Literals

--- a/src/Fable.Transforms/Replacements.Util.fs
+++ b/src/Fable.Transforms/Replacements.Util.fs
@@ -180,6 +180,7 @@ let withTag tag =
     | Call(e, i, t, r) -> Call(e, { i with Tags = tag :: i.Tags }, t, r)
     | Get(e, FieldGet i, t, r) -> Get(e, FieldGet { i with Tags = tag :: i.Tags }, t, r)
     | Operation(op, tags, t, r) -> Operation(op, tag :: tags, t, r)
+    | Emit(i, t, r) -> Emit({ i with EmitInfo.CallInfo.Tags = tag :: i.CallInfo.Tags }, t, r)
     | e -> e
 
 let getTags =

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -1052,9 +1052,9 @@ let fableCoreLib (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Exp
         | "importDynamic", [ path ] ->
             let path = fixDynamicImportPath path
             Helper.GlobalCall("import", t, [ path ], ?loc = r) |> Some
-        | "emitTopDirectivePrologue", [ StringConst arg ] ->
+        | "emitJsTopDirectivePrologue", [ StringConst arg ] ->
             "\"" + arg + "\"" |> emit r t [] false |> withTag "topDirectiveProloge" |> Some
-        | "emitDirectivePrologue", [ StringConst arg ] -> "\"" + arg + "\"" |> emit r t [] false |> Some
+        | "emitJsDirectivePrologue", [ StringConst arg ] -> "\"" + arg + "\"" |> emit r t [] false |> Some
         | "importValueDynamic", [ MaybeInScope ctx arg ] ->
             let dynamicImport selector path apply =
                 let path = fixDynamicImportPath path

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -1052,6 +1052,9 @@ let fableCoreLib (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Exp
         | "importDynamic", [ path ] ->
             let path = fixDynamicImportPath path
             Helper.GlobalCall("import", t, [ path ], ?loc = r) |> Some
+        | "emitTopDirectivePrologue", [ StringConst arg ] ->
+            "\"" + arg + "\"" |> emit r t [] false |> withTag "topDirectiveProloge" |> Some
+        | "emitDirectivePrologue", [ StringConst arg ] -> "\"" + arg + "\"" |> emit r t [] false |> Some
         | "importValueDynamic", [ MaybeInScope ctx arg ] ->
             let dynamicImport selector path apply =
                 let path = fixDynamicImportPath path


### PR DESCRIPTION
Fix #3533

I have an integration test suits ready but we need to release Fable.Core package in order to run it. 

If we use `ProjectReference` the test end up generating a bunch of `.jsx.actual` in Fable.Core source folder...

Example:

```fs
module TopLevel

open Fable.Core
open Fable.Core.JsInterop

let log () = printfn "Hello"

emitTopDirectivePrologue "use client"

let hello () =
    printfn "Hello from F#"

emitTopDirectivePrologue "use strict"
```

generates

```js
"use client";
"use strict";

import { printf, toConsole } from "./fable_modules/fable-library-js.5.0.0-alpha.13/String.js";

export function log() {
    toConsole(printf("Hello"));
}


export function hello() {
    toConsole(printf("Hello from F#"));
}
```