### PR TITLE
Fix use of `--cwd` argument in integration test

### DIFF
--- a/tests/Integration/Integration/CompilationTests.fs
+++ b/tests/Integration/Integration/CompilationTests.fs
@@ -20,7 +20,7 @@ let tests =
 
                 // Compile project
                 let exitCode =
-                    Fable.Cli.Entry.main [| project; "--cwd"; "$\"{testCaseDir}\""; "-e"; ".jsx.actual" |]
+                    Fable.Cli.Entry.main [| project; "--cwd"; $"'%s{testCaseDir}'"; "-e"; ".jsx.actual" |]
 
                 Expect.equal exitCode 0 "Expected exit code to be 0"
 


### PR DESCRIPTION
The integration tests in https://github.com/fable-compiler/Fable/pull/4261 fail due to a misconfigured value in the `--cwd` argument.

This bug surfaced with https://github.com/fable-compiler/Fable/pull/4261 since it actually uses the value passed by the `--cwd` argument. It appears that the other tests never used the `--cwd` argument for anything (or at least not in way that would fail with the misconfigured value).

The errors were like:
```
System.ComponentModel.Win32Exception (2): An error occurred trying to start process '/usr/share/dotnet/dotnet' with working directory
'/home/runner/work/Fable/Fable/tests/Integration/Integration/$"{testCaseDir}"'. No such file or directory
```

I.e. `$"{testCaseDir}"` is used as the argument rather than the actual value of `testCaseDir`.

This PR fixes that to use the `testCaseDir` path directly. The value is enclosed in single quotes to allow spaces in the path (but not double quotes to avoid acidental interpretation).
