### PR TITLE
[Python] Fix generic type parameter handling for class methods and ResizeArray Seq compatibility

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* [Python] Fix `ResizeArray` compatibility with `Seq`/`Array` (by @dbrattli)
+* [Python] Fix `ResizeArray` compatibility with `Seq`/`Array` functions (by @dbrattli)
+* [Python] Fix `FSharpList` generic type parameter handling for `IEnumerable_1` compatibility (by @dbrattli)
 
 ## 5.0.0-alpha.20 - 2025-12-08
 

--- a/src/Fable.Compiler/CHANGELOG.md
+++ b/src/Fable.Compiler/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* [Python] Fix `ResizeArray` compatibility with `Seq`/`Array` (by @dbrattli)
+* [Python] Fix `ResizeArray` compatibility with `Seq`/`Array` functions (by @dbrattli)
+* [Python] Fix `FSharpList` generic type parameter handling for `IEnumerable_1` compatibility (by @dbrattli)
 
 ## 5.0.0-alpha.19 - 2025-12-08
 


### PR DESCRIPTION

  - Fix FSharpList and other generic classes to not redeclare class-level type parameters on methods like GetEnumerator and `__iter__`
  - Add class generic parameters to ScopedTypeParams context before processing attached members
  - Filter out class-level generics from method type parameters in calculateTypeParams
  - Wrap ResizeArray (Python list) arguments with to_enumerable() in Seq module functions for type compatibility
