### PR TITLE
[Python] Move int parse to Rust

### DIFF
--- a/src/Fable.Transforms/Python/Fable2Python.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.fs
@@ -783,7 +783,7 @@ module Annotation =
         | Fable.Tuple(genArgs, _) -> makeGenericTypeAnnotation com ctx "tuple" genArgs None, []
         | Fable.Array(genArg, Fable.ArrayKind.ResizeArray) ->
             makeGenericTypeAnnotation com ctx "list" [ genArg ] None, []
-        | Fable.Array(genArg, _) -> fableModuleTypeHint com ctx "types" "Array" [ genArg ] repeatedGenerics
+        | Fable.Array(genArg, _) -> fableModuleTypeHint com ctx "array_" "Array" [ genArg ] repeatedGenerics
         | Fable.List genArg -> fableModuleTypeHint com ctx "list" "FSharpList" [ genArg ] repeatedGenerics
         | Replacements.Util.Builtin kind -> makeBuiltinTypeAnnotation com ctx kind repeatedGenerics
         | Fable.AnonymousRecordType(_, _genArgs, _) ->
@@ -3769,7 +3769,10 @@ module Util =
     // Declares a Python entry point, i.e `if __name__ == "__main__"`
     let declareEntryPoint (com: IPythonCompiler) (ctx: Context) (funcExpr: Expression) =
         com.GetImportExpr(ctx, "sys") |> ignore
-        let args = emitExpression None "sys.argv[1:]" []
+
+        let args =
+            emitExpression None "sys.argv[1:]" []
+            |> fun expr -> arrayExpr com ctx expr Fable.ImmutableArray Fable.String
 
         let test =
             Expression.compare (
@@ -3954,7 +3957,7 @@ module Util =
 
         let classFields = slotMembers // TODO: annotations
         let classMembers = classCons @ classMembers
-        //printfn "ClassMembers: %A" classMembers
+
         let classBody =
             let body = [ yield! classFields; yield! classMembers ]
 

--- a/src/fable-library-py/fable_library/core/_core.pyi
+++ b/src/fable-library-py/fable_library/core/_core.pyi
@@ -7,10 +7,31 @@ methods we have written in Rust. The file will never be used by Python at runtim
 from . import array, floats, ints, option, strings, types
 from .array import FSharpArray
 from .floats import Float32, Float64
-from .ints import Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64
+from .ints import (
+    ALLOW_HEX_SPECIFIER,
+    ALLOW_LEADING_WHITE,
+    ALLOW_TRAILING_WHITE,
+    Int8,
+    Int16,
+    Int32,
+    Int64,
+    UInt8,
+    UInt16,
+    UInt32,
+    UInt64,
+    get_range,
+    get_range_64,
+    parse_int32,
+    parse_int64,
+    try_parse_int32,
+    try_parse_int64,
+)
 from .types import FSharpRef
 
 __all__: list[str] = [
+    "ALLOW_HEX_SPECIFIER",
+    "ALLOW_LEADING_WHITE",
+    "ALLOW_TRAILING_WHITE",
     "FSharpArray",
     "FSharpRef",
     "Float32",
@@ -25,8 +46,14 @@ __all__: list[str] = [
     "UInt64",
     "array",
     "floats",
+    "get_range",
+    "get_range_64",
     "ints",
     "option",
+    "parse_int32",
+    "parse_int64",
     "strings",
+    "try_parse_int32",
+    "try_parse_int64",
     "types",
 ]

--- a/src/fable-library-py/fable_library/core/ints.pyi
+++ b/src/fable-library-py/fable_library/core/ints.pyi
@@ -1,8 +1,6 @@
 """Stub file for Fable integer types."""
 
-from typing import Any, Protocol, SupportsFloat, SupportsInt, final
-
-from typing_extensions import Self
+from typing import Any, Protocol, Self, SupportsFloat, SupportsInt, final
 
 class NumericInts(Protocol):
     """Protocol for Integer types"""
@@ -71,7 +69,135 @@ class UInt64(NumericInts): ...
 @final
 class Int64(NumericInts): ...
 
+# Integer parsing functions with F#-compatible semantics
+def parse_int32(
+    string: str,
+    style: int,
+    unsigned: bool,
+    radix: int = 10,
+) -> int:
+    """
+    Parses a string representation of a 32-bit integer with F#-compatible semantics.
+    This function matches the behavior of int32.py parse function exactly.
+
+    Args:
+        string: The string to parse
+        style: NumberStyles flags controlling parsing behavior
+        unsigned: Whether to treat the result as unsigned (u32)
+        radix: Default radix to use (defaults to 10)
+
+    Returns:
+        The parsed integer value as int
+
+    Raises:
+        ValueError: If the string is not in a valid format or value is out of range
+    """
+    ...
+
+def parse_int64(
+    string: str,
+    style: int,
+    unsigned: bool,
+    radix: int = 10,
+) -> int:
+    """
+    Parses a string representation of a 64-bit integer with F#-compatible semantics.
+    This function matches the behavior of long.py parse function exactly.
+
+    Args:
+        string: The string to parse
+        style: NumberStyles flags controlling parsing behavior
+        unsigned: Whether to treat the result as unsigned (u64)
+        radix: Default radix to use (defaults to 10)
+
+    Returns:
+        The parsed integer value as int
+
+    Raises:
+        ValueError: If the string is not in a valid format or value is out of range
+    """
+    ...
+
+def try_parse_int32(
+    string: str,
+    style: int,
+    unsigned: bool,
+    def_value: Any,
+    radix: int = 10,
+) -> bool:
+    """
+    Attempts to parse a 32-bit integer with F#-style try semantics.
+
+    Args:
+        string: The string to parse
+        style: NumberStyles flags controlling parsing behavior
+        unsigned: Whether to treat the result as unsigned (u32)
+        def_value: Python object reference to store the result on success
+        radix: Default radix to use (defaults to 10)
+
+    Returns:
+        True if parsing succeeded, False otherwise
+    """
+    ...
+
+def try_parse_int64(
+    string: str,
+    style: int,
+    unsigned: bool,
+    def_value: Any,
+    radix: int = 10,
+) -> bool:
+    """
+    Attempts to parse a 64-bit integer with F#-style try semantics.
+
+    Args:
+        string: The string to parse
+        style: NumberStyles flags controlling parsing behavior
+        unsigned: Whether to treat the result as unsigned (u64)
+        def_value: Python object reference to store the result on success
+        radix: Default radix to use (defaults to 10)
+
+    Returns:
+        True if parsing succeeded, False otherwise
+    """
+    ...
+
+def get_range(unsigned: bool, bitsize: int) -> tuple[int, int]:
+    """
+    Returns the valid range for a given bit size and signedness.
+    This matches the behavior of int32.py get_range function.
+
+    Args:
+        unsigned: Whether the range should be for unsigned integers
+        bitsize: The bit width (8, 16, or 32)
+
+    Returns:
+        A tuple containing (minimum_value, maximum_value) for the specified type
+    """
+    ...
+
+def get_range_64(unsigned: bool) -> tuple[int, int]:
+    """
+    Returns the valid range for 64-bit integers.
+    This matches the behavior of long.py get_range function.
+
+    Args:
+        unsigned: Whether the range should be for unsigned integers
+
+    Returns:
+        A tuple containing (minimum_value, maximum_value) for 64-bit integers
+    """
+    ...
+
+# .NET NumberStyles constants
+ALLOW_HEX_SPECIFIER: int
+ALLOW_LEADING_WHITE: int
+ALLOW_TRAILING_WHITE: int
+
 __all__ = [
+    "ALLOW_HEX_SPECIFIER",
+    "ALLOW_LEADING_WHITE",
+    "ALLOW_TRAILING_WHITE",
     "Int8",
     "Int16",
     "Int32",
@@ -80,4 +206,10 @@ __all__ = [
     "UInt16",
     "UInt32",
     "UInt64",
+    "get_range",
+    "get_range_64",
+    "parse_int32",
+    "parse_int64",
+    "try_parse_int32",
+    "try_parse_int64",
 ]

--- a/src/fable-library-py/fable_library/int32.py
+++ b/src/fable-library-py/fable_library/int32.py
@@ -1,52 +1,10 @@
-from .types import FSharpRef
+from .core._core import get_range
+from .core._core import parse_int32 as parse
+from .core._core import try_parse_int32 as try_parse
 
 
-def get_range(unsigned: bool, bitsize: int) -> tuple[int, int]:
-    if bitsize == 8:
-        return (0, 255) if unsigned else (-128, 127)
-    if bitsize == 16:
-        return (0, 65535) if unsigned else (-32768, 32767)
-    if bitsize == 32:
-        return (0, 4294967295) if unsigned else (-2147483648, 2147483647)
-    raise ValueError("Invalid bit size.")
-
-
+# Re-export constants for compatibility
 AllowHexSpecifier = 0x00000200
-
-
-def parse(string: str, style: int, unsigned: bool, bitsize: int, radix: int = 10) -> int:
-    # const res = isValid(str, style, radix);
-    if style & AllowHexSpecifier or string.startswith("0x"):
-        radix = 16
-    elif string.startswith("0b"):
-        radix = 2
-    elif string.startswith("0o"):
-        radix = 8
-
-    try:
-        v = int(string, base=radix)
-    except Exception:
-        raise ValueError(f"The input string {string} was not in a correct format.")
-
-    (umin, umax) = get_range(True, bitsize)
-    if not unsigned and radix != 10 and v >= umin and v <= umax:
-        mask = 1 << (bitsize - 1)
-        if v & mask:  # Test if negative
-            v = v - (mask << 1)
-
-    (min, max) = get_range(unsigned, bitsize)
-    if v >= min and v <= max:
-        return v
-
-    raise ValueError(f"The input string {string} was not in a correct format.")
-
-
-def try_parse(string: str, style: int, unsigned: bool, bitsize: int, defValue: FSharpRef[int]) -> bool:
-    try:
-        defValue.contents = parse(string, style, unsigned, bitsize)
-        return True
-    except Exception:
-        return False
 
 
 def op_unary_negation_int8(x: int) -> int:

--- a/src/fable-library-py/fable_library/long.py
+++ b/src/fable-library-py/fable_library/long.py
@@ -1,6 +1,9 @@
 from typing import Any
 
-from .types import FSharpRef, float64, int64, uint64
+from .core._core import get_range_64 as get_range
+from .core._core import parse_int64 as parse
+from .core._core import try_parse_int64 as try_parse
+from .types import float64, int64, uint64
 
 
 def compare(x: int, y: int) -> int:
@@ -135,46 +138,8 @@ def from_integer(value: int, unsigned: bool | None = None, kind: int | None = No
         return int64(value)
 
 
-def get_range(unsigned: bool) -> tuple[int, int]:
-    return (0, 18446744073709551615) if unsigned else (-9223372036854775808, 9223372036854775807)
-
-
+# Re-export constants for compatibility
 AllowHexSpecifier = 0x00000200
-
-
-def parse(string: str, style: int, unsigned: bool, bitsize: int, radix: int = 10) -> int:
-    # const res = isValid(str, style, radix);
-    if style & AllowHexSpecifier or string.startswith("0x"):
-        radix = 16
-    elif string.startswith("0b"):
-        radix = 2
-    elif string.startswith("0o"):
-        radix = 8
-
-    try:
-        v = int(string, base=radix)
-    except Exception:
-        raise ValueError(f"The input string {string} was not in a correct format.")
-
-    (umin, umax) = get_range(True)
-    if not unsigned and radix != 10 and v >= umin and v <= umax:
-        mask = 1 << (bitsize - 1)
-        if v & mask:  # Test if negative
-            v = v - (mask << 1)
-
-    (min, max) = get_range(unsigned)
-    if v >= min and v <= max:
-        return v
-
-    raise ValueError(f"The input string {string} was not in a correct format.")
-
-
-def try_parse(string: str, style: int, unsigned: bool, bitsize: int, defValue: FSharpRef[int]) -> bool:
-    try:
-        defValue.contents = parse(string, style, unsigned, bitsize)
-        return True
-    except Exception:
-        return False
 
 
 def to_string(x: int) -> str:

--- a/src/fable-library-py/src/lib.rs
+++ b/src/fable-library-py/src/lib.rs
@@ -36,6 +36,7 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     register_float_module(m)?;
     register_string_module(m)?;
     register_types_module(m)?;
+    register_int_module(m)?;
 
     Ok(())
 }


### PR DESCRIPTION
- Move int32 parse to Rust
- Move long parse to Rust
- Fix type issues in generated Python code

All internal, no changes for the Fable user