### PR TITLE
[Python] Update PyO3 from 0.27.2 to 0.28.2

### DIFF
--- a/src/fable-library-py/Cargo.lock
+++ b/src/fable-library-py/Cargo.lock
@@ -120,15 +120,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,15 +146,6 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "num-traits"
@@ -197,36 +179,33 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.27.2"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
+checksum = "cf85e27e86080aafd5a22eae58a162e133a589551542b3e5cee4beb27e54f8e1"
 dependencies = [
  "chrono",
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.27.2"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
+checksum = "8bf94ee265674bf76c09fa430b0e99c26e319c945d96ca0d5a8215f31bf81cf7"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.27.2"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
+checksum = "491aa5fc66d8059dd44a75f4580a2962c1862a1c2945359db36f6c2818b748dc"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -234,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.27.2"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5b10c9bf9888125d917fb4d2ca2d25c8df94c7ab5a52e13313a07e050a3b02"
+checksum = "f5d671734e9d7a43449f8480f8b38115df67bef8d21f76837fa75ee7aaa5e52e"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -246,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.27.2"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
+checksum = "22faaa1ce6c430a1f71658760497291065e6450d7b5dc2bcf254d49f66ee700a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -329,12 +308,6 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "wasm-bindgen"

--- a/src/fable-library-py/Cargo.toml
+++ b/src/fable-library-py/Cargo.toml
@@ -12,7 +12,7 @@ name = "_core"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.27.2", features = ["extension-module", "chrono"] }
+pyo3 = { version = "0.28.2", features = ["extension-module", "chrono"] }
 byteorder = "1.5.0"
 chrono = "0.4.42"
 regex = "1.12.1"

--- a/src/fable-library-py/src/floats.rs
+++ b/src/fable-library-py/src/floats.rs
@@ -10,7 +10,7 @@ use std::ops::Deref;
 // Macro to generate float wrapper types (Float32, Float64)
 macro_rules! float_variant {
     ($name:ident, $type:ty) => {
-        #[pyclass(module = "fable", frozen)]
+        #[pyclass(module = "fable", frozen, from_py_object)]
         #[derive(Clone, Copy)] // Floats are typically Copy
         pub struct $name(pub $type);
 

--- a/src/fable-library-py/src/ints.rs
+++ b/src/fable-library-py/src/ints.rs
@@ -204,7 +204,7 @@ macro_rules! integer_variant {
         /// - Full Python special method support
         /// - Type-safe operations with automatic conversions
         /// - Direct access to the underlying value via Deref
-        #[pyclass(module = "fable", frozen)]
+        #[pyclass(module = "fable", frozen, from_py_object)]
         #[derive(Clone)]
         pub struct $name(pub $type); // Make the inner field public
 

--- a/src/fable-library-py/src/strings.rs
+++ b/src/fable-library-py/src/strings.rs
@@ -107,7 +107,7 @@ mod printf {
     /// def fail(msg): raise Exception(msg)
     /// printf("Error: %s").cont(fail)("something went wrong")  # raises Exception
     /// ```
-    #[pyclass(module = "fable")]
+    #[pyclass(module = "fable", from_py_object)]
     pub struct IPrintfFormat {
         /// The original format string with placeholders
         input: String,
@@ -633,7 +633,7 @@ mod printf {
     }
 
     /// Console printer wrapper that maintains F# currying semantics
-    #[pyclass]
+    #[pyclass(from_py_object)]
     #[derive(Clone)]
     pub struct ConsolePrinter {
         format: IPrintfFormat,
@@ -1676,7 +1676,7 @@ mod formatting {
     }
 
     /// String comparison enumeration
-    #[pyclass(module = "fable")]
+    #[pyclass(module = "fable", from_py_object)]
     #[derive(Clone, Copy)]
     pub struct StringComparison {
         pub value: i32,


### PR DESCRIPTION
## Summary
- Update PyO3 dependency from 0.27.2 to 0.28.2
- Add `from_py_object` to all `#[pyclass]` types that derive `Clone` (new PyO3 0.28 requirement)
- Replace deprecated `Py::from_borrowed_ptr` with `Bound::from_borrowed_ptr` + `cast_into_unchecked`