### PR TITLE
[All] Pin transitive dependencies in Fable.Cli to avoid CVE warnings

### DIFF
--- a/src/Fable.Cli/Fable.Cli.fsproj
+++ b/src/Fable.Cli/Fable.Cli.fsproj
@@ -43,6 +43,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Buildalyzer" Version="8.0.0-fable-001" />
+    <!-- Pin Microsoft.Build transitive dependencies to fix CVE-2025-55247 (GHSA-w3q9-fxm7-j8fq) -->
+    <PackageReference Include="Microsoft.Build" Version="17.10.46" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.10.46" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.10.46" />
     <PackageReference Include="EasyBuild.PackageReleaseNotes.Tasks" Version="2.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Pin Microsoft.Build transitive dependencies for now to fix CVE-2025-55247 and avoid warnings, or should we instead do it in the `Buildalyzer 8.0.0-fable-001`? Not sure where that package comes from?

```
Fable/src/Fable.Cli/Fable.Cli.fsproj : warning NU1903: Package 'Microsoft.Build' 17.10.4 has a known high severity vulnerability, https://github.com/advisories/GHSA-w3q9-fxm7-j8fq
Fable/src/Fable.Cli/Fable.Cli.fsproj : warning NU1903: Package 'Microsoft.Build.Tasks.Core' 17.10.29 has a known high severity vulnerability, https://github.com/advisories/GHSA-w3q9-fxm7-j8fq
Fable/src/Fable.Cli/Fable.Cli.fsproj : warning NU1903: Package 'Microsoft.Build.Utilities.Core' 17.10.29 has a known high severity vulnerability, https://github.com/advisories/GHSA-w3q9-fxm7-j8fq
Fable/src/Fable.Cli/Fable.Cli.fsproj : warning NU1903: Package 'Microsoft.Build' 17.10.4 has a known high severity vulnerability, https://github.com/advisories/GHSA-w3q9-fxm7-j8fq
Fable/src/Fable.Cli/Fable.Cli.fsproj : warning NU1903: Package 'Microsoft.Build.Tasks.Core' 17.10.29 has a known high severity vulnerability, https://github.com/advisories/GHSA-w3q9-fxm7-j8fq
Fable/src/Fable.Cli/Fable.Cli.fsproj : warning NU1903: Package 'Microsoft.Build.Utilities.Core' 17.10.29 has a known high severity vulnerability, https://github.com/advisories/GHSA-w3q9-fxm7-j8fq
```