### PR TITLE
[Python] Python erased interfaces should not generate any code

### DIFF
--- a/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
@@ -3695,6 +3695,9 @@ let rec transformDeclaration (com: IPythonCompiler) ctx (decl: Fable.Declaration
                 let name = com.GetIdentifierAsExpr(ctx, decl.Name)
                 let anyType = com.GetImportExpr(ctx, "typing", "Any")
                 [ Statement.assign ([ name ], anyType) ]
+        elif hasEraseAttribute && ent.IsInterface then
+            // Erased interfaces should not generate any code
+            []
         else
             // Check for PythonClass attribute and extract parameters
             let classAttributes =


### PR DESCRIPTION
- Fixed regression since v4 that erased interfaces should not generate any code. Not a bug since the code would not do anything e.g `IExports` for bindings etc, but we should not emit it.
- Not adding to changelog since this issue was not present in Fable v4 and is a regression from one of the v5-alpha changes.