### PR TITLE
[Python] Refactor static properties to use Python class attributes, descriptors and meta-classes

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* [Python] Fixed static properties and are now translated as Python class attributes (by @dbrattli)
 * [Python] Fixed DateTime with DateTimeKind generates proper enum reference (#3689) (by @dbrattli)
 * [Python] Fixed Dictionary KeyValuePair enumeration when casting to IEnumerable (#3771) (by @dbrattli)
 * [Python] Fixed `createEmpty<T>` for interfaces using `SimpleNamespace` with type casting (#3604) (by @dbrattli)

--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -2470,14 +2470,15 @@ module Util =
             let callInfo = { callInfo with ThisArg = None }
             let info = getAbstractMemberInfo com entity memb
 
-            // Python do not support static getters, so we need to call a getter function instead
-            let isPythonStaticMember =
-                com.Options.Language = Python && not memb.IsInstanceMember
+            // Python do not support static getters traditionally, but with our StaticProperty descriptor pattern they do
+            // Allow static properties to use field access syntax when using descriptors
+            let isPythonStaticMemberWithoutDescriptor =
+                com.Options.Language = Python && not memb.IsInstanceMember && false // Disable for now to enable descriptor pattern
 
             if
                 not info.isMangled
                 && info.isGetter
-                && not isPythonStaticMember
+                && not isPythonStaticMemberWithoutDescriptor
                 && not (com.Options.Language = Rust)
             then
                 // Set the field as maybe calculated so it's not displaced by beta reduction

--- a/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
@@ -3219,7 +3219,9 @@ let getInitialValue
         // Use transformValue for literal values - never wrapped
         let value = transformValue com ctx r kind |> fst
         value, false, []
-    | Fable.Get(Fable.IdentExpr _, Fable.FieldGet fieldInfo, _, _) when fieldInfo.Name.EndsWith("@") ->
+    | Fable.Get(Fable.IdentExpr _, Fable.FieldGet fieldInfo, _, _) when
+        fieldInfo.Name.EndsWith("@", System.StringComparison.Ordinal)
+        ->
         // For @ fields (backing fields), use fallback value directly instead of lambda reference
         // The static constructor will set the actual value
         fallback, false, []

--- a/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
@@ -3392,12 +3392,12 @@ let transformStaticProperties (com: IPythonCompiler) (ctx: Context) (decl: Fable
 
         let allStatements = List.ofSeq propStatements
 
-        // Separate external field declarations (for class body) from setter functions (for module level)
+        // Separate backing field declarations (for class body) from setter functions (for module level)
         let backingFieldDeclarations, setterFunctions =
             allStatements
             |> List.partition (fun stmt ->
                 match stmt with
-                | Statement.AnnAssign _ -> true // External field declarations go in class body
+                | Statement.AnnAssign _ -> true // Backing field declarations go in class body
                 | Statement.FunctionDef _ -> false // Setter functions go at module level
                 | _ -> false
             )

--- a/src/Fable.Transforms/Python/Fable2Python.Types.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.Types.fs
@@ -31,6 +31,7 @@ type MemberKind =
     | Attached of isStatic: bool
 
 // Represents different kinds of field access for proper naming convention selection
+[<Struct>]
 type FieldNamingKind =
     | RegularField
     | InstancePropertyBacking

--- a/src/Fable.Transforms/Python/Fable2Python.Types.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.Types.fs
@@ -30,6 +30,12 @@ type MemberKind =
     | NonAttached of funcName: string
     | Attached of isStatic: bool
 
+// Represents different kinds of field access for proper naming convention selection
+type FieldNamingKind =
+    | RegularField
+    | InstancePropertyBacking
+    | StaticProperty
+
 type UsedNames =
     {
         RootScope: HashSet<string>

--- a/src/Fable.Transforms/Python/Prelude.fs
+++ b/src/Fable.Transforms/Python/Prelude.fs
@@ -270,4 +270,6 @@ module Naming =
         // Apply standard sanitization
         sanitizeIdent pyBuiltins.Contains cleanName Naming.NoMemberPart
 
-    let toPropertyBackingFieldNaming (name: string) = $"_{toPropertyNaming name}"
+    let toPropertyBackingFieldNaming (name: string) =
+        let propertyName = name |> toPropertyNaming
+        $"_{Naming.applyCaseRule CaseRules.SnakeCase propertyName}"

--- a/src/Fable.Transforms/Python/Prelude.fs
+++ b/src/Fable.Transforms/Python/Prelude.fs
@@ -251,13 +251,21 @@ module Naming =
         )
 
     let sanitizeIdent conflicts (name: string) part =
-        let name =
-            if name.EndsWith("@", StringComparison.Ordinal) then
-                $"_{name.Substring(0, name.Length - 1)}"
-            else
-                name
         // Replace Forbidden Chars
         buildName sanitizeIdentForbiddenChars name part
         |> checkPyKeywords
         // Check if it already exists
         |> preventConflicts conflicts
+
+    /// Convert name to Python naming convention.
+    /// Removes @ suffixes and applies standard Python naming rules.
+    let toStaticPropertyNaming (name: string) =
+        let pythonName = toPythonNaming name
+        // Remove @ suffix
+        let cleanName =
+            if pythonName.EndsWith("@", StringComparison.Ordinal) then
+                pythonName.Substring(0, pythonName.Length - 1)
+            else
+                pythonName
+        // Apply standard sanitization
+        sanitizeIdent pyBuiltins.Contains cleanName Naming.NoMemberPart

--- a/src/Fable.Transforms/Python/Prelude.fs
+++ b/src/Fable.Transforms/Python/Prelude.fs
@@ -259,7 +259,7 @@ module Naming =
 
     /// Convert name to Python naming convention.
     /// Removes @ suffixes and applies standard Python naming rules.
-    let toStaticPropertyNaming (name: string) =
+    let toPropertyNaming (name: string) =
         let pythonName = toPythonNaming name
         // Remove @ suffix
         let cleanName =
@@ -269,3 +269,5 @@ module Naming =
                 pythonName
         // Apply standard sanitization
         sanitizeIdent pyBuiltins.Contains cleanName Naming.NoMemberPart
+
+    let toPropertyBackingFieldNaming (name: string) = $"_{toPropertyNaming name}"

--- a/src/Fable.Transforms/Python/Prelude.fs
+++ b/src/Fable.Transforms/Python/Prelude.fs
@@ -271,5 +271,9 @@ module Naming =
         sanitizeIdent pyBuiltins.Contains cleanName Naming.NoMemberPart
 
     let toPropertyBackingFieldNaming (name: string) =
-        let propertyName = name |> toPropertyNaming
-        $"_{Naming.applyCaseRule CaseRules.SnakeCase propertyName}"
+        let propertyName =
+            name
+            |> toPropertyNaming
+            |> fun name -> Naming.applyCaseRule CaseRules.SnakeCase name
+
+        $"_%s{propertyName}"

--- a/src/Fable.Transforms/Python/Prelude.fs
+++ b/src/Fable.Transforms/Python/Prelude.fs
@@ -262,13 +262,10 @@ module Naming =
     let toPropertyNaming (name: string) =
         let pythonName = toPythonNaming name
         // Remove @ suffix
-        let cleanName =
-            if pythonName.EndsWith("@", StringComparison.Ordinal) then
-                pythonName.Substring(0, pythonName.Length - 1)
-            else
-                pythonName
-        // Apply standard sanitization
-        sanitizeIdent pyBuiltins.Contains cleanName Naming.NoMemberPart
+        if pythonName.EndsWith("@", StringComparison.Ordinal) then
+            pythonName.Substring(0, pythonName.Length - 1)
+        else
+            pythonName
 
     let toPropertyBackingFieldNaming (name: string) =
         let propertyName =

--- a/src/Fable.Transforms/Python/Python.AST.fs
+++ b/src/Fable.Transforms/Python/Python.AST.fs
@@ -382,7 +382,7 @@ type ClassDef =
     {
         Name: Identifier
         Bases: Expression list
-        Keyword: Keyword list
+        Keywords: Keyword list
         Body: Statement list
         DecoratorList: Expression list
         TypeParams: TypeParam list
@@ -947,7 +947,7 @@ module PythonExtensions =
             {
                 Name = name
                 Bases = defaultArg bases []
-                Keyword = defaultArg keywords []
+                Keywords = defaultArg keywords []
                 Body = defaultArg body []
                 DecoratorList = defaultArg decoratorList []
                 TypeParams = defaultArg typeParams []

--- a/src/Fable.Transforms/Python/PythonPrinter.fs
+++ b/src/Fable.Transforms/Python/PythonPrinter.fs
@@ -193,11 +193,33 @@ module PrinterExtensions =
             // Print type parameters if any (Python 3.12+ syntax)
             printer.PrintTypeParams(cd.TypeParams)
 
-            match cd.Bases with
-            | [] -> ()
-            | xs ->
+            // Print bases and keywords (like metaclass=StaticPropertyMeta)
+            let hasBases = not (List.isEmpty cd.Bases)
+            let hasKeywords = not (List.isEmpty cd.Keywords)
+
+            if hasBases || hasKeywords then
                 printer.Print("(")
-                printer.PrintCommaSeparatedList(xs)
+
+                // Print bases first
+                if hasBases then
+                    printer.PrintCommaSeparatedList(cd.Bases)
+
+                // Print keywords after bases (if both exist, separate with comma)
+                if hasKeywords then
+                    if hasBases then
+                        printer.Print(", ")
+
+                    cd.Keywords
+                    |> List.iteri (fun i kw ->
+                        if i > 0 then
+                            printer.Print(", ")
+
+                        let (Identifier name) = kw.Arg
+                        printer.Print(name)
+                        printer.Print("=")
+                        printer.Print(kw.Value)
+                    )
+
                 printer.Print(")")
 
             printer.Print(":")

--- a/src/fable-library-py/fable_library/util.py
+++ b/src/fable-library-py/fable_library/util.py
@@ -2702,3 +2702,93 @@ def get_platform() -> PlatformID:
         return PlatformID.MacOSX
 
     return PlatformID.Other
+
+
+class StaticProperty[T]:
+    """Static property descriptor.
+
+    This is a descriptor that can be used to define static properties on
+    a class. Supports lazy initialization with factory functions.
+    """
+
+    __slots__ = "_initialized", "factory", "setter_func", "value"
+
+    def __init__(
+        self, initial_value_or_factory: T | Callable[[], T], setter_func: Callable[[T], None] | None = None
+    ) -> None:
+        if callable(initial_value_or_factory):
+            # Factory function for lazy initialization
+            self.factory = initial_value_or_factory
+            self.value = None
+            self._initialized = False
+        else:
+            # Direct value
+            self.value = initial_value_or_factory
+            self.factory = None
+            self._initialized = True
+        self.setter_func = setter_func
+
+    def __get__(self, instance: Any, owner: Any) -> T:
+        if not self._initialized and self.factory is not None:
+            # Lazy initialization - call factory function
+            self.value = self.factory()
+            self._initialized = True
+        return self.value  # type: ignore
+
+    def __set__(self, instance: Any, value: T) -> None:
+        if self.setter_func:
+            self.setter_func(value)
+
+        self.value = value
+        self._initialized = True  # Mark as initialized after manual assignment
+
+
+__all__ = [
+    "ObjectRef",
+    "ObjectRef",
+    "PlatformID",
+    "PlatformID",
+    "PlatformID",
+    "PlatformID",
+    "StaticProperty",
+    "StaticProperty",
+    "array_hash",
+    "array_hash",
+    "copy_to_array",
+    "copy_to_array",
+    "curry2",
+    "curry3",
+    "curry4",
+    "curry5",
+    "curry6",
+    "curry7",
+    "curry8",
+    "curry9",
+    "curry10",
+    "escape_data_string",
+    "escape_data_string",
+    "escape_uri_string",
+    "escape_uri_string",
+    "get_platform",
+    "get_platform",
+    "get_platform",
+    "get_platform",
+    "get_platform",
+    "identity_hash",
+    "ignore",
+    "null_arg_check",
+    "number_hash",
+    "physical_hash",
+    "randint",
+    "round",
+    "uncurry2",
+    "uncurry3",
+    "uncurry4",
+    "uncurry5",
+    "uncurry6",
+    "uncurry7",
+    "uncurry8",
+    "uncurry9",
+    "uncurry10",
+    "unescape_data_string",
+]


### PR DESCRIPTION
Static properties for Python were more (or less) broken. This PR adds static properties as class attributes using `StaticProperty` helper class with descriptors, and meta-classes to solve the problems and generate more correct code for something that turned out to be super-hard to fix 🙈 Happy with the generated code now, but `.Transforms` need a bit of cleanup.

E.g:

```fs
[<AttachMembers>]
type User() =
    // Static backing field - this causes scoping issues
    static let mutable backingField = "BackingValue"

    static member val Id: int = 0 with get, set
    static member val Name: string = "Default" with get, set
    static member MaxConnections
        with get() = 30
        and set(value) =
            if value < 1 then failwith "Invalid"
            else printfn "Setting MaxConnections to %d" value

    // Custom property with static let backing field
    static member CustomProperty
        with get() = backingField
        and set(value: string) = backingField <- value.ToUpper()

    member val Email: string option = None with get, set
```

Will now look like:

```py
class User(metaclass=StaticPropertyMeta):
    def __init__(self, __unit: None=None) -> None:
        self._Email: str | None = None

    @property
    def Email(self, __unit: None=None) -> str | None:
        __: User = self
        return __._Email

    @Email.setter
    def Email(self, v: str | None=None) -> None:
        __: User = self
        __._Email = v

    backing_field: str = ""
    CustomProperty = StaticLazyProperty[str](lambda: User.backing_field, _User_CustomProperty_setter)
    Id = StaticProperty[int32](int32(0))
    MaxConnections = StaticProperty[int32](int32(30), _User_MaxConnections_setter)
    Name = StaticProperty[str]("")
```