### PR TITLE
[Python] Fixed unit function (zero arguments functions) are transpiled inconsistently

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* [Python] Fixed unit function (zero arguments functions) are transpiled inconsistently (#4126) (by @dbrattli)
 * [Python] Fixed resource managers with empty body (#3912) (by @dbrattli)
 * [Python] Fixed `Async.Sleep`to handle TimeSpan correctly (#4137) (by @dbrattli)
 * [Python] Make sure snake-cased Record do not conflict (by @dbrattli)


### PR DESCRIPTION
## Why

Unit arguments are erased for Python, so we should not call functions with unit arguments as `None`. 

Fixes #4126

## How

- Remove single unit arguments from function calls
- Assign `None` as default value for arguments accepting unit.