### PR TITLE
[Beam] Fix char-to-string binary syntax for complex expressions

### DIFF
--- a/src/Fable.Transforms/Beam/Replacements.fs
+++ b/src/Fable.Transforms/Beam/Replacements.fs
@@ -244,7 +244,7 @@ let private operators
     | "ToString", [ arg ] ->
         match arg.Type with
         | Type.String -> Some arg
-        | Type.Char -> emitExpr r _t [ arg ] "<<$0/utf8>>" |> Some
+        | Type.Char -> emitExpr r _t [ arg ] "<<($0)/utf8>>" |> Some
         | Type.Number(kind, _) ->
             match kind with
             | Decimal -> Helper.LibCall(com, "fable_decimal", "to_string", _t, [ arg ], ?loc = r) |> Some
@@ -582,7 +582,7 @@ let private objects
     | "GetType", Some arg, _ -> makeTypeInfo r arg.Type |> Some
     | "ToString", Some thisObj, [] ->
         match thisObj.Type with
-        | Type.Char -> emitExpr r t [ thisObj ] "<<$0/utf8>>" |> Some
+        | Type.Char -> emitExpr r t [ thisObj ] "<<($0)/utf8>>" |> Some
         | Type.Number(kind, _) ->
             match kind with
             | Decimal ->
@@ -814,7 +814,7 @@ let private strings
     // str.StartsWith(prefix)
     | "StartsWith", Some c, [ prefix ] ->
         match prefix.Type with
-        | Type.Char -> emitExpr r t [ c; prefix ] "fable_string:starts_with($0, <<$1/utf8>>)" |> Some
+        | Type.Char -> emitExpr r t [ c; prefix ] "fable_string:starts_with($0, <<($1)/utf8>>)" |> Some
         | _ -> Helper.LibCall(com, "fable_string", "starts_with", t, [ c; prefix ]) |> Some
     | "StartsWith", Some c, [ prefix; _compType ] ->
         emitExpr r t [ c; prefix ] "fable_string:starts_with(string:lowercase($0), string:lowercase($1))"
@@ -825,7 +825,7 @@ let private strings
     // str.EndsWith(suffix)
     | "EndsWith", Some c, [ suffix ] ->
         match suffix.Type with
-        | Type.Char -> emitExpr r t [ c; suffix ] "fable_string:ends_with($0, <<$1/utf8>>)" |> Some
+        | Type.Char -> emitExpr r t [ c; suffix ] "fable_string:ends_with($0, <<($1)/utf8>>)" |> Some
         | _ -> Helper.LibCall(com, "fable_string", "ends_with", t, [ c; suffix ]) |> Some
     | "EndsWith", Some c, [ suffix; _compType ] ->
         emitExpr r t [ c; suffix ] "fable_string:ends_with(string:lowercase($0), string:lowercase($1))"
@@ -964,12 +964,12 @@ let private strings
     // str.IndexOf(sub) / str.IndexOf(sub, startIdx)
     | "IndexOf", Some c, [ sub ] ->
         match sub.Type with
-        | Type.Char -> emitExpr r t [ c; sub ] "fable_string:index_of($0, <<$1/utf8>>)" |> Some
+        | Type.Char -> emitExpr r t [ c; sub ] "fable_string:index_of($0, <<($1)/utf8>>)" |> Some
         | _ -> Helper.LibCall(com, "fable_string", "index_of", t, [ c; sub ]) |> Some
     | "IndexOf", Some c, [ sub; startIdx ] ->
         match sub.Type with
         | Type.Char ->
-            emitExpr r t [ c; sub; startIdx ] "fable_string:index_of($0, <<$1/utf8>>, $2)"
+            emitExpr r t [ c; sub; startIdx ] "fable_string:index_of($0, <<($1)/utf8>>, $2)"
             |> Some
         | _ -> Helper.LibCall(com, "fable_string", "index_of", t, [ c; sub; startIdx ]) |> Some
     // str.IndexOfAny(chars) / str.IndexOfAny(chars, startIdx)
@@ -984,12 +984,12 @@ let private strings
     // str.LastIndexOf(sub) / str.LastIndexOf(sub, maxIdx)
     | "LastIndexOf", Some c, [ sub ] ->
         match sub.Type with
-        | Type.Char -> emitExpr r t [ c; sub ] "fable_string:last_index_of($0, <<$1/utf8>>)" |> Some
+        | Type.Char -> emitExpr r t [ c; sub ] "fable_string:last_index_of($0, <<($1)/utf8>>)" |> Some
         | _ -> Helper.LibCall(com, "fable_string", "last_index_of", t, [ c; sub ]) |> Some
     | "LastIndexOf", Some c, [ sub; maxIdx ] ->
         match sub.Type with
         | Type.Char ->
-            emitExpr r t [ c; sub; maxIdx ] "fable_string:last_index_of($0, <<$1/utf8>>, $2)"
+            emitExpr r t [ c; sub; maxIdx ] "fable_string:last_index_of($0, <<($1)/utf8>>, $2)"
             |> Some
         | _ ->
             Helper.LibCall(com, "fable_string", "last_index_of", t, [ c; sub; maxIdx ])
@@ -1203,7 +1203,7 @@ let private conversions
 
         match arg.Type with
         | Type.String -> Some arg
-        | Type.Char -> emitExpr r t [ arg ] "<<$0/utf8>>" |> Some
+        | Type.Char -> emitExpr r t [ arg ] "<<($0)/utf8>>" |> Some
         | Type.Number(kind, _) ->
             match kind with
             | Decimal -> Helper.LibCall(com, "fable_decimal", "to_string", t, [ arg ], ?loc = r) |> Some

--- a/tests/Beam/NonRegressionTests.fs
+++ b/tests/Beam/NonRegressionTests.fs
@@ -128,3 +128,17 @@ let ``test issue 3912`` () =
         use x = x
         ()
     equal x.IsDisposed true
+
+// Char-to-string binary syntax needs parentheses around complex expressions
+// e.g. <<(erlang:element(2, Pair))/utf8>> not <<erlang:element(2, Pair)/utf8>>
+[<Fact>]
+let ``test char to string from tuple element`` () =
+    let pair = (1, 'A')
+    let result = string (snd pair)
+    equal "A" result
+
+[<Fact>]
+let ``test string StartsWith char from tuple element`` () =
+    let pair = (1, 'H')
+    let result = "Hello".StartsWith(snd pair)
+    equal true result


### PR DESCRIPTION
## Summary
- Wrap emitted char arguments in parentheses inside Erlang binary syntax (`<<($0)/utf8>>` instead of `<<$0/utf8>>`) so that complex expressions like `erlang:element/2` (from tuple access) produce valid Erlang code
- Affects `ToString`, `string()`, `StartsWith`, `EndsWith`, `IndexOf`, and `LastIndexOf` when called with a char argument
- Add two regression tests covering `string (snd pair)` and `"Hello".StartsWith(snd pair)`

## Test plan
- [x] All 2104 Beam tests pass
- [x] New regression tests verify char-to-string from tuple element works
- [x] New regression test verifies `StartsWith` with char from tuple element works

🤖 Generated with [Claude Code](https://claude.com/claude-code)