### PR TITLE
Erase reference nullable types

### DIFF
--- a/src/Fable.Transforms/Python/Fable2Python.Annotation.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.Annotation.fs
@@ -231,10 +231,13 @@ let typeAnnotation
         stdlibModuleTypeHint com ctx "collections.abc" "Callable" (argTypes @ [ returnType ])
     | Fable.DelegateType(argTypes, returnType) ->
         stdlibModuleTypeHint com ctx "collections.abc" "Callable" (argTypes @ [ returnType ])
-    | Fable.Nullable(genArg, _isStruct) ->
-        // For nullable reference types, use T | None pattern similar to Option but without special handling
-        let innerType, stmts = typeAnnotation com ctx repeatedGenerics genArg
-        Expression.binOp (innerType, BinaryOrBitwise, Expression.none), stmts
+    | Fable.Nullable(genArg, isStruct) ->
+        if isStruct then
+            // For nullable value types, use T | None pattern similar to Option but without special handling
+            let innerType, stmts = typeAnnotation com ctx repeatedGenerics genArg
+            Expression.binOp (innerType, BinaryOrBitwise, Expression.none), stmts
+        else
+            typeAnnotation com ctx repeatedGenerics genArg // nullable reference types are erased
     | Fable.Option(Fable.Unit, _) ->
         // unit option -> just None instead of None | None
         Expression.none, []

--- a/src/Fable.Transforms/Python/Fable2Python.Reflection.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.Reflection.fs
@@ -160,7 +160,8 @@ let transformTypeInfo (com: IPythonCompiler) ctx r (genMap: Map<string, Expressi
     | Fable.LambdaType(argType, returnType) -> genericTypeInfo "lambda" [| argType; returnType |]
     | Fable.DelegateType(argTypes, returnType) -> genericTypeInfo "delegate" [| yield! argTypes; yield returnType |]
     | Fable.Tuple(genArgs, _) -> genericTypeInfo "tuple" (List.toArray genArgs)
-    | Fable.Nullable(genArg, _) -> genericTypeInfo "option" [| genArg |]
+    | Fable.Nullable(genArg, true) -> genericTypeInfo "option" [| genArg |]
+    | Fable.Nullable(genArg, false) -> transformTypeInfo com ctx r genMap genArg
     | Fable.Option(genArg, _) -> genericTypeInfo "option" [| genArg |]
     | Fable.Array(genArg, Fable.ArrayKind.ResizeArray) -> genericTypeInfo "list" [| genArg |]
     | Fable.Array(genArg, _) -> genericTypeInfo "array" [| genArg |]

--- a/src/Fable.Transforms/Rust/Fable2Rust.fs
+++ b/src/Fable.Transforms/Rust/Fable2Rust.fs
@@ -397,6 +397,7 @@ module TypeInfo =
         | Fable.Char -> true
         // | Fable.Number(BigInt, _) -> false
         | Fable.Number _ -> true
+        | Fable.Nullable(_, isStruct) -> isStruct
         | Fable.Option(_, isStruct) -> isStruct
         | Fable.Tuple(_, isStruct) -> isStruct
         | Fable.AnonymousRecordType(_, _, isStruct) -> isStruct
@@ -407,6 +408,7 @@ module TypeInfo =
 
     let isTypeOfType (com: IRustCompiler) isTypeOf isEntityOf entNames typ =
         match typ with
+        | Fable.Nullable(genArg, _) -> isTypeOf com entNames genArg
         | Fable.Option(genArg, _) -> isTypeOf com entNames genArg
         | Fable.Array(genArg, _) -> isTypeOf com entNames genArg
         | Fable.List genArg -> isTypeOf com entNames genArg
@@ -466,6 +468,7 @@ module TypeInfo =
     //     | Fable.String
     //     | Fable.Regex
     //     | Fable.List _ -> false
+    //     | Fable.Nullable(_, isStruct) when not isStruct -> false
     //     | Fable.Option(_, isStruct) when not isStruct -> false
     //     | Fable.Tuple(_, isStruct) when not isStruct -> false
     //     | Fable.AnonymousRecordType(_, _, isStruct) when not isStruct -> false
@@ -802,7 +805,7 @@ module TypeInfo =
         if isStruct then
             transformImportType com ctx [ genArg ] "Native" "Nullable"
         else
-            transformType com ctx genArg // nullable reference types are transparent
+            transformType com ctx genArg // nullable reference types are erased
 
     let transformOptionType com ctx _isStruct genArg : Rust.Ty =
         transformGenericType com ctx [ genArg ] (rawIdent "Option")

--- a/src/fable-library-ts/Util.ts
+++ b/src/fable-library-ts/Util.ts
@@ -32,11 +32,11 @@ export interface IDisposable {
 }
 
 export interface IComparer<T> {
-  Compare(x: Nullable<T>, y: Nullable<T>): number;
+  Compare(x: T, y: T): number;
 }
 
 export interface IEqualityComparer<T> {
-  Equals(x: Nullable<T>, y: Nullable<T>): boolean;
+  Equals(x: T, y: T): boolean;
   GetHashCode(x: T): number;
 }
 
@@ -462,13 +462,7 @@ export function physicalEquals<T>(x: T, y: T): boolean {
   return x === y;
 }
 
-export function nullableEquals<T>(x: Nullable<T>, y: Nullable<T>): boolean {
-  if (x == null) { return y == null; }
-  if (y == null) { return false; }
-  return equals(x, y);
-}
-
-export function equals<T>(x: T, y: T): boolean {
+export function equals<T>(x: Nullable<T>, y: Nullable<T>): boolean {
   if (x === y) {
     return true;
   } else if (x == null) {


### PR DESCRIPTION
I know, I know, we just added these, and now we're erasing them :(

But hear me out, I had some second thoughts on that subject, for several reasons:

- Technically Nullable Reference Types (NRTs) are only checked at compile time for .NET code,
the IL produced is the same with or without 'Nullable', so the interoperability is good.
(feel free to correct me if I'm wrong, though).

- As much as I would like to have NRTs as actual types in the target language, it introduces potential API friction.
It requires using anonymous unions (for languages that support anonymous sum types, aka anonumous DUs, aka erased DUs), so we can have some interoperability between code compiled with `Nullable` and code compiled without.

- Even using anonymous union types for NRTs only gives you interoperability in one direction:
From code *not* compiled with union types to code compiled *with* `Nullable`, it's fine (except for Rust).
The other direction still breaks the contract, e.g. passing `T` to `T | null` works, but the reverse does not.

- In the case of Rust, there are no anonymous sum types (yet), so neither direction works, so the only option is
to either erase NRTs to the inner type, or hope that everything is compiled with the same `Nullable` setting. 
For now I have opted to erase NRTs for Rust, but this can be revisited.

- Of course, this is *not* an issue *at all*, when all your code is compiled the same, either all `Nullable` or all not `Nullable`.
And Fable more or less always recompiles all source code for all dependencies at once, so it's less of an issue
(but it could be, when mixing already precompiled code bases).

- Nevermind the separate but very likely issue of trying to compile dependencies that have not been retrofitted to be compilable with `Nullable`, so the compilation will have lots of nullability warnings.

So this PR is meant just to stir some conversation, please share your thoughts.

Perhaps I'm overreacting and this PR is completely unnecessary, given that we already have a switch that drives the NRT behavior (i.e. the `Nullable` project option, aka `checknulls+`), and most of the time it will be fine, since all dependencies are compiled the same as the main project, so the issue is only about interoperability between disjoint code bases precompiled with different nullability settings.

Thoughts @MangelMaxime @dbrattli ?