### PR TITLE
Fixes for publish-pypi GH action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -190,9 +190,7 @@ jobs:
       uses: actions/setup-node@v2.4.1
 
     - name: Setup Rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
+      uses: dtolnay/rust-toolchain@stable
 
     - name: Fable Library - Rust
       run: ./build.sh fable-library --rust

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -12,14 +12,20 @@ permissions:
   contents: read
 
 jobs:
-  build-fable-library:
-    runs-on: ubuntu-latest
-    steps:
+    build-fable-library:
+      runs-on: ubuntu-latest
+      steps:
       - uses: actions/checkout@v4
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '9.0.x'
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
       - name: Install Uv and Maturin
         run: |
           pipx install uv
@@ -46,234 +52,234 @@ jobs:
           path: ./temp/fable-library-py
           retention-days: 1
 
-  test:
-    needs: build-fable-library
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.12", "3.13"]
+    test:
+      needs: build-fable-library
+      runs-on: ${{ matrix.os }}
+      strategy:
+        matrix:
+          os: [ubuntu-latest, windows-latest, macos-latest]
+          python-version: ["3.12", "3.13"]
 
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-      - name: Install Uv
-        run: pipx install uv
-      - name: Download fable-library-py
-        uses: actions/download-artifact@v4
-        with:
-          name: fable-library-py
-          path: ./src/fable-library-py
-      - name: Build and install
-        uses: PyO3/maturin-action@v1
-        with:
-          working-directory: ./src/fable-library-py
-          args: --release --features=pyo3/extension-module
-      - name: Test
-        run: |
-          cd src/fable-library-py
-          uv sync
-          uv run maturin develop --release
-          uv run pytest tests
+      steps:
+        - uses: actions/checkout@v4
+        - name: Set up Python ${{ matrix.python-version }}
+          uses: actions/setup-python@v5
+          with:
+            python-version: ${{ matrix.python-version }}
+        - name: Install Rust
+          uses: dtolnay/rust-toolchain@stable
+        - name: Install Uv
+          run: pipx install uv
+        - name: Download fable-library-py
+          uses: actions/download-artifact@v4
+          with:
+            name: fable-library-py
+            path: ./src/fable-library-py
+        - name: Build and install
+          uses: PyO3/maturin-action@v1
+          with:
+            working-directory: ./src/fable-library-py
+            args: --release --features=pyo3/extension-module
+        - name: Test
+          run: |
+            cd src/fable-library-py
+            uv sync
+            uv run maturin develop --release
+            uv run pytest tests
 
-  linux:
-    needs: build-fable-library
-    runs-on: ${{ matrix.platform.runner }}
-    strategy:
-      matrix:
-        platform:
-          - runner: ubuntu-22.04
-            target: x86_64
-          - runner: ubuntu-22.04
-            target: x86
-          - runner: ubuntu-22.04
-            target: aarch64
-          - runner: ubuntu-22.04
-            target: armv7
-          - runner: ubuntu-22.04
-            target: s390x
-          - runner: ubuntu-22.04
-            target: ppc64le
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
-      - name: Download fable-library-py
-        uses: actions/download-artifact@v4
-        with:
-          name: fable-library-py
-          path: ./temp/fable-library-py
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
-          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
-          manylinux: auto
-          working-directory: ./temp/fable-library-py
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-linux-${{ matrix.platform.target }}
-          path: ./temp/fable-library-py/dist
+    linux:
+      needs: build-fable-library
+      runs-on: ${{ matrix.platform.runner }}
+      strategy:
+        matrix:
+          platform:
+            - runner: ubuntu-22.04
+              target: x86_64
+            - runner: ubuntu-22.04
+              target: x86
+            - runner: ubuntu-22.04
+              target: aarch64
+            - runner: ubuntu-22.04
+              target: armv7
+            - runner: ubuntu-22.04
+              target: s390x
+            - runner: ubuntu-22.04
+              target: ppc64le
+      steps:
+        - uses: actions/checkout@v4
+        - uses: actions/setup-python@v5
+          with:
+            python-version: 3.x
+        - name: Download fable-library-py
+          uses: actions/download-artifact@v4
+          with:
+            name: fable-library-py
+            path: ./temp/fable-library-py
+        - name: Build wheels
+          uses: PyO3/maturin-action@v1
+          with:
+            target: ${{ matrix.platform.target }}
+            args: --release --out dist --find-interpreter
+            sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+            manylinux: auto
+            working-directory: ./temp/fable-library-py
+        - name: Upload wheels
+          uses: actions/upload-artifact@v4
+          with:
+            name: wheels-linux-${{ matrix.platform.target }}
+            path: ./temp/fable-library-py/dist
 
-  musllinux:
-    needs: build-fable-library
-    runs-on: ${{ matrix.platform.runner }}
-    strategy:
-      matrix:
-        platform:
-          - runner: ubuntu-22.04
-            target: x86_64
-          - runner: ubuntu-22.04
-            target: x86
-          - runner: ubuntu-22.04
-            target: aarch64
-          - runner: ubuntu-22.04
-            target: armv7
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
-      - name: Download fable-library-py
-        uses: actions/download-artifact@v4
-        with:
-          name: fable-library-py
-          path: ./temp/fable-library-py
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
-          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
-          manylinux: musllinux_1_2
-          working-directory: ./temp/fable-library-py
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-musllinux-${{ matrix.platform.target }}
-          path: ./temp/fable-library-py/dist
+    musllinux:
+      needs: build-fable-library
+      runs-on: ${{ matrix.platform.runner }}
+      strategy:
+        matrix:
+          platform:
+            - runner: ubuntu-22.04
+              target: x86_64
+            - runner: ubuntu-22.04
+              target: x86
+            - runner: ubuntu-22.04
+              target: aarch64
+            - runner: ubuntu-22.04
+              target: armv7
+      steps:
+        - uses: actions/checkout@v4
+        - uses: actions/setup-python@v5
+          with:
+            python-version: 3.x
+        - name: Download fable-library-py
+          uses: actions/download-artifact@v4
+          with:
+            name: fable-library-py
+            path: ./temp/fable-library-py
+        - name: Build wheels
+          uses: PyO3/maturin-action@v1
+          with:
+            target: ${{ matrix.platform.target }}
+            args: --release --out dist --find-interpreter
+            sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+            manylinux: musllinux_1_2
+            working-directory: ./temp/fable-library-py
+        - name: Upload wheels
+          uses: actions/upload-artifact@v4
+          with:
+            name: wheels-musllinux-${{ matrix.platform.target }}
+            path: ./temp/fable-library-py/dist
 
-  windows:
-    needs: build-fable-library
-    runs-on: ${{ matrix.platform.runner }}
-    strategy:
-      matrix:
-        platform:
-          - runner: windows-latest
-            target: x64
-          - runner: windows-latest
-            target: x86
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
-          architecture: ${{ matrix.platform.target }}
-      - name: Download fable-library-py
-        uses: actions/download-artifact@v4
-        with:
-          name: fable-library-py
-          path: ./temp/fable-library-py
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
-          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
-          working-directory: ./temp/fable-library-py
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-windows-${{ matrix.platform.target }}
-          path: ./temp/fable-library-py/dist
+    windows:
+      needs: build-fable-library
+      runs-on: ${{ matrix.platform.runner }}
+      strategy:
+        matrix:
+          platform:
+            - runner: windows-latest
+              target: x64
+            - runner: windows-latest
+              target: x86
+      steps:
+        - uses: actions/checkout@v4
+        - uses: actions/setup-python@v5
+          with:
+            python-version: 3.x
+            architecture: ${{ matrix.platform.target }}
+        - name: Download fable-library-py
+          uses: actions/download-artifact@v4
+          with:
+            name: fable-library-py
+            path: ./temp/fable-library-py
+        - name: Build wheels
+          uses: PyO3/maturin-action@v1
+          with:
+            target: ${{ matrix.platform.target }}
+            args: --release --out dist --find-interpreter
+            sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+            working-directory: ./temp/fable-library-py
+        - name: Upload wheels
+          uses: actions/upload-artifact@v4
+          with:
+            name: wheels-windows-${{ matrix.platform.target }}
+            path: ./temp/fable-library-py/dist
 
-  macos:
-    needs: build-fable-library
-    runs-on: ${{ matrix.platform.runner }}
-    strategy:
-      matrix:
-        platform:
-          - runner: macos-13
-            target: x86_64
-          - runner: macos-14
-            target: aarch64
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
-      - name: Download fable-library-py
-        uses: actions/download-artifact@v4
-        with:
-          name: fable-library-py
-          path: ./temp/fable-library-py
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
-          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
-          working-directory: ./temp/fable-library-py
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-macos-${{ matrix.platform.target }}
-          path: ./temp/fable-library-py/dist
+    macos:
+      needs: build-fable-library
+      runs-on: ${{ matrix.platform.runner }}
+      strategy:
+        matrix:
+          platform:
+            - runner: macos-13
+              target: x86_64
+            - runner: macos-14
+              target: aarch64
+      steps:
+        - uses: actions/checkout@v4
+        - uses: actions/setup-python@v5
+          with:
+            python-version: 3.x
+        - name: Download fable-library-py
+          uses: actions/download-artifact@v4
+          with:
+            name: fable-library-py
+            path: ./temp/fable-library-py
+        - name: Build wheels
+          uses: PyO3/maturin-action@v1
+          with:
+            target: ${{ matrix.platform.target }}
+            args: --release --out dist --find-interpreter
+            sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+            working-directory: ./temp/fable-library-py
+        - name: Upload wheels
+          uses: actions/upload-artifact@v4
+          with:
+            name: wheels-macos-${{ matrix.platform.target }}
+            path: ./temp/fable-library-py/dist
 
-  sdist:
-    needs: build-fable-library
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Download fable-library-py
-        uses: actions/download-artifact@v4
-        with:
-          name: fable-library-py
-          path: ./temp/fable-library-py
-      - name: Build sdist
-        uses: PyO3/maturin-action@v1
-        with:
-          command: sdist
-          args: --out dist
-          working-directory: ./temp/fable-library-py
-      - name: Upload sdist
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-sdist
-          path: ./temp/fable-library-py/dist
+    sdist:
+      needs: build-fable-library
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v4
+        - name: Download fable-library-py
+          uses: actions/download-artifact@v4
+          with:
+            name: fable-library-py
+            path: ./temp/fable-library-py
+        - name: Build sdist
+          uses: PyO3/maturin-action@v1
+          with:
+            command: sdist
+            args: --out dist
+            working-directory: ./temp/fable-library-py
+        - name: Upload sdist
+          uses: actions/upload-artifact@v4
+          with:
+            name: wheels-sdist
+            path: ./temp/fable-library-py/dist
 
-  release:
-    name: Release
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
-    needs: [linux, musllinux, windows, macos, sdist]
-    permissions:
-      # Use to sign the release artifacts
-      id-token: write
-      # Used to upload release artifacts
-      contents: write
-      # Used to generate artifact attestation
-      attestations: write
-    steps:
-      - uses: actions/download-artifact@v4
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: 'wheels-*/*'
-      - name: Publish to PyPI
-        if: ${{ github.event_name == 'release' }}
-        uses: PyO3/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-        with:
-          command: upload
-          args: --non-interactive --skip-existing wheels-*/*
-          working-directory: ./temp/fable-library-py
+    release:
+      name: Release
+      runs-on: ubuntu-latest
+      if: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
+      needs: [linux, musllinux, windows, macos, sdist]
+      permissions:
+        # Use to sign the release artifacts
+        id-token: write
+        # Used to upload release artifacts
+        contents: write
+        # Used to generate artifact attestation
+        attestations: write
+      steps:
+        - uses: actions/download-artifact@v4
+        - name: Generate artifact attestation
+          uses: actions/attest-build-provenance@v2
+          with:
+            subject-path: 'wheels-*/*'
+        - name: Publish to PyPI
+          if: ${{ github.event_name == 'release' }}
+          uses: PyO3/maturin-action@v1
+          env:
+            MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+          with:
+            command: upload
+            args: --non-interactive --skip-existing wheels-*/*
+            working-directory: ./temp/fable-library-py


### PR DESCRIPTION
## Why

Looking at the GH action run log I see:

https://github.com/fable-compiler/Fable/actions/runs/16103023239/job/45510132091

Sun, 06 Jul 2025 20:49:34 GMT
Artifact fable-library-py has been successfully uploaded! Final size is 44151193 bytes. Artifact ID is 3472951971

Mon, 07 Jul 2025 21:25:37 GMT
Error: Unable to download artifact(s): Artifact not found for name: fable-library-py

This means that this run took over 24 hours to run, and we have an artifact retention of 1 day. This looks like a issue with GH actions either congestion, rate-limiting, limits, runner availability etc. Thus, I think this was an intermittent issue. If it happens again, we should increase the artifact retention time.

## How

These are just some general fixes to the GH actions workflows I fixed while investigating. It will not fix the issue above if it happens again.

- Fixes for Python publish-pypi GH action, making some dependencies explicit
- Fixed indentation issues in `publish-pypi.yml` GH action
- Upgrades archived `actions-rs/toolchain@v1` to `dtolnay/rust-toolchain@stable` for Rust build