### PR TITLE
[TS] Initialize un-initialized variables

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * [TS/Dart] Fixed optional parameter types (by @ncave)
+* [TS] Initialize un-initialized variables (by @ncave)
 
 ## 5.0.0-alpha.14 - 2025-07-25
 

--- a/src/Fable.Compiler/CHANGELOG.md
+++ b/src/Fable.Compiler/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * [TS/Dart] Fixed optional parameter types (by @ncave)
+* [TS] Initialize un-initialized variables (by @ncave)
 
 ## 5.0.0-alpha.14 - 2025-07-25
 

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -1241,6 +1241,15 @@ module Util =
             |> Seq.map (fun (id, value) ->
                 let ta, tp = makeTypeAnnotationWithParametersIfTypeScript com ctx id.Type value
 
+                let value =
+                    if com.IsTypeScript && Option.isNone value then
+                        // initialize un-initialized variables to "undefined as any"
+                        let expr = Expression.Undefined(?loc = None)
+                        let ta = makeTypeAnnotation com ctx Fable.Type.Any
+                        AsExpression(expr, ta) |> Some
+                    else
+                        value
+
                 VariableDeclarator.variableDeclarator (
                     id.Name,
                     ?annotation = ta,


### PR DESCRIPTION
- [TS] Explicitly initialize un-initialized variables to `undefined as any`.
This fixes some rare false-positive TypeScript "uninitialized variable" flow errors for union case matching.