### PR TITLE
[JS/TS] Initial support for Nullable Reference Types

### DIFF
--- a/src/Fable.AST/CHANGELOG.md
+++ b/src/Fable.AST/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* [All] Support for Nullable Reference Types (by @ncave and @MangelMaxime)
+
 ## 5.0.0-beta.1 - 2025-02-16
 
 ### Added

--- a/src/Fable.AST/Fable.fs
+++ b/src/Fable.AST/Fable.fs
@@ -191,19 +191,20 @@ type Type =
     | String
     | Regex
     | Number of kind: NumberKind * info: NumberInfo
-    | Option of genericArg: Type * isStruct: bool
-    | Tuple of genericArgs: Type list * isStruct: bool
-    | Array of genericArg: Type * kind: ArrayKind
-    | List of genericArg: Type
+    | Option of genArg: Type * isStruct: bool
+    | Tuple of genArg: Type list * isStruct: bool
+    | Array of genArg: Type * kind: ArrayKind
+    | List of genArg: Type
     | LambdaType of argType: Type * returnType: Type
     | DelegateType of argTypes: Type list * returnType: Type
     | GenericParam of name: string * isMeasure: bool * constraints: Constraint list
-    | DeclaredType of ref: EntityRef * genericArgs: Type list
-    | AnonymousRecordType of fieldNames: string[] * genericArgs: Type list * isStruct: bool
-    | Nullable of Type
+    | DeclaredType of ref: EntityRef * genArgs: Type list
+    | AnonymousRecordType of fieldNames: string[] * genArgs: Type list * isStruct: bool
+    | Nullable of genArg: Type * isStruct: bool
 
     member this.Generics =
         match this with
+        | Nullable(gen, _)
         | Option(gen, _)
         | Array(gen, _)
         | List gen -> [ gen ]
@@ -212,7 +213,6 @@ type Type =
         | Tuple(gen, _) -> gen
         | DeclaredType(_, gen) -> gen
         | AnonymousRecordType(_, gen, _) -> gen
-        | Nullable typ -> typ.Generics
         // TODO: Check numbers with measure?
         | MetaType
         | Any
@@ -227,6 +227,7 @@ type Type =
 
     member this.MapGenerics f =
         match this with
+        | Nullable(gen, isStruct) -> Nullable(f gen, isStruct)
         | Option(gen, isStruct) -> Option(f gen, isStruct)
         | Array(gen, kind) -> Array(f gen, kind)
         | List gen -> List(f gen)
@@ -235,7 +236,6 @@ type Type =
         | Tuple(gen, isStruct) -> Tuple(List.map f gen, isStruct)
         | DeclaredType(e, gen) -> DeclaredType(e, List.map f gen)
         | AnonymousRecordType(e, gen, isStruct) -> AnonymousRecordType(e, List.map f gen, isStruct)
-        | Nullable typ -> Nullable(f typ)
         | MetaType
         | Any
         | Unit

--- a/src/Fable.AST/Fable.fs
+++ b/src/Fable.AST/Fable.fs
@@ -200,6 +200,7 @@ type Type =
     | GenericParam of name: string * isMeasure: bool * constraints: Constraint list
     | DeclaredType of ref: EntityRef * genericArgs: Type list
     | AnonymousRecordType of fieldNames: string[] * genericArgs: Type list * isStruct: bool
+    | Nullable of Type
 
     member this.Generics =
         match this with
@@ -211,6 +212,7 @@ type Type =
         | Tuple(gen, _) -> gen
         | DeclaredType(_, gen) -> gen
         | AnonymousRecordType(_, gen, _) -> gen
+        | Nullable typ -> typ.Generics
         // TODO: Check numbers with measure?
         | MetaType
         | Any
@@ -233,6 +235,7 @@ type Type =
         | Tuple(gen, isStruct) -> Tuple(List.map f gen, isStruct)
         | DeclaredType(e, gen) -> DeclaredType(e, List.map f gen)
         | AnonymousRecordType(e, gen, isStruct) -> AnonymousRecordType(e, List.map f gen, isStruct)
+        | Nullable typ -> Nullable(f typ)
         | MetaType
         | Any
         | Unit

--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * [JS/TS] Fix #3533: Add directives prologues supports (by @MangelMaxime)
+* [TS] Initial support for Nullable Reference Types (by @ncave)
 
 ### Changed
 

--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * [JS/TS] Fix #3533: Add directives prologues supports (by @MangelMaxime)
-* [TS] Initial support for Nullable Reference Types (by @ncave)
+* [JS/TS] Support for Nullable Reference Types (by @ncave and @MangelMaxime)
 
 ### Changed
 

--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -737,7 +737,7 @@ and FableCompiler(checker: InteractiveChecker, projCracked: ProjectCracked, fabl
             let fableProj =
                 Project.From(
                     projCracked.ProjectFile,
-                    projCracked.ProjectOptions.SourceFiles,
+                    projCracked.ProjectOptions,
                     [],
                     assemblies,
                     Log.log,

--- a/src/Fable.Compiler/CHANGELOG.md
+++ b/src/Fable.Compiler/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * [JS/TS] Fix #3533: Add directives prologues supports (by @MangelMaxime)
+* [TS] Initial support for Nullable Reference Types (by @ncave)
 
 ### Changed
 

--- a/src/Fable.Compiler/CHANGELOG.md
+++ b/src/Fable.Compiler/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * [JS/TS] Fix #3533: Add directives prologues supports (by @MangelMaxime)
-* [TS] Initial support for Nullable Reference Types (by @ncave)
+* [JS/TS] Support for Nullable Reference Types (by @ncave and @MangelMaxime)
 
 ### Changed
 

--- a/src/Fable.Compiler/Library.fs
+++ b/src/Fable.Compiler/Library.fs
@@ -164,7 +164,7 @@ module CodeServices =
             let fableProj =
                 Project.From(
                     cliArgs.ProjectFile,
-                    crackerResponse.ProjectOptions.SourceFiles,
+                    crackerResponse.ProjectOptions,
                     checkProjectResult.AssemblyContents.ImplementationFiles,
                     assemblies,
                     Log.log,
@@ -205,7 +205,7 @@ module CodeServices =
             let fableProj =
                 Project.From(
                     cliArgs.ProjectFile,
-                    crackerResponse.ProjectOptions.SourceFiles,
+                    crackerResponse.ProjectOptions,
                     typeCheckProjectResult.ProjectCheckResults.AssemblyContents.ImplementationFiles,
                     typeCheckProjectResult.Assemblies,
                     Log.log,
@@ -298,7 +298,7 @@ module CodeServices =
             let fableProj =
                 Project.From(
                     cliArgs.ProjectFile,
-                    crackerResponse.ProjectOptions.SourceFiles,
+                    crackerResponse.ProjectOptions,
                     checkProjectResult.AssemblyContents.ImplementationFiles,
                     assemblies,
                     Log.log,

--- a/src/Fable.Transforms/Dart/Fable2Dart.fs
+++ b/src/Fable.Transforms/Dart/Fable2Dart.fs
@@ -194,6 +194,9 @@ module Util =
         let tup = List.length genArgs |> getTupleTypeIdent com ctx
         Type.reference (tup, genArgs)
 
+    let transformNullableType com ctx genArg =
+        transformType com ctx genArg |> Nullable
+
     let transformOptionType com ctx genArg =
         let genArg = transformType com ctx genArg
 
@@ -215,7 +218,6 @@ module Util =
         | Types.array, _ -> List Dynamic
         | "System.Tuple`1", _ -> transformTupleType com ctx genArgs
         | Types.valueType, _ -> Object
-        | Types.nullable, [ genArg ]
         | "Fable.Core.Dart.DartNullable`1", [ genArg ] -> Nullable genArg
         | Types.regexGroup, _ -> Nullable String
         | Types.regexMatch, _ -> makeTypeRefFromName "Match" []
@@ -650,6 +652,7 @@ module Util =
             | BigInt
             | NativeInt
             | UNativeInt -> Dynamic // TODO
+        | Fable.Nullable(genArg, _isStruct) -> transformNullableType com ctx genArg
         | Fable.Option(genArg, _isStruct) -> transformOptionType com ctx genArg
         | Fable.Array(TransformType com ctx genArg, _) -> List genArg
         | Fable.List(TransformType com ctx genArg) -> Type.reference (getFSharpListTypeIdent com ctx, [ genArg ])

--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -1632,12 +1632,12 @@ module TypeHelpers =
             else
                 Fable.Any // failwithf "Unexpected non-declared F# type: %A" t
 
-        // TODO:
-        // if not t.IsGenericParameter && t.HasNullAnnotation // || t.IsNullAmbivalent
-        // then
-        //     makeRuntimeType [ typ ] Types.nullable // represent it as Nullable<T>
-        // else typ
-        typ
+        if
+            Compiler.CheckNulls && not t.IsGenericParameter && t.HasNullAnnotation // || t.IsNullAmbivalent
+        then
+            makeRuntimeType [ typ ] Types.nullable // represent Nullable Reference Types as Nullable<T>
+        else
+            typ
 
     let makeType (ctxTypeArgs: Map<string, Fable.Type>) t =
         makeTypeWithConstraints true ctxTypeArgs t

--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -1557,6 +1557,8 @@ module TypeHelpers =
             | Types.string -> Fable.String
             | Types.regex -> Fable.Regex
             | Types.type_ -> Fable.MetaType
+            | Types.nullable ->
+                Fable.Nullable(makeTypeGenArgsWithConstraints withConstraints ctxTypeArgs genArgs |> List.head, true)
             | Types.valueOption ->
                 Fable.Option(makeTypeGenArgsWithConstraints withConstraints ctxTypeArgs genArgs |> List.head, true)
             | Types.option ->
@@ -1635,7 +1637,7 @@ module TypeHelpers =
         if
             Compiler.CheckNulls && t.HasNullAnnotation // || t.IsNullAmbivalent
         then
-            makeRuntimeType [ typ ] Types.nullable // represent Nullable Reference Types as Nullable<T>
+            Fable.Nullable(typ, false)
         else
             typ
 

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -345,6 +345,7 @@ module Reflection =
             List.zip (fieldNames |> Array.toList) genArgs
             |> List.map (fun (k, t) -> Expression.arrayExpression [| Expression.stringLiteral (k); t |])
             |> libReflectionCall com ctx None "anonRecord"
+        | Fable.Nullable typ -> transformTypeInfoFor purpose com ctx r genMap typ
         | Fable.DeclaredType(entRef, genArgs) ->
             let fullName = entRef.FullName
 
@@ -495,6 +496,7 @@ module Reflection =
         | Fable.MetaType -> jsInstanceof (libValue com ctx "Reflection" "TypeInfo") expr
         | Fable.Option _ -> warnAndEvalToFalse "options" // TODO
         | Fable.GenericParam _ -> warnAndEvalToFalse "generic parameters"
+        | Fable.Nullable typ -> transformTypeTest com ctx range expr typ
         | Fable.DeclaredType(ent, genArgs) ->
             match ent.FullName with
             | Types.idisposable ->
@@ -618,6 +620,7 @@ module Annotation =
         | Fable.DelegateType(argTypes, returnType) -> makeFunctionTypeAnnotation com ctx typ argTypes returnType
         | Fable.AnonymousRecordType(fieldNames, fieldTypes, _isStruct) ->
             makeAnonymousRecordTypeAnnotation com ctx fieldNames fieldTypes
+        | Fable.Nullable typ -> makeNullableTypeAnnotation com ctx typ
         | Replacements.Util.Builtin kind -> makeBuiltinTypeAnnotation com ctx typ kind
         | Fable.DeclaredType(entRef, genArgs) -> com.GetEntity(entRef) |> makeEntityTypeAnnotation com ctx genArgs
 

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -693,7 +693,7 @@ module Annotation =
         makeFableLibImportTypeAnnotation com ctx [] moduleName typeName
 
     let makeNullableTypeAnnotation com ctx genArg =
-        makeFableLibImportTypeAnnotation com ctx [ genArg ] "Option" "Nullable"
+        makeFableLibImportTypeAnnotation com ctx [ genArg ] "Util" "Nullable"
 
     let makeOptionTypeAnnotation com ctx genArg =
         makeFableLibImportTypeAnnotation com ctx [ genArg ] "Option" "Option"

--- a/src/Fable.Transforms/Global/Babel.fs
+++ b/src/Fable.Transforms/Global/Babel.fs
@@ -522,6 +522,7 @@ type TypeAnnotation =
     | TypeofTypeAnnotation of Expression
     | IndexedTypeAnnotation of typ: TypeAnnotation * prop: TypeAnnotation
     | LiteralTypeAnnotation of Literal
+    // | NullableTypeAnnotation of TypeAnnotation
 
 type TypeParameter = | TypeParameter of name: string * bound: TypeAnnotation option * ``default``: TypeAnnotation option
 

--- a/src/Fable.Transforms/Global/Babel.fs
+++ b/src/Fable.Transforms/Global/Babel.fs
@@ -522,7 +522,6 @@ type TypeAnnotation =
     | TypeofTypeAnnotation of Expression
     | IndexedTypeAnnotation of typ: TypeAnnotation * prop: TypeAnnotation
     | LiteralTypeAnnotation of Literal
-    // | NullableTypeAnnotation of TypeAnnotation
 
 type TypeParameter = | TypeParameter of name: string * bound: TypeAnnotation option * ``default``: TypeAnnotation option
 

--- a/src/Fable.Transforms/Global/Compiler.fs
+++ b/src/Fable.Transforms/Global/Compiler.fs
@@ -124,15 +124,20 @@ module CompilerExt =
             false
 
     let private coreAssemblyNames = set Metadata.coreAssemblies
-    let mutable private _lang = JavaScript
+
+    let mutable private _language = JavaScript
+    let mutable private _checkNulls = false
 
     type Compiler with
 
         static member CoreAssemblyNames = coreAssemblyNames
 
-        static member Language = _lang
-        /// Use this only once at the start of the program
-        static member SetLanguageUnsafe lang = _lang <- lang
+        static member Language = _language
+        static member CheckNulls = _checkNulls
+
+        /// Set these only once at the start of the program
+        static member SetLanguageUnsafe language = _language <- language
+        static member SetCheckNullsUnsafe enabled = _checkNulls <- enabled
 
         member com.GetEntity(entityRef: Fable.EntityRef) =
             match com.TryGetEntity(entityRef) with

--- a/src/Fable.Transforms/OverloadSuffix.fs
+++ b/src/Fable.Transforms/OverloadSuffix.fs
@@ -56,6 +56,15 @@ let private getConstraintHash genParams =
 
 let rec private getTypeFastFullName (genParams: IDictionary<_, _>) (t: Fable.Type) =
     match t with
+    | Fable.Nullable(genArg, isStruct) ->
+        let typeName = getTypeFastFullName genParams genArg
+
+        if isStruct then
+            $"System.Nullable<{typeName}>"
+        else
+            // there is no overload distinction for nullable reference types,
+            // so the name and overload suffix are the same as the inner type
+            typeName
     | Fable.Measure fullname -> fullname
     | Fable.GenericParam(name, isMeasure, constraints) ->
         if isMeasure then

--- a/src/Fable.Transforms/Php/Fable2Php.fs
+++ b/src/Fable.Transforms/Php/Fable2Php.fs
@@ -805,6 +805,7 @@ let rec convertTypeRef (com: IPhpCompiler) (t: Fable.Type) =
                 Namespace = Some "FSharpList"
                 Class = None
             }
+    | Fable.Nullable(t, _)
     | Fable.Option(t, _) ->
         ExType
             {

--- a/src/Fable.Transforms/Python/Fable2Python.Reflection.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.Reflection.fs
@@ -160,6 +160,7 @@ let transformTypeInfo (com: IPythonCompiler) ctx r (genMap: Map<string, Expressi
     | Fable.LambdaType(argType, returnType) -> genericTypeInfo "lambda" [| argType; returnType |]
     | Fable.DelegateType(argTypes, returnType) -> genericTypeInfo "delegate" [| yield! argTypes; yield returnType |]
     | Fable.Tuple(genArgs, _) -> genericTypeInfo "tuple" (List.toArray genArgs)
+    | Fable.Nullable(genArg, _) -> genericTypeInfo "option" [| genArg |]
     | Fable.Option(genArg, _) -> genericTypeInfo "option" [| genArg |]
     | Fable.Array(genArg, Fable.ArrayKind.ResizeArray) -> genericTypeInfo "list" [| genArg |]
     | Fable.Array(genArg, _) -> genericTypeInfo "array" [| genArg |]
@@ -336,6 +337,7 @@ let transformTypeTest (com: IPythonCompiler) ctx range expr (typ: Fable.Type) : 
     | Fable.List _ -> pyInstanceof (libValue com ctx "List" "FSharpList") expr
     | Fable.AnonymousRecordType _ -> warnAndEvalToFalse "anonymous records", []
     | Fable.MetaType -> pyInstanceof (libValue com ctx "Reflection" "TypeInfo") expr
+    | Fable.Nullable _ -> warnAndEvalToFalse "options", [] // TODO
     | Fable.Option _ -> warnAndEvalToFalse "options", [] // TODO
     | Fable.GenericParam _ -> warnAndEvalToFalse "generic parameters", []
     | Fable.DeclaredType(ent, genArgs) ->

--- a/src/Fable.Transforms/Replacements.Util.fs
+++ b/src/Fable.Transforms/Replacements.Util.fs
@@ -715,20 +715,6 @@ let (|IsEntity|_|) fullName =
             None
     | _ -> None
 
-let (|IsNullable|_|) =
-    function
-    | DeclaredType(entRef, [ genArg ]) ->
-        if entRef.FullName = Types.nullable then
-            Some(genArg)
-        else
-            None
-    | _ -> None
-
-let (|MaybeNullable|) =
-    function
-    | IsNullable(t) -> t
-    | t -> t
-
 let (|IDictionary|IEqualityComparer|Other|) =
     function
     | MaybeNullable(DeclaredType(entRef, _))

--- a/src/Fable.Transforms/Replacements.Util.fs
+++ b/src/Fable.Transforms/Replacements.Util.fs
@@ -715,8 +715,23 @@ let (|IsEntity|_|) fullName =
             None
     | _ -> None
 
+let (|IsNullable|_|) =
+    function
+    | DeclaredType(entRef, [ genArg ]) ->
+        if entRef.FullName = Types.nullable then
+            Some(genArg)
+        else
+            None
+    | _ -> None
+
+let (|MaybeNullable|) =
+    function
+    | IsNullable(t) -> t
+    | t -> t
+
 let (|IDictionary|IEqualityComparer|Other|) =
     function
+    | MaybeNullable(DeclaredType(entRef, _))
     | DeclaredType(entRef, _) ->
         match entRef.FullName with
         | Types.idictionary -> IDictionary
@@ -726,6 +741,7 @@ let (|IDictionary|IEqualityComparer|Other|) =
 
 let (|IEnumerable|IEqualityComparer|Other|) =
     function
+    | MaybeNullable(DeclaredType(entRef, _))
     | DeclaredType(entRef, _) ->
         match entRef.FullName with
         | Types.ienumerableGeneric -> IEnumerable
@@ -745,6 +761,7 @@ let (|Enumerator|Other|) =
 
 let (|IsEnumerator|_|) =
     function
+    | MaybeNullable(DeclaredType(entRef, genArgs))
     | DeclaredType(entRef, genArgs) ->
         match entRef.FullName with
         | Enumerator -> Some(entRef, genArgs)

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -549,7 +549,8 @@ let rec equals (com: ICompiler) ctx r equal (left: Expr) (right: Expr) =
     | Char
     | String
     | Number _
-    | MetaType ->
+    | MetaType
+    | IsEntity (Types.nullable) _ ->
         let op =
             if equal then
                 BinaryEqual
@@ -977,6 +978,7 @@ let rec defaultof (com: ICompiler) (ctx: Context) r t =
     | Builtin BclDateOnly
     | Builtin BclTimeOnly -> getZero com ctx t
     | Builtin BclGuid -> emptyGuid ()
+    | IsEntity (Types.nullable) _ -> Value(Null t, r)
     | DeclaredType(entRef, _) ->
         let ent = com.GetEntity(entRef)
         // TODO: For BCL types we cannot access the constructor, raise error or warning?
@@ -2296,8 +2298,7 @@ let results (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (_: Expr o
 let nullables (com: ICompiler) (_: Context) r (t: Type) (i: CallInfo) (thisArg: Expr option) (args: Expr list) =
     match i.CompiledName, thisArg with
     | ".ctor", None -> List.tryHead args
-    // | "get_Value", Some c -> Get(c, OptionValue, t, r) |> Some // Get(OptionValue) doesn't do a null check
-    | "get_Value", Some c -> Helper.LibCall(com, "Option", "value", t, [ c ], ?loc = r) |> Some
+    | "get_Value", Some c -> Helper.LibCall(com, "Option", "nullableValue", t, [ c ], ?loc = r) |> Some
     | "get_HasValue", Some c -> Test(c, OptionTest true, r) |> Some
     | _ -> None
 

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -991,6 +991,7 @@ let rec defaultof (com: ICompiler) (ctx: Context) r t =
             // Null t |> makeValue None
             Helper.LibCall(com, "Util", "defaultOf", t, [], ?loc = r)
         )
+    | Nullable _ -> Value(Null Any, None) // null
     // TODO: Fail (or raise warning) if this is an unresolved generic parameter?
     | _ ->
         // Null t |> makeValue None

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -550,7 +550,7 @@ let rec equals (com: ICompiler) ctx r equal (left: Expr) (right: Expr) =
     | String
     | Number _
     | MetaType
-    | IsEntity (Types.nullable) _ ->
+    | IsNullable _ ->
         let op =
             if equal then
                 BinaryEqual
@@ -978,7 +978,7 @@ let rec defaultof (com: ICompiler) (ctx: Context) r t =
     | Builtin BclDateOnly
     | Builtin BclTimeOnly -> getZero com ctx t
     | Builtin BclGuid -> emptyGuid ()
-    | IsEntity (Types.nullable) _ -> Value(Null t, r)
+    | IsNullable _ -> Value(Null t, r)
     | DeclaredType(entRef, _) ->
         let ent = com.GetEntity(entRef)
         // TODO: For BCL types we cannot access the constructor, raise error or warning?
@@ -1744,13 +1744,13 @@ let strings (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr opt
     | "Join", None, _ ->
         let methName =
             match i.SignatureArgTypes with
-            | [ _; Array _; Number _; Number _ ] -> "joinWithIndices"
+            | [ _; MaybeNullable(Array _); Number _; Number _ ] -> "joinWithIndices"
             | _ -> "join"
 
         Helper.LibCall(com, "String", methName, t, args, ?loc = r) |> Some
     | "Concat", None, _ ->
         match i.SignatureArgTypes with
-        | [ Array _ | IEnumerable ] ->
+        | [ MaybeNullable(Array _) | MaybeNullable(IEnumerable) ] ->
             Helper.LibCall(com, "String", "join", t, ((makeStrConst "") :: args), ?loc = r)
             |> Some
         | _ ->

--- a/src/Fable.Transforms/Rust/Fable2Rust.fs
+++ b/src/Fable.Transforms/Rust/Fable2Rust.fs
@@ -956,6 +956,11 @@ module TypeInfo =
         | Fable.Operation(Fable.Unary(UnaryOperator.UnaryAddressOf, e), _, _, _) -> true
         | _ -> false
 
+    let isNullableType (com: IRustCompiler) =
+        function
+        | Replacements.Util.IsNullable _ -> true
+        | _ -> false
+
     let isByRefType (com: IRustCompiler) =
         function
         | Replacements.Util.IsByRefType com _ -> true
@@ -991,17 +996,17 @@ module TypeInfo =
            && not (Set.contains name ctx.ScopedEntityGenArgs)
            && not (Set.contains name ctx.ScopedMemberGenArgs)
 
-    let isNullableReferenceType com ctx constraints =
-        let isNullable = constraints |> List.contains Fable.Constraint.IsNullable
-        let isNotNullable = constraints |> List.contains Fable.Constraint.IsNotNullable
-        let isReferenceType = constraints |> List.contains Fable.Constraint.IsReferenceType
-        isNullable || isNotNullable && isReferenceType
+    // let isNullableReferenceType com ctx constraints =
+    //     let isNullable = constraints |> List.contains Fable.Constraint.IsNullable
+    //     let isNotNullable = constraints |> List.contains Fable.Constraint.IsNotNullable
+    //     let isReferenceType = constraints |> List.contains Fable.Constraint.IsReferenceType
+    //     isNullable || isNotNullable && isReferenceType
 
     let transformGenericParamType com ctx name isMeasure constraints : Rust.Ty =
-        // if isNullableReferenceType com ctx constraints then
-        //     // primitiveType name |> makeNullableTy com ctx
-        //     primitiveType name |> makeLrcPtrTy com ctx
-        // elif
+        // if Compiler.CheckNulls && isNullableReferenceType com ctx constraints then
+        //     primitiveType name |> makeNullableTy com ctx
+        //     // primitiveType name |> makeLrcPtrTy com ctx
+        // else
         if isInferredGenericParam com ctx name isMeasure then
             mkInferTy () // mkNeverTy ()
         else
@@ -1058,7 +1063,7 @@ module TypeInfo =
             | Fable.List genArg -> transformListType com ctx genArg
             | Fable.Regex -> transformRegexType com ctx
             | Fable.AnonymousRecordType(fieldNames, genArgs, isStruct) -> transformTupleType com ctx isStruct genArgs
-            | Replacements.Util.IsEntity (Types.nullable) (entRef, [ genArg ]) -> transformNullableType com ctx genArg
+            | Replacements.Util.IsNullable genArg -> transformNullableType com ctx genArg
 
             // interfaces implemented as the type itself
             | Replacements.Util.IsEntity (Types.iset) (entRef, [ genArg ]) -> transformHashSetType com ctx genArg
@@ -2788,34 +2793,47 @@ module Util =
         exprs |> List.map (transformAsStmt com ctx) |> mkStmtBlockExpr
 
     let transformIfThenElse (com: IRustCompiler) ctx range guard thenBody elseBody =
-        // match canTransformDecisionTreeAsSwitch guard thenBody elseBody with
-        // | Some(evalExpr, cases, defaultCase) ->
-        //     transformSwitch com ctx evalExpr cases (Some defaultCase)
-        // | _ ->
-        let guardExpr =
-            match guard with
-            | Fable.Test(expr, Fable.TypeTest typ, r) -> transformTypeTest com ctx r true typ expr
-            | Fable.Test(expr, Fable.OptionTest isSome, r) -> makeOptionTest com ctx r isSome expr
-            | Fable.Test(expr, Fable.UnionCaseTest tag, r) -> makeUnionCaseTest com ctx r tag expr
-            | _ -> transformLeaveContext com ctx None guard
-
-        let thenExpr =
-            let ctx =
-                match guard with
-                // | Fable.Test(Fable.IdentExpr ident, Fable.OptionTest _, _)
-                | Fable.Test(Fable.IdentExpr ident, Fable.UnionCaseTest _, _) ->
-                    // add scoped ident to ctx for thenBody
-                    let usages = calcIdentUsages [ ident ] [ thenBody ]
-                    getScopedIdentCtx com ctx ident true false false false usages
-                | _ -> ctx
-
-            transformLeaveContext com ctx None thenBody
-
-        match elseBody with
-        | Fable.Value(Fable.UnitConstant, _) -> mkIfThenExpr guardExpr thenExpr // ?loc=range)
-        | _ ->
+        // transform nullable types null check
+        match guard with
+        | Fable.Test(Fable.IdentExpr ident, Fable.OptionTest false, r) when isNullableType com ident.Type ->
+            let value = transformIdentGet com ctx r ident
+            let pat = makeUnionCasePat (rawIdent "Some") [ makeFullNameIdentPat ident.Name ]
+            let letExpr = mkLetExpr pat value
+            let thenExpr = transformLeaveContext com ctx None thenBody
             let elseExpr = transformLeaveContext com ctx None elseBody
-            mkIfThenElseExpr guardExpr thenExpr elseExpr // ?loc=range)
+
+            match thenBody with
+            | Fable.Value(Fable.UnitConstant, _) -> mkIfThenExpr letExpr elseExpr // ?loc=range)
+            | _ -> mkIfThenElseExpr letExpr elseExpr thenExpr // ?loc=range)
+        | _ ->
+            // match canTransformDecisionTreeAsSwitch guard thenBody elseBody with
+            // | Some(evalExpr, cases, defaultCase) ->
+            //     transformSwitch com ctx evalExpr cases (Some defaultCase)
+            // | _ ->
+            let guardExpr =
+                match guard with
+                | Fable.Test(expr, Fable.TypeTest typ, r) -> transformTypeTest com ctx r true typ expr
+                | Fable.Test(expr, Fable.OptionTest isSome, r) -> makeOptionTest com ctx r isSome expr
+                | Fable.Test(expr, Fable.UnionCaseTest tag, r) -> makeUnionCaseTest com ctx r tag expr
+                | _ -> transformLeaveContext com ctx None guard
+
+            let thenExpr =
+                let ctx =
+                    match guard with
+                    // | Fable.Test(Fable.IdentExpr ident, Fable.OptionTest _, _)
+                    | Fable.Test(Fable.IdentExpr ident, Fable.UnionCaseTest _, _) ->
+                        // add scoped ident to ctx for thenBody
+                        let usages = calcIdentUsages [ ident ] [ thenBody ]
+                        getScopedIdentCtx com ctx ident true false false false usages
+                    | _ -> ctx
+
+                transformLeaveContext com ctx None thenBody
+
+            match elseBody with
+            | Fable.Value(Fable.UnitConstant, _) -> mkIfThenExpr guardExpr thenExpr // ?loc=range)
+            | _ ->
+                let elseExpr = transformLeaveContext com ctx None elseBody
+                mkIfThenElseExpr guardExpr thenExpr elseExpr // ?loc=range)
 
     let transformWhileLoop (com: IRustCompiler) ctx range guard body =
         let guardExpr = transformExpr com ctx guard
@@ -4851,17 +4869,6 @@ module Util =
         let ofTrait = mkTraitRef path |> Some
         let implItem = memberItems |> makeTraitImpl com ctx entName genArgs ofTrait
         [ implItem ]
-
-    // let objectMemberNames =
-    //     set
-    //         [
-    //             // "Equals"
-    //             // "GetHashCode"
-    //             // "MemberwiseClone"
-    //             // "ReferenceEquals"
-    //             "GetType"
-    //             "ToString"
-    //         ]
 
     let findInterfaceGenArgs (com: IRustCompiler) (ent: Fable.Entity) (ifcEntRef: Fable.EntityRef) =
         let ifcOpt =

--- a/src/Fable.Transforms/Rust/Replacements.fs
+++ b/src/Fable.Transforms/Rust/Replacements.fs
@@ -2882,6 +2882,7 @@ let getArgsSuffix (thisArg: Expr option) (args: Expr list) =
                 | GenericParam _ -> 'g'
                 | DeclaredType _ -> '_'
                 | AnonymousRecordType _ -> '_'
+                | Nullable _ -> '_'
         |]
 
     System.String(chars)

--- a/src/Fable.Transforms/Rust/Replacements.fs
+++ b/src/Fable.Transforms/Rust/Replacements.fs
@@ -483,8 +483,8 @@ let equals (com: ICompiler) ctx r (left: Expr) (right: Expr) =
     // | MetaType ->
     //     Helper.LibCall(com, "Reflection", "equals", t, [left; right], ?loc=r)
     | HasReferenceEquality com _ -> referenceEquals com ctx r left right
-    | IsNullable _ ->
-        // transforms null check into option test
+    | Nullable _ ->
+        // transforms null checks into option tests
         match left, right with
         | expr, Value(NewOption(None, _, _), _) -> Test(expr, OptionTest false, r)
         | Value(NewOption(None, _, _), _), expr -> Test(expr, OptionTest false, r)
@@ -567,15 +567,14 @@ let applyCompareOp (com: ICompiler) (ctx: Context) r t opName (left: Expr) (righ
 //     let body = equals com ctx None (IdentExpr x) (IdentExpr y)
 //     Delegate([x; y], body, None, Tags.empty)
 
-let makeEqualityComparer (com: ICompiler) ctx typArg =
-    let x = makeUniqueIdent ctx typArg "x"
-    let y = makeUniqueIdent ctx typArg "y"
-
-    objExpr
-        [
-            "Equals", Delegate([ x; y ], equals com ctx None (IdentExpr x) (IdentExpr y), None, Tags.empty)
-            "GetHashCode", Delegate([ x ], getHashCode com ctx None (IdentExpr x), None, Tags.empty)
-        ]
+// let makeEqualityComparer (com: ICompiler) ctx typArg =
+//     let x = makeUniqueIdent ctx typArg "x"
+//     let y = makeUniqueIdent ctx typArg "y"
+//     objExpr
+//         [
+//             "Equals", Delegate([ x; y ], equals com ctx None (IdentExpr x) (IdentExpr y), None, Tags.empty)
+//             "GetHashCode", Delegate([ x ], getHashCode com ctx None (IdentExpr x), None, Tags.empty)
+//         ]
 
 // // TODO: Try to detect at compile-time if the object already implements `Compare`?
 // let inline makeComparerFromEqualityComparer e =
@@ -625,6 +624,7 @@ let makeMap (com: ICompiler) ctx r t args genArg =
 
 let rec getZero (com: ICompiler) (ctx: Context) (t: Type) =
     match t with
+    | Nullable(genArg, _) -> NewOption(None, genArg, false) |> makeValue None
     | Boolean -> makeBoolConst false
     | Number(BigInt, _) -> Helper.LibCall(com, "BigInt", "zero", t, [])
     | Number(Decimal, _) -> Helper.LibValue(com, "Decimal", "Zero", t)
@@ -641,7 +641,6 @@ let rec getZero (com: ICompiler) (ctx: Context) (t: Type) =
     | Builtin BclGuid -> Helper.LibValue(com, "Guid", "empty", t)
     | Builtin(BclKeyValuePair(k, v)) -> makeTuple None true [ getZero com ctx k; getZero com ctx v ]
     | ListSingleton(CustomOp com ctx None t "get_Zero" [] e) -> e
-    | IsNullable genArg -> NewOption(None, genArg, false) |> makeValue None
     | HasReferenceEquality com _ -> Null t |> makeValue None
     | _ -> Helper.LibCall(com, "Native", "getZero", t, [])
 
@@ -1288,8 +1287,8 @@ let strings (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr opt
     | ".ctor", _, _ ->
         match i.SignatureArgTypes with
         | [ Char; Number(Int32, _) ] -> Helper.LibCall(com, "String", "fromChar", t, args, ?loc = r) |> Some
-        | [ Array(Char, _) ] -> Helper.LibCall(com, "String", "fromChars", t, args, ?loc = r) |> Some
-        | [ Array(Char, _); Number(Int32, _); Number(Int32, _) ] ->
+        | [ MaybeNullable(Array(Char, _)) ] -> Helper.LibCall(com, "String", "fromChars", t, args, ?loc = r) |> Some
+        | [ MaybeNullable(Array(Char, _)); Number(Int32, _); Number(Int32, _) ] ->
             Helper.LibCall(com, "String", "fromChars2", t, args, ?loc = r) |> Some
         | _ -> None
     | "get_Length", Some c, _ -> Helper.LibCall(com, "String", "length", t, c :: args, ?loc = r) |> Some
@@ -2856,6 +2855,28 @@ let activator (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr o
 
 // alternative member suffix for languages that don't support member overloads
 let getArgsSuffix (thisArg: Expr option) (args: Expr list) =
+    let rec typeSuffix =
+        function
+        | Nullable(t, _) -> typeSuffix t // suffix from the actual type
+        | Measure _ -> '_'
+        | MetaType -> '_'
+        | Any -> '_'
+        | Unit -> 'u'
+        | Boolean -> 'b'
+        | Char -> 'c'
+        | String -> 's'
+        | Regex -> 'r'
+        | Number _ -> 'n'
+        | Option _ -> 'o'
+        | Tuple _ -> 't'
+        | Array _ -> 'a'
+        | List _ -> 'l'
+        | LambdaType _ -> 'f'
+        | DelegateType _ -> 'f'
+        | GenericParam _ -> 'g'
+        | DeclaredType _ -> '_'
+        | AnonymousRecordType _ -> '_'
+
     let chars =
         [|
             if thisArg.IsNone then
@@ -2863,26 +2884,7 @@ let getArgsSuffix (thisArg: Expr option) (args: Expr list) =
             if args.Length > 0 then
                 '_'
             for arg in args do
-                match arg.Type with
-                | Measure _ -> '_'
-                | MetaType -> '_'
-                | Any -> '_'
-                | Unit -> 'u'
-                | Boolean -> 'b'
-                | Char -> 'c'
-                | String -> 's'
-                | Regex -> 'r'
-                | Number _ -> 'n'
-                | Option _ -> 'o'
-                | Tuple _ -> 't'
-                | Array _ -> 'a'
-                | List _ -> 'l'
-                | LambdaType _ -> 'f'
-                | DelegateType _ -> 'f'
-                | GenericParam _ -> 'g'
-                | DeclaredType _ -> '_'
-                | AnonymousRecordType _ -> '_'
-                | Nullable _ -> '_'
+                typeSuffix arg.Type
         |]
 
     System.String(chars)

--- a/src/Fable.Transforms/State.fs
+++ b/src/Fable.Transforms/State.fs
@@ -4,6 +4,7 @@ open Fable
 open Fable.AST
 open System.Collections.Concurrent
 open System.Collections.Generic
+open FSharp.Compiler.CodeAnalysis
 open FSharp.Compiler.Symbols
 open System
 
@@ -169,8 +170,8 @@ type PrecompiledInfo =
 type Project
     private
     (
-        projFile: string,
-        sourceFiles: string[],
+        projectFile: string,
+        projectOptions: FSharpProjectOptions,
         implFiles: Map<string, ImplFile>,
         assemblies: Assemblies,
         ?precompiledInfo: PrecompiledInfo
@@ -192,8 +193,8 @@ type Project
 
     static member From
         (
-            projFile: string,
-            sourceFiles: string[],
+            projectFile: string,
+            projectOptions: FSharpProjectOptions,
             fsharpFiles: FSharpImplementationFileContents list,
             fsharpAssemblies: FSharpAssembly list,
             addLog: Severity -> string -> unit,
@@ -201,6 +202,9 @@ type Project
             ?precompiledInfo: PrecompiledInfo
         )
         =
+
+        let checknulls = projectOptions.OtherOptions |> Array.exists ((=) "--checknulls+")
+        Compiler.SetCheckNullsUnsafe checknulls // set it one time only as early as possible
 
         let getPlugin = defaultArg getPlugin (fun _ -> failwith "Plugins are not supported")
 
@@ -215,7 +219,7 @@ type Project
             )
             |> Map
 
-        Project(projFile, sourceFiles, implFilesMap, assemblies, ?precompiledInfo = precompiledInfo)
+        Project(projectFile, projectOptions, implFilesMap, assemblies, ?precompiledInfo = precompiledInfo)
 
     member this.Update(files: FSharpImplementationFileContents list) =
         let implFiles =
@@ -226,7 +230,7 @@ type Project
                 Map.add key file implFiles
             )
 
-        Project(this.ProjectFile, this.SourceFiles, implFiles, this.Assemblies, this.PrecompiledInfo)
+        Project(this.ProjectFile, this.ProjectOptions, implFiles, this.Assemblies, this.PrecompiledInfo)
 
     member _.TryGetInlineExpr(com: Compiler, memberUniqueName: string) =
         inlineExprsDic
@@ -240,8 +244,8 @@ type Project
             implFile.InlineExprs
             |> List.mapToArray (fun (uniqueName, expr) -> uniqueName, expr.Calculate(com))
 
-    member _.ProjectFile = projFile
-    member _.SourceFiles = sourceFiles
+    member _.ProjectFile = projectFile
+    member _.ProjectOptions = projectOptions
     member _.ImplementationFiles = implFiles
     member _.Assemblies = assemblies
     member _.PrecompiledInfo = precompiledInfo
@@ -303,7 +307,7 @@ type CompilerImpl
         member _.OutputDir = outDir
         member _.OutputType = outType
         member _.ProjectFile = project.ProjectFile
-        member _.SourceFiles = project.SourceFiles
+        member _.SourceFiles = project.ProjectOptions.SourceFiles
 
         member _.IncrementCounter() =
             counter <- counter + 1

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -1357,6 +1357,7 @@ module AST =
             && listEquals (typeEquals strict) gen1 gen2
             && isStruct1 = isStruct2
         | Measure _, Measure _ -> true
+        | Nullable typ1, Nullable typ2 -> typeEquals strict typ1 typ2
         | _ -> false
 
     let rec getEntityFullName prettify (entRef: EntityRef) gen =

--- a/src/fable-library-rust/Cargo.toml
+++ b/src/fable-library-rust/Cargo.toml
@@ -31,7 +31,7 @@ rust_decimal = { version = "1.37", features = ["maths"], default-features = fals
 startup = { version = "0.1", path = "vendored/startup", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-uuid = { version = "1.16", features = ["v4"], default-features = false, optional = true }
+uuid = { version = "1.17", features = ["v4"], default-features = false, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-uuid = { version = "1.16", features = ["v4", "js"], default-features = false, optional = true }
+uuid = { version = "1.17", features = ["v4", "js"], default-features = false, optional = true }

--- a/src/fable-library-rust/src/Array.fs
+++ b/src/fable-library-rust/src/Array.fs
@@ -981,7 +981,7 @@ let distinct<'T when 'T: equality> (xs: 'T[]) : 'T[] =
     let hashSet = System.Collections.Generic.HashSet<'T>()
     xs |> filter (fun x -> hashSet.Add(x))
 
-let distinctBy<'T, 'Key when 'Key: equality> (projection: 'T -> 'Key) (xs: 'T[]) : 'T[] =
+let distinctBy<'T, 'Key when 'Key: equality and 'Key: not null> (projection: 'T -> 'Key) (xs: 'T[]) : 'T[] =
     let hashSet = System.Collections.Generic.HashSet<'Key>()
     xs |> filter (fun x -> hashSet.Add(projection x))
 
@@ -989,7 +989,7 @@ let except<'T when 'T: equality> (itemsToExclude: seq<'T>) (xs: 'T[]) : 'T[] =
     let hashSet = System.Collections.Generic.HashSet<'T>(itemsToExclude)
     xs |> filter (fun x -> hashSet.Add(x))
 
-let countBy<'T, 'Key when 'Key: equality> (projection: 'T -> 'Key) (xs: 'T[]) : ('Key * int)[] =
+let countBy<'T, 'Key when 'Key: equality and 'Key: not null> (projection: 'T -> 'Key) (xs: 'T[]) : ('Key * int)[] =
     let dict = System.Collections.Generic.Dictionary<'Key, int>()
     let keys = ResizeArray<'Key>()
 
@@ -1004,7 +1004,7 @@ let countBy<'T, 'Key when 'Key: equality> (projection: 'T -> 'Key) (xs: 'T[]) : 
 
     keys |> asArray |> map (fun key -> key, dict[key])
 
-let groupBy<'T, 'Key when 'Key: equality> (projection: 'T -> 'Key) (xs: 'T[]) : ('Key * 'T[])[] =
+let groupBy<'T, 'Key when 'Key: equality and 'Key: not null> (projection: 'T -> 'Key) (xs: 'T[]) : ('Key * 'T[])[] =
     let dict = System.Collections.Generic.Dictionary<'Key, ResizeArray<'T>>()
     let keys = ResizeArray<'Key>()
 

--- a/src/fable-library-rust/src/FSharp.Core.fs
+++ b/src/fable-library-rust/src/FSharp.Core.fs
@@ -1,19 +1,32 @@
 namespace FSharp.Core
 
 module LanguagePrimitives =
+
+    // let GenericEquality<'T> (x: 'T) (y: 'T) : bool =
+    //     System.Collections.Generic.EqualityComparer<'T>.Default.Equals(x, y)
+
+    // let GenericEqualityIntrinsic<'T> (x: 'T) (y: 'T) : bool =
+    //     System.Collections.Generic.EqualityComparer<'T>.Default.Equals(x, y)
+
+    // let GenericComparison<'T> (x: 'T) (y: 'T) : int =
+    //     System.Collections.Generic.Comparer<'T>.Default.Compare(x, y)
+
+    // let GenericComparisonIntrinsic<'T> (x: 'T) (y: 'T) : int =
+    //     System.Collections.Generic.Comparer<'T>.Default.Compare(x, y)
+
     let GenericEqualityComparer =
         { new System.Collections.IEqualityComparer with
-            override __.Equals(x: obj, y: obj) = LanguagePrimitives.GenericEquality x y
+            override _.Equals(x: obj, y: obj) = LanguagePrimitives.GenericEquality x y
 
-            override __.GetHashCode(x: obj) = LanguagePrimitives.GenericHash x
+            override _.GetHashCode(x: obj) = LanguagePrimitives.GenericHash x
         }
 
     let GenericEqualityERComparer =
         { new System.Collections.IEqualityComparer with
-            override __.Equals(x: obj, y: obj) =
+            override _.Equals(x: obj, y: obj) =
                 LanguagePrimitives.GenericEqualityER x y
 
-            override __.GetHashCode(x: obj) = LanguagePrimitives.GenericHash x
+            override _.GetHashCode(x: obj) = LanguagePrimitives.GenericHash x
         }
 
     let FastGenericComparer<'T when 'T: comparison> =

--- a/src/fable-library-rust/src/FSharp.Core.fs
+++ b/src/fable-library-rust/src/FSharp.Core.fs
@@ -51,13 +51,13 @@ module Operators =
     let lock _lockObj action = action () // no locking, just invoke
 
     [<CompiledName("IsNull")>]
-    let isNull (value: 'T) =
+    let isNull (value: 'T when 'T: null) =
         match value with
         | null -> true
         | _ -> false
 
     [<CompiledName("IsNotNull")>]
-    let isNotNull (value: 'T) =
+    let isNotNull (value: 'T when 'T: null) =
         match value with
         | null -> false
         | _ -> true
@@ -66,7 +66,7 @@ module Operators =
     let isNullV (value: System.Nullable<'T>) = not value.HasValue
 
     [<CompiledName("NonNull")>]
-    let nonNull (value: 'T) =
+    let nonNull (value: 'T when 'T: null) =
         match value with
         | null -> raise (System.NullReferenceException())
         | _ -> value
@@ -79,20 +79,20 @@ module Operators =
             raise (System.NullReferenceException())
 
     [<CompiledName("NullMatchPattern")>]
-    let (|Null|NonNull|) (value: 'T) =
+    let (|Null|NonNull|) (value: 'T when 'T: null) =
         match value with
         | null -> Null()
-        | _ -> NonNull value
+        | _ -> NonNull(value)
 
     [<CompiledName("NullValueMatchPattern")>]
     let (|NullV|NonNullV|) (value: System.Nullable<'T>) =
         if value.HasValue then
-            NonNullV value.Value
+            NonNullV(value.Value)
         else
             NullV()
 
     [<CompiledName("NonNullQuickPattern")>]
-    let (|NonNullQuick|) (value: 'T) =
+    let (|NonNullQuick|) (value: 'T when 'T: null) =
         match value with
         | null -> raise (System.NullReferenceException())
         | _ -> value
@@ -105,7 +105,7 @@ module Operators =
             raise (System.NullReferenceException())
 
     [<CompiledName("WithNull")>]
-    let withNull (value: 'T) : 'T = value
+    let withNull (value: 'T when 'T: null) = value
 
     [<CompiledName("WithNullV")>]
     let withNullV (value: 'T) : System.Nullable<'T> = System.Nullable<'T>(value)
@@ -115,7 +115,7 @@ module Operators =
         System.Nullable<'T>()
 
     [<CompiledName("NullArgCheck")>]
-    let nullArgCheck (argumentName: string) (value: 'T) =
+    let nullArgCheck (argumentName: string) (value: 'T when 'T: null) =
         match value with
         | null -> raise (new System.ArgumentNullException(argumentName))
         | _ -> value

--- a/src/fable-library-rust/src/Fable.Library.Rust.fsproj
+++ b/src/fable-library-rust/src/Fable.Library.Rust.fsproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <DefineConstants>$(DefineConstants);FABLE_COMPILER</DefineConstants>
+    <!-- <Nullable>enable</Nullable> -->
+    <!-- <WarningsAsErrors>FS3261</WarningsAsErrors> -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/fable-library-rust/src/List.fs
+++ b/src/fable-library-rust/src/List.fs
@@ -817,7 +817,7 @@ let distinct<'T when 'T: equality> (xs: 'T list) : 'T list =
     let hashSet = System.Collections.Generic.HashSet<'T>()
     xs |> filter (fun x -> hashSet.Add(x))
 
-let distinctBy<'T, 'Key when 'Key: equality> (projection: 'T -> 'Key) (xs: 'T list) : 'T list =
+let distinctBy<'T, 'Key when 'Key: equality and 'Key: not null> (projection: 'T -> 'Key) (xs: 'T list) : 'T list =
     let hashSet = System.Collections.Generic.HashSet<'Key>()
     xs |> filter (fun x -> hashSet.Add(projection x))
 
@@ -825,7 +825,11 @@ let except<'T when 'T: equality> (itemsToExclude: seq<'T>) (xs: 'T list) : 'T li
     let hashSet = System.Collections.Generic.HashSet<'T>(itemsToExclude)
     xs |> filter (fun x -> hashSet.Add(x))
 
-let countBy<'T, 'Key when 'Key: equality> (projection: 'T -> 'Key) (xs: 'T list) : ('Key * int) list =
+let countBy<'T, 'Key when 'Key: equality and 'Key: not null>
+    (projection: 'T -> 'Key)
+    (xs: 'T list)
+    : ('Key * int) list
+    =
     let dict = System.Collections.Generic.Dictionary<'Key, int>()
     let keys = ResizeArray<'Key>()
 
@@ -842,7 +846,11 @@ let countBy<'T, 'Key when 'Key: equality> (projection: 'T -> 'Key) (xs: 'T list)
 
     keys |> asArray |> Array.map (fun key -> key, dict[key]) |> ofArray
 
-let groupBy<'T, 'Key when 'Key: equality> (projection: 'T -> 'Key) (xs: 'T list) : ('Key * 'T list) list =
+let groupBy<'T, 'Key when 'Key: equality and 'Key: not null>
+    (projection: 'T -> 'Key)
+    (xs: 'T list)
+    : ('Key * 'T list) list
+    =
     let dict = System.Collections.Generic.Dictionary<'Key, ResizeArray<'T>>()
     let keys = ResizeArray<'Key>()
 

--- a/src/fable-library-rust/src/Seq.fs
+++ b/src/fable-library-rust/src/Seq.fs
@@ -1252,26 +1252,26 @@ let chunkBySize (chunkSize: int) (xs: 'T seq) : 'T[] seq =
 
 let distinct<'T when 'T: equality> (xs: 'T seq) =
     delay (fun () ->
-        let hashSet = System.Collections.Generic.HashSet<'T>()
+        let hashSet = HashSet<'T>()
         xs |> filter (fun x -> hashSet.Add(x))
     )
 
-let distinctBy<'T, 'Key when 'Key: equality> (projection: 'T -> 'Key) (xs: 'T seq) =
+let distinctBy<'T, 'Key when 'Key: equality and 'Key: not null> (projection: 'T -> 'Key) (xs: 'T seq) =
     delay (fun () ->
-        let hashSet = System.Collections.Generic.HashSet<'Key>()
+        let hashSet = HashSet<'Key>()
         xs |> filter (fun x -> hashSet.Add(projection x))
     )
 
 let except<'T when 'T: equality> (itemsToExclude: 'T seq) (xs: 'T seq) =
     delay (fun () ->
-        let hashSet = System.Collections.Generic.HashSet<'T>(toArray itemsToExclude)
+        let hashSet = HashSet<'T>(toArray itemsToExclude)
 
         xs |> filter (fun x -> hashSet.Add(x))
     )
 
-let countBy<'T, 'Key when 'Key: equality> (projection: 'T -> 'Key) (xs: 'T seq) : ('Key * int) seq =
+let countBy<'T, 'Key when 'Key: equality and 'Key: not null> (projection: 'T -> 'Key) (xs: 'T seq) : ('Key * int) seq =
     delay (fun () ->
-        let dict = System.Collections.Generic.Dictionary<'Key, int>()
+        let dict = Dictionary<'Key, int>()
         let keys = ResizeArray<'Key>()
 
         for x in xs do
@@ -1286,10 +1286,13 @@ let countBy<'T, 'Key when 'Key: equality> (projection: 'T -> 'Key) (xs: 'T seq) 
         keys |> asArray |> Array.map (fun key -> key, dict[key]) |> ofArray
     )
 
-let groupBy<'T, 'Key when 'Key: equality> (projection: 'T -> 'Key) (xs: 'T seq) : ('Key * 'T seq) seq =
+let groupBy<'T, 'Key when 'Key: equality and 'Key: not null>
+    (projection: 'T -> 'Key)
+    (xs: 'T seq)
+    : ('Key * 'T seq) seq
+    =
     delay (fun () ->
-        let dict = System.Collections.Generic.Dictionary<'Key, ResizeArray<'T>>()
-
+        let dict = Dictionary<'Key, ResizeArray<'T>>()
         let keys = ResizeArray<'Key>()
 
         for x in xs do

--- a/src/fable-library-ts/Array.fs
+++ b/src/fable-library-ts/Array.fs
@@ -761,12 +761,12 @@ let splitAt (index: int) (array: 'T[]) : 'T[] * 'T[] =
 // Note that, though it's not consistent with `compare` operator,
 // Array.compareWith doesn't compare first the length, see #2961
 let compareWith (comparer: 'T -> 'T -> int) (source1: 'T[]) (source2: 'T[]) =
-    if isNull source1 then
-        if isNull source2 then
+    if isNull (box source1) then
+        if isNull (box source2) then
             0
         else
             -1
-    elif isNull source2 then
+    elif isNull (box source2) then
         1
     else
         let len1 = source1.Length
@@ -795,12 +795,12 @@ let compareWith (comparer: 'T -> 'T -> int) (source1: 'T[]) (source2: 'T[]) =
             0
 
 let compareTo (comparer: 'T -> 'T -> int) (source1: 'T[]) (source2: 'T[]) =
-    if isNull source1 then
-        if isNull source2 then
+    if isNull (box source1) then
+        if isNull (box source2) then
             0
         else
             -1
-    elif isNull source2 then
+    elif isNull (box source2) then
         1
     else
         let len1 = source1.Length
@@ -820,19 +820,19 @@ let compareTo (comparer: 'T -> 'T -> int) (source1: 'T[]) (source2: 'T[]) =
 
             res
 
-let equalsWith (equals: 'T -> 'T -> bool) (array1: 'T[]) (array2: 'T[]) =
-    if isNull array1 then
-        if isNull array2 then
+let equalsWith (equals: 'T -> 'T -> bool) (source1: 'T[]) (source2: 'T[]) =
+    if isNull (box source1) then
+        if isNull (box source2) then
             true
         else
             false
-    elif isNull array2 then
+    elif isNull (box source2) then
         false
     else
         let mutable i = 0
         let mutable result = true
-        let length1 = array1.Length
-        let length2 = array2.Length
+        let length1 = source1.Length
+        let length2 = source2.Length
 
         if length1 > length2 then
             false
@@ -840,7 +840,7 @@ let equalsWith (equals: 'T -> 'T -> bool) (array1: 'T[]) (array2: 'T[]) =
             false
         else
             while i < length1 && result do
-                result <- equals array1.[i] array2.[i]
+                result <- equals source1.[i] source2.[i]
                 i <- i + 1
 
             result
@@ -1249,7 +1249,7 @@ let resize
 
     let zero = defaultArg zero Unchecked.defaultof<_>
 
-    if isNull xs then
+    if isNull (box xs) then
         xs <- fillImpl (allocateArrayFromCons cons newSize) zero 0 newSize
 
     else

--- a/src/fable-library-ts/FSharp.Core.fs
+++ b/src/fable-library-ts/FSharp.Core.fs
@@ -1,6 +1,7 @@
 namespace FSharp.Core
 
 module LanguagePrimitives =
+
     let GenericEqualityComparer =
         { new System.Collections.IEqualityComparer with
             override __.Equals(x: obj, y: obj) = LanguagePrimitives.GenericEquality x y

--- a/src/fable-library-ts/FSharp.Core.fs
+++ b/src/fable-library-ts/FSharp.Core.fs
@@ -1,5 +1,7 @@
 namespace FSharp.Core
 
+#nowarn "42" // This construct is deprecated: it is only for use in the F# library
+
 module LanguagePrimitives =
 
     let GenericEqualityComparer =

--- a/src/fable-library-ts/FSharp.Core.fs
+++ b/src/fable-library-ts/FSharp.Core.fs
@@ -51,7 +51,7 @@ module Operators =
     let lock _lockObj action = action () // no locking, just invoke
 
     [<CompiledName("IsNull")>]
-    let isNull (value: 'T) =
+    let isNull (value: 'T when 'T: null) =
         match box value with
         | null -> true
         | _ -> false
@@ -66,10 +66,10 @@ module Operators =
     let isNullV (value: System.Nullable<'T>) = not value.HasValue
 
     [<CompiledName("NonNull")>]
-    let nonNull (value: 'T) =
+    let nonNull (value: 'T | null when 'T: not null and 'T: not struct) =
         match box value with
         | null -> raise (System.NullReferenceException())
-        | _ -> value
+        | _ -> (# "" value : 'T #)
 
     [<CompiledName("NonNullV")>]
     let nonNullV (value: System.Nullable<'T>) =
@@ -79,10 +79,10 @@ module Operators =
             raise (System.NullReferenceException())
 
     [<CompiledName("NullMatchPattern")>]
-    let (|Null|NonNull|) (value: 'T) =
-        match box value with
+    let (|Null|NonNull|) (value: 'T | null when 'T: not null and 'T: not struct) =
+        match value with
         | null -> Null()
-        | _ -> NonNull value
+        | _ -> NonNull (# "" value : 'T #)
 
     [<CompiledName("NullValueMatchPattern")>]
     let (|NullV|NonNullV|) (value: System.Nullable<'T>) =
@@ -92,10 +92,10 @@ module Operators =
             NullV()
 
     [<CompiledName("NonNullQuickPattern")>]
-    let (|NonNullQuick|) (value: 'T) =
+    let (|NonNullQuick|) (value: 'T | null when 'T: not null and 'T: not struct) =
         match box value with
         | null -> raise (System.NullReferenceException())
-        | _ -> value
+        | _ -> (# "" value : 'T #)
 
     [<CompiledName("NonNullQuickValuePattern")>]
     let (|NonNullQuickV|) (value: System.Nullable<'T>) =
@@ -105,19 +105,20 @@ module Operators =
             raise (System.NullReferenceException())
 
     [<CompiledName("WithNull")>]
-    let withNull (value: 'T) : 'T = value
+    let withNull (value: 'T when 'T: not null and 'T: not struct) = (# "" value : 'T | null #)
 
     [<CompiledName("WithNullV")>]
     let withNullV (value: 'T) : System.Nullable<'T> = System.Nullable<'T>(value)
 
     [<CompiledName("NullV")>]
-    let nullV<'T when 'T: struct and 'T: (new: unit -> 'T) and 'T :> System.ValueType> () = System.Nullable<'T>()
+    let nullV<'T when 'T: struct and 'T: (new: unit -> 'T) and 'T :> System.ValueType> =
+        System.Nullable<'T>()
 
     [<CompiledName("NullArgCheck")>]
-    let nullArgCheck (argumentName: string) (value: 'T) =
-        match box value with
+    let nullArgCheck (argumentName: string) (value: 'T | null when 'T: not null and 'T: not struct) =
+        match value with
         | null -> raise (new System.ArgumentNullException($"Value cannot be null. (Parameter '{argumentName}')"))
-        | _ -> value
+        | _ -> (# "" value : 'T #)
 
 module ExtraTopLevelOperators =
     [<CompiledName("LazyPattern")>]

--- a/src/fable-library-ts/FSharp.Core.fs
+++ b/src/fable-library-ts/FSharp.Core.fs
@@ -111,8 +111,7 @@ module Operators =
     let withNullV (value: 'T) : System.Nullable<'T> = System.Nullable<'T>(value)
 
     [<CompiledName("NullV")>]
-    let nullV<'T when 'T: struct and 'T: (new: unit -> 'T) and 'T :> System.ValueType> =
-        System.Nullable<'T>()
+    let nullV<'T when 'T: struct and 'T: (new: unit -> 'T) and 'T :> System.ValueType> () = System.Nullable<'T>()
 
     [<CompiledName("NullArgCheck")>]
     let nullArgCheck (argumentName: string) (value: 'T) =

--- a/src/fable-library-ts/Fable.Library.TypeScript.fsproj
+++ b/src/fable-library-ts/Fable.Library.TypeScript.fsproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <!-- <WarningsAsErrors>FS3261</WarningsAsErrors> -->
     <DefineConstants>$(DefineConstants);FABLE_COMPILER</DefineConstants>
     <!-- <DefineConstants>$(DefineConstants);FX_NO_BIGINT</DefineConstants> -->
   </PropertyGroup>

--- a/src/fable-library-ts/Fable.Library.TypeScript.fsproj
+++ b/src/fable-library-ts/Fable.Library.TypeScript.fsproj
@@ -17,11 +17,6 @@
     <!-- <Compile Include="BigInt.fs" /> -->
     <!-- <Compile Include="BigInt/q.fsi"/> -->
     <!-- <Compile Include="BigInt/q.fs"/> -->
-    <Compile Include="SystemException.fs" />
-    <Compile Include="System.Text.fs" />
-    <Compile Include="System.Collections.Generic.fs" />
-    <Compile Include="FSharp.Collections.fs" />
-    <Compile Include="FSharp.Core.fs" />
     <Compile Include="Native.fs" />
     <Compile Include="MutableMap.fs" />
     <Compile Include="MutableSet.fs" />
@@ -35,7 +30,12 @@
     <Compile Include="Random.fs" />
     <Compile Include="Set.fs" />
     <Compile Include="Map.fs" />
+    <Compile Include="FSharp.Collections.fs" />
+    <Compile Include="FSharp.Core.fs" />
     <Compile Include="FSharp.Core.CompilerServices.fs" />
+    <Compile Include="System.Collections.Generic.fs" />
+    <Compile Include="System.Text.fs" />
+    <Compile Include="SystemException.fs" />
     <TypeScriptCompile Include="Async.ts" />
     <TypeScriptCompile Include="AsyncBuilder.ts" />
     <TypeScriptCompile Include="BitConverter.ts" />

--- a/src/fable-library-ts/Fable.Library.TypeScript.fsproj
+++ b/src/fable-library-ts/Fable.Library.TypeScript.fsproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <!-- <WarningsAsErrors>FS3261</WarningsAsErrors> -->
+    <WarningsAsErrors>FS3261</WarningsAsErrors>
     <DefineConstants>$(DefineConstants);FABLE_COMPILER</DefineConstants>
     <!-- <DefineConstants>$(DefineConstants);FX_NO_BIGINT</DefineConstants> -->
   </PropertyGroup>

--- a/src/fable-library-ts/MutableMap.fs
+++ b/src/fable-library-ts/MutableMap.fs
@@ -83,7 +83,7 @@ type MutableMap<'Key, 'Value when 'Key: equality>
     // Native JS Map (used for primitive keys) doesn't work with `JSON.stringify` but
     // let's add `toJSON` for consistency with the types within fable-library.
     interface Fable.Core.IJsonSerializable with
-        member this.toJSON() = Helpers.arrayFrom (this) |> box
+        member this.toJSON() = Helpers.arrayFrom (this)
 
 
     interface System.Collections.IEnumerable with

--- a/src/fable-library-ts/MutableSet.fs
+++ b/src/fable-library-ts/MutableSet.fs
@@ -70,7 +70,7 @@ type MutableSet<'T when 'T: equality>(items: 'T seq, comparer: IEqualityComparer
     // Native JS Set (used for primitive keys) doesn't work with `JSON.stringify` but
     // let's add `toJSON` for consistency with the types within fable-library.
     interface Fable.Core.IJsonSerializable with
-        member this.toJSON() = Helpers.arrayFrom (this) |> box
+        member this.toJSON() = Helpers.arrayFrom (this)
 
 
     interface System.Collections.IEnumerable with

--- a/src/fable-library-ts/Native.fs
+++ b/src/fable-library-ts/Native.fs
@@ -7,7 +7,7 @@ open System.Collections.Generic
 open Fable.Core
 open Fable.Core.JsInterop
 
-[<AllowNullLiteral; Erase>]
+[<Erase>]
 type Cons<'T> =
     [<Emit("new $0($1)")>]
     abstract Allocate: len: int -> 'T[]
@@ -22,11 +22,14 @@ module Helpers =
     [<Emit("new $0.constructor($1)")>]
     let allocateArrayFrom (xs: 'T[]) (len: int) : 'T[] = nativeOnly
 
-    let allocateArrayFromCons (cons: Cons<'T>) (len: int) : 'T[] =
-        if jsTypeof cons = "function" then
-            cons.Allocate(len)
-        else
-            JS.Constructors.Array.Create(len)
+    let allocateArrayFromCons (cons: Cons<'T> | null) (len: int) : 'T[] =
+        match cons with
+        | null -> JS.Constructors.Array.Create(len)
+        | cons ->
+            if jsTypeof cons = "function" then
+                cons.Allocate(len)
+            else
+                JS.Constructors.Array.Create(len)
 
     let inline isDynamicArrayImpl arr = JS.Constructors.Array.isArray arr
 

--- a/src/fable-library-ts/Option.ts
+++ b/src/fable-library-ts/Option.ts
@@ -1,4 +1,4 @@
-import { structuralHash, equals, compare } from "./Util.js";
+import { Nullable, structuralHash, equals, compare } from "./Util.js";
 
 // Options are erased in runtime by Fable, but we have
 // the `Some` type below to wrap values that would evaluate
@@ -11,8 +11,6 @@ import { structuralHash, equals, compare } from "./Util.js";
 
 // Note: We use non-strict null check for backwards compatibility with
 // code that use F# options to represent values that could be null in JS
-
-export type Nullable<T> = T | null | undefined;
 
 export type Option<T> = T | Some<T> | undefined;
 

--- a/src/fable-library-ts/Option.ts
+++ b/src/fable-library-ts/Option.ts
@@ -52,7 +52,7 @@ export class Some<T> {
   }
 }
 
-export function nullableValue<T>(x: Nullable<T>): T {
+export function nonNullValue<T>(x: Nullable<T>): T {
   if (x == null) {
     throw new Error("Nullable has no value");
   } else {

--- a/src/fable-library-ts/Option.ts
+++ b/src/fable-library-ts/Option.ts
@@ -54,6 +54,14 @@ export class Some<T> {
   }
 }
 
+export function nullableValue<T>(x: Nullable<T>): T {
+  if (x == null) {
+    throw new Error("Nullable has no value");
+  } else {
+    return x;
+  }
+}
+
 export function value<T>(x: Option<T>) {
   if (x == null) {
     throw new Error("Option has no value");

--- a/src/fable-library-ts/Random.fs
+++ b/src/fable-library-ts/Random.fs
@@ -10,7 +10,7 @@ module private Native =
 
     let randomNext (min: int, max: int) : int =
         emitJsStatement
-            ()
+            (box () |> nonNull)
             """
         if (max < min) {
             throw new Error("minValue must be less than maxValue");
@@ -20,7 +20,7 @@ module private Native =
 
     let randomBytes (buffer: byte array) : unit =
         emitJsStatement
-            ()
+            (box () |> nonNull)
             """
         if (buffer == null) {
             throw new Error("Buffer cannot be null");

--- a/src/fable-library-ts/Random.fs
+++ b/src/fable-library-ts/Random.fs
@@ -172,7 +172,7 @@ type Seeded(seed: int) =
         member this.NextDouble() = this.Sample()
 
         member this.NextBytes(buffer: byte array) =
-            if isNull buffer then
+            if isNull (box buffer) then
                 raise <| ArgumentNullException("buffer")
 
             for i = 0 to buffer.Length - 1 do

--- a/src/fable-library-ts/Seq.fs
+++ b/src/fable-library-ts/Seq.fs
@@ -285,15 +285,11 @@ module Enumerator =
 let indexNotFound () =
     raise (System.Collections.Generic.KeyNotFoundException(SR.keyNotFoundAlt))
 
-let checkNonNull argName arg =
-    if isNull arg then
-        nullArg argName
-
 let mkSeq (f: unit -> IEnumerator<'T>) : seq<'T> =
     Enumerator.Enumerable(f) :> IEnumerable<'T>
 
 let ofSeq (xs: seq<'T>) : IEnumerator<'T> =
-    checkNonNull "source" xs
+    let xs = nullArgCheck "source" xs
     xs.GetEnumerator()
 
 let delay (generator: unit -> seq<'T>) =
@@ -350,7 +346,7 @@ let append (xs: seq<'T>) (ys: seq<'T>) = concat [| xs; ys |]
 
 let cast (xs: IEnumerable<'T>) =
     mkSeq (fun () ->
-        checkNonNull "source" xs
+        let xs = nullArgCheck "source" xs
         xs.GetEnumerator() |> Enumerator.cast
     )
 
@@ -785,7 +781,7 @@ let map3 (mapping: 'T1 -> 'T2 -> 'T3 -> 'U) (xs: seq<'T1>) (ys: seq<'T2>) (zs: s
         )
 
 let readOnly (xs: seq<'T>) =
-    checkNonNull "source" xs
+    let xs = nullArgCheck "source" xs
     map id xs
 
 type CachedSeq<'T>(cleanup, res: seq<'T>) =
@@ -803,7 +799,7 @@ type CachedSeq<'T>(cleanup, res: seq<'T>) =
 
 // Adapted from https://github.com/dotnet/fsharp/blob/eb1337f218275da5294b5fbab2cf77f35ca5f717/src/fsharp/FSharp.Core/seq.fs#L971
 let cache (source: seq<'T>) =
-    checkNonNull "source" source
+    let source = nullArgCheck "source" source
     // Wrap a seq to ensure that it is enumerated just once and only as far as is necessary.
     //
     // This code is required to be thread safe.
@@ -1056,13 +1052,13 @@ let sortWith (comparer: 'T -> 'T -> int) (xs: seq<'T>) =
     )
 
 let sort (xs: seq<'T>) ([<Inject>] comparer: System.Collections.Generic.IComparer<'T>) =
-    sortWith (fun x y -> comparer.Compare(x, y)) xs
+    sortWith (fun (x: 'T) (y: 'T) -> comparer.Compare(x, y)) xs
 
 let sortBy (projection: 'T -> 'U) (xs: seq<'T>) ([<Inject>] comparer: System.Collections.Generic.IComparer<'U>) =
     sortWith (fun x y -> comparer.Compare(projection x, projection y)) xs
 
 let sortDescending (xs: seq<'T>) ([<Inject>] comparer: System.Collections.Generic.IComparer<'T>) =
-    sortWith (fun x y -> comparer.Compare(x, y) * -1) xs
+    sortWith (fun (x: 'T) (y: 'T) -> comparer.Compare(x, y) * -1) xs
 
 let sortByDescending
     (projection: 'T -> 'U)

--- a/src/fable-library-ts/Seq2.fs
+++ b/src/fable-library-ts/Seq2.fs
@@ -2,42 +2,38 @@
 module SeqModule2
 
 open Fable.Core
+open System.Collections.Generic
 
-let distinct (xs: seq<'T>) ([<Inject>] comparer: System.Collections.Generic.IEqualityComparer<'T>) =
+let distinct<'T> (xs: seq<'T>) ([<Inject>] comparer: IEqualityComparer<'T>) =
     Seq.delay (fun () ->
-        let hashSet = System.Collections.Generic.HashSet<'T>(comparer)
+        let hashSet = HashSet<'T>(comparer)
         xs |> Seq.filter (fun x -> hashSet.Add(x))
     )
 
-let distinctBy
+let distinctBy<'T, 'Key when 'Key: not null>
     (projection: 'T -> 'Key)
     (xs: seq<'T>)
-    ([<Inject>] comparer: System.Collections.Generic.IEqualityComparer<'Key>)
+    ([<Inject>] comparer: IEqualityComparer<'Key>)
     =
     Seq.delay (fun () ->
-        let hashSet = System.Collections.Generic.HashSet<'Key>(comparer)
+        let hashSet = HashSet<'Key>(comparer)
         xs |> Seq.filter (fun x -> hashSet.Add(projection x))
     )
 
-let except
-    (itemsToExclude: seq<'T>)
-    (xs: seq<'T>)
-    ([<Inject>] comparer: System.Collections.Generic.IEqualityComparer<'T>)
-    =
+let except<'T> (itemsToExclude: seq<'T>) (xs: seq<'T>) ([<Inject>] comparer: IEqualityComparer<'T>) =
     Seq.delay (fun () ->
-        let hashSet = System.Collections.Generic.HashSet<'T>(itemsToExclude, comparer)
-
+        let hashSet = HashSet<'T>(itemsToExclude, comparer)
         xs |> Seq.filter (fun x -> hashSet.Add(x))
     )
 
-let countBy
+let countBy<'T, 'Key when 'Key: not null>
     (projection: 'T -> 'Key)
     (xs: seq<'T>)
-    ([<Inject>] comparer: System.Collections.Generic.IEqualityComparer<'Key>)
+    ([<Inject>] comparer: IEqualityComparer<'Key>)
     : ('Key * int) seq
     =
     Seq.delay (fun () ->
-        let dict = System.Collections.Generic.Dictionary<'Key, int>(comparer)
+        let dict = Dictionary<'Key, int>(comparer)
         let keys = ResizeArray<'Key>()
 
         for x in xs do
@@ -52,14 +48,14 @@ let countBy
         Seq.map (fun key -> key, dict.[key]) keys
     )
 
-let groupBy
+let groupBy<'T, 'Key when 'Key: not null>
     (projection: 'T -> 'Key)
     (xs: seq<'T>)
-    ([<Inject>] comparer: System.Collections.Generic.IEqualityComparer<'Key>)
+    ([<Inject>] comparer: IEqualityComparer<'Key>)
     : ('Key * seq<'T>) seq
     =
     Seq.delay (fun () ->
-        let dict = System.Collections.Generic.Dictionary<'Key, ResizeArray<'T>>(comparer)
+        let dict = Dictionary<'Key, ResizeArray<'T>>(comparer)
 
         let keys = ResizeArray<'Key>()
 
@@ -77,68 +73,37 @@ let groupBy
 
 module Array =
 
-    let distinct (xs: 'T[]) ([<Inject>] comparer: System.Collections.Generic.IEqualityComparer<'T>) : 'T[] =
-        distinct xs comparer |> Seq.toArray
+    let distinct (xs: 'T[]) ([<Inject>] comparer: IEqualityComparer<'T>) : 'T[] = distinct xs comparer |> Seq.toArray
 
-    let distinctBy
-        (projection: 'T -> 'Key)
-        (xs: 'T[])
-        ([<Inject>] comparer: System.Collections.Generic.IEqualityComparer<'Key>)
-        : 'T[]
-        =
+    let distinctBy (projection: 'T -> 'Key) (xs: 'T[]) ([<Inject>] comparer: IEqualityComparer<'Key>) : 'T[] =
         distinctBy projection xs comparer |> Seq.toArray
 
-    let except
-        (itemsToExclude: seq<'T>)
-        (xs: 'T[])
-        ([<Inject>] comparer: System.Collections.Generic.IEqualityComparer<'T>)
-        : 'T[]
-        =
+    let except (itemsToExclude: seq<'T>) (xs: 'T[]) ([<Inject>] comparer: IEqualityComparer<'T>) : 'T[] =
         except itemsToExclude xs comparer |> Seq.toArray
 
-    let countBy
-        (projection: 'T -> 'Key)
-        (xs: 'T[])
-        ([<Inject>] comparer: System.Collections.Generic.IEqualityComparer<'Key>)
-        : ('Key * int)[]
-        =
+    let countBy (projection: 'T -> 'Key) (xs: 'T[]) ([<Inject>] comparer: IEqualityComparer<'Key>) : ('Key * int)[] =
         countBy projection xs comparer |> Seq.toArray
 
-    let groupBy
-        (projection: 'T -> 'Key)
-        (xs: 'T[])
-        ([<Inject>] comparer: System.Collections.Generic.IEqualityComparer<'Key>)
-        : ('Key * 'T[])[]
-        =
+    let groupBy (projection: 'T -> 'Key) (xs: 'T[]) ([<Inject>] comparer: IEqualityComparer<'Key>) : ('Key * 'T[])[] =
         groupBy projection xs comparer
         |> Seq.map (fun (key, values) -> key, Seq.toArray values)
         |> Seq.toArray
 
 module List =
 
-    let distinct (xs: 'T list) ([<Inject>] comparer: System.Collections.Generic.IEqualityComparer<'T>) : 'T list =
+    let distinct (xs: 'T list) ([<Inject>] comparer: IEqualityComparer<'T>) : 'T list =
         distinct xs comparer |> Seq.toList
 
-    let distinctBy
-        (projection: 'T -> 'Key)
-        (xs: 'T list)
-        ([<Inject>] comparer: System.Collections.Generic.IEqualityComparer<'Key>)
-        : 'T list
-        =
+    let distinctBy (projection: 'T -> 'Key) (xs: 'T list) ([<Inject>] comparer: IEqualityComparer<'Key>) : 'T list =
         distinctBy projection xs comparer |> Seq.toList
 
-    let except
-        (itemsToExclude: seq<'T>)
-        (xs: 'T list)
-        ([<Inject>] comparer: System.Collections.Generic.IEqualityComparer<'T>)
-        : 'T list
-        =
+    let except (itemsToExclude: seq<'T>) (xs: 'T list) ([<Inject>] comparer: IEqualityComparer<'T>) : 'T list =
         except itemsToExclude xs comparer |> Seq.toList
 
     let countBy
         (projection: 'T -> 'Key)
         (xs: 'T list)
-        ([<Inject>] comparer: System.Collections.Generic.IEqualityComparer<'Key>)
+        ([<Inject>] comparer: IEqualityComparer<'Key>)
         : ('Key * int) list
         =
         countBy projection xs comparer |> Seq.toList
@@ -146,7 +111,7 @@ module List =
     let groupBy
         (projection: 'T -> 'Key)
         (xs: 'T list)
-        ([<Inject>] comparer: System.Collections.Generic.IEqualityComparer<'Key>)
+        ([<Inject>] comparer: IEqualityComparer<'Key>)
         : ('Key * 'T list) list
         =
         groupBy projection xs comparer

--- a/src/fable-library-ts/System.Collections.Generic.fs
+++ b/src/fable-library-ts/System.Collections.Generic.fs
@@ -1,6 +1,6 @@
 namespace System.Collections.Generic
 
-type Comparer<'T when 'T: comparison>(comparison: 'T -> 'T -> int) =
+type Comparer<'T when 'T: comparison and 'T: null>(comparison: 'T -> 'T -> int) =
 
     static member Default = Comparer<'T>(LanguagePrimitives.GenericComparison)
 
@@ -9,9 +9,14 @@ type Comparer<'T when 'T: comparison>(comparison: 'T -> 'T -> int) =
     member _.Compare(x, y) = comparison x y
 
     interface IComparer<'T> with
-        member _.Compare(x, y) = comparison x y
+        member _.Compare(x, y) =
+            match x, y with
+            | null, null -> 0
+            | null, y -> -1
+            | x, null -> 1
+            | x, y -> comparison x y
 
-type EqualityComparer<'T when 'T: equality>(equals: 'T -> 'T -> bool, getHashCode: 'T -> int) =
+type EqualityComparer<'T when 'T: equality and 'T: null>(equals: 'T -> 'T -> bool, getHashCode: 'T -> int) =
 
     static member Default =
         EqualityComparer<'T>(LanguagePrimitives.GenericEquality, LanguagePrimitives.GenericHash)
@@ -20,10 +25,17 @@ type EqualityComparer<'T when 'T: equality>(equals: 'T -> 'T -> bool, getHashCod
         EqualityComparer<'T>(equals, getHashCode)
 
     member _.Equals(x, y) = equals x y
+
     member _.GetHashCode(x) = getHashCode x
 
     interface IEqualityComparer<'T> with
-        member _.Equals(x, y) = equals x y
+        member _.Equals(x, y) =
+            match x, y with
+            | null, null -> true
+            | null, y -> false
+            | x, null -> false
+            | x, y -> equals x y
+
         member _.GetHashCode(x) = getHashCode x
 
 type Stack<'T> private (initialContents, initialCount) =

--- a/src/fable-library-ts/System.Text.fs
+++ b/src/fable-library-ts/System.Text.fs
@@ -11,12 +11,12 @@ type StringBuilder(value: string, capacity: int) =
     new(value: string) = StringBuilder(value, 16)
     new() = StringBuilder("", 16)
 
-    member x.Append(s: string) =
-        buf.Add(s)
+    member x.Append(s: string | null) =
+        buf.Add(string s)
         x
 
-    member x.Append(s: string, startIndex: int, count: int) =
-        buf.Add(s.Substring(startIndex, count))
+    member x.Append(s: string | null, startIndex: int, count: int) =
+        buf.Add((string s).Substring(startIndex, count))
         x
 
     member x.Append(c: char) =

--- a/src/fable-library-ts/Util.ts
+++ b/src/fable-library-ts/Util.ts
@@ -458,8 +458,14 @@ function equalObjects(x: { [k: string]: any }, y: { [k: string]: any }): boolean
   return true;
 }
 
-export function physicalEquality<T>(x: T, y: T): boolean {
+export function physicalEquals<T>(x: T, y: T): boolean {
   return x === y;
+}
+
+export function nullableEquals<T>(x: Nullable<T>, y: Nullable<T>): boolean {
+  if (x == null) { return y == null; }
+  if (y == null) { return false; }
+  return equals(x, y);
 }
 
 export function equals<T>(x: T, y: T): boolean {

--- a/src/fable-library-ts/Util.ts
+++ b/src/fable-library-ts/Util.ts
@@ -1,3 +1,5 @@
+export type Nullable<T> = T | null | undefined;
+
 // Don't change, this corresponds to DateTime.Kind enum values in .NET
 export const enum DateKind {
   Unspecified = 0,
@@ -30,11 +32,11 @@ export interface IDisposable {
 }
 
 export interface IComparer<T> {
-  Compare(x: T, y: T): number;
+  Compare(x: Nullable<T>, y: Nullable<T>): number;
 }
 
 export interface IEqualityComparer<T> {
-  Equals(x: T, y: T): boolean;
+  Equals(x: Nullable<T>, y: Nullable<T>): boolean;
   GetHashCode(x: T): number;
 }
 
@@ -426,7 +428,7 @@ export function safeHash<T>(x: T): number {
   return identityHash(x);
 }
 
-export function equalArraysWith<T>(x: ArrayLike<T>, y: ArrayLike<T>, eq: (x: T, y: T) => boolean): boolean {
+export function equalArraysWith<T>(x: Nullable<ArrayLike<T>>, y: Nullable<ArrayLike<T>>, eq: (x: T, y: T) => boolean): boolean {
   if (x == null) { return y == null; }
   if (y == null) { return false; }
   if (x.length !== y.length) { return false; }
@@ -436,7 +438,7 @@ export function equalArraysWith<T>(x: ArrayLike<T>, y: ArrayLike<T>, eq: (x: T, 
   return true;
 }
 
-export function equalArrays<T>(x: ArrayLike<T>, y: ArrayLike<T>): boolean {
+export function equalArrays<T>(x: Nullable<ArrayLike<T>>, y: Nullable<ArrayLike<T>>): boolean {
   return equalArraysWith(x, y, equals);
 }
 

--- a/src/fable-standalone/src/Main.fs
+++ b/src/fable-standalone/src/Main.fs
@@ -169,7 +169,7 @@ let makeProject (projectOptions: FSharpProjectOptions) (checkResults: FSharpChec
 
     Project.From(
         projectOptions.ProjectFileName,
-        projectOptions.SourceFiles,
+        projectOptions,
         implFiles,
         checkResults.ProjectContext.GetReferencedAssemblies(),
         addLog

--- a/src/fable-standalone/test/bench-compiler/ProjectParser.fs
+++ b/src/fable-standalone/test/bench-compiler/ProjectParser.fs
@@ -264,7 +264,11 @@ let makeHashSetIgnoreCase () =
     let equalityComparerIgnoreCase =
         { new IEqualityComparer<string> with
             member _.Equals(x, y) =
-                x.ToLowerInvariant() = y.ToLowerInvariant()
+                match x, y with
+                | null, null -> true
+                | null, y -> false
+                | x, null -> false
+                | x, y -> x.ToLowerInvariant() = y.ToLowerInvariant()
 
             member _.GetHashCode(x) = hash (x.ToLowerInvariant())
         }

--- a/src/fable-standalone/test/bench-compiler/package.json
+++ b/src/fable-standalone/test/bench-compiler/package.json
@@ -12,6 +12,9 @@
     "prebuild-cli-js": "npm run clean && FABLE=fable-cli npm run build-lib-ts",
     "build-cli-js": "npm run fable-cli -- bench-compiler.fsproj --outDir ./out-node --fableLib ./out-lib-js",
     "postbuild-cli-js": "npm run rollup-bundle",
+    "prebuild-cli-ts": "npm run clean && FABLE=fable-cli npm run build-lib-ts",
+    "build-cli-ts": "npm run fable-cli -- bench-compiler.fsproj --outDir ./out-ts --fableLib ./out-lib-ts --lang TypeScript",
+    "postbuild-cli-ts": "cp tsconfig.json out-ts && npm run tsc -- -p ./out-ts --outDir ./out-js",
     "build-cli-rust": "npm run fable-cli -- bench-compiler.fsproj --outDir ./out-rust --lang Rust --noCache",
 
     "fable": "dotnet run -c Release --project bench-compiler.fsproj",

--- a/src/fable-standalone/test/bench-compiler/package.json
+++ b/src/fable-standalone/test/bench-compiler/package.json
@@ -34,7 +34,7 @@
 
     "publish-native": "cd src && dotnet publish -c Release -r linux-x64 & echo \u001B[35m Needs PublishAot enabled in project!",
     "prefable-native": "npm run publish-native",
-    "fable-native": "./bin/Release/net8.0/linux-x64/native/bench-compiler",
+    "fable-native": "./bin/Release/net9.0/linux-x64/native/bench-compiler",
     "prebuild-native-js": "FABLE=fable-native npm run build-lib-ts",
     "build-native-js": "npm run fable-native -- bench-compiler.fsproj --outDir ./out-node --fableLib ./out-lib-js",
     "build-test-native-js": "npm run fable-native -- ../../../../../fable-test/fable-test.fsproj --outDir ./out-test",
@@ -42,7 +42,7 @@
 
     "publish-wasm": "cd src && dotnet publish -c Release /p:RunAOTCompilation=true /p:RuntimeIdentifier=browser-wasm",
     "prefable-wasm": "npm run publish-wasm",
-    "fable-wasm": "node ./bin/Release/net8.0/browser-wasm/AppBundle/main.mjs",
+    "fable-wasm": "node ./bin/Release/net9.0/browser-wasm/AppBundle/main.mjs",
     "prebuild-wasm-js": "FABLE=fable-wasm npm run build-lib-ts",
     "build-wasm-js": "npm run fable-wasm -- bench-compiler.fsproj --outDir ./out-node --fableLib ./out-lib-js",
 
@@ -87,9 +87,10 @@
     "webpack": "node ../../../../node_modules/webpack-cli/bin/cli.js",
     "splitter": "node ../../../../node_modules/fable-splitter/dist/cli",
 
+    "ultra": "ultra profile -- bin\\Release\\net9.0\\bench-compiler.exe bench-compiler.fsproj --outDir ./out-node2 --benchmark",
     "perf": "perf record -q -e cpu-clock -F 99 -g -- node --perf-basic-prof --interpreted-frames-native-stack dist/bundle.js bench-compiler.fsproj --outDir ./out-node2 --benchmark",
     "perf-es": "perf record -q -e cpu-clock -F 99 -g -- node --perf-basic-prof --interpreted-frames-native-stack ./out-node/app.js bench-compiler.fsproj --outDir ./out-node2 --benchmark",
-    "perf-native": "perf record -q -e cpu-clock -F 997 -g -- ./bin/Release/net8.0/linux-x64/native/bench-compiler bench-compiler.fsproj --outDir ./out-node2 --benchmark",
+    "perf-native": "perf record -q -e cpu-clock -F 997 -g -- ./bin/Release/net9.0/linux-x64/native/bench-compiler bench-compiler.fsproj --outDir ./out-node2 --benchmark",
     "perf-report": "perf report -n --stdio -g srcline -s dso,sym,srcline --inline > perf-report.log",
     "perf-script": "perf script -F +pid > perf-script.perf",
     "profile": "node --prof out-node/app.js bench-compiler.fsproj --outDir ./out-node2 --benchmark",
@@ -100,11 +101,11 @@
     "speedscope": "speedscope profile.v8log.json",
     "flamegraph": "perf script | ../../../../../FlameGraph/stackcollapse-perf.pl | ../../../../../FlameGraph/flamegraph.pl > perf.svg",
     "trace-node": "node --trace-deopt out-node/app.js bench-compiler.fsproj --outDir ./out-node2 > deopt.log",
-    "trace-rust": "dotnet trace collect --duration 00:00:03:00 --format speedscope -- dotnet ./bin/Release/net8.0/bench-compiler.dll bench-compiler.fsproj --outDir ./out-rust2 --fableLib ./out-lib-rust --lang Rust",
-    "trace-rust-tests": "dotnet trace collect --duration 00:00:01:00 --format speedscope -- dotnet ./bin/Release/net8.0/bench-compiler.dll ../../../../tests/Rust/Fable.Tests.Rust.fsproj --outDir ./out-tests-rust --fableLib ./out-lib-rust --lang Rust",
-    "heaptrack-native": "heaptrack ./bin/Release/net8.0/linux-x64/native/bench-compiler bench-compiler.fsproj --outDir ./out-node2 --benchmark",
+    "trace-rust": "dotnet trace collect --duration 00:00:03:00 --format speedscope -- dotnet ./bin/Release/net9.0/bench-compiler.dll bench-compiler.fsproj --outDir ./out-rust2 --fableLib ./out-lib-rust --lang Rust",
+    "trace-rust-tests": "dotnet trace collect --duration 00:00:01:00 --format speedscope -- dotnet ./bin/Release/net9.0/bench-compiler.dll ../../../../tests/Rust/Fable.Tests.Rust.fsproj --outDir ./out-tests-rust --fableLib ./out-lib-rust --lang Rust",
+    "heaptrack-native": "heaptrack ./bin/Release/net9.0/linux-x64/native/bench-compiler bench-compiler.fsproj --outDir ./out-node2 --benchmark",
     "heaptrack-print": "heaptrack_print heaptrack.*.gz -F heap_alloc.log",
     "heaptrack-flamegraph": "../../../../../FlameGraph/flamegraph.pl --title \"heaptrack: allocations\" --colors mem --countname allocations < heap_alloc.log > heap_alloc.svg",
-    "coz": "coz run --- ./bin/Release/net8.0/linux-x64/native/bench-compiler bench-compiler.fsproj --outDir ./out-node2 --benchmark"
+    "coz": "coz run --- ./bin/Release/net9.0/linux-x64/native/bench-compiler bench-compiler.fsproj --outDir ./out-node2 --benchmark"
   }
 }

--- a/tests/Js/Main/DictionaryTests.fs
+++ b/tests/Js/Main/DictionaryTests.fs
@@ -12,7 +12,7 @@ type MyRecord = { a: int }
 
 type R = { i: int; s: string }
 
-type Table<'K,'V when 'K:equality> () =
+type Table<'K, 'V when 'K: equality and 'K: not null> () =
 
     let dic = new Dictionary<'K,'V>()
 
@@ -23,6 +23,7 @@ type Table<'K,'V when 'K:equality> () =
         addKeyValue key value
 
     member _.Dic = dic
+
 let tests =
   testList "Dictionaries" [
     testCase "Dictionary KeyValuePattern works" <| fun () -> // See #509

--- a/tests/Js/Main/Fable.Tests.fsproj
+++ b/tests/Js/Main/Fable.Tests.fsproj
@@ -3,6 +3,8 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
     <RollForward>Major</RollForward>
+    <!-- <Nullable>enable</Nullable> -->
+    <!-- <WarningsAsErrors>FS3261</WarningsAsErrors> -->
     <OtherFlags>$(OtherFlags) --crossoptimize- --nowarn:3370</OtherFlags>
     <FableDefinesQueue>True</FableDefinesQueue>
     <LangVersion>Preview</LangVersion>


### PR DESCRIPTION
- [JS/TS] Initial Support for [Nullable Reference Types](https://devblogs.microsoft.com/dotnet/nullable-reference-types-in-fsharp-9/).
- Not tested yet on larger code bases using NRTs, but seems to address the original issues raised in #4085.
- Supersedes #4085.
- Contains a change to `Fable.AST` which will need to be versioned and released.
 The AST change is intentionally positioned at the end of the `Fable.Type` union to keep it (mostly) backwards compatible with older plugins (to the extent possible).