### PR TITLE
[PHP] Fix php import extensions

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* [PHP] Fix php import extensions (by @MangelMaxime)
 * [TS] Fix #3973 Typescript imports file extension (by @ncave)
 * [TS] Fix support for abstract classes and members (by @ncave)
 * [TS] Fix getters, setters, indexers in interfaces (by @ncave)

--- a/src/Fable.Compiler/CHANGELOG.md
+++ b/src/Fable.Compiler/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* [PHP] Fix php import extensions (by @MangelMaxime)
 * [TS] Fix #3973 Typescript imports file extension (by @ncave)
 * [TS] Fix support for abstract classes and members (by @ncave)
 * [TS] Fix getters, setters, indexers in interfaces (by @ncave)

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -1131,7 +1131,8 @@ module AST =
         | Rust -> com.LibraryDir + "/" + moduleName + ".rs"
         | Dart -> com.LibraryDir + "/" + moduleName + ".dart"
         | TypeScript -> com.LibraryDir + "/" + moduleName + ".ts"
-        | _ -> com.LibraryDir + "/" + moduleName + ".js"
+        | JavaScript -> com.LibraryDir + "/" + moduleName + ".js"
+        | Php -> com.LibraryDir + "/" + moduleName + ".php"
 
     let makeImportUserGenerated r t (selector: string) (path: string) =
         Import(


### PR DESCRIPTION
This is mainly to avoid the default catch in the pattern matching