### PR TITLE
[Python] Fix python quicktest runscript

### DIFF
--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -964,7 +964,7 @@ let private checkRunProcess (state: State) (projCracked: ProjectCracked) (compil
             match cliArgs.CompilerOptions.Language, runProc.ExeFile with
             | Python, Naming.placeholder ->
                 let lastFilePath = findLastFileRelativePath ()
-                "python", lastFilePath :: runProc.Args
+                "uv", "run" :: "python" :: lastFilePath :: runProc.Args
             | Rust, Naming.placeholder ->
                 let lastFileDir = IO.Path.GetDirectoryName(findLastFileFullPath ())
 


### PR DESCRIPTION
We use `uv` for handling Python and Python dependencies configured in pyproject.toml. Make sure we run Python using `uv´ i.e `uv run python`. This fixes the error you get below you have no global python installed.

```txt
Cannot run: An error occurred trying to start process 'python' with working directory '/Users/dbrattli/Developer/Fable/src/quicktest-py'. No such file or directory
```
It is also important that we run QuickTest using the same version of Python as we used to build Fable Library or the Rust extension will not work since it's built for the specific version of Python. This makes it much easier to test with different versions of Python by using e.g `uv python pin <version>`.