### PR TITLE
Document Refactor N2

### DIFF
--- a/src/Fable.Core/Fable.Core.JsInterop.fs
+++ b/src/Fable.Core/Fable.Core.JsInterop.fs
@@ -3,7 +3,18 @@ module Fable.Core.JsInterop
 open System
 open Fable.Core
 
-/// Compiles to ?? operator in JavaScript
+/// <summary>
+/// Compiles to <c>??</c> nullish coalescing operator in JavaScript.
+/// </summary>
+/// <remarks>
+/// <code lang="fsharp">
+/// expr1 ?? expr2
+/// </code>
+/// Returns <c>expr1</c> if it is neither <c>null</c> nor <c>undefined</c> on runtime; otherwise, returns <c>expr2</c>
+/// </remarks>
+/// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing">
+/// JavaScript Documentation
+/// </seealso>
 [<Emit("$0 ?? $1")>]
 let (??=) (nullable: 'T) (defaultValue: 'T) : 'T = nativeOnly
 
@@ -48,20 +59,40 @@ let emitJsExpr<'T> (args: obj) (jsCode: string) : 'T = nativeOnly
 let emitJsStatement<'T> (args: obj) (jsCode: string) : 'T = nativeOnly
 
 /// <summary>
-/// Emit a directive prologue at the top of the file (before the imports)
-///
+/// Emit a directive prologue at the top of the file (before the imports).
+/// <br/><br/>
 /// This is useful when working with Next.js or other frameworks that require
 /// a specific directive at the top of the file, such as "use client" or "use server".
 /// </summary>
+/// <example><code lang="fsharp">
+/// let x = 5
+/// emitJsTopDirectivePrologue "use server"
+/// </code>
+/// Compiles to:
+/// <code lang="js">
+/// "use server";
+/// export const x = 5;
+/// </code>
+/// </example>
 /// <param name="text">Directive text</param>
 let emitJsTopDirectivePrologue (text: string) : unit = nativeOnly
 
 /// <summary>
 /// Emit a directive prologue at the calling position.
-///
+/// <br/><br/>
 /// This is useful when you need to emit a directive prologue for a specific part of the code,
 /// such as "use client" or "use server".
 /// </summary>
+/// <example><code lang="fsharp">
+/// let x = 5
+/// emitJsDirectivePrologue "use server"
+/// </code>
+/// Compiles to:
+/// <code lang="js">
+/// export const x = 5;
+/// "use server";
+/// </code>
+/// </example>
 /// <param name="text">Directive text</param>
 let emitJsDirectivePrologue (text: string) : unit = nativeOnly
 

--- a/src/Fable.Core/Fable.Core.JsInterop.fs
+++ b/src/Fable.Core/Fable.Core.JsInterop.fs
@@ -59,10 +59,9 @@ let emitJsExpr<'T> (args: obj) (jsCode: string) : 'T = nativeOnly
 let emitJsStatement<'T> (args: obj) (jsCode: string) : 'T = nativeOnly
 
 /// <summary>
-/// Emit a directive prologue at the top of the file (before the imports).
-/// <br/><br/>
-/// This is useful when working with Next.js or other frameworks that require
-/// a specific directive at the top of the file, such as "use client" or "use server".
+/// <para>Emit a directive prologue at the top of the file (before the imports).</para>
+/// <para>This is useful when working with Next.js or other frameworks that require
+/// a specific directive at the top of the file, such as "use client" or "use server".</para>
 /// </summary>
 /// <example><code lang="fsharp">
 /// let x = 5
@@ -78,10 +77,9 @@ let emitJsStatement<'T> (args: obj) (jsCode: string) : 'T = nativeOnly
 let emitJsTopDirectivePrologue (text: string) : unit = nativeOnly
 
 /// <summary>
-/// Emit a directive prologue at the calling position.
-/// <br/><br/>
-/// This is useful when you need to emit a directive prologue for a specific part of the code,
-/// such as "use client" or "use server".
+/// <para>Emit a directive prologue at the calling position.</para>
+/// <para>This is useful when you need to emit a directive prologue for a specific part of the code,
+/// such as "use client" or "use server".</para>
 /// </summary>
 /// <example><code lang="fsharp">
 /// let x = 5


### PR DESCRIPTION
Adjustment to previous xml docs too.

The following does not render breaks without the use of either `<para>` or `<br/>` in Rider.

```fs
/// <summary>
/// Emit a directive prologue at the calling position.
///
/// This is useful when you need to emit a directive prologue for a specific part of the code,
/// such as "use client" or "use server".
/// </summary>
/// <param name="text">Directive text</param>
let emitJsDirectivePrologue (text: obj) : unit = nativeOnly
```

Changes to

```fs
/// <summary>
/// <para>Emit a directive prologue at the calling position.</para>
/// <para>This is useful when you need to emit a directive prologue for a specific part of the code,
/// such as "use client" or "use server".</para>
/// </summary>
/// <param name="text">Directive text</param>
let emitJsDirectivePrologue (text: obj) : unit = nativeOnly
```
