### PR TITLE
[Beam] Fix DateTime tests to use InvariantCulture for locale independence

### DIFF
--- a/tests/Beam/DateTimeTests.fs
+++ b/tests/Beam/DateTimeTests.fs
@@ -410,16 +410,25 @@ let ``test DateTime.ToString("d") works`` () =
 
 [<Fact>]
 let ``test DateTime.ToShortTimeString works`` () =
+#if !FABLE_COMPILER
+    Threading.Thread.CurrentThread.CurrentCulture <- CultureInfo.InvariantCulture
+#endif
     DateTime(2014, 9, 11, 16, 37, 0).ToShortTimeString()
     |> equal "16:37"
 
 [<Fact>]
 let ``test DateTime.ToLongTimeString works`` () =
+#if !FABLE_COMPILER
+    Threading.Thread.CurrentThread.CurrentCulture <- CultureInfo.InvariantCulture
+#endif
     DateTime(2014, 9, 11, 16, 37, 0).ToLongTimeString()
     |> equal "16:37:00"
 
 [<Fact>]
 let ``test DateTime.ToLongDateString works`` () =
+#if !FABLE_COMPILER
+    Threading.Thread.CurrentThread.CurrentCulture <- CultureInfo.InvariantCulture
+#endif
     DateTime(2014, 9, 11, 16, 37, 0).ToLongDateString()
     |> equal "Thursday, 11 September 2014"
 
@@ -433,6 +442,9 @@ let ``test DateTime.ToShortDateString works`` () =
 
 [<Fact>]
 let ``test DateTime.ToString("T") (upper) works`` () =
+#if !FABLE_COMPILER
+    Threading.Thread.CurrentThread.CurrentCulture <- CultureInfo.InvariantCulture
+#endif
     DateTime(2014, 9, 11, 3, 37, 11, 345).ToString("T")
     |> equal "03:37:11"
 
@@ -441,6 +453,9 @@ let ``test DateTime.ToString("T") (upper) works`` () =
 
 [<Fact>]
 let ``test DateTime.ToString("t") (lower) works`` () =
+#if !FABLE_COMPILER
+    Threading.Thread.CurrentThread.CurrentCulture <- CultureInfo.InvariantCulture
+#endif
     DateTime(2014, 9, 11, 3, 37, 11, 345).ToString("t")
     |> equal "03:37"
 


### PR DESCRIPTION
## Summary
- Fixed 5 DateTime formatting tests that failed on systems with non-US/UK locales
- Added `CultureInfo.InvariantCulture` wrapped in `#if !FABLE_COMPILER` to ensure consistent behavior across all system locales when running on .NET

The tests were expecting UK-style date/time formats (24-hour, day before month) but would fail on systems with other locale settings (e.g., US or Norwegian locales).

## Test plan
- [x] Verified tests pass locally with `./build.sh test beam`
- [x] All 2020 Beam tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)