### PR TITLE
[Discussion] Add flag to format generated output

### DIFF
--- a/src/Fable.AST/Plugins.fs
+++ b/src/Fable.AST/Plugins.fs
@@ -38,6 +38,7 @@ type CompilerOptions =
         FileExtension: string
         TriggeredByDependency: bool
         NoReflection: bool
+        Format: bool
     }
 
 type PluginHelper =

--- a/src/Fable.Build/Quicktest/Core.fs
+++ b/src/Fable.Build/Quicktest/Core.fs
@@ -53,6 +53,7 @@ let genericQuicktest (config: QuicktestConfig) (args: string list) =
         |> CmdLine.appendRaw "--noCache"
         |> CmdLine.appendRaw "--verbose"
         |> CmdLine.appendRaw "--watch"
+        |> CmdLine.appendRaw "--format"
         |> appendRunMode,
         workingDirectory = projectDir
     )

--- a/src/Fable.Cli/Entry.fs
+++ b/src/Fable.Cli/Entry.fs
@@ -127,6 +127,7 @@ let knownCliArgs () =
         [ "--trimRootModule" ], []
         [ "--fableLib" ], []
         [ "--replace" ], []
+        [ "--format" ], []
     ]
 
 let printKnownCliArgs () =
@@ -354,7 +355,8 @@ type Runner =
                     debugMode = (configuration = "Debug"),
                     optimizeFSharpAst = args.FlagEnabled "--optimize",
                     noReflection = args.FlagEnabled "--noReflection",
-                    verbosity = verbosity
+                    verbosity = verbosity,
+                    format = args.FlagEnabled "--format"
                 )
 
             let cliArgs =

--- a/src/Fable.Cli/Pipeline.fs
+++ b/src/Fable.Cli/Pipeline.fs
@@ -336,6 +336,17 @@ module Python =
 
                 do! PythonPrinter.run writer python
 
+                if cliArgs.CompilerOptions.Format then
+                    // Run Ruff formatter on all generated files
+                    let outDir = IO.Path.GetDirectoryName outPath
+                    Console.WriteLine $"Running ruff format on {outPath}"
+                    // First sort imports. This is currently handled by the linter. A unified command for both linting
+                    // and formatting is planned. https://github.com/astral-sh/ruff/issues/8232
+                    Process.runSync outDir "ruff" [ "check"; "--select"; "I"; "--fix"; outPath ]
+                    |> ignore
+
+                    Process.runSync outDir "ruff" [ "format"; outPath ] |> ignore
+
                 match com.OutputType with
                 | OutputType.Library ->
                     // Make sure we include an empty `__init__.py` in every directory of a library

--- a/src/Fable.Transforms/Global/Compiler.fs
+++ b/src/Fable.Transforms/Global/Compiler.fs
@@ -18,7 +18,8 @@ type CompilerOptionsHelper =
             ?verbosity,
             ?fileExtension,
             ?clampByteArrays,
-            ?noReflection
+            ?noReflection,
+            ?format
         )
         =
         {
@@ -32,6 +33,7 @@ type CompilerOptionsHelper =
             ClampByteArrays = defaultArg clampByteArrays false
             NoReflection = defaultArg noReflection false
             TriggeredByDependency = false
+            Format = defaultArg format false
         }
 
 [<RequireQualifiedAccess>]


### PR DESCRIPTION
## Why

It would be nice to generate nicely formatted output so code looks the way you expect it to be, and do not give warnings by linters in code editors. For many languages these days it the code has a default recommended formatting e.g `cargo fmt`, `ruff format`. 

<img width="1596" height="504" alt="image" src="https://github.com/user-attachments/assets/992c81eb-3d4c-44b9-ad84-99fc3ad2d3a1" />


## How

Add a flag `--format` so the target languages can perform "standard" formatting to the generated output. Not sure this is the right place, or if we could do it in a single step for all the generated files at once. 

What do you think? @MangelMaxime @ncave 