### PR TITLE
[Python] Improve Pydantic interop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ reportMissingTypeStubs = false
 reportMissingImports = false
 reportUnnecessaryTypeIgnoreComment = true
 reportUnusedImport = true
-reportUnusedVariable = true
+reportUnusedVariable = false
 reportUnnecessaryIsInstance = true
 reportUnnecessaryComparison = true
 reportUnnecessaryCast = true
@@ -54,7 +54,7 @@ reportOverlappingOverload = true
 reportInconsistentConstructor = true
 reportImplicitStringConcatenation = true
 pythonVersion = "3.12"
-typeCheckingMode = "strict"
+typeCheckingMode = "standard"
 
 [tool.ruff]
 # Keep in sync with .pre-commit-config.yaml

--- a/src/Fable.Build/FableLibrary/Python.fs
+++ b/src/Fable.Build/FableLibrary/Python.fs
@@ -43,7 +43,6 @@ type BuildFableLibraryPython() =
 
         Shell.deleteDir (this.BuildDir </> "fable_library/fable-library-ts")
 
-
         // Run Ruff linter checking import sorting and fix any issues
         Command.Run("uv", $"run ruff check --select I --fix {this.BuildDir}")
         // Run Ruff formatter on all generated files

--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* [Python] Improve Python (e.g. Pydantic) interop (by @dbrattli)
 * [JS/TS] Fix #4041 missing unit argument (by @ncave)
 * [JS/TS/Python] Fixed eq comparer mangling (by @ncave)
 * [All] Fix all `BitConverter` return types (by @ncave)

--- a/src/Fable.Transforms/Python/Fable2Python.Annotation.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.Annotation.fs
@@ -49,10 +49,6 @@ let getGenericTypeParams (types: Fable.Type list) =
 let getEntityGenParams (ent: Fable.Entity) =
     ent.GenericParameters |> Seq.map (fun x -> x.Name) |> Set.ofSeq
 
-let makeTypeParamDecl (com: IPythonCompiler) ctx (genParams: Set<string>) =
-    // Python 3.12+ syntax: no longer need Generic[T] base classes
-    []
-
 let makeTypeParams (com: IPythonCompiler) ctx (genParams: Set<string>) : TypeParam list =
     // Python 3.12+ syntax: create TypeParam list for class/function declaration
     genParams

--- a/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
@@ -757,10 +757,7 @@ let transformCallArgs
 
     match objArg with
     | None -> args, [], stmts @ stmts'
-    | Some objArg ->
-        //let name = Expression.name(Helpers.getUniqueIdentifier "kw")
-        //let kw = Statement.assign([ name], objArg)
-        args, objArg, stmts @ stmts'
+    | Some objArg -> args, objArg, stmts @ stmts'
 
 let resolveExpr (ctx: Context) _t strategy pyExpr : Statement list =
     // printfn "resolveExpr: %A" (pyExpr, strategy)
@@ -776,12 +773,6 @@ let resolveExpr (ctx: Context) _t strategy pyExpr : Statement list =
 let transformOperation com ctx range opKind tags : Expression * Statement list =
     match opKind with
     | Fable.Unary(op, TransformExpr com ctx (expr, stmts)) -> Expression.unaryOp (op, expr, ?loc = range), stmts
-
-    // | Fable.Binary (BinaryInstanceOf, TransformExpr com ctx (left, stmts), TransformExpr com ctx (right, stmts')) ->
-    //     let func = Expression.name ("isinstance")
-    //     let args = [ left; right ]
-    //     Expression.call (func, args), stmts' @ stmts
-
     | Fable.Binary(op, left, right: Fable.Expr) ->
         let typ = right.Type
         let left_typ = left.Type

--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -299,7 +299,9 @@ let toInt com (ctx: Context) r targetType (args: Expr list) =
         | UInt8 -> Helper.LibCall(com, "types", "byte", targetType, [ arg ])
         | UInt16 -> Helper.LibCall(com, "types", "uint16", targetType, [ arg ])
         | UInt32 -> Helper.LibCall(com, "types", "uint32", targetType, [ arg ])
-        | _ -> FableError $"Unexpected non-integer type %A{typeTo}" |> raise
+        | _ ->
+            // Use normal Python int for BigInt, NativeInt, UNativeInt
+            Helper.GlobalCall("int", targetType, [ arg ])
 
     match sourceType, targetType with
     | Char, Number(typeTo, _) ->
@@ -326,7 +328,7 @@ let toChar com (ctx: Context) r (arg: Expr) =
     | Char
     | String -> arg
     | _ ->
-        let code = toInt com ctx r UInt16.Number [ arg ]
+        let code = Helper.GlobalCall("int", Int32.Number, [ arg ])
         Helper.GlobalCall("chr", Char, [ code ])
 
 let toString com (ctx: Context) r (args: Expr list) =

--- a/src/fable-library-py/fable_library/big_int.py
+++ b/src/fable-library-py/fable_library/big_int.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 from typing import Any
 
-from .types import FSharpRef
+from .types import FSharpRef, int32, int64
 
 
 def compare(x: int, y: int) -> int:
@@ -188,11 +188,11 @@ def from_one() -> int:
     return 1
 
 
-def from_int32(x: int) -> int:
+def from_int32(x: int32) -> int:
     return int(x)
 
 
-def from_int64(x: int) -> int:
+def from_int64(x: int64) -> int:
     return int(x)
 
 

--- a/src/fable-library-py/fable_library/core/array.pyi
+++ b/src/fable-library-py/fable_library/core/array.pyi
@@ -16,6 +16,8 @@ ArrayType = Literal[
     "UInt8",
     "Int16",
     "UInt16",
+    "Int32",
+    "UInt32",
     "SupportsInt",
     "USupportsInt",
     "Int64",

--- a/src/fable-library-py/fable_library/long.py
+++ b/src/fable-library-py/fable_library/long.py
@@ -3,7 +3,7 @@ from typing import Any, Literal, SupportsFloat, SupportsInt, overload
 from .core._core import get_range_64 as get_range
 from .core._core import parse_int64 as parse
 from .core._core import try_parse_int64 as try_parse
-from .types import float64, int64, uint64
+from .types import float64, int32, int64, uint64
 
 
 def compare(x: int64, y: int64) -> int64:
@@ -14,11 +14,27 @@ def sign(x: int64) -> int64:
     return int64.NEG_ONE if x < int64.ZERO else int64.ONE if x > int64.ZERO else int64.ZERO
 
 
-def max(x: int64, y: int64) -> int64:
+@overload
+def max(x: int64, y: int64) -> int64: ...
+
+
+@overload
+def max(x: uint64, y: uint64) -> uint64: ...
+
+
+def max(x: int64 | uint64, y: int64 | uint64) -> int64 | uint64:
     return x if x > y else y
 
 
-def min(x: int64, y: int64) -> int64:
+@overload
+def min(x: int64, y: int64) -> int64: ...
+
+
+@overload
+def min(x: uint64, y: uint64) -> uint64: ...
+
+
+def min(x: int64 | uint64, y: int64 | uint64) -> int64 | uint64:
     return x if x < y else y
 
 
@@ -27,59 +43,155 @@ def op_unary_negation(value: int64) -> int64:
     return -value if value != int64.NEG_ONE else int64.NEG_ONE
 
 
-def op_unary_plus(a: int64) -> int64:
+@overload
+def op_unary_plus(a: int64) -> int64: ...
+
+
+@overload
+def op_unary_plus(a: uint64) -> uint64: ...
+
+
+def op_unary_plus(a: int64 | uint64) -> int64 | uint64:
     return +a
 
 
-def op_logical_not(a: int64) -> int64:
+@overload
+def op_logical_not(a: int64) -> int64: ...
+
+
+@overload
+def op_logical_not(a: uint64) -> uint64: ...
+
+
+def op_logical_not(a: int64 | uint64) -> int64 | uint64:
     return ~a
 
 
-def op_addition(a: int64, b: int64) -> int64:
+@overload
+def op_addition(a: int64, b: int64) -> int64: ...
+
+
+@overload
+def op_addition(a: uint64, b: uint64) -> uint64: ...
+
+
+def op_addition(a: int64 | uint64, b: int64 | uint64) -> int64 | uint64:
     return a + b
 
 
-def op_subtraction(a: int64, b: int64) -> int64:
+@overload
+def op_subtraction(a: int64, b: int64) -> int64: ...
+
+
+@overload
+def op_subtraction(a: uint64, b: uint64) -> uint64: ...
+
+
+def op_subtraction(a: int64 | uint64, b: int64 | uint64) -> int64 | uint64:
     return a - b
 
 
-def op_multiply(a: int64, b: int64) -> int64:
+@overload
+def op_multiply(a: int64, b: int64) -> int64: ...
+
+
+@overload
+def op_multiply(a: uint64, b: uint64) -> uint64: ...
+
+
+def op_multiply(a: int64 | uint64, b: int64 | uint64) -> int64 | uint64:
     return a * b
 
 
-def op_division(a: int64, b: int64) -> int64:
+@overload
+def op_division(a: int64, b: int64) -> int64: ...
+
+
+@overload
+def op_division(a: uint64, b: uint64) -> uint64: ...
+
+
+def op_division(a: int64 | uint64, b: int64 | uint64) -> int64 | uint64:
     return a // b
 
 
-def op_modulus(a: int64, b: int64) -> int64:
+@overload
+def op_modulus(a: int64, b: int64) -> int64: ...
+
+
+@overload
+def op_modulus(a: uint64, b: uint64) -> uint64: ...
+
+
+def op_modulus(a: int64 | uint64, b: int64 | uint64) -> int64 | uint64:
     return a % b
 
 
-def op_right_shift(a: int64, b: int64) -> int64:
+@overload
+def op_right_shift(a: int64, b: int32) -> int64: ...
+
+
+@overload
+def op_right_shift(a: uint64, b: int32) -> uint64: ...
+
+
+def op_right_shift(a: int64 | uint64, b: int32) -> int64 | uint64:
     return a >> b
 
 
-def op_left_shift(a: int64, b: int64) -> int64:
+@overload
+def op_left_shift(a: int64, b: int32) -> int64: ...
+
+
+@overload
+def op_left_shift(a: uint64, b: int32) -> uint64: ...
+
+
+def op_left_shift(a: int64 | uint64, b: int32) -> int64 | uint64:
     return a << b
 
 
-def op_bitwise_and(a: int64, b: int64) -> int64:
+@overload
+def op_bitwise_and(a: int64, b: int64) -> int64: ...
+
+
+@overload
+def op_bitwise_and(a: uint64, b: uint64) -> uint64: ...
+
+
+def op_bitwise_and(a: int64 | uint64, b: int64 | uint64) -> int64 | uint64:
     return a & b
 
 
-def op_bitwise_or(a: int64, b: int64) -> int64:
+@overload
+def op_bitwise_or(a: int64, b: int64) -> int64: ...
+
+
+@overload
+def op_bitwise_or(a: uint64, b: uint64) -> uint64: ...
+
+
+def op_bitwise_or(a: int64 | uint64, b: int64 | uint64) -> int64 | uint64:
     return a | b
 
 
-def op_exclusive_or(a: int64, b: int64) -> int64:
+@overload
+def op_exclusive_or(a: int64, b: int64) -> int64: ...
+
+
+@overload
+def op_exclusive_or(a: uint64, b: uint64) -> uint64: ...
+
+
+def op_exclusive_or(a: int64 | uint64, b: int64 | uint64) -> int64 | uint64:
     return a ^ b
 
 
-def op_less_than(a: int64, b: int64) -> bool:
+def op_less_than(a: int64 | uint64, b: int64 | uint64) -> bool:
     return a < b
 
 
-def op_less_than_or_equal(a: int64, b: int64) -> bool:
+def op_less_than_or_equal(a: int64 | uint64, b: int64 | uint64) -> bool:
     return a <= b
 
 
@@ -123,11 +235,22 @@ def from_value(value: Any, unsigned: bool = False) -> int64:
     return value
 
 
-def from_number(value: SupportsInt, unsigned: bool) -> int64:
-    return int64(value)
+@overload
+def from_number(value: SupportsInt, unsigned: Literal[True]) -> uint64: ...
 
 
-def to_number(value: SupportsFloat) -> float64:
+@overload
+def from_number(value: SupportsInt, unsigned: Literal[False]) -> int64: ...
+
+
+def from_number(value: SupportsInt, unsigned: bool) -> int64 | uint64:
+    if unsigned:
+        return uint64(value)
+    else:
+        return int64(value)
+
+
+def to_number(value: SupportsFloat | SupportsInt) -> float64:
     return float64(value)
 
 
@@ -150,7 +273,7 @@ def from_integer(value: int, unsigned: bool | None = None, kind: int | None = No
 AllowHexSpecifier = 0x00000200
 
 
-def to_string(x: int64) -> str:
+def to_string(x: int64 | uint64) -> str:
     return str(x)
 
 

--- a/src/fable-library-py/fable_library/types.py
+++ b/src/fable-library-py/fable_library/types.py
@@ -254,6 +254,9 @@ class FSharpException(Exception, IComparable):
     def CompareTo(self, other: FSharpException):
         return compare(self.Data0, other.Data0)
 
+    def __cmp__(self, other: FSharpException):
+        return compare(self.Data0, other.Data0)
+
 
 class char(int):
     __slots__ = ()

--- a/src/fable-library-py/fable_library/util.py
+++ b/src/fable-library-py/fable_library/util.py
@@ -22,6 +22,7 @@ from typing import (
     Any,
     ClassVar,
     Protocol,
+    TypeGuard,
     cast,
 )
 from urllib.parse import quote, unquote
@@ -161,23 +162,23 @@ class IComparer_1[T_in](Protocol):
     """
 
     @abstractmethod
-    def Compare(self, __x: T_in, __y: T_in) -> int32:
+    def Compare(self, /, x: T_in, y: T_in) -> int32:
         raise NotImplementedError
 
 
 class IEqualityComparer(Protocol):
     @abstractmethod
-    def Equals(self, x: Any = None, y: Any = None) -> bool:
+    def Equals(self, /, x: Any = None, y: Any = None) -> bool:
         raise NotImplementedError
 
     @abstractmethod
-    def GetHashCode(self, x_1: Any = None) -> int32:
+    def GetHashCode(self, /, x: Any = None) -> int32:
         raise NotImplementedError
 
 
 class IEqualityComparer_1[T_in](Protocol):
     @abstractmethod
-    def Equals(self, __x: T_in, __y: T_in) -> bool:
+    def Equals(self, /, x: T_in, y: T_in) -> bool:
         raise NotImplementedError
 
     @abstractmethod
@@ -2547,7 +2548,11 @@ def dispose(x: IDisposable | AbstractContextManager[Any]) -> None:
             raise ex
 
 
-def is_hashable(x: Any) -> bool:
+class HashCode(Protocol):
+    def GetHashCode(self) -> int32: ...
+
+
+def is_hashable(x: Any) -> TypeGuard[HashCode]:
     return hasattr(x, "GetHashCode")
 
 
@@ -2583,11 +2588,11 @@ class ObjectRef:
         return ObjectRef.id_map[_id]
 
 
-def safe_hash(x: Any) -> int:
+def safe_hash(x: Any) -> int32:
     return (
-        0
+        int32.ZERO
         if x is None
-        else hash(x)
+        else int32(hash(x))
         if is_hashable_py(x)
         else x.GetHashCode()
         if is_hashable(x)
@@ -2647,8 +2652,8 @@ def round(value: float64, digits: int = 0) -> float64:
     return value.round(digits)
 
 
-def randint(a: int, b: int) -> int:
-    return random.randint(a, b - 1)
+def randint(a: int32, b: int32) -> int32:
+    return int32(random.randint(int(a), int(b) - 1))
 
 
 def unescape_data_string(s: str) -> str:


### PR DESCRIPTION
## Why

Libraries like Pydantic expect constructor arguments to be named arguments. This PR fixes this issue.

```fs
[<Erase>]
type Field<'T> = 'T

module Field =
    [<Import("Field", "pydantic")>]
    [<Emit("$0(frozen=$1)")>]
    let Frozen (frozen: bool) : Field<'T> = nativeOnly

    [<Import("Field", "pydantic")>]
    [<Emit("$0(default=$1)")>]
    let Default(value: 'T) : Field<'T> = nativeOnly

[<Import("BaseModel", "pydantic")>]
type BaseModel () = class end

[<Py.ClassAttributes(style="attributes", init=false)>]
type PydanticUser(Name: string, Age: bigint, Email: string option, Enabled: bool) =
    inherit BaseModel()
    member val Name: string = Field.Frozen(true) with get, set
    member val Age: bigint = Age with get, set
    member val Email: string option = None with get, set
    member val Enabled: bool = Field.Default(false) with get, set

let user = PydanticUser(Name = "Test User", Age=23, Email=None, Enabled=true)
```

This will now translate to:

```py
class PydanticUser(BaseModel):
    Age: int
    Email: str | None
    Enabled: bool = Field(default=False)
    Name: str = Field(frozen=True)

PydanticUser_reflection = _expr1

user: PydanticUser = PydanticUser(Name = "Test User", Age = 23, Email = None, Enabled = True)
```