### PR TITLE
[Python] Generate async def for F# task { } expressions

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+* [Python] F# `task { }` expressions now generate Python `async def` functions (by @dbrattli)
+
 ## 5.0.0-alpha.20 - 2025-12-08
 
 ### Added

--- a/src/Fable.Compiler/CHANGELOG.md
+++ b/src/Fable.Compiler/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+* [Python] F# `task { }` expressions now generate Python `async def` functions (by @dbrattli)
+
 ## 5.0.0-alpha.19 - 2025-12-08
 
 ### Added

--- a/src/Fable.Transforms/Python/Fable2Python.Util.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.Util.fs
@@ -891,6 +891,21 @@ module Helpers =
         let callInfo = Fable.CallInfo.Create(args = [ e ])
         makeIdentExpr "str" |> makeCall None Fable.String callInfo
 
+    /// Transform return statements to wrap their values with await
+    let wrapReturnWithAwait (body: Statement list) : Statement list =
+        body
+        |> List.map (fun stmt ->
+            match stmt with
+            | Statement.Return { Value = Some value } -> Statement.return' (Await value)
+            | other -> other
+        )
+
+    /// Unwrap Task[T] to T for async function return types
+    let unwrapTaskType (returnType: Expression) : Expression =
+        match returnType with
+        | Subscript { Slice = innerType } -> innerType
+        | _ -> returnType
+
 
 /// Expression builders with automatic statement threading
 [<RequireQualifiedAccess>]


### PR DESCRIPTION
## Why

Python frameworks like FastAPI require actual `async def` functions to properly handle async I/O. Previously, Fable generated regular `def` functions returning `Awaitable[T]`, which prevented FastAPI from detecting async endpoints.

## How

- F# task { } expressions now transpile to Python `async def` functions instead of regular functions returning `Awaitable[T]`
- Return type is unwrapped from `Task[T]` to T for async functions (Python requires this)
- Return statements are automatically wrapped with `await`

