### PR TITLE
[Python] fixes for dunder method return types

### DIFF
--- a/src/fable-library-py/Cargo.lock
+++ b/src/fable-library-py/Cargo.lock
@@ -187,9 +187,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.26.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
+checksum = "37a6df7eab65fc7bee654a421404947e10a0f7085b6951bf2ea395f4659fb0cf"
 dependencies = [
  "chrono",
  "indoc",
@@ -205,18 +205,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.26.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
+checksum = "f77d387774f6f6eec64a004eac0ed525aab7fa1966d94b42f743797b3e395afb"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.26.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
+checksum = "2dd13844a4242793e02df3e2ec093f540d948299a6a77ea9ce7afd8623f542be"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -224,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.26.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
+checksum = "eaf8f9f1108270b90d3676b8679586385430e5c0bb78bb5f043f95499c821a71"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -236,9 +236,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.26.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
+checksum = "70a3b2274450ba5288bc9b8c1b69ff569d1d61189d4bff38f8d22e03d17f932b"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/src/fable-library-py/Cargo.toml
+++ b/src/fable-library-py/Cargo.toml
@@ -12,7 +12,7 @@ name = "_core"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.26.0", features = ["extension-module", "chrono"] }
+pyo3 = { version = "0.27.1", features = ["extension-module", "chrono"] }
 byteorder = "1.5.0"
 chrono = "0.4.42"
 regex = "1.12.1"

--- a/src/fable-library-py/fable_library/task.py
+++ b/src/fable-library-py/fable_library/task.py
@@ -10,20 +10,20 @@ from __future__ import annotations
 import asyncio
 from asyncio import AbstractEventLoop, Future
 from collections.abc import Awaitable
-from typing import Any, Generic, TypeVar
+from typing import Any, TypeVar
 
 
 _T = TypeVar("_T")
 
 
-class TaskCompletionSource(Generic[_T]):
+class TaskCompletionSource[T]:
     __slots__ = "future", "loop"
 
     def __init__(self) -> None:
         self.loop: AbstractEventLoop = asyncio.get_event_loop()
-        self.future: Future[_T] = self.loop.create_future()
+        self.future: Future[T] = self.loop.create_future()
 
-    def SetResult(self, value: _T) -> None:
+    def SetResult(self, value: T) -> None:
         """Set result.
 
         Transitions the underlying Task[TResult] into the
@@ -59,7 +59,7 @@ class TaskCompletionSource(Generic[_T]):
 
         self.loop.call_soon_threadsafe(action)
 
-    def get_task(self) -> Awaitable[_T]:
+    def get_task(self) -> Awaitable[T]:
         return asyncio.ensure_future(self.future)
 
 
@@ -67,35 +67,41 @@ async def zero() -> None:
     return
 
 
-async def from_result(value: _T) -> _T:
+async def from_result[T](value: T) -> T:
     return value
 
 
-def get_awaiter(value: Awaitable[_T]) -> Awaitable[_T]:
+def get_awaiter[T](value: Awaitable[T]) -> Awaitable[T]:
     # Wrap awaitable in coroutine (so we can run it using create_task)
-    async def get_value() -> _T:
+    async def get_value() -> T:
         return await asyncio.ensure_future(value)
 
     return get_value()
 
 
-def get_result(value: Awaitable[_T]) -> _T:
+def get_result[T](value: Awaitable[T]) -> T:
     """Get the result.
 
     Ends the wait for the completion of the asynchronous task.
     """
 
-    async def runner() -> _T:
+    async def runner() -> T:
         return await value
 
     return asyncio.run(runner())
 
 
+_running_tasks = set[Awaitable[Any]]()
+
+
 def start(task: Awaitable[Any]) -> None:
     async def runner():
-        return await task
+        result = await task
+        _running_tasks.remove(task)
+        return result
 
-    asyncio.create_task(runner())
+    task = asyncio.create_task(runner())
+    _running_tasks.add(task)
 
 
 def run_synchronously(task: Awaitable[Any]) -> None:

--- a/src/fable-library-py/fable_library/types.py
+++ b/src/fable-library-py/fable_library/types.py
@@ -154,7 +154,7 @@ class Record(IComparable):
     def Equals(self, other: Record) -> bool:
         return record_equals(self, other)
 
-    def __cmp__(self, other: Record) -> int32:
+    def __cmp__(self, other: Record) -> int:
         return record_compare_to(self, other)
 
     def __str__(self) -> str:

--- a/src/fable-library-py/fable_library/util.py
+++ b/src/fable-library-py/fable_library/util.py
@@ -21,6 +21,7 @@ from types import TracebackType
 from typing import (
     Any,
     ClassVar,
+    Literal,
     Protocol,
     TypeGuard,
     cast,
@@ -76,7 +77,7 @@ class IDisposable(ABC):
         exctype: type[BaseException] | None,
         excinst: BaseException | None,
         exctb: TracebackType | None,
-    ) -> bool:
+    ) -> Literal[False]:
         """Exit context management."""
 
         self.Dispose()
@@ -121,12 +122,12 @@ class AnonymousDisposable(IDisposable):
 class IEquatable(Protocol):
     def __eq__(self, other: Any) -> bool: ...
 
-    def __hash__(self) -> int32: ...
+    def __hash__(self) -> int: ...
 
 
 class IComparable(IEquatable, Protocol):
     @abstractmethod
-    def __cmp__(self, __other: Any) -> int32:
+    def __cmp__(self, __other: Any) -> int:
         raise NotImplementedError
 
     @abstractmethod
@@ -136,7 +137,7 @@ class IComparable(IEquatable, Protocol):
 
 class IComparable_1[T_in](IEquatable, Protocol):
     @abstractmethod
-    def __cmp__(self, __other: T_in) -> int32:
+    def __cmp__(self, __other: T_in) -> int:
         raise NotImplementedError
 
     @abstractmethod
@@ -162,13 +163,13 @@ class IComparer_1[T_in](Protocol):
     """
 
     @abstractmethod
-    def Compare(self, /, x: T_in, y: T_in) -> int32:
+    def Compare(self, x: T_in, y: T_in, /) -> int32:
         raise NotImplementedError
 
 
 class IEqualityComparer(Protocol):
     @abstractmethod
-    def Equals(self, /, x: Any = None, y: Any = None) -> bool:
+    def Equals(self, x: Any = None, y: Any = None, /) -> bool:
         raise NotImplementedError
 
     @abstractmethod
@@ -263,13 +264,13 @@ def compare_dicts(x: dict[str, Any], y: dict[str, Any]) -> int:
     if len(x_keys) != len(y_keys):
         return -1 if len(x_keys) < len(y_keys) else 1
 
-    x_keys = sorted(x_keys)
-    y_keys = sorted(y_keys)
+    x_keys_ = sorted(x_keys)
+    y_keys_ = sorted(y_keys)
 
     j = 0
-    for i, key in enumerate(x_keys):
-        if key != y_keys[i]:
-            return -1 if key < y_keys[i] else 1
+    for i, key in enumerate(x_keys_):
+        if key != y_keys_[i]:
+            return -1 if key < y_keys_[i] else 1
         else:
             j = compare(x[key], y[key])
             if j != 0:
@@ -548,12 +549,10 @@ class Enumerator[T](IEnumerator[T]):
 
     def __init__(self, iter: Iterator[T]) -> None:
         self.iter = iter
-        self.current = None
+        self.current: T
 
     def System_Collections_Generic_IEnumerator_1_get_Current(self) -> T:
-        if self.current is not None:
-            return self.current
-        return None  # type: ignore
+        return self.current
 
     def System_Collections_IEnumerator_MoveNext(self) -> bool:
         try:

--- a/src/fable-library-py/src/native_array.rs
+++ b/src/fable-library-py/src/native_array.rs
@@ -24,8 +24,10 @@ pub enum ArrayType {
 }
 
 // Implement FromPyObject for ArrayType
-impl<'source> FromPyObject<'source> for ArrayType {
-    fn extract_bound(ob: &Bound<'source, PyAny>) -> PyResult<Self> {
+impl<'py> FromPyObject<'_, 'py> for ArrayType {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'_, 'py, PyAny>) -> Result<Self, Self::Error> {
         let s: &str = ob.extract()?;
         Ok(ArrayType::from_str(s))
     }
@@ -195,7 +197,7 @@ impl NativeArray {
 
     pub fn equals(&self, other: &NativeArray, py: Python<'_>) -> bool {
         // Helper for comparing PyObject with other types
-        fn compare_pyobject_with<T: PartialEq + for<'a> pyo3::FromPyObject<'a>>(
+        fn compare_pyobject_with<T: PartialEq + for<'a, 'py> pyo3::FromPyObject<'a, 'py>>(
             py_vec: &std::sync::MutexGuard<Vec<Py<PyAny>>>,
             other_vec: &[T],
             py: Python<'_>,

--- a/src/fable-library-py/src/strings.rs
+++ b/src/fable-library-py/src/strings.rs
@@ -841,9 +841,7 @@ mod formatting {
 
         // **Pattern matching**: Determine if first argument is a format provider
         let (format_str, start_index) = match args.get_item(0)? {
-            first_arg
-                if first_arg.is_none() || first_arg.downcast::<pyo3::types::PyDict>().is_ok() =>
-            {
+            first_arg if first_arg.is_none() || first_arg.cast::<pyo3::types::PyDict>().is_ok() => {
                 // Has provider: format(provider, string, ...args)
                 (args.get_item(1)?.str()?.to_string(), 2)
             }
@@ -883,7 +881,7 @@ mod formatting {
             1 => {
                 // **Pattern matching**: Check if single argument is a tuple (Rust-style)
                 let single_arg = args.get_item(start_index)?;
-                if let Ok(tuple_args) = single_arg.downcast::<pyo3::types::PyTuple>() {
+                if let Ok(tuple_args) = single_arg.cast::<pyo3::types::PyTuple>() {
                     // Rust-style: format("Hello {0}", ("World",))
                     (0..tuple_args.len())
                         .map(|i| -> PyResult<String> {

--- a/src/fable-library-py/uv.lock
+++ b/src/fable-library-py/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <4.0"
 
 [[package]]
@@ -51,7 +51,7 @@ dev = [
 [package.metadata.requires-dev]
 dev = [
     { name = "hypothesis", specifier = ">=6.131.9,<7" },
-    { name = "maturin", specifier = ">=1.8.3,<2" },
+    { name = "maturin", specifier = ">=1.9.6,<2" },
     { name = "pyright", specifier = ">=1.1.401,<2" },
     { name = "pytest", specifier = ">=8.3.5,<9" },
     { name = "pytest-benchmark", specifier = ">=5.1.0,<6" },
@@ -82,25 +82,26 @@ wheels = [
 
 [[package]]
 name = "maturin"
-version = "1.8.6"
+version = "1.9.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/34/bc/c7df50a359c3a31490785c77d1ddd5fc83cc8cc07a4eddd289dbae53545a/maturin-1.8.6.tar.gz", hash = "sha256:0e0dc2e0bfaa2e1bd238e0236cf8a2b7e2250ccaa29c1aa8d0e61fa664b0289d", size = 203320, upload-time = "2025-05-13T13:56:11.033Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/35/c3370188492f4c139c7a318f438d01b8185c216303c49c4bc885c98b6afb/maturin-1.9.6.tar.gz", hash = "sha256:2c2ae37144811d365509889ed7220b0598487f1278c2441829c3abf56cc6324a", size = 214846, upload-time = "2025-10-07T12:45:08.408Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/f1/e493add40aebdab88ac1aefb41b9c84ac288fb00025bc96b9213ee02c958/maturin-1.8.6-py3-none-linux_armv6l.whl", hash = "sha256:1bf4c743dd2b24448e82b8c96251597818956ddf848e1d16b59356512c7e58d8", size = 7831195, upload-time = "2025-05-13T13:55:42.634Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/1c/588afdb7bf79c4f15e33e9af6d7f3b12ec662bc63a22919e3bf39afa2a1e/maturin-1.8.6-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:4ea89cf76048bc760e12b36b608fc3f5ef4f7359c0895e9afe737be34041d948", size = 15276471, upload-time = "2025-05-13T13:55:46.196Z" },
-    { url = "https://files.pythonhosted.org/packages/62/0b/4ce97f7f3a42068fbb42ba47d8b072e098c060fc1f64d8523e5588c57543/maturin-1.8.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4dd2e2f005ca63ac7ef0dddf2d65324ee480277a11544dcc4e7e436af68034dd", size = 7966129, upload-time = "2025-05-13T13:55:48.633Z" },
-    { url = "https://files.pythonhosted.org/packages/84/bf/4eae9d12920c580baf9d47ee63fec3ae0233e90a3aa8987bd7909cdc36a0/maturin-1.8.6-py3-none-manylinux_2_12_i686.manylinux2010_i686.musllinux_1_1_i686.whl", hash = "sha256:b0637604774e2c50ab48a0e9023fe2f071837ecbc817c04ec28e1cfcc25224c2", size = 7835935, upload-time = "2025-05-13T13:55:51.235Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/aa/8090f8b3f5f7ec46bc95deb0f5b29bf52c98156ef594f2e65d20bf94cea1/maturin-1.8.6-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:bec5948c6475954c8089b17fae349966258756bb2ca05e54099e476a08070795", size = 8282553, upload-time = "2025-05-13T13:55:53.266Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/50/4348da6cc16c006dab4e6cd479cf00dc0afa80db289a115a314df9909ee6/maturin-1.8.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:62a65f70ebaadd6eb6083f5548413744f2ef12400445778e08d41d4facf15bbe", size = 7618339, upload-time = "2025-05-13T13:55:55.706Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/77/16458e29487d068c8cdb7f06a4403393568a10b44993fe2ec9c3b29fdccd/maturin-1.8.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:5c0ff7ad43883920032b63c94c76dcdd5758710d7b72b68db69e7826c40534ac", size = 7686748, upload-time = "2025-05-13T13:55:57.97Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/c1/a52f3c1171c053810606c7c7fae5ce4637446ef9df44f281862d2bef3750/maturin-1.8.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.musllinux_1_1_ppc64le.whl", hash = "sha256:ca30fdb158a24cf312f3e53072a6e987182c103fa613efea2d28b5f52707d04a", size = 9767394, upload-time = "2025-05-13T13:56:00.694Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/ab/abae74f36a0f200384eda985ebeb9ee5dcbb19bfe1558c3335ef6f297094/maturin-1.8.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b1e786ec9b5f7315c7e3fcc62b0715f9d99ffe477b06d0d62655a71e6a51a67b", size = 10995574, upload-time = "2025-05-13T13:56:03.101Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/1c/c478578a62c1e34b5b0641a474de78cb56d6c4aad0ba88f90dfa9f2a15f7/maturin-1.8.6-py3-none-win32.whl", hash = "sha256:dade5edfaf508439ff6bbc7be4f207e04c0999c47d9ef7e1bae16258e76b1518", size = 7027171, upload-time = "2025-05-13T13:56:05.472Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/89/2c57d29f25e06696cb3c5b3770ba0b40dfe87f91a879ecbcdc92e071a26b/maturin-1.8.6-py3-none-win_amd64.whl", hash = "sha256:6bc9281b90cd37e2a7985f2e5d6e3d35a1d64cf6e4d04ce5ed25603d162995b9", size = 7947998, upload-time = "2025-05-13T13:56:07.428Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/f5/3ee1c6aa4e277323bef38ea0ec07262a9b88711d1a29cb5bb08ce3807a6f/maturin-1.8.6-py3-none-win_arm64.whl", hash = "sha256:24f66624db69b895b134a8f1592efdf04cd223c9b3b65243ad32080477936d14", size = 6684974, upload-time = "2025-05-13T13:56:09.415Z" },
+    { url = "https://files.pythonhosted.org/packages/55/5c/b435418ba4ba2647a1f7a95d53314991b1e556e656ae276dea993c3bce1d/maturin-1.9.6-py3-none-linux_armv6l.whl", hash = "sha256:26e3ab1a42a7145824210e9d763f6958f2c46afb1245ddd0bab7d78b1f59bb3f", size = 8134483, upload-time = "2025-10-07T12:44:44.274Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/1c/8e58eda6601f328b412cdeeaa88a9b6a10e591e2a73f313e8c0154d68385/maturin-1.9.6-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:5263dda3f71feef2e4122baf5c4620e4b3710dbb7f2121f85a337182de214369", size = 15776470, upload-time = "2025-10-07T12:44:47.476Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/33/8c967cce6848cdd87a2e442c86120ac644b80c5ed4c32e3291bde6a17df8/maturin-1.9.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fe78262c2800c92f67d1ce3c0f6463f958a692cc67bfb572e5dbf5b4b696a8ba", size = 8226557, upload-time = "2025-10-07T12:44:49.844Z" },
+    { url = "https://files.pythonhosted.org/packages/58/bd/3e2675cdc8b7270700ba30c663c852a35694441732a107ac30ebd6878bd8/maturin-1.9.6-py3-none-manylinux_2_12_i686.manylinux2010_i686.musllinux_1_1_i686.whl", hash = "sha256:7ab827c6e8c022eb2e1e7fb6deede54549c8460b20ccc2e9268cc6e8cde957a8", size = 8166544, upload-time = "2025-10-07T12:44:51.396Z" },
+    { url = "https://files.pythonhosted.org/packages/58/1f/a2047ddf2230e700d5f8a13dd4b9af5ce806ad380c32e58105888205926e/maturin-1.9.6-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:0246202377c49449315305209f45c8ecef6e2d6bd27a04b5b6f1ab3e4ea47238", size = 8641010, upload-time = "2025-10-07T12:44:53.658Z" },
+    { url = "https://files.pythonhosted.org/packages/be/1f/265d63c7aa6faf363d4a3f23396f51bc6b4d5c7680a4190ae68dba25dea2/maturin-1.9.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:f5bac167700fbb6f8c8ed1a97b494522554b4432d7578e11403b894b6a91d99f", size = 7965945, upload-time = "2025-10-07T12:44:55.248Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ca/a8e61979ccfe080948bcc1bddd79356157aee687134df7fb013050cec783/maturin-1.9.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:7f53d3b1d8396d3fea3e1ee5fd37558bca5719090f3d194ba1c02b0b56327ae3", size = 7978820, upload-time = "2025-10-07T12:44:56.919Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/4a/81b412f8ad02a99801ef19ec059fba0822d1d28fb44cb6a92e722f05f278/maturin-1.9.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.musllinux_1_1_ppc64le.whl", hash = "sha256:7f506eb358386d94d6ec3208c003130cf4b69cab26034fc0cbbf8bf83afa4c2e", size = 10452064, upload-time = "2025-10-07T12:44:58.232Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/12/cc96c7a8cb51d8dcc9badd886c361caa1526fba7fa69d1e7892e613b71d4/maturin-1.9.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f2d6984ab690af509f525dbd2b130714207c06ebb14a5814edbe1e42b17ae0de", size = 8852401, upload-time = "2025-10-07T12:44:59.8Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8e/653ac3c9f2c25cdd81aefb0a2d17ff140ca5a14504f5e3c7f94dcfe4dbb7/maturin-1.9.6-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:5c2252b0956bb331460ac750c805ddf0d9b44442449fc1f16e3b66941689d0bc", size = 8425057, upload-time = "2025-10-07T12:45:01.711Z" },
+    { url = "https://files.pythonhosted.org/packages/db/29/f13490328764ae9bfc1da55afc5b707cebe4fa75ad7a1573bfa82cfae0c6/maturin-1.9.6-py3-none-win32.whl", hash = "sha256:f2c58d29ebdd4346fd004e6be213d071fdd94a77a16aa91474a21a4f9dbf6309", size = 7165956, upload-time = "2025-10-07T12:45:03.766Z" },
+    { url = "https://files.pythonhosted.org/packages/db/9f/dd51e5ac1fce47581b8efa03d77a03f928c0ef85b6e48a61dfa37b6b85a2/maturin-1.9.6-py3-none-win_amd64.whl", hash = "sha256:1b39a5d82572c240d20d9e8be024d722dfb311d330c5e28ddeb615211755941a", size = 8145722, upload-time = "2025-10-07T12:45:05.487Z" },
+    { url = "https://files.pythonhosted.org/packages/65/f2/e97aaba6d0d78c5871771bf9dd71d4eb8dac15df9109cf452748d2207412/maturin-1.9.6-py3-none-win_arm64.whl", hash = "sha256:ac02a30083553d2a781c10cd6f5480119bf6692fd177e743267406cad2ad198c", size = 6857006, upload-time = "2025-10-07T12:45:06.813Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Make sure Python dunder methods return Python types (i.e int and not int32)
- Upgrade PyO3