### PR TITLE
[Python] Add [<ClassAttributes>] attribute to control Python class generation

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+* [Python] Added `ClassAttributes` attribute to control Python class generation (@dbrattli)
+
 ### Fixed
 
 * [TS/Dart] Fixed optional parameter types (by @ncave)
@@ -105,14 +109,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [Python] Fix date formatting when repeating a format token more than the known format (example repeating 'd' more than 4 times) (by @MangelMaxime)
 * [JS/TS] Fix #4010: Supports direct nested types when using `jsOptions` (by @MangelMaxime)
 
-    ```fs
+```fs
     let opts =
         jsOptions<Level1> (fun o ->
             o.level2.level3.valueA <- 10
             o.level2.level3.valueB <- 20
             o.topValueA <- 20
         )
-    ```
+```
 
 * [JS/TS] Fix numeric formats (by @MangelMaxime)
 

--- a/src/Fable.Core/CHANGELOG.md
+++ b/src/Fable.Core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+* [Python] Added `ClassAttributes` attribute to control Python class generation (@dbrattli)
+
 ## 5.0.0-beta.1 - 2025-07-25
 
 ### Added

--- a/src/Fable.Core/Fable.Core.Py.fs
+++ b/src/Fable.Core/Fable.Core.Py.fs
@@ -27,6 +27,30 @@ module Py =
 
         abstract Decorate: fn: Callable * info: Reflection.MethodInfo -> Callable
 
+    /// <summary>
+    /// Used on a class to provide Python-specific control over how F# types are transpiled to Python classes.
+    /// This attribute implies member attachment (similar to AttachMembers) while offering Python-specific parameters.
+    /// </summary>
+    /// <remarks>
+    /// <para>When placed on a class, all members are attached without mangling (like AttachMembers).</para>
+    /// <para>Additional Python-specific parameters control the generated Python class style and features.</para>
+    /// </remarks>
+    [<AttributeUsage(AttributeTargets.Class)>]
+    type ClassAttributes() =
+        inherit Attribute()
+
+        new(style: string) = ClassAttributes()
+
+        new(style: string, init: bool) = ClassAttributes()
+
+        new(style: string, init: bool, slots: bool) = ClassAttributes()
+
+        new(style: string, init: bool, slots: bool, frozen: bool) = ClassAttributes()
+
+        new(style: string, init: bool, slots: bool, frozen: bool, repr: bool) = ClassAttributes()
+
+        new(style: string, init: bool, slots: bool, frozen: bool, repr: bool, eq: bool) = ClassAttributes()
+
     // Hack because currently Fable doesn't keep information about spread for anonymous functions
     [<Emit("lambda *args: $0(args)")>]
     let argsFunc (fn: obj[] -> obj) : Callable = nativeOnly

--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -2106,6 +2106,7 @@ module Util =
             // Should we make sure the attribute is not an alias?
             match att.AttributeType.TryFullName with
             | Some Atts.attachMembers -> true
+            | Some Atts.pyClassAttributes -> true
             | _ -> false
         ))
 

--- a/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
@@ -2460,6 +2460,9 @@ let declareClassType
     (baseExpr: Expression option)
     (classMembers: Statement list)
     slotMembers
+    (classAttributes: ClassAttributes option)
+    (attachedMembers: Fable.MemberDecl list)
+    (extractedInitialValues: (string * Fable.MemberDecl * Expression) list)
     =
     // printfn "declareClassType: %A" consBody
     let generics = makeEntityTypeParamDecl com ctx ent
@@ -2471,13 +2474,62 @@ let declareClassType
         else
             None
 
-    let classCons = makeClassConstructor consArgs isOptional fieldTypes com ctx consBody
+
+    // Generate class constructor if init is enabled
+    let classCons =
+        match classAttributes with
+        | Some parms when not parms.Init -> [] // Skip constructor when init=false
+        | _ -> makeClassConstructor consArgs isOptional fieldTypes com ctx consBody
 
     let classFields = slotMembers // TODO: annotations
+
+    // Generate class attributes if using attributes style
+    let classAttributes =
+        match classAttributes with
+        | Some parms when parms.Style = ClassStyle.Attributes ->
+            // Generate class attributes for attached members (deduplicate by property name)
+            ent.MembersFunctionsAndValues
+            |> Seq.filter (fun memb -> memb.IsInstance && (memb.IsGetter || memb.IsSetter))
+            |> Seq.groupBy (fun memb -> memb.DisplayName)
+            |> Seq.map (fun (propertyName, members) ->
+                // Use the getter's return type for the class attribute type annotation
+                let getter = members |> Seq.find (fun memb -> memb.IsGetter)
+                let ta, _ = Annotation.typeAnnotation com ctx None getter.ReturnParameter.Type
+
+                if parms.Init then
+                    // For attributes style with init, class attributes should only have type annotations
+                    // Default values are handled by the constructor parameters
+                    Statement.annAssign (Expression.name (propertyName |> Naming.toPropertyNaming), annotation = ta)
+                else
+                    // For attributes style with init=false, class attributes should have initial values
+                    // Use the extracted initial values from the constructor body
+                    // printfn "Looking for extracted initial value for property: %s" propertyName
+                    let defaultValue =
+                        extractedInitialValues
+                        |> List.tryFind (fun (propName, _getterMemb, _defaultValue) ->
+                            propName = (propertyName |> Naming.toPropertyNaming)
+                        )
+                        |> function
+                            | Some(_propName, _getterMemb, defaultValue) ->
+                                // printfn "Found extracted initial value for %s: %A" propertyName defaultValue
+                                defaultValue
+                            | None ->
+                                // printfn "No extracted initial value found for %s, using type default" propertyName
+                                Util.getDefaultValueForType com ctx getter.ReturnParameter.Type
+
+                    Statement.annAssign (
+                        Expression.name (propertyName |> Naming.toPropertyNaming),
+                        annotation = ta,
+                        value = defaultValue
+                    )
+            )
+            |> List.ofSeq
+        | _ -> []
+
     let classMembers = classCons @ classMembers
 
     let classBody =
-        let body = [ yield! classFields; yield! classMembers ]
+        let body = [ yield! classFields; yield! classAttributes; yield! classMembers ]
 
         match body with
         | [] -> [ Statement.ellipsis ]
@@ -2588,6 +2640,9 @@ let declareType
     (consBody: Statement list)
     (baseExpr: Expression option)
     (classMembers: Statement list)
+    (pythonClassParams: ClassAttributes option)
+    (attachedMembers: Fable.MemberDecl list)
+    (extractedInitialValues: (string * Fable.MemberDecl * Expression) list)
     : Statement list
     =
     let slotMembers = createSlotsForRecordType com ctx ent
@@ -2596,7 +2651,21 @@ let declareType
         match ent.IsFSharpRecord with
         | true ->
             declareDataClassType com ctx ent entName consArgs isOptional consBody baseExpr classMembers slotMembers
-        | false -> declareClassType com ctx ent entName consArgs isOptional consBody baseExpr classMembers slotMembers
+        | false ->
+            declareClassType
+                com
+                ctx
+                ent
+                entName
+                consArgs
+                isOptional
+                consBody
+                baseExpr
+                classMembers
+                slotMembers
+                pythonClassParams
+                attachedMembers
+                extractedInitialValues
 
     let reflectionDeclaration, stmts =
         let ta = fableModuleAnnotation com ctx "Reflection" "TypeInfo" []
@@ -2784,6 +2853,7 @@ let transformAttachedProperty
     (ent: Fable.Entity)
     (info: Fable.MemberFunctionOrValue)
     (memb: Fable.MemberDecl)
+    (pythonClassParams: ClassAttributes option)
     =
     let isStatic = not info.IsInstance
     let isGetter = info.IsGetter
@@ -2794,42 +2864,53 @@ let transformAttachedProperty
         // They will be processed at the class level
         []
     else
-        // Instance properties use the traditional approach
-        let decorators =
-            [
-                if isGetter then
-                    Expression.name "property"
-                else
-                    Expression.name $"%s{memb.Name}.setter"
-            ]
+        // Check if we should use attributes style
+        let useAttributesStyle =
+            match pythonClassParams with
+            | Some parms when parms.Style = ClassStyle.Attributes -> true
+            | _ -> false
 
-        let args, body, returnType =
-            getMemberArgsAndBody com ctx (Attached isStatic) false memb.Args memb.Body
+        if useAttributesStyle then
+            // For attributes style, we don't generate property methods
+            // The attributes will be handled at the class level
+            []
+        else
+            // Instance properties use the traditional approach (properties style)
+            let decorators =
+                [
+                    if isGetter then
+                        Expression.name "property"
+                    else
+                        Expression.name $"%s{memb.Name}.setter"
+                ]
 
-        // Apply the same naming convention as record fields for record types
-        let propertyName =
-            //if shouldUseRecordFieldNaming ent then
-            //    memb.Name |> Naming.toRecordFieldSnakeCase |> Helpers.clean
-            //else
-            memb.Name |> Naming.toPropertyNaming
+            let args, body, returnType =
+                getMemberArgsAndBody com ctx (Attached isStatic) false memb.Args memb.Body
 
-        let key = com.GetIdentifier(ctx, propertyName)
+            // Apply the same naming convention as record fields for record types
+            let propertyName =
+                //if shouldUseRecordFieldNaming ent then
+                //    memb.Name |> Naming.toRecordFieldSnakeCase |> Helpers.clean
+                //else
+                memb.Name |> Naming.toPropertyNaming
 
-        let self = Arg.arg "self"
-        let arguments = { args with Args = self :: args.Args }
+            let key = com.GetIdentifier(ctx, propertyName)
 
-        let typeParams =
-            calculateTypeParams com ctx info arguments returnType memb.Body.Type
+            let self = Arg.arg "self"
+            let arguments = { args with Args = self :: args.Args }
 
-        Statement.functionDef (
-            key,
-            arguments,
-            body = body,
-            decoratorList = decorators,
-            returns = returnType,
-            typeParams = typeParams
-        )
-        |> List.singleton
+            let typeParams =
+                calculateTypeParams com ctx info arguments returnType memb.Body.Type
+
+            Statement.functionDef (
+                key,
+                arguments,
+                body = body,
+                decoratorList = decorators,
+                returns = returnType,
+                typeParams = typeParams
+            )
+            |> List.singleton
 
 let transformAttachedMethod (com: IPythonCompiler) ctx (info: Fable.MemberFunctionOrValue) (memb: Fable.MemberDecl) =
     // printfn "transformAttachedMethod: %A" memb
@@ -2949,7 +3030,7 @@ let transformUnion (com: IPythonCompiler) ctx (ent: Fable.Entity) (entName: stri
     let baseExpr = libValue com ctx "types" "Union" |> Some
     let classMembers = List.append [ cases ] classMembers
 
-    declareType com ctx ent entName args isOptional body baseExpr classMembers
+    declareType com ctx ent entName args isOptional body baseExpr classMembers None [] []
 
 let transformClassWithCompilerGeneratedConstructor
     (com: IPythonCompiler)
@@ -2957,6 +3038,7 @@ let transformClassWithCompilerGeneratedConstructor
     (ent: Fable.Entity)
     (entName: string)
     classMembers
+    (classAttributes: ClassAttributes)
     =
     // printfn "transformClassWithCompilerGeneratedConstructor"
     let fieldIds = getEntityFieldsAsIdents com ent
@@ -2981,23 +3063,38 @@ let transformClassWithCompilerGeneratedConstructor
             if Option.isSome baseExpr then
                 yield callSuperAsStatement []
 
-            yield!
-                ent.FSharpFields
-                |> List.collecti (fun i field ->
-                    let fieldName =
-                        if shouldUseRecordFieldNaming ent then
-                            field.Name |> Naming.toRecordFieldSnakeCase |> Helpers.clean
-                        else
-                            match Util.getFieldNamingKind com field.FieldType field.Name with
-                            | InstancePropertyBacking -> field.Name |> Naming.toPropertyBackingFieldNaming
-                            | StaticProperty -> field.Name |> Naming.toPropertyNaming
-                            | RegularField -> field.Name |> Naming.toPythonNaming
+            // For attributes style, use direct attribute names and proper parameter handling
+            if classAttributes.Style = ClassStyle.Attributes then
+                yield!
+                    ent.FSharpFields
+                    |> List.collect (fun field ->
+                        let fieldName = field.Name |> Naming.toPropertyNaming
+                        let left = get com ctx None thisExpr fieldName false
+                        // For attributes style, use the property name as the argument name
+                        let argName = field.Name |> Naming.toPropertyNaming
+                        let right = Expression.name argName |> wrapIntExpression field.FieldType
 
-                    let left = get com ctx None thisExpr fieldName false
-                    let right = args[i] |> wrapIntExpression field.FieldType
+                        // Always assign the parameter value to the attribute
+                        assign None left right |> exprAsStatement ctx
+                    )
+            else
+                yield!
+                    ent.FSharpFields
+                    |> List.collecti (fun i field ->
+                        let fieldName =
+                            if shouldUseRecordFieldNaming ent then
+                                field.Name |> Naming.toRecordFieldSnakeCase |> Helpers.clean
+                            else
+                                match Util.getFieldNamingKind com field.FieldType field.Name with
+                                | InstancePropertyBacking -> field.Name |> Naming.toPropertyBackingFieldNaming
+                                | StaticProperty -> field.Name |> Naming.toPropertyNaming
+                                | RegularField -> field.Name |> Naming.toPythonNaming
 
-                    assign None left right |> exprAsStatement ctx
-                )
+                        let left = get com ctx None thisExpr fieldName false
+                        let right = args[i] |> wrapIntExpression field.FieldType
+
+                        assign None left right |> exprAsStatement ctx
+                    )
         ]
 
     let args =
@@ -3008,7 +3105,7 @@ let transformClassWithCompilerGeneratedConstructor
         )
         |> (fun args -> Arguments.arguments (args = args))
 
-    declareType com ctx ent entName args isOptional body baseExpr classMembers
+    declareType com ctx ent entName args isOptional body baseExpr classMembers (Some classAttributes) [] []
 
 let transformClassWithPrimaryConstructor
     (com: IPythonCompiler)
@@ -3016,15 +3113,82 @@ let transformClassWithPrimaryConstructor
     (classDecl: Fable.ClassDecl)
     (classMembers: Statement list)
     (cons: Fable.MemberDecl)
+    (classAttributes: ClassAttributes)
     =
-    // printfn "transformClassWithPrimaryConstructor: %A" classDecl
+    // printfn "transformClassWithPrimaryConstructor: %A" classDecl.Name
+    // printfn "PythonClass params: style=%A, init=%b" classAttributes.Style classAttributes.Init
     let classEnt = com.GetEntity(classDecl.Entity)
     let classIdent = Expression.name (com.GetIdentifier(ctx, classDecl.Name))
 
-    let consArgs, consBody, _returnType =
-        let info = com.GetMember(cons.MemberRef)
+    // Extract initial values from constructor body for both init=true and init=false cases
+    let getterMembers =
+        if classAttributes.Style = ClassStyle.Attributes then
+            classDecl.AttachedMembers
+            |> List.filter (fun memb ->
+                let info = com.GetMember(memb.MemberRef)
+                info.IsGetter
+            )
+        else
+            []
 
-        getMemberArgsAndBody com ctx ClassConstructor info.HasSpread cons.Args cons.Body
+    let extractedInitialValues, stmts =
+        if classAttributes.Style = ClassStyle.Attributes then
+            getterMembers
+            |> List.map (fun getterMemb ->
+                // printfn "Extracting default value for property %s" (getterMemb.Name |> Naming.toPropertyNaming)
+                let propertyName = getterMemb.Name |> Naming.toPropertyNaming
+
+                let extracted =
+                    Util.tryExtractInitializationValueFromConstructor com ctx cons.Body propertyName
+
+                let result, stmts =
+                    extracted
+                    |> Option.defaultWith (fun () ->
+                        // printfn "Using type default for property %s" propertyName
+                        Util.getDefaultValueForType com ctx getterMemb.Body.Type, []
+                    )
+                // printfn "Final default value for %s: %A" propertyName result
+                (propertyName, getterMemb, result), stmts
+            )
+            |> List.unzip
+            // Flatten the list of statements generated from the property extractions
+            |> fun (extractedInitialValues, stmts) -> extractedInitialValues, List.concat stmts
+        else
+            [], []
+
+    let consArgs, consBody, _returnType =
+        if classAttributes.Style = ClassStyle.Attributes then
+            if classAttributes.Init then
+                // For attributes style with init=true, generate new constructor with property names
+                let propertyArgs =
+                    let args =
+                        extractedInitialValues
+                        |> List.map (fun (propertyName, getterMemb, _defaultValue) ->
+                            let ta, _ = Annotation.typeAnnotation com ctx None getterMemb.Body.Type
+                            Arg.arg (propertyName, annotation = ta)
+                        )
+
+                    let defaults =
+                        extractedInitialValues
+                        |> List.map (fun (_propertyName, _getterMemb, defaultValue) -> defaultValue)
+
+                    Arguments.arguments (args = args, defaults = defaults)
+
+                let propertyBody =
+                    extractedInitialValues
+                    |> List.collect (fun (propertyName, _getterMemb, _defaultValue) ->
+                        let left = get com ctx None thisExpr propertyName false
+                        let right = Expression.name propertyName
+                        assign None left right |> exprAsStatement ctx
+                    )
+
+                propertyArgs, propertyBody, Expression.none
+            else
+                // For attributes style with init=false, no constructor arguments or body
+                Arguments.empty, [], Expression.none
+        else
+            let info = com.GetMember(cons.MemberRef)
+            getMemberArgsAndBody com ctx ClassConstructor info.HasSpread cons.Args cons.Body
 
     let isOptional = Helpers.isOptional (cons.Args |> Array.ofList)
 
@@ -3038,11 +3202,16 @@ let transformClassWithPrimaryConstructor
         makeGenericTypeAnnotation' com ctx classDecl.Name (genParams |> List.ofSeq) (Some availableGenerics)
 
     let exposedCons =
-        let argExprs = consArgs.Args |> List.map (fun p -> Expression.identifier p.Arg)
+        if classAttributes.Style = ClassStyle.Attributes && not classAttributes.Init then
+            // For attributes style with init=false, don't generate an exposed constructor
+            // since there's no __init__ method to call
+            []
+        else
+            let argExprs = consArgs.Args |> List.map (fun p -> Expression.identifier p.Arg)
 
-        let exposedConsBody = Expression.call (classIdent, argExprs)
-        let name = com.GetIdentifier(ctx, cons.Name)
-        makeFunction name (consArgs, exposedConsBody, [], returnType)
+            let exposedConsBody = Expression.call (classIdent, argExprs)
+            let name = com.GetIdentifier(ctx, cons.Name)
+            [ makeFunction name (consArgs, exposedConsBody, [], returnType) ]
 
     let baseExpr, consBody =
         classDecl.BaseCall
@@ -3061,8 +3230,22 @@ let transformClassWithPrimaryConstructor
         |> Option.defaultValue (None, consBody)
 
     [
-        yield! declareType com ctx classEnt classDecl.Name consArgs isOptional consBody baseExpr classMembers
-        exposedCons
+        yield! stmts
+        yield!
+            declareType
+                com
+                ctx
+                classEnt
+                classDecl.Name
+                consArgs
+                isOptional
+                consBody
+                baseExpr
+                classMembers
+                (Some classAttributes)
+                classDecl.AttachedMembers
+                extractedInitialValues
+        yield! exposedCons
     ]
 
 let transformInterface (com: IPythonCompiler) ctx (classEnt: Fable.Entity) (_classDecl: Fable.ClassDecl) =
@@ -3475,6 +3658,17 @@ let rec transformDeclaration (com: IPythonCompiler) ctx (decl: Fable.Declaration
                 let anyType = com.GetImportExpr(ctx, "typing", "Any")
                 [ Statement.assign ([ name ], anyType) ]
         else
+            // Check for PythonClass attribute and extract parameters
+            let classAttributes =
+                if hasPythonClassAttribute ent.Attributes then
+                    getPythonClassParameters ent.Attributes
+                else
+                    ClassAttributes.Default
+
+            // Raise error if classAttributes.Style is ClassStyle.Properties and classAttributes.Init is false
+            if classAttributes.Style = ClassStyle.Properties && not classAttributes.Init then
+                failwithf "ClassAttributes.Init must be true when ClassAttributes.Style is ClassStyle.Properties"
+
             let classMembers =
                 decl.AttachedMembers
                 |> List.collect (fun memb ->
@@ -3486,7 +3680,7 @@ let rec transformDeclaration (com: IPythonCompiler) ctx (decl: Fable.Declaration
                             |> Option.defaultWith (fun () -> com.GetMember(memb.MemberRef))
 
                         if not memb.IsMangled && (info.IsGetter || info.IsSetter) then
-                            transformAttachedProperty com ctx ent info memb
+                            transformAttachedProperty com ctx ent info memb (Some classAttributes)
                         else
                             transformAttachedMethod com ctx info memb
                 )
@@ -3510,12 +3704,12 @@ let rec transformDeclaration (com: IPythonCompiler) ctx (decl: Fable.Declaration
                 withCurrentScope ctx cons.UsedNames
                 <| fun ctx ->
                     let classStmts =
-                        transformClassWithPrimaryConstructor com ctx decl allClassMembers cons
+                        transformClassWithPrimaryConstructor com ctx decl allClassMembers cons classAttributes
 
                     allStatements @ classStmts
             | _, None ->
                 let classStmts =
-                    transformClassWithCompilerGeneratedConstructor com ctx ent decl.Name allClassMembers
+                    transformClassWithCompilerGeneratedConstructor com ctx ent decl.Name allClassMembers classAttributes
 
                 allStatements @ classStmts
 
@@ -3624,7 +3818,7 @@ let transformFile (com: IPythonCompiler) (file: Fable.File) =
             NarrowedTypes = Map.empty
         }
 
-    //printfn "file: %A" file.Declarations
+    // printfn "file: %A" file.Declarations
     let rootDecls = List.collect (transformDeclaration com ctx) file.Declarations
 
     let rootComment =

--- a/src/Fable.Transforms/Python/Fable2Python.Types.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.Types.fs
@@ -37,6 +37,34 @@ type FieldNamingKind =
     | InstancePropertyBacking
     | StaticProperty
 
+
+/// Represents different styles of Python class generation
+[<RequireQualifiedAccess>]
+type ClassStyle =
+    | Properties
+    | Attributes
+
+/// Represents the parameters for the Python class attribute
+type ClassAttributes =
+    {
+        Style: ClassStyle
+        Init: bool
+        Slots: bool
+        Frozen: bool
+        Repr: bool
+        Eq: bool
+    }
+
+    static member Default =
+        {
+            Style = ClassStyle.Properties
+            Init = true
+            Slots = false
+            Frozen = false
+            Repr = false
+            Eq = false
+        }
+
 type UsedNames =
     {
         RootScope: HashSet<string>

--- a/src/Fable.Transforms/Python/Fable2Python.Util.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.Util.fs
@@ -42,6 +42,72 @@ module Util =
         || hasAttribute Atts.emitIndexer atts
         || hasAttribute Atts.emitProperty atts
 
+    let hasPythonClassAttribute (atts: Fable.Attribute seq) =
+        hasAttribute Atts.pyClassAttributes atts
+
+    let parseClassStyle (styleStr: string) =
+        match styleStr with
+        | "attributes" -> ClassStyle.Attributes
+        | "properties" -> ClassStyle.Properties
+        | _ -> ClassStyle.Properties // Default to Properties for unknown values
+
+    let getPythonClassParameters (atts: Fable.Attribute seq) =
+        let defaultParams = ClassAttributes.Default
+
+        atts
+        |> Seq.tryFind (fun att -> att.Entity.FullName = Atts.pyClassAttributes)
+        |> Option.map (fun att ->
+            // Extract parameters from the attribute constructor arguments
+            match att.ConstructorArgs with
+            | [] -> defaultParams
+            | [ :? string as styleParam ] -> { defaultParams with Style = parseClassStyle styleParam }
+            | [ :? string as styleParam; :? bool as initParam ] ->
+                { defaultParams with
+                    Style = parseClassStyle styleParam
+                    Init = initParam
+                }
+            | [ :? string as styleParam; :? bool as initParam; :? bool as slotsParam ] ->
+                { defaultParams with
+                    Style = parseClassStyle styleParam
+                    Init = initParam
+                    Slots = slotsParam
+                }
+            | [ :? string as styleParam; :? bool as initParam; :? bool as slotsParam; :? bool as frozenParam ] ->
+                { defaultParams with
+                    Style = parseClassStyle styleParam
+                    Init = initParam
+                    Slots = slotsParam
+                    Frozen = frozenParam
+                }
+            | [ :? string as styleParam
+                :? bool as initParam
+                :? bool as slotsParam
+                :? bool as frozenParam
+                :? bool as reprParam ] ->
+                { defaultParams with
+                    Style = parseClassStyle styleParam
+                    Init = initParam
+                    Slots = slotsParam
+                    Frozen = frozenParam
+                    Repr = reprParam
+                }
+            | [ :? string as styleParam
+                :? bool as initParam
+                :? bool as slotsParam
+                :? bool as frozenParam
+                :? bool as reprParam
+                :? bool as eqParam ] ->
+                { defaultParams with
+                    Style = parseClassStyle styleParam
+                    Init = initParam
+                    Slots = slotsParam
+                    Frozen = frozenParam
+                    Repr = reprParam
+                    Eq = eqParam
+                }
+            | _ -> defaultParams // Fallback for unexpected parameter combinations
+        )
+        |> Option.defaultValue defaultParams
 
     let getIdentifier (_com: IPythonCompiler) (_ctx: Context) (name: string) =
         let name = Helpers.clean name
@@ -428,6 +494,36 @@ module Util =
         | Fable.DeclaredType(ent, _) -> Expression.none
         | _ -> Expression.none
 
+    /// Extract initialization value from constructor body by looking for backing field assignments
+    let tryExtractInitializationValueFromConstructor
+        (com: IPythonCompiler)
+        (ctx: Context)
+        (constructorBody: Fable.Expr)
+        (propertyName: string)
+        : (Expression * Statement list) option
+        =
+        let backingFieldName = propertyName + "@"
+
+        let rec findAssignment expr =
+            match expr with
+            | Fable.Sequential exprs -> exprs |> List.tryPick findAssignment
+            | Fable.Set(_, Fable.FieldSet fieldName, _, value, _) when fieldName = backingFieldName ->
+                let expr, stmts = com.TransformAsExpr(ctx, value)
+                Some(expr, stmts)
+            | Fable.Set(Fable.Get(_, Fable.FieldGet { Name = fieldName }, _, _), Fable.FieldSet fieldName2, _, value, _) when
+                fieldName = backingFieldName
+                ->
+                let expr, stmts = com.TransformAsExpr(ctx, value)
+                Some(expr, stmts)
+            | Fable.Set(Fable.Get(_, Fable.FieldGet { Name = fieldName }, _, _), Fable.ValueSet, _, value, _) when
+                fieldName = backingFieldName
+                ->
+                let expr, stmts = com.TransformAsExpr(ctx, value)
+                Some(expr, stmts)
+            | _ -> None
+
+        findAssignment constructorBody
+
     let makeClassConstructor
         (args: Arguments)
         (isOptional: bool)
@@ -437,7 +533,7 @@ module Util =
         body
         =
         // printfn "makeClassConstructor: %A" (args.Args, body)
-        let name = Identifier("__init__")
+        let name = Identifier "__init__"
         let self = Arg.arg "self"
 
         let args_ =

--- a/src/Fable.Transforms/Python/Python.AST.fs
+++ b/src/Fable.Transforms/Python/Python.AST.fs
@@ -987,6 +987,15 @@ module PythonExtensions =
             }
             |> AsyncFunctionDef
 
+        static member annAssign(target, ?value, ?annotation, ?simple) : Statement =
+            {
+                AnnAssign.Target = target
+                Value = value
+                Annotation = annotation |> Option.defaultValue (Expression.none)
+                Simple = defaultArg simple false
+            }
+            |> AnnAssign
+
         static member assign(targets, value, ?typeComment) : Statement =
             {
                 Targets = targets

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -122,7 +122,7 @@ module Atts =
     let pyReflectedDecorator = "Fable.Core.Py.ReflectedDecoratorAttribute" // typeof<Fable.Core.Py.ReflectedDecoratorAttribute>.FullName
 
     [<Literal>]
-    let pyMemberNaming = "Fable.Core.Py.MemberNamingAttribute" // typeof<Fable.Core.Py.MemberNamingAttribute>.FullName
+    let pyClassAttributes = "Fable.Core.Py.ClassAttributes" // typeof<Fable.Core.Py.ClassAttributes>.FullName
 
     [<Literal>]
     let dartIsConst = "Fable.Core.Dart.IsConstAttribute" // typeof<Fable.Core.Dart.IsConstAttribute>.FullName


### PR DESCRIPTION
## Overview

Introduce a new `[<ClassAttributes>]` attribute that provides Python-specific control over how F# types are transpiled to Python classes. This attribute implies member attachment (similar to `AttachMembers`) while offering Python-specific parameters for better integration with Python frameworks like Pydantic, dataclasses, and SQLAlchemy.

## Current AttachMembers Behavior (For Context)

### Without AttachMembers (Default)

```fsharp
type User() =
    member val Name: string = "" with get, set
```

Generates:

```python
class User:
    def __init__(self, __unit: None=None) -> None:
        pass

def User_get_Name(self) -> str:
    return self._Name

def User_set_Name(self, value: str) -> None:
    self._Name = value
```

### With AttachMembers (Current)

```fsharp
[<AttachMembers>]
type User() =
    member val Name: string = "" with get, set
```

Generates:

```python
class User:
    def __init__(self, __unit: None=None) -> None:
        self._Name: str = ""

    @property
    def Name(self) -> str:
        return self._Name

    @Name.setter
    def Name(self, value: str) -> None:
        self._Name = value
```

---

## New ClassAttributes Attribute

### Basic Syntax

```fsharp
// Replaces [<AttachMembers>] for Python with same behavior (properties style)
[<ClassAttributes>]
type User() = ...

// New: Generate class attributes instead of @property
[<ClassAttributes(Style="attributes")>]
type User() = ...

// With additional Python-specific parameters
[<ClassAttributes(Style="attributes", Slots=true, Frozen=true)>]
type Config() = ...
```

### Style: "attributes" (New Feature)

#### F# Input

```fsharp
[<ClassAttributes(Style="attributes")>]
type User() =
    member val Name: string = "" with get, set
    member val Age: int = 0 with get, set
    member val Email: string option = None with get, set
```

#### Generated Output

```python
class User:
    Name: str
    Age: int
    Email: str | None

    def __init__(self, Name: str = "", Age: int = 0, Email: str | None = None):
        self.Name = Name
        self.Age = Age
        self.Email = Email
```

---

## Parameter Reference

|Parameter|Type|Default|Description|
|---|---|---|---|
|`style`|string|`"properties"`|`"properties"` (current behavior) or `"attributes"`|
|`init`|bool|`true`|Generate `__init__` method|
|`slots`|bool|`false`|Add `__slots__` for memory efficiency|
|`frozen`|bool|`false`|Make attributes read-only after init|
|`repr`|bool|`false`|Generate `__repr__` method|
|`eq`|bool|`false`|Generate `__eq__` method|

### Parameter Examples

#### Suppress **init** Generation

```fsharp
[<ClassAttributes(style="attributes", init=false)>]
type Config() =
    member val Debug: bool = false with get, set
    member val Timeout: int = 30 with get, set
```

```python
class Config:
    Debug: bool = False
    Timeout: int = 30
    # No __init__ method generated