### PR TITLE
[Python] Do not run publish-pypi on pull requests

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
   workflow_dispatch:
   release:
     types: [published]


### PR DESCRIPTION
## Why

Running publish to pypi on every pull-request adds a lot of time for every PR being made. We should only run it on main merge.

Fixes #4148

## How

Remove `pull_request` from `publish-pypi.yml`.