### PR TITLE
CLI Rewrite with System.CommandLine

### DIFF
--- a/src/Fable.Cli/CommandLine.fs
+++ b/src/Fable.Cli/CommandLine.fs
@@ -1,0 +1,169 @@
+﻿// We expose the main System.CommandLine namespace types through this
+// namespace so that we can alias the `System.CommandLine.Option` type.
+namespace System.CommandLine.FSharp
+
+open System.CommandLine.Parsing
+
+type Argument = System.CommandLine.Argument
+type ArgumentArity = System.CommandLine.ArgumentArity
+type ArgumentValidation = System.CommandLine.ArgumentValidation
+type Argument<'T> = System.CommandLine.Argument<'T>
+type Command = System.CommandLine.Command
+type CompletionSourceExtensions = System.CommandLine.CompletionSourceExtensions
+type DiagramDirective = System.CommandLine.DiagramDirective
+type Directive = System.CommandLine.Directive
+type EnvironmentVariablesDirective = System.CommandLine.EnvironmentVariablesDirective
+type InvocationConfiguration = System.CommandLine.InvocationConfiguration
+type CommandOption = System.CommandLine.Option
+type CommandOptionValidation = System.CommandLine.OptionValidation
+type CommandOption<'T> = System.CommandLine.Option<'T>
+type ParserConfiguration = System.CommandLine.ParserConfiguration
+type ParseResult = System.CommandLine.ParseResult
+type RootCommand = System.CommandLine.RootCommand
+type Symbol = System.CommandLine.Symbol
+type VersionOption = System.CommandLine.VersionOption
+
+module Utils =
+    // Static type resolution is used since ParseResult and SymbolResult share some members but are
+    // not within a type hierarchy.
+    // If a command, argument, or option is not present, then we receive ValueNone
+    // If the above has a default value, then we will receive a value.
+    let inline getCommandResult<'ParseResult when 'ParseResult: (member GetResult: Command -> CommandResult)>
+        (command: Command)
+        : 'ParseResult -> CommandResult voption
+        =
+        _.GetResult(command) >> ValueOption.ofObj
+
+    let inline getArgumentResult<'ParseResult when 'ParseResult: (member GetResult: Argument -> ArgumentResult)>
+        (command: Argument)
+        : 'ParseResult -> ArgumentResult voption
+        =
+        _.GetResult(command) >> ValueOption.ofObj
+
+    let inline getOptionResult<'T, 'ParseResult
+        when 'T :> CommandOption and 'ParseResult: (member GetResult: CommandOption -> OptionResult)>
+        (command: 'T)
+        : 'ParseResult -> OptionResult voption
+        =
+        _.GetResult(command :> CommandOption) >> ValueOption.ofObj
+
+    let inline getNamedResult<'ParseResult when 'ParseResult: (member GetResult: string -> SymbolResult)>
+        (command: string)
+        : 'ParseResult -> SymbolResult voption
+        =
+        _.GetResult(command) >> ValueOption.ofObj
+
+    let inline getArgumentValue<'T, 'ParseResult when 'ParseResult: (member GetValue: Argument<'T> -> 'T)>
+        (arg: Argument<'T>)
+        : 'ParseResult -> 'T voption
+        =
+        _.GetValue(arg)
+        >> function
+            | value when box value |> isNull -> ValueNone
+            | value -> ValueSome value
+
+    let inline getOptionValue<'T, 'ParseResult when 'ParseResult: (member GetValue: CommandOption<'T> -> 'T)>
+        (cmdOption: CommandOption<'T>)
+        : 'ParseResult -> 'T voption
+        =
+        _.GetValue(cmdOption)
+        >> function
+            | value when box value |> isNull -> ValueNone
+            | value -> ValueSome value
+
+    let inline getNamedValue<'ParseResult when 'ParseResult: (member GetValue: string -> obj)>
+        (arg: string)
+        : 'ParseResult -> obj voption
+        =
+        _.GetValue(arg)
+        >> function
+            | value when box value |> isNull -> ValueNone
+            | value -> ValueSome value
+// Explicit warning and hint that we are mutating C# objects. Warning is for posterity
+module Mutate =
+    let inline description desc (symbol: #Symbol) : #Symbol =
+        symbol.Description <- desc
+        symbol
+
+    let inline hide (symbol: #Symbol) : #Symbol =
+        symbol.Hidden <- true
+        symbol
+
+    module CommandOption =
+        let description = description
+        let hide = hide
+
+        let addAlias alias (opt: #CommandOption) : #CommandOption =
+            opt.Aliases.Add alias
+            opt
+
+        let require (opt: #CommandOption) : #CommandOption =
+            opt.Required <- true
+            opt
+
+        let recursive (opt: #CommandOption) : #CommandOption =
+            opt.Recursive <- true
+            opt
+        // It seems these are noops in the current beta of System.CommandLine
+        let filePathsOnly (opt: CommandOption<string>) : CommandOption<string> = opt.AcceptLegalFilePathsOnly()
+        let fileNamesOnly (opt: CommandOption<string>) : CommandOption<string> = opt.AcceptLegalFileNamesOnly()
+        //
+        let valueOneOf (values: 'T seq) (opt: CommandOption<'T>) : CommandOption<'T> =
+            opt.AcceptOnlyFromAmong(values |> Seq.map _.ToString() |> Seq.toArray)
+
+        let valueOneOfStrings (values: string seq) (opt: CommandOption<'T>) : CommandOption<'T> =
+            opt.AcceptOnlyFromAmong(values |> Seq.toArray)
+
+        let arity (value: ArgumentArity) (opt: #CommandOption) : #CommandOption =
+            opt.Arity <- value
+            opt
+        // Messing with the argument result in the factory func can cause issues and is mostly unneeded
+        let defaultValue (value: 'T) (opt: CommandOption<'T>) : CommandOption<'T> =
+            opt.DefaultValueFactory <- (fun _ -> value)
+            opt
+        // Useful for options like `--language` which has many possible values (abbrevs and full names) and we want to
+        // only have a select few written in the help message
+        let helpName (msg: string) (opt: CommandOption<'T>) : CommandOption<'T> =
+            opt.HelpName <- msg
+            opt
+
+    module Argument =
+        let description = description
+        let hide = hide
+
+        let arity (value: ArgumentArity) (opt: #Argument) : #Argument =
+            opt.Arity <- value
+            opt
+
+        let defaultValue (value: 'T) (arg: Argument<'T>) : Argument<'T> =
+            arg.DefaultValueFactory <- (fun _ -> value)
+            arg
+
+    module Command =
+        let description = description
+        let hide = hide
+
+        let addAlias alias (cmd: #Command) : #Command =
+            cmd.Aliases.Add alias
+            cmd
+
+        let mapAction (func: ParseResult -> int) (cmd: #Command) : #Command =
+            cmd.SetAction(func)
+            cmd
+
+        let iterAction (func: ParseResult -> int) = mapAction func >> ignore
+
+module CommandOption =
+    let create<'T> name = CommandOption<'T>(name)
+
+module Argument =
+    let create<'T> name = Argument<'T>(name)
+
+module RootCommand =
+    let create description = RootCommand(description)
+
+module Command =
+    let create name = Command(name)
+    let parse (argv: string array) : #Command -> ParseResult = _.Parse(argv)
+    let invoke: ParseResult -> int = _.Invoke()
+    let parseAndInvoke argv = parse argv >> invoke

--- a/src/Fable.Cli/Fable.Cli.fsproj
+++ b/src/Fable.Cli/Fable.Cli.fsproj
@@ -13,15 +13,17 @@
     <Description>F# to JS compiler</Description>
     <OtherFlags>$(OtherFlags) --nowarn:3536</OtherFlags>
   </PropertyGroup>
+<!--  <ItemGroup>-->
+<!--    <Content Include="..\..\temp\fable-library-js\**\*.*" PackagePath="fable-library-js\" />-->
+<!--    <Content Include="..\..\temp\fable-library-ts\**\*.*" PackagePath="fable-library-ts\" />-->
+<!--    <Content Include="..\..\temp\fable-library-py\**\*.*" PackagePath="fable-library-py\" />-->
+<!--    <Content Include="..\..\temp\fable-library-rust\**\*.*" PackagePath="fable-library-rust\" />-->
+<!--    <Content Include="..\..\temp\fable-library-dart\**\*.*" PackagePath="fable-library-dart\" />-->
+<!--    <Content Include="..\fable-library-php\**\*.*" PackagePath="fable-library-php\" />-->
+<!--  </ItemGroup>-->
   <ItemGroup>
-    <Content Include="..\..\temp\fable-library-js\**\*.*" PackagePath="fable-library-js\" />
-    <Content Include="..\..\temp\fable-library-ts\**\*.*" PackagePath="fable-library-ts\" />
-    <Content Include="..\..\temp\fable-library-py\**\*.*" PackagePath="fable-library-py\" />
-    <Content Include="..\..\temp\fable-library-rust\**\*.*" PackagePath="fable-library-rust\" />
-    <Content Include="..\..\temp\fable-library-dart\**\*.*" PackagePath="fable-library-dart\" />
-    <Content Include="..\fable-library-php\**\*.*" PackagePath="fable-library-php\" />
-  </ItemGroup>
-  <ItemGroup>
+    <Compile Include="CommandLine.fs" />
+    <Compile Include="Spec.fs" />
     <Compile Include="Contributors.fs" />
     <Compile Include="Printers.fs" />
     <Compile Include="FileWatchers.fsi" />
@@ -47,8 +49,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="EluciusFTW.SpectreCoff" Version="0.50.7" />
     <PackageReference Include="FSharp.SystemTextJson" Version="1.3.13" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
     <PackageReference Include="source-map-sharp" Version="1.0.9" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta7.25380.108" />
   </ItemGroup>
 </Project>

--- a/src/Fable.Cli/Spec.fs
+++ b/src/Fable.Cli/Spec.fs
@@ -1,0 +1,155 @@
+﻿module Fable.Cli.Spec
+
+open System.CommandLine
+open System.CommandLine.FSharp
+open Fable
+
+
+// Specification of CLI settings reflected by interfaces
+
+// Status is turned to a union so we can control things like stringification
+// for style
+[<Struct>]
+type LanguageStatus =
+    | Stable
+    | Beta
+    | Alpha
+    | Experimental
+
+    override this.ToString() =
+        match this with
+        | Stable -> "stable"
+        | Beta -> "beta"
+        | Alpha -> "alpha"
+        | Experimental -> "experimental"
+
+[<Struct>]
+type BuildConfig =
+    | Release
+    | Debug
+
+let getStatus =
+    function
+    | JavaScript
+    | TypeScript -> Stable
+    | Dart
+    | Python -> Beta
+    | Rust -> Alpha
+    | Php -> Experimental
+
+let getLibPkgVersion =
+    function
+    | JavaScript -> ValueSome("npm", "@fable-org/fable-library-js", Literals.JS_LIBRARY_VERSION)
+    | TypeScript -> ValueSome("npm", "@fable-org/fable-library-ts", Literals.JS_LIBRARY_VERSION)
+    | Python
+    | Rust
+    | Dart
+    | Php -> ValueNone
+
+type ICommonOptions =
+    abstract workDir: string
+    abstract projPath: string
+    abstract verbosity: Verbosity
+    abstract language: Language
+    abstract yes: bool
+
+type ICompileOptions =
+    inherit ICommonOptions
+    abstract defines: string list
+    abstract output: string voption
+    abstract config: BuildConfig
+    abstract watch: bool
+    abstract watchDelay: int
+    abstract run: string voption
+    abstract runFast: string voption
+    abstract runWatch: string voption
+    abstract noRestore: bool
+    abstract noCache: bool
+    abstract exclude: string[]
+    abstract optimize: bool
+    abstract legacyCracker: bool
+    abstract printAst: bool
+    abstract trimRootModule: bool
+    abstract fableLib: string voption
+    abstract replace: Map<string, string>
+    abstract precompiledLib: string voption
+    abstract noReflection: bool
+    abstract noParallelTypeCheck: bool
+
+type IJavaScriptOptions =
+    inherit ICompileOptions
+    abstract typedArrays: bool
+    abstract sourceMap: bool
+    abstract sourceMapRoot: string voption
+    abstract runScript: string voption
+
+type ITypeScriptOptions =
+    inherit IJavaScriptOptions
+
+type IPythonOptions =
+    inherit ICompileOptions
+
+type IRustOptions =
+    inherit ICompileOptions
+
+type IDartOptions =
+    inherit ICompileOptions
+
+type IPhpOptions =
+    inherit ICompileOptions
+
+type ICliOptions =
+    inherit ICommonOptions
+    inherit ICompileOptions
+    inherit IJavaScriptOptions
+    inherit ITypeScriptOptions
+    inherit IPythonOptions
+    inherit IRustOptions
+    inherit IDartOptions
+    inherit IPhpOptions
+
+module Utils =
+    open FSharp.Reflection
+
+    module Unions =
+        let getAllCaseStringOrInitials<'T> =
+            FSharpType.GetUnionCases typeof<'T>
+            |> Array.map _.Name
+            |> Array.collect (fun case ->
+                match case.Length with
+                | 0 -> [||]
+                | 1 -> [| case.ToLower() |]
+                | _ -> [| case.ToLower(); (string case[0]).ToLower() |]
+            )
+
+        let addCustomParser (map: 'T -> string list) (opt: CommandOption<'T>) : CommandOption<'T> =
+            let caseParsers =
+                FSharpType.GetUnionCases typeof<'T>
+                |> Array.map (fun case ->
+                    let caseValue = FSharpValue.MakeUnion(case, [||])
+                    caseValue |> unbox<'T>, caseValue |> unbox<'T> |> map
+                )
+                |> fun possibles (inputCase: string) ->
+                    possibles
+                    |> Array.tryFind (snd >> List.map _.ToLower() >> List.contains (inputCase.ToLower()))
+                    |> Option.map fst
+                    |> Option.get
+
+            opt.CustomParser <- (fun parseResult -> parseResult.Tokens[0].Value |> caseParsers)
+            opt
+
+    let addToCommands (commands: #Command list) (opt: CommandOption<'T>) =
+        commands |> List.iter _.Add(opt)
+        opt
+
+    let addToCommand (command: #Command) (opt: CommandOption<'T>) =
+        command.Add(opt)
+        opt
+
+    let addArgToCommands (commands: #Command list) (arg: Argument<'T>) =
+        commands |> List.iter _.Add(arg)
+        arg
+
+    let addArgToCommand (command: #Command) (arg: Argument<'T>) =
+        command.Add arg
+        arg


### PR DESCRIPTION
This pull uses the community & microsoft driven library System.CommandLine which is currently in v2-beta5.

When compared to Spectre.Console.Cli, this means no requirements for interfaces/classes and attributes to derive the CLI interface.

We miss out on aesthetics. But I am fine to be patient with this, as it's simply a matter of the library becoming polished enough to allow more hooks and customisation with the help message rendering.

We can still use Spectre.Console to render everything outside the help messages.

## Completions?

Using `dotnet-suggest`, System.CommandLine supports completions for zsh, bash and powershell.

## Progress

After tinkering and testing some elements of the package, I've implemented a skeleton structure to show how the CLI interface could be logically reasoned and derived.

I have *again* implemented the CLI options as a interface hierarchy, as this simplifies consuming the args imo.

Nothing has actually been hooked in yet, as some validation has to be added (there should be architecture already existing that supports multiple validation error message reporting like I did with Spectre.Console.Cli).

It's important before this progresses to know whether this API for creating the CLI is acceptable.


> Some example option creation and manipulation

```fs
    let projPath =
        Argument.create<string voption> "PATH"
        |> Mutate.Argument.defaultValue (System.Environment.CurrentDirectory |> ValueSome)
        |> Mutate.description $"{dim}Path containing project files{dimOff}"
        |> Utils.addArgToCommand root
    // extension argument for clean only
    let extensionArg =
        Argument.create<string voption> "EXT"
        |> Mutate.Argument.defaultValue (".fs.js" |> ValueSome)
        |> Mutate.description $"{dim}Path extension for cleaning{dimOff}"
        |> Utils.addArgToCommand cleanCommand

    let workingDirectory =
        CommandOption.create<string> "--cwd"
        |> Mutate.description $"{dim}Set the working directory{dimOff}"
        |> Mutate.CommandOption.filePathsOnly
        |> Mutate.CommandOption.defaultValue System.Environment.CurrentDirectory
        |> Utils.addToCommands rootAndCommands

    let verbosity =
        CommandOption.create<Verbosity> "--verbosity"
        |> Mutate.description $"{dim}Set the logging volume{dimOff}"
        |> Mutate.CommandOption.addAlias "-v"
        |> Mutate.CommandOption.valueOneOfStrings Utils.Unions.getAllCaseStringOrInitials<Verbosity>
        |> Utils.Unions.addCustomParser (
            function
            | Verbosity.Normal -> [ "n"; "normal" ]
            | Verbosity.Silent -> [ "s"; "silent" ]
            | Verbosity.Verbose -> [ "v"; "verbose" ]
        )
        |> Mutate.CommandOption.defaultValue Verbosity.Normal
        |> Mutate.CommandOption.helpName $"{dim}n|normal|s|silent|v|verbose{dimOff}"
        |> Utils.addToCommands rootAndCommands
```

---

<details><summary>Images</summary>

As a proof of concept and test, I used ANSI escape sequences to color what is readily available dim. All descriptions can be safely manipulated.

> [!NOTE]
> There is a way to color everything, except the headers, but it requires a hack.
>
> The method would be to render a option which uses escape sequences, and then the proper option which is hidden.
> This is because it is impossible to match the options if they have escape sequences.

<img width="873" height="797" alt="image" src="https://github.com/user-attachments/assets/664226e8-42a7-448f-a6c7-383973a3c656" />

<img width="820" height="280" alt="image" src="https://github.com/user-attachments/assets/8885f7e1-fd14-4cc1-a495-e51f4d7d3f0a" />
