### PR TITLE
[JS/TS] Fix #4041 missing unit argument

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* [JS/TS] Fix #4041 missing unit argument (by @ncave)
 * [JS/TS/Python] Fixed eq comparer mangling (by @ncave)
 * [All] Fix all `BitConverter` return types (by @ncave)
 * [TS] Don't cast union case types to `any` (by @ncave)

--- a/src/Fable.Compiler/CHANGELOG.md
+++ b/src/Fable.Compiler/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* [JS/TS] Fix #4041 missing unit argument (by @ncave)
 * [JS/TS/Python] Fixed eq comparer mangling (by @ncave)
 * [All] Fix all `BitConverter` return types (by @ncave)
 * [TS] Don't cast union case types to `any` (by @ncave)

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -3542,22 +3542,9 @@ but thanks to the optimisation done below we get
     let tryFindAnyEntAttribute fullNames (ent: Fable.Entity) : (string * obj list) option =
         tryFindAnyAttribute fullNames ent.Attributes
 
-    let transformModuleFunction
-        (com: IBabelCompiler)
-        ctx
-        (info: Fable.MemberFunctionOrValue)
-        (membName: string)
-        (args: Fable.Ident list)
-        body
-        =
-        let isJsx = hasAttribute Atts.jsxComponent info.Attributes
-
+    let transformModuleFunction com ctx (info: Fable.MemberFunctionOrValue) membName (args: Fable.Ident list) body =
         let args, body =
-            match args with
-            | [] -> args, body
-            | [ arg ] when arg.Type = Fable.Unit -> [], body
-            | _ when not isJsx -> args, body
-            | _ ->
+            if info.Attributes |> hasAttribute Atts.jsxComponent then
                 // SolidJS requires values being accessed directly from the props object for reactivity to work properly
                 // https://www.solidjs.com/guides/rendering#props
                 let propsArg = makeIdent "$props"
@@ -3569,6 +3556,8 @@ but thanks to the optimisation done below we get
                     |> Map
 
                 [ propsArg ], FableTransforms.replaceValues replacements body
+            else
+                args, body
 
         let args, body, returnType, typeParamDecl =
             getMemberArgsAndBody com ctx (NonAttached membName) None info args body

--- a/tests/Dart/src/TypeTests.fs
+++ b/tests/Dart/src/TypeTests.fs
@@ -584,7 +584,15 @@ type VeryOptionalInterface =
 //     static member DefaultNullParam([<Optional; DefaultParameterValue(null:obj)>] x: obj) = x
 //     static member inline InlineAdd(x: int, ?y: int) = x + (defaultArg y 2)
 
+type Model = unit
+
+let update (model: Model) =
+    model, ()
+
 let tests() =
+
+    // testCase "Unit arguments work" <| fun () ->
+    //     update () |> equal ((), ())
 
     testCase "Optional arguments work" <| fun () ->
         let x = MyOptionalClass(?arg2 = Some "2")

--- a/tests/Js/Main/TypeTests.fs
+++ b/tests/Js/Main/TypeTests.fs
@@ -639,8 +639,16 @@ type StaticClass =
     static member DefaultNullParam([<Optional; DefaultParameterValue(null:obj)>] x: obj) = x
     static member inline InlineAdd(x: int, ?y: int) = x + (defaultArg y 2)
 
+type Model = unit
+
+let update (model: Model) =
+    model, ()
+
 let tests =
   testList "Types" [
+
+    testCase "Unit arguments work" <| fun () ->
+        update () |> equal ((), ())
 
     testCase "Optional arguments work" <| fun () ->
         let x = MyOptionalClass(?arg2 = Some "2")

--- a/tests/Python/TestType.fs
+++ b/tests/Python/TestType.fs
@@ -637,6 +637,15 @@ type StaticClass =
     static member DefaultNullParam([<Optional; DefaultParameterValue(null:obj)>] x: obj) = x
     static member inline InlineAdd(x: int, ?y: int) = x + (defaultArg y 2)
 
+type Model = unit
+
+let update (model: Model) =
+    model, ()
+
+[<Fact>]
+let ``test Unit arguments work`` () =
+    update () |> equal ((), ())
+
 [<Fact>]
 let ``test Optional arguments work`` () =
     let x = MyOptionalClass(?arg2 = Some "2")

--- a/tests/Rust/tests/src/TypeTests.fs
+++ b/tests/Rust/tests/src/TypeTests.fs
@@ -563,6 +563,15 @@ type StaticClass =
 //     static member DefaultNullParam([<Optional; DefaultParameterValue(null:obj)>] x: obj) = x
     static member inline InlineAdd(x: int, ?y: int) = x + (defaultArg y 2)
 
+type Model = unit
+
+let update (model: Model) =
+    model, ()
+
+// [<Fact>]
+// let ``Unit arguments work`` () =
+//     update () |> equal ((), ())
+
 [<Fact>]
 let ``Optional arguments work`` () =
     let x = MyOptionalClass(?arg2 = Some "2")


### PR DESCRIPTION
- [JS/TS] Fix #4041 missing unit argument

JS/TS/Python tests pass cause you can just omit unit args, but Rust and Dart would need some work.