### PR TITLE
fix(python): Fix printf.cont() not applying continuation function

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+* [Python] Fix printf.cont() not applying continuation function when currying (by @dbrattli)
+
 ## 5.0.0-alpha.18 - 2025-12-03
 
 ### Fixed

--- a/src/Fable.Compiler/CHANGELOG.md
+++ b/src/Fable.Compiler/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+* [Python] Fix printf.cont() not applying continuation function when currying (by @dbrattli)
+
 ## 5.0.0-alpha.17 - 2025-12-03
 
 ### Fixed

--- a/tests/Python/TestString.fs
+++ b/tests/Python/TestString.fs
@@ -993,6 +993,54 @@ let ``test calling ToString(CultureInfo.InvariantCulture) works`` () =
     (7923209UL).ToString(CultureInfo.InvariantCulture) |> equal "7923209"
 
 
+[<Fact>]
+let ``test printf.cont applies continuation after all args collected`` () =
+    let mutable called = false
+    let mutable receivedMsg = ""
+    let cont msg =
+        called <- true
+        receivedMsg <- msg
+
+    Printf.kprintf cont "%s: %d" "Value" 42
+
+    called |> equal true
+    receivedMsg |> equal "Value: 42"
+
+[<Fact>]
+let ``test printf.cont works with single argument`` () =
+    let mutable result = ""
+    let cont msg = result <- msg
+
+    Printf.kprintf cont "Hello %s" "World"
+
+    result |> equal "Hello World"
+
+[<Fact>]
+let ``test printf.cont raises exception via continuation`` () =
+    let fail msg = failwith msg
+
+    let mutable exceptionRaised = false
+    try
+        Printf.kprintf fail "Error: %s" "test error" |> ignore
+    with
+    | ex ->
+        exceptionRaised <- true
+        ex.Message |> equal "Error: test error"
+
+    exceptionRaised |> equal true
+
+[<Fact>]
+let ``test failwithf works`` () =
+    let mutable exceptionRaised = false
+    try
+        failwithf "Error: %s %d" "test" 42
+    with
+    | ex ->
+        exceptionRaised <- true
+        ex.Message |> equal "Error: test 42"
+
+    exceptionRaised |> equal true
+
 #if FABLE_COMPILER
 open Fable.Core
 


### PR DESCRIPTION
- Printf Continuation: Fixed printf.cont() not storing the continuation function when called before arguments are provided.
- This broke F# patterns like failwithf and assertion functions in Fable.Pyxpecto.
- Various code cleanup of strings.rs
- Added test to TestStrings.fs to verify fix

FYI: @Freymaurer 