### PR TITLE
Fix UseMSBuildForCracking default

### DIFF
--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -849,7 +849,7 @@ type State =
             PendingFiles = [||]
             SilentCompilation = false
             RecompileAllFiles = defaultArg recompileAllFiles false
-            UseMSBuildForCracking = defaultArg useMSBuildForCracking false
+            UseMSBuildForCracking = defaultArg useMSBuildForCracking true
         }
 
 let private getFilesToCompile


### PR DESCRIPTION
- Fix UseMSBuildForCracking default to match the Fable CLI arg default