### PR TITLE
[Python] Fix typing for union tag

### DIFF
--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -4204,11 +4204,7 @@ module Util =
 
                         let right =
                             match id.Type with
-                            | Fable.Number _ ->
-                                Expression.boolOp (
-                                    BoolOperator.Or,
-                                    [ identAsExpr com ctx id; Expression.intConstant 0 ]
-                                )
+                            | Fable.Number _ -> identAsExpr com ctx id
                             | Fable.Array _ ->
                                 // Convert varArg from tuple to array. TODO: we might need to do this other places as well.
                                 let array = libValue com ctx "array_" "Array"

--- a/src/fable-library-py/fable_library/types.py
+++ b/src/fable-library-py/fable_library/types.py
@@ -17,7 +17,7 @@ class Union(IComparable):
     __slots__: tuple[str, ...] = ("fields", "tag")
 
     def __init__(self) -> None:
-        self.tag: int
+        self.tag: int32
         self.fields: Array[Any] = Array[Any]()
 
     @staticmethod


### PR DESCRIPTION
## Why

Current code was inherited from JS target and generated `tag or 0`. For Python we do not need it and tag was also wrongly typed as `int`. Should be `int32`.

No change for the user of Fable, this is only the typing of the generated code to be more correct.

## How

- Change type of tag to `int32`
- Remove the `or 0` part when initializing the union