### PR TITLE
ci: PyPI. Build fable-library for Python 3.14

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -58,7 +58,7 @@ jobs:
       strategy:
         matrix:
           os: [ubuntu-latest, windows-latest, macos-latest]
-          python-version: ["3.12", "3.13"]
+          python-version: ["3.12", "3.13", "3.14"]
 
       steps:
         - uses: actions/checkout@v5


### PR DESCRIPTION
- Need to build fable-library for PyPI also for Python 3.14