### PR TITLE
[Python] Use enum for class attributes style

### DIFF
--- a/src/Fable.Core/Fable.Core.Py.fs
+++ b/src/Fable.Core/Fable.Core.Py.fs
@@ -45,11 +45,17 @@ module Py =
     [<AttributeUsage(AttributeTargets.Class, AllowMultiple = true)>]
     type DecorateAttribute(decorator: string) =
         inherit Attribute()
-
         new(decorator: string, parameters: string) = DecorateAttribute(decorator)
 
         member val Decorator: string = decorator with get, set
         member val Parameters: string = "" with get, set
+
+    [<RequireQualifiedAccess>]
+    type ClassAttributeStyle =
+        // Translates to properties with instance attributes backing
+        | Properties = 0
+        // Translates to class attributes
+        | Attributes = 1
 
     /// Used on a class to provide Python-specific control over how F# types are transpiled to Python classes.
     /// This attribute implies member attachment (similar to AttachMembers) while offering Python-specific parameters.
@@ -62,9 +68,9 @@ module Py =
     type ClassAttributes() =
         inherit Attribute()
 
-        new(style: string) = ClassAttributes()
+        new(style: ClassAttributeStyle) = ClassAttributes()
 
-        new(style: string, init: bool) = ClassAttributes()
+        new(style: ClassAttributeStyle, init: bool) = ClassAttributes()
 
     // Hack because currently Fable doesn't keep information about spread for anonymous functions
     [<Emit("lambda *args: $0(args)")>]

--- a/src/Fable.Transforms/Python/Fable2Python.Annotation.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.Annotation.fs
@@ -471,7 +471,7 @@ let makeBuiltinTypeAnnotation com ctx kind repeatedGenerics =
 
 let transformFunctionWithAnnotations (com: IPythonCompiler) ctx name (args: Fable.Ident list) (body: Fable.Expr) =
     // printfn "transformFunctionWithAnnotations: %A" (name, args, body.Type)
-    let argTypes = args |> List.map (fun id -> id.Type)
+    let argTypes = args |> List.map _.Type
 
     // In Python a generic type arg must appear both in the argument and the return type (cannot appear only once)
     let repeatedGenerics = getRepeatedGenericTypeParams ctx (argTypes @ [ body.Type ])

--- a/src/Fable.Transforms/Python/Fable2Python.Util.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.Util.fs
@@ -45,10 +45,10 @@ module Util =
     let hasPythonClassAttribute (atts: Fable.Attribute seq) =
         hasAttribute Atts.pyClassAttributes atts
 
-    let parseClassStyle (styleStr: string) =
+    let parseClassStyle (styleStr: int) =
         match styleStr with
-        | "attributes" -> ClassStyle.Attributes
-        | "properties" -> ClassStyle.Properties
+        | 0 -> ClassStyle.Properties
+        | 1 -> ClassStyle.Attributes
         | _ -> ClassStyle.Properties // Default to Properties for unknown values
 
     let getPythonClassParameters (atts: Fable.Attribute seq) =
@@ -60,8 +60,8 @@ module Util =
             // Extract parameters from the attribute constructor arguments
             match att.ConstructorArgs with
             | [] -> defaultParams
-            | [ :? string as styleParam ] -> { defaultParams with Style = parseClassStyle styleParam }
-            | [ :? string as styleParam; :? bool as initParam ] ->
+            | [ :? int as styleParam ] -> { defaultParams with Style = parseClassStyle styleParam }
+            | [ :? int as styleParam; :? bool as initParam ] ->
                 {
                     Style = parseClassStyle styleParam
                     Init = initParam
@@ -164,13 +164,14 @@ module Util =
     /// Determines if we should use the special record field naming convention (toRecordFieldSnakeCase)
     /// for the given entity. Returns true for user-defined F# records, false for built-in F# Core types.
     let shouldUseRecordFieldNaming (ent: Fable.Entity) =
-        ent.IsFSharpRecord && not (ent.FullName.StartsWith("Microsoft.FSharp.Core"))
+        ent.IsFSharpRecord
+        && not (ent.FullName.StartsWith("Microsoft.FSharp.Core", StringComparison.Ordinal))
 
     /// Determines if we should use the special record field naming convention (toRecordFieldSnakeCase)
     /// for the given entity reference. Returns true for user-defined F# records, false for built-in F# Core types.
     let shouldUseRecordFieldNamingForRef (entityRef: Fable.EntityRef) (ent: Fable.Entity) =
         ent.IsFSharpRecord
-        && not (entityRef.FullName.StartsWith("Microsoft.FSharp.Core"))
+        && not (entityRef.FullName.StartsWith("Microsoft.FSharp.Core", StringComparison.Ordinal))
 
     // Helper function to determine the kind of field access for proper naming
     let getFieldNamingKind (com: IPythonCompiler) (typ: Fable.Type) (fieldName: string) : FieldNamingKind =

--- a/src/Fable.Transforms/Python/PythonCompiler.fs
+++ b/src/Fable.Transforms/Python/PythonCompiler.fs
@@ -32,9 +32,9 @@ type PythonCompiler(com: Compiler) =
 
             let isQualifiedPythonImport =
                 match name with
-                | ""
                 | "default"
                 | "*" -> false
+                | name when name.Length = 0 -> false // CA1820
                 | _ -> true
 
             let cachedName =

--- a/tests/Python/TestPyInterop.fs
+++ b/tests/Python/TestPyInterop.fs
@@ -444,7 +444,7 @@ module Field =
 [<Import("BaseModel", "pydantic")>]
 type BaseModel () = class end
 
-[<Py.ClassAttributes(style="attributes", init=false)>]
+[<Py.ClassAttributes(style=Py.ClassAttributeStyle.Attributes, init=false)>]
 type PydanticUser(Name: string, Age: bigint, Email: string option, Enabled: bool) =
     inherit BaseModel()
     member val Name: string = Field.Frozen(true) with get, set
@@ -461,7 +461,7 @@ let ``test PydanticUser`` () =
     user.Enabled |> equal true
 
 [<Py.Decorate("dataclasses.dataclass")>]
-[<Py.ClassAttributes(style="attributes", init=false)>]
+[<Py.ClassAttributes(style=Py.ClassAttributeStyle.Attributes, init=false)>]
 type DecoratedUser() =
     member val Name: string = "" with get, set
     member val Age: int = 0 with get, set
@@ -477,7 +477,7 @@ let ``test simple decorator without parameters`` () =
     user.Age |> equal 25
 
 [<Py.Decorate("functools.lru_cache", "maxsize=128")>]
-[<Py.ClassAttributes(style="attributes", init=false)>]
+[<Py.ClassAttributes(style=Py.ClassAttributeStyle.Attributes, init=false)>]
 type DecoratedCache() =
     member val Value: string = "cached" with get, set
 
@@ -489,7 +489,7 @@ let ``test decorator with parameters`` () =
 
 [<Py.Decorate("dataclasses.dataclass")>]
 [<Py.Decorate("functools.total_ordering")>]
-[<Py.ClassAttributes(style="attributes", init=false)>]
+[<Py.ClassAttributes(style=Py.ClassAttributeStyle.Attributes, init=false)>]
 type MultiDecoratedClass() =
     member val Priority: int = 0 with get, set
     member val Name: string = "" with get, set
@@ -508,7 +508,7 @@ let ``test multiple decorators applied in correct order`` () =
     obj.Name |> equal "test"
 
 [<Py.Decorate("attrs.define", "auto_attribs=True, slots=True")>]
-[<Py.ClassAttributes(style="attributes", init=false)>]
+[<Py.ClassAttributes(style=Py.ClassAttributeStyle.Attributes, init=false)>]
 type AttrsDecoratedClass() =
     member val Data: string = "attrs_data" with get, set
     member val Count: int = 42 with get, set
@@ -523,7 +523,7 @@ let ``test complex decorator parameters`` () =
 // Test combining Decorate with existing F# features
 
 [<Py.Decorate("dataclasses.dataclass")>]
-[<Py.ClassAttributes(style="attributes", init=false)>]
+[<Py.ClassAttributes(style=Py.ClassAttributeStyle.Attributes, init=false)>]
 type InheritedDecoratedClass() =
     inherit DecoratedUser()
     member val Email: string = "" with get, set
@@ -539,5 +539,20 @@ let ``test decorator with inheritance`` () =
     obj.Name |> equal "Inherited"
     obj.Age |> equal 30
     obj.Email |> equal "test@example.com"
+
+[<Py.ClassAttributes(style=Py.ClassAttributeStyle.Properties, init=true)>]
+type PropertiesUserWithInit(Name: string, Age: bigint, Email: string option, Enabled: bool) =
+    member val Name: string = Name with get, set
+    member val Age: bigint = Age with get, set
+    member val Email: string option = Email with get, set
+    member val Enabled: bool = Enabled with get, set
+
+[<Fact>]
+let ``test PropertiesUserWithInit`` () =
+    let user = PropertiesUserWithInit(Name = "Test User", Age = 25I, Email = Some "test@example.com", Enabled = true)
+    user.Name |> equal "Test User"
+    user.Age |> equal 25I
+    user.Email |> equal (Some "test@example.com")
+    user.Enabled |> equal true
 
 #endif


### PR DESCRIPTION
Follow-up PR to #4199 to avoid stringly typed class style