### PR TITLE
[Python] Refactor expression with statements threading

### DIFF
--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -390,7 +390,7 @@ let applyOp (com: ICompiler) (ctx: Context) r t opName (args: Expr list) =
         Operation(Binary(op, left, right), Tags.empty, t, r)
 
     let binOpChar op left right =
-        let toUInt16 e = toInt com ctx None UInt16.Number [ e ]
+        let toUInt16 e = toInt com ctx r UInt16.Number [ e ]
 
         Operation(Binary(op, toUInt16 left, toUInt16 right), Tags.empty, UInt16.Number, r)
         |> toChar com ctx r


### PR DESCRIPTION
- Use the `Expression.withStmts` builder to hide away the statement handling. When expressions are transformed, we need to lift out e.g arrow functions or non-local variables etc.

- Just pure refactor and code cleanup. No new functionality here