### PR TITLE
[Python] Fix static properties with IDisposable

### DIFF
--- a/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
@@ -2461,6 +2461,55 @@ let declareDataClassType
         Statement.classDef (name, body = classBody, decoratorList = decorators, bases = bases, typeParams = typeParams)
     ]
 
+let transformClassAttributes
+    (com: IPythonCompiler)
+    (ctx: Context)
+    (ent: Fable.Entity)
+    (classAttributes: ClassAttributes option)
+    (extractedInitialValues: (string * Fable.MemberDecl * Expression) list)
+    : Statement list
+    =
+    match classAttributes with
+    | Some parms when parms.Style = ClassStyle.Attributes ->
+        // Generate class attributes for attached members (deduplicate by property name)
+        ent.MembersFunctionsAndValues
+        |> Seq.filter (fun memb -> memb.IsInstance && (memb.IsGetter || memb.IsSetter))
+        |> Seq.groupBy (fun memb -> memb.DisplayName)
+        |> Seq.map (fun (propertyName, members) ->
+            // Use the getter's return type for the class attribute type annotation
+            let getter = members |> Seq.find (fun memb -> memb.IsGetter)
+            let ta, _ = Annotation.typeAnnotation com ctx None getter.ReturnParameter.Type
+
+            if parms.Init then
+                // For attributes style with init, class attributes should only have type annotations
+                // Default values are handled by the constructor parameters
+                Statement.annAssign (Expression.name (propertyName |> Naming.toPropertyNaming), annotation = ta)
+            else
+                // For attributes style with init=false, class attributes should have initial values
+                // Use the extracted initial values from the constructor body
+                // printfn "Looking for extracted initial value for property: %s" propertyName
+                let defaultValue =
+                    extractedInitialValues
+                    |> List.tryFind (fun (propName, _getterMemb, _defaultValue) ->
+                        propName = (propertyName |> Naming.toPropertyNaming)
+                    )
+                    |> function
+                        | Some(_propName, _getterMemb, defaultValue) ->
+                            // printfn "Found extracted initial value for %s: %A" propertyName defaultValue
+                            defaultValue
+                        | None ->
+                            // printfn "No extracted initial value found for %s, using type default" propertyName
+                            Util.getDefaultValueForType com ctx getter.ReturnParameter.Type
+
+                Statement.annAssign (
+                    Expression.name (propertyName |> Naming.toPropertyNaming),
+                    annotation = ta,
+                    value = defaultValue
+                )
+        )
+        |> List.ofSeq
+    | _ -> []
+
 let declareClassType
     (com: IPythonCompiler)
     (ctx: Context)
@@ -2486,7 +2535,6 @@ let declareClassType
         else
             None
 
-
     // Generate class constructor if init is enabled
     let classCons =
         match classAttributes with
@@ -2497,46 +2545,7 @@ let declareClassType
 
     // Generate class attributes if using attributes style
     let classAttributes =
-        match classAttributes with
-        | Some parms when parms.Style = ClassStyle.Attributes ->
-            // Generate class attributes for attached members (deduplicate by property name)
-            ent.MembersFunctionsAndValues
-            |> Seq.filter (fun memb -> memb.IsInstance && (memb.IsGetter || memb.IsSetter))
-            |> Seq.groupBy (fun memb -> memb.DisplayName)
-            |> Seq.map (fun (propertyName, members) ->
-                // Use the getter's return type for the class attribute type annotation
-                let getter = members |> Seq.find (fun memb -> memb.IsGetter)
-                let ta, _ = Annotation.typeAnnotation com ctx None getter.ReturnParameter.Type
-
-                if parms.Init then
-                    // For attributes style with init, class attributes should only have type annotations
-                    // Default values are handled by the constructor parameters
-                    Statement.annAssign (Expression.name (propertyName |> Naming.toPropertyNaming), annotation = ta)
-                else
-                    // For attributes style with init=false, class attributes should have initial values
-                    // Use the extracted initial values from the constructor body
-                    // printfn "Looking for extracted initial value for property: %s" propertyName
-                    let defaultValue =
-                        extractedInitialValues
-                        |> List.tryFind (fun (propName, _getterMemb, _defaultValue) ->
-                            propName = (propertyName |> Naming.toPropertyNaming)
-                        )
-                        |> function
-                            | Some(_propName, _getterMemb, defaultValue) ->
-                                // printfn "Found extracted initial value for %s: %A" propertyName defaultValue
-                                defaultValue
-                            | None ->
-                                // printfn "No extracted initial value found for %s, using type default" propertyName
-                                Util.getDefaultValueForType com ctx getter.ReturnParameter.Type
-
-                    Statement.annAssign (
-                        Expression.name (propertyName |> Naming.toPropertyNaming),
-                        annotation = ta,
-                        value = defaultValue
-                    )
-            )
-            |> List.ofSeq
-        | _ -> []
+        transformClassAttributes com ctx ent classAttributes extractedInitialValues
 
     let classMembers = classCons @ classMembers
 
@@ -2546,7 +2555,6 @@ let declareClassType
         match body with
         | [] -> [ Statement.ellipsis ]
         | _ -> body
-
 
     let interfaces, stmts =
         // We only use a few interfaces as base classes. The rest is handled as Python protocols (PEP 544) to avoid a massive
@@ -2603,14 +2611,15 @@ let declareClassType
             false
         else
             // Get the original member declarations from the entity
-            let members = ent.MembersFunctionsAndValues |> Seq.toList
+            let members = ent.MembersFunctionsAndValues
 
             members
-            |> List.exists (fun info -> not info.IsInstance && (info.IsGetter || info.IsSetter))
+            |> Seq.exists (fun info -> not info.IsInstance && (info.IsGetter || info.IsSetter))
 
-    // Add metaclass if the class has static properties
     let keywords =
-        if hasStaticProperties then
+        // Add metaclass if the class has static properties but only if the class is
+        // decorated with [<AttachMembers>]
+        if hasStaticProperties && hasAttribute Atts.attachMembers ent.Attributes then
             let staticPropertyMetaExpr = libValue com ctx "util" "StaticPropertyMeta"
             [ Keyword.keyword (Identifier "metaclass", staticPropertyMetaExpr) ]
         else
@@ -2699,7 +2708,6 @@ let declareType
         let generics = genArgs |> Array.mapToList (identAsExpr com ctx)
 
         let body, stmts = transformReflectionInfo com ctx None ent generics
-
         let expr, stmts' = makeFunctionExpression com ctx None (args, body, [], ta)
 
         let name =
@@ -3319,8 +3327,10 @@ let transformInterface (com: IPythonCompiler) ctx (classEnt: Fable.Entity) (_cla
     ]
 
 // Helper function to extract initial value from getter body
-// Returns (value, isFactory, externalFields) where isFactory indicates if the value is a lambda function
-// and externalFields contains field names that need to be added as class attributes
+// Returns (value, isFactory, externalFields, stmts) where isFactory indicates if the value is a lambda function,
+// externalFields contains field names that need to be added as class attributes
+// and stmts contains statements (e.g., local function declarations) from closurd that need lifted out of the
+// to the nearest enclosing scope.
 let getInitialValue
     com
     ctx
@@ -3328,19 +3338,19 @@ let getInitialValue
     (getterMemb: Fable.MemberDecl)
     (wrapInLambda: bool)
     (fallback: Expression)
-    : (Expression * bool * string list)
+    : (Expression * bool * string list * Statement list)
     =
     match getterMemb.Body with
     | Fable.Value(kind, r) ->
         // Use transformValue for literal values - never wrapped
-        let value = transformValue com ctx r kind |> fst
-        value, false, []
+        let value, stmts = transformValue com ctx r kind
+        value, false, [], stmts
     | Fable.Get(Fable.IdentExpr _, Fable.FieldGet fieldInfo, _, _) when
         fieldInfo.Name.EndsWith("@", System.StringComparison.Ordinal)
         ->
         // For @ fields (backing fields), use fallback value directly instead of lambda reference
         // The static constructor will set the actual value
-        fallback, false, []
+        fallback, false, [], []
     | Fable.Get(Fable.IdentExpr identExpr, Fable.FieldGet fieldInfo, _, _) when identExpr.Name = className ->
         // For external field references (like backing_field), create lambda and note the field
         let classNameExpr = Expression.name identExpr.Name
@@ -3352,20 +3362,20 @@ let getInitialValue
             Expression.attribute (classNameExpr, Identifier transformedFieldName)
 
         if wrapInLambda then
-            Expression.lambda (Arguments.arguments [], fieldAccess), true, [ transformedFieldName ]
+            Expression.lambda (Arguments.arguments [], fieldAccess), true, [ transformedFieldName ], []
         else
-            fieldAccess, false, [ transformedFieldName ]
+            fieldAccess, false, [ transformedFieldName ], []
     | _ ->
         // For other expressions, try to transform
         try
-            let expr, _ = com.TransformAsExpr(ctx, getterMemb.Body)
+            let expr, stmts = com.TransformAsExpr(ctx, getterMemb.Body)
 
             if wrapInLambda then
-                Expression.lambda (Arguments.arguments [], expr), true, []
+                Expression.lambda (Arguments.arguments [], expr), true, [], stmts
             else
-                expr, false, []
+                expr, false, [], stmts
         with _ ->
-            fallback, false, []
+            fallback, false, [], []
 
 
 // Process a single static property and return (property assignment, extra statements, external field declarations)
@@ -3432,7 +3442,7 @@ let transformStaticProperty
         // Read-only property
         let fallback = Util.getDefaultValueForType com ctx getterMemb.Body.Type
 
-        let initialValue, isFactory, externalFields =
+        let initialValue, isFactory, externalFields, initialValueStmts =
             getInitialValue com ctx name getterMemb true fallback
 
         let propExpr = makeStaticProperty getterMemb.Body.Type [ initialValue ] isFactory
@@ -3440,7 +3450,7 @@ let transformStaticProperty
         // Generate class attribute declarations for external fields
         let externalFieldDeclarations = generateExternalFieldDeclarations externalFields
 
-        Some(propertyName, propExpr), externalFieldDeclarations
+        Some(propertyName, propExpr), initialValueStmts @ externalFieldDeclarations
 
     | Some getterMemb, Some setterMemb ->
         // Property with both getter and setter
@@ -3449,7 +3459,7 @@ let transformStaticProperty
 
         let fallback = Util.getDefaultValueForType com ctx getterMemb.Body.Type
 
-        let initialValue, isFactory, externalFields =
+        let initialValue, isFactory, externalFields, initialValueStmts =
             getInitialValue com ctx name getterMemb true fallback
 
         // Check if setter has custom logic beyond simple assignment to the property itself
@@ -3480,7 +3490,7 @@ let transformStaticProperty
             // Generate class attribute declarations for external fields
             let externalFieldDeclarations = generateExternalFieldDeclarations externalFields
 
-            Some(propertyName, propExpr), [ setterFunc ] @ externalFieldDeclarations
+            Some(propertyName, propExpr), initialValueStmts @ [ setterFunc ] @ externalFieldDeclarations
         else
             // Simple setter, no custom function needed - just use the descriptor
             let propExpr = makeStaticProperty getterMemb.Body.Type [ initialValue ] isFactory
@@ -3488,7 +3498,7 @@ let transformStaticProperty
             // Generate class attribute declarations for external fields
             let externalFieldDeclarations = generateExternalFieldDeclarations externalFields
 
-            Some(propertyName, propExpr), externalFieldDeclarations
+            Some(propertyName, propExpr), initialValueStmts @ externalFieldDeclarations
 
     | None, Some setterMemb ->
         // Setter-only property (unusual but possible)

--- a/src/fable-library-py/fable_library/util.py
+++ b/src/fable-library-py/fable_library/util.py
@@ -6,7 +6,7 @@ import platform
 import random
 import re
 import weakref
-from abc import ABC, abstractmethod
+from abc import ABC, ABCMeta, abstractmethod
 from collections.abc import (
     Callable,
     Iterable,
@@ -56,8 +56,9 @@ class ObjectDisposedException(Exception):
 class IDisposable(ABC):
     """IDisposable interface.
 
-    Note currently not a protocol since it also impmelents resource
-    management and needs to be inherited from.
+    Note: IDisposable is currently not a protocol since it also
+    implements resource management and thus cannot use static subtyping
+    and needs to be inherited from.
     """
 
     __slots__ = ()
@@ -2771,8 +2772,13 @@ class StaticLazyProperty[T](StaticPropertyBase[T]):
         pass  # The factory handles value retrieval
 
 
-class StaticPropertyMeta(type):
-    """Metaclass that enables StaticProperty descriptors to work with class-level assignment."""
+class StaticPropertyMeta(ABCMeta):
+    """Metaclass that enables StaticProperty descriptors to work with class-level
+    assignment.
+
+    Note: We inherit from ABCMeta to be compatible when combined with classes that also
+    inherit from ABC, such as IDisposable.
+    """
 
     def __setattr__(cls, name: str, value: Any) -> None:
         # Check if the attribute exists and is a StaticPropertyBase


### PR DESCRIPTION
## Why

- Fixes issues with types having static properties and inheriting from `IDisposable`. This gave confusing error such as `TypeError: metaclass conflict: the metaclass of a derived class must be a (non-strict) subclass of the metaclasses of all its bases`
- Fixes missing closures (local functions) in the generation of static properties. There statements were ignored, but this PR lifts the them out and renders them in the nearest enclosing statement block