### PR TITLE
[Python] Fixed `createEmpty<T>` for interfaces using `SimpleNamespace` with type casting

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* [Python] Fixed `createEmpty<T>` for interfaces using `SimpleNamespace` with type casting (#3604) (by @dbrattli)
 * [Python] Fixed EmitMethod + ParamObject losing keyword arguments (#3871) (by @dbrattli)
 * [Python] Fixed EmitConstructor + ParamObject losing keyword arguments (#3871) (by @dbrattli)
 * [Python] Fixed DateTimeOffset.TryParse, ToString() and Offset property access (#3854) (by @dbrattli)

--- a/tests/Python/TestPyInterop.fs
+++ b/tests/Python/TestPyInterop.fs
@@ -132,6 +132,11 @@ type MyInterface =
     abstract foo: int
     abstract bar: string
 
+// Test interface for createEmpty functionality
+type IUser =
+    abstract Name: string with get, set
+    abstract Age: int with get, set
+
 let validatePassword = function
     | OldPassword -> "op"
     | NewPassword -> "np"
@@ -409,5 +414,17 @@ let ``test ParamObject with EmitConstructor preserves keyword arguments`` () =
     // Also test with default parameter (no arguments)
     let proc2 = TestProcess.Create()
     proc2.name |> equal "default"
+
+[<Fact>]
+let ``test createEmpty works with interfaces`` () =
+    // Test that createEmpty<T> works with interfaces by creating a SimpleNamespace
+    // that can have properties set dynamically
+    let user = createEmpty<IUser>
+    user.Name <- "Kaladin"
+    user.Age <- 20
+
+    // Verify the properties can be accessed
+    user.Name |> equal "Kaladin"
+    user.Age |> equal 20
 
 #endif


### PR DESCRIPTION
## Why

Fixes #3604 #3598

Some reflection over `SimpeNamespaces` vs `TypedDict`:

| Feature | SimpleNamespace | TypedDict |
|---------|----------------|-----------|
| **Dot notation** | ✅ `obj.Name` works | ❌ AttributeError: 'dict' has no attribute |
| **Bracket notation** | ❌ TypeError: not subscriptable | ✅ `obj["Name"]` works |
| **Dynamic properties** | ✅ Can add any property at runtime | ❌ Fixed structure, static analysis only |
| **Type checking** | ✅ Works with `cast(IInterface, ...)` | ✅ Native TypedDict support |
| **F# interface compatibility** | ✅ Perfect match for `user.Name <- "value"` | ❌ Wrong syntax (needs bracket notation) |
| **Python interop** | ⚠️ Limited (not dict-compatible) | ✅ Excellent (is a dict at runtime) |
| **Serialization** | ❌ Not JSON serializable by default | ✅ Standard dict serialization |
| **Runtime behavior** | Real object with attributes | Just a dict with type hints |
| **Memory usage** | Slightly higher (object overhead) | Lower (just a dict) |
| **Duck typing compatibility** | ❌ Won't work with dict-expecting APIs | ✅ Works anywhere dict is expected |

## Key Takeaway:

**SimpleNamespace** is the clear winner for F# interfaces because:
- F# interface syntax (`user.Name <- "value"`) **requires** dot notation
- TypedDict is just typing sugar over dict and doesn't solve the fundamental dot notation issue
- Interfaces are typically used for F#-to-F# contracts, not Python interop

**TypedDict** would be better for data structures intended for Python interop where you want dict-like behavior with type safety.

## How

The most Pythonic solution here is to modify the `createEmpty` implementation to use `types.SimpleNamespace` when the target type is an interface since this allows dynamic property setting. We also need to use casting to make the type checker happy.