### PR TITLE
[Python] fix: named arguments needs snake casing

### DIFF
--- a/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
@@ -682,7 +682,9 @@ let transformCallArgs
                     |> List.unzip
                     |> fun (kv, stmts) ->
                         kv
-                        |> List.map (fun (keyword, value) -> Keyword.keyword (Identifier keyword, value)),
+                        |> List.map (fun (keyword, value) ->
+                            Keyword.keyword (Identifier(Naming.toPythonNaming keyword), value)
+                        ),
                         stmts |> List.collect id
 
                 args, Some objArg, stmts
@@ -717,7 +719,9 @@ let transformCallArgs
                         |> List.unzip
                         |> fun (kv, stmts) ->
                             kv
-                            |> List.map (fun (keyword, value) -> Keyword.keyword (Identifier keyword, value)),
+                            |> List.map (fun (keyword, value) ->
+                                Keyword.keyword (Identifier(Naming.toPythonNaming keyword), value)
+                            ),
                             stmts |> List.collect id
 
                     [], Some objArg, stmts

--- a/tests/Python/TestNonRegression.fs
+++ b/tests/Python/TestNonRegression.fs
@@ -265,3 +265,22 @@ type Disposable(cancel) =
 let ``test static properties works when inheriting from IDisposable`` () =
     let d: IDisposable = Disposable.Empty
     d.Dispose()
+
+// Test that named arguments are converted to snake_case in Python
+module NamedArgsSnakeCase =
+    [<AttachMembers>]
+    type TestRunner(testCase: string, ?configArgs: string array) =
+        member val TestCase = testCase with get
+        member val ConfigArgs = defaultArg configArgs [||] with get
+
+[<Fact>]
+let ``test named arguments are converted to snake_case`` () =
+    // Test with optional named argument
+    let runner1 = NamedArgsSnakeCase.TestRunner("test", configArgs = [| "arg1"; "arg2" |])
+    equal "test" runner1.TestCase
+    equal [| "arg1"; "arg2" |] runner1.ConfigArgs
+
+    // Test with all named arguments
+    let runner2 = NamedArgsSnakeCase.TestRunner(testCase = "test2", configArgs = [| "arg3" |])
+    equal "test2" runner2.TestCase
+    equal [| "arg3" |] runner2.ConfigArgs


### PR DESCRIPTION
- Fix regression. Python named arguments needs snake casing

Thanks to @Freymaurer for reporting this issue