### PR TITLE
[Beam] Format source files and suppress build warnings

### DIFF
--- a/src/Fable.Build/Test/Beam.fs
+++ b/src/Fable.Build/Test/Beam.fs
@@ -75,7 +75,11 @@ let handle (args: string list) =
                 let fileName = Path.GetFileName(erlFile)
 
                 try
-                    Command.Run("erlc", fileName, workingDirectory = fableModulesLibDir)
+                    Command.Run(
+                        "erlc",
+                        $"+nowarn_ignored +nowarn_failed +nowarn_shadow_vars {fileName}",
+                        workingDirectory = fableModulesLibDir
+                    )
                 with _ ->
                     printfn $"WARNING: erlc failed for {fileName} (library), skipping"
                     compileErrors <- compileErrors + 1
@@ -87,7 +91,11 @@ let handle (args: string list) =
             let fileName = Path.GetFileName(erlFile)
 
             try
-                Command.Run("erlc", $"-pa fable_modules/fable-library-beam {fileName}", workingDirectory = buildDir)
+                Command.Run(
+                    "erlc",
+                    $"+nowarn_ignored +nowarn_failed +nowarn_shadow_vars -pa fable_modules/fable-library-beam {fileName}",
+                    workingDirectory = buildDir
+                )
             with _ ->
                 printfn $"WARNING: erlc failed for {fileName}, skipping"
                 compileErrors <- compileErrors + 1

--- a/src/fable-library-beam/fable_bit_converter.erl
+++ b/src/fable-library-beam/fable_bit_converter.erl
@@ -1,7 +1,15 @@
 -module(fable_bit_converter).
--export([get_bytes/2, get_bytes_bool/1, to_int/3, to_uint/3, to_float/3,
-         to_boolean/2, to_string/1, to_string/2, to_string/3,
-         int64_bits_to_double/1, double_to_int64_bits/1]).
+-export([
+    get_bytes/2,
+    get_bytes_bool/1,
+    to_int/3,
+    to_uint/3,
+    to_float/3,
+    to_boolean/2,
+    to_string/1, to_string/2, to_string/3,
+    int64_bits_to_double/1,
+    double_to_int64_bits/1
+]).
 
 -spec get_bytes(integer() | float(), integer()) -> tuple().
 -spec get_bytes_bool(boolean()) -> tuple().

--- a/src/fable-library-beam/fable_char.erl
+++ b/src/fable-library-beam/fable_char.erl
@@ -1,13 +1,26 @@
 -module(fable_char).
 -export([
-    to_upper/1, to_lower/1, to_string/1,
-    is_letter/1, is_digit/1, is_letter_or_digit/1,
-    is_upper/1, is_lower/1, is_number/1,
-    is_whitespace/1, is_control/1,
-    is_punctuation/1, is_separator/1, is_symbol/1,
-    is_high_surrogate/1, is_low_surrogate/1,
-    is_surrogate/1, is_surrogate_pair/2,
-    char_at/2, parse/1, try_parse/2,
+    to_upper/1,
+    to_lower/1,
+    to_string/1,
+    is_letter/1,
+    is_digit/1,
+    is_letter_or_digit/1,
+    is_upper/1,
+    is_lower/1,
+    is_number/1,
+    is_whitespace/1,
+    is_control/1,
+    is_punctuation/1,
+    is_separator/1,
+    is_symbol/1,
+    is_high_surrogate/1,
+    is_low_surrogate/1,
+    is_surrogate/1,
+    is_surrogate_pair/2,
+    char_at/2,
+    parse/1,
+    try_parse/2,
     get_unicode_category/1
 ]).
 
@@ -72,13 +85,26 @@ is_lower(_) -> false.
 is_number(C) when C >= $0, C =< $9 -> true;
 is_number(_) -> false.
 
-is_whitespace(C) when C =:= $\s; C =:= $\t; C =:= $\n; C =:= $\r;
-                      C =:= 16#000B; C =:= 16#000C; C =:= 16#0085;
-                      C =:= 16#00A0; C =:= 16#1680;
-                      C >= 16#2000, C =< 16#200A;
-                      C =:= 16#2028; C =:= 16#2029;
-                      C =:= 16#202F; C =:= 16#205F; C =:= 16#3000 -> true;
-is_whitespace(_) -> false.
+is_whitespace(C) when
+    C =:= $\s;
+    C =:= $\t;
+    C =:= $\n;
+    C =:= $\r;
+    C =:= 16#000B;
+    C =:= 16#000C;
+    C =:= 16#0085;
+    C =:= 16#00A0;
+    C =:= 16#1680;
+    C >= 16#2000, C =< 16#200A;
+    C =:= 16#2028;
+    C =:= 16#2029;
+    C =:= 16#202F;
+    C =:= 16#205F;
+    C =:= 16#3000
+->
+    true;
+is_whitespace(_) ->
+    false.
 
 is_control(C) when C >= 0, C =< 16#001F -> true;
 is_control(C) when C >= 16#007F, C =< 16#009F -> true;
@@ -90,18 +116,38 @@ is_punctuation(C) when C =:= $,; C =:= $-; C =:= $.; C =:= $/ -> true;
 is_punctuation(C) when C =:= $:; C =:= $; -> true;
 is_punctuation(C) when C =:= $?; C =:= $@ -> true;
 is_punctuation(C) when C >= $[, C =< $] -> true;
-is_punctuation(C) when C =:= $_; C =:= ${ ; C =:= $}  -> true;
+is_punctuation(C) when C =:= $_; C =:= ${; C =:= $} -> true;
 is_punctuation(_) -> false.
 
-is_separator(C) when C =:= $\s; C =:= 16#00A0; C =:= 16#1680;
-                     C >= 16#2000, C =< 16#200A;
-                     C =:= 16#2028; C =:= 16#2029;
-                     C =:= 16#202F; C =:= 16#205F; C =:= 16#3000 -> true;
-is_separator(_) -> false.
+is_separator(C) when
+    C =:= $\s;
+    C =:= 16#00A0;
+    C =:= 16#1680;
+    C >= 16#2000, C =< 16#200A;
+    C =:= 16#2028;
+    C =:= 16#2029;
+    C =:= 16#202F;
+    C =:= 16#205F;
+    C =:= 16#3000
+->
+    true;
+is_separator(_) ->
+    false.
 
-is_symbol(C) when C =:= $$; C =:= $+; C =:= $<; C =:= $=; C =:= $>;
-                  C =:= $^; C =:= $`; C =:= $|; C =:= $~ -> true;
-is_symbol(_) -> false.
+is_symbol(C) when
+    C =:= $$;
+    C =:= $+;
+    C =:= $<;
+    C =:= $=;
+    C =:= $>;
+    C =:= $^;
+    C =:= $`;
+    C =:= $|;
+    C =:= $~
+->
+    true;
+is_symbol(_) ->
+    false.
 
 %% Extract character at index from a binary string
 char_at(Str, Idx) ->
@@ -144,8 +190,18 @@ get_unicode_category(C) when C >= $a, C =< $z -> 1;
 get_unicode_category(C) when C >= $0, C =< $9 -> 8;
 get_unicode_category(C) when C =:= $\s -> 11;
 get_unicode_category(C) when C =:= $- -> 18;
-get_unicode_category(C) when C =:= $+; C =:= $<; C =:= $=; C =:= $>;
-                             C =:= $|; C =:= $~; C =:= $^ -> 24;
+get_unicode_category(C) when
+    C =:= $+;
+    C =:= $<;
+    C =:= $=;
+    C =:= $>;
+    C =:= $|;
+    C =:= $~;
+    C =:= $^
+->
+    24;
 get_unicode_category(C) when C =:= $$ -> 25;
 get_unicode_category(C) when C =:= $_ -> 14;
-get_unicode_category(_) -> 28. %% OtherNotAssigned
+%% OtherNotAssigned
+get_unicode_category(_) ->
+    28.

--- a/src/fable-library-beam/fable_convert.erl
+++ b/src/fable-library-beam/fable_convert.erl
@@ -1,8 +1,18 @@
 -module(fable_convert).
--export([to_float/1, to_int/1, to_int_with_base/2, to_string/1, to_string_with_base/3,
-         to_base64/1, from_base64/1, boolean_parse/1, boolean_try_parse/2,
-         int_to_string_with_format/2,
-         try_parse_int/2, try_parse_float/2]).
+-export([
+    to_float/1,
+    to_int/1,
+    to_int_with_base/2,
+    to_string/1,
+    to_string_with_base/3,
+    to_base64/1,
+    from_base64/1,
+    boolean_parse/1,
+    boolean_try_parse/2,
+    int_to_string_with_format/2,
+    try_parse_int/2,
+    try_parse_float/2
+]).
 
 -spec to_float(binary() | integer() | float()) -> float().
 -spec to_int(binary() | integer() | float()) -> integer().
@@ -22,10 +32,12 @@
 %% .NET accepts these, so we normalize before converting.
 to_float(Bin) when is_binary(Bin) ->
     case binary_to_list(Bin) of
-        [] -> erlang:error(badarg);
+        [] ->
+            erlang:error(badarg);
         Str ->
             case string:to_float(Str) of
-                {Float, []} -> Float;
+                {Float, []} ->
+                    Float;
                 _ ->
                     %% Partial parse or no float found - try as integer
                     try_as_integer(Str)
@@ -37,7 +49,8 @@ to_float(F) when is_float(F) -> F.
 try_as_integer(Str) ->
     case string:to_integer(Str) of
         {Int, []} -> float(Int);
-        {Int, "."} -> float(Int);  %% Handle trailing dot like "1."
+        %% Handle trailing dot like "1."
+        {Int, "."} -> float(Int);
         _ -> erlang:error(badarg)
     end.
 
@@ -84,8 +97,10 @@ to_string(Value) when is_float(Value) ->
 to_string(Value) when is_atom(Value) -> atom_to_binary(Value);
 to_string(Value) when is_list(Value) ->
     %% Lists could be charlists or regular lists
-    try list_to_binary(Value)
-    catch _:_ -> iolist_to_binary(io_lib:format("~p", [Value]))
+    try
+        list_to_binary(Value)
+    catch
+        _:_ -> iolist_to_binary(io_lib:format("~p", [Value]))
     end;
 to_string(Value) ->
     iolist_to_binary(io_lib:format("~p", [Value])).
@@ -108,22 +123,32 @@ from_base64(Str) when is_binary(Str) ->
 try_parse_int(Bin, OutRef) when is_binary(Bin) ->
     Trimmed = string:trim(binary_to_list(Bin)),
     case string:to_integer(Trimmed) of
-        {Int, []} -> put(OutRef, Int), true;
-        _ -> false
+        {Int, []} ->
+            put(OutRef, Int),
+            true;
+        _ ->
+            false
     end;
-try_parse_int(_, _) -> false.
+try_parse_int(_, _) ->
+    false.
 
 try_parse_float(Bin, OutRef) when is_binary(Bin) ->
     Trimmed = string:trim(binary_to_list(Bin)),
     case string:to_float(Trimmed) of
-        {Float, []} -> put(OutRef, Float), true;
+        {Float, []} ->
+            put(OutRef, Float),
+            true;
         _ ->
             case string:to_integer(Trimmed) of
-                {Int, []} -> put(OutRef, float(Int)), true;
-                _ -> false
+                {Int, []} ->
+                    put(OutRef, float(Int)),
+                    true;
+                _ ->
+                    false
             end
     end;
-try_parse_float(_, _) -> false.
+try_parse_float(_, _) ->
+    false.
 
 %% Boolean.Parse - case insensitive, trims whitespace
 boolean_parse(Bin) when is_binary(Bin) ->
@@ -140,9 +165,15 @@ boolean_try_parse(Bin, OutRef) when is_binary(Bin) ->
     Trimmed = string:trim(binary_to_list(Bin)),
     Lower = string:lowercase(Trimmed),
     case Lower of
-        "true" -> put(OutRef, true), true;
-        "false" -> put(OutRef, false), true;
-        _ -> put(OutRef, false), false
+        "true" ->
+            put(OutRef, true),
+            true;
+        "false" ->
+            put(OutRef, false),
+            true;
+        _ ->
+            put(OutRef, false),
+            false
     end.
 
 %% Int32/Int64 ToString with format specifier
@@ -156,8 +187,9 @@ int_to_string_with_format(Value, Fmt) when is_binary(Fmt) ->
             Width = list_to_integer(WidthStr),
             S = integer_to_list(Value),
             Len = length(S),
-            if Len >= Width -> list_to_binary(S);
-               true -> list_to_binary(string:pad(S, Width, leading, $0))
+            if
+                Len >= Width -> list_to_binary(S);
+                true -> list_to_binary(string:pad(S, Width, leading, $0))
             end;
         [$x] ->
             list_to_binary(string:lowercase(integer_to_list(Value, 16)));
@@ -165,8 +197,9 @@ int_to_string_with_format(Value, Fmt) when is_binary(Fmt) ->
             Width = list_to_integer(WidthStr),
             S = string:lowercase(integer_to_list(Value, 16)),
             Len = length(S),
-            if Len >= Width -> list_to_binary(S);
-               true -> list_to_binary(string:pad(S, Width, leading, $0))
+            if
+                Len >= Width -> list_to_binary(S);
+                true -> list_to_binary(string:pad(S, Width, leading, $0))
             end;
         _ ->
             integer_to_binary(Value)

--- a/src/fable-library-beam/fable_date.erl
+++ b/src/fable-library-beam/fable_date.erl
@@ -1,23 +1,49 @@
 -module(fable_date).
--compile({no_auto_import,[now/0]}).
+-compile({no_auto_import, [now/0]}).
 -export([
     create/3, create/6, create/7, create/8, create/9,
     from_ticks/1, from_ticks/2,
-    year/1, month/1, day/1, hour/1, minute/1, second/1,
-    millisecond/1, microsecond/1, ticks/1, kind/1,
-    day_of_week/1, day_of_year/1, date/1,
-    now/0, utc_now/0, today/0,
-    min_value/0, max_value/0,
-    is_leap_year/1, days_in_month/2,
-    add/2, subtract/2,
-    add_years/2, add_months/2,
-    add_days/2, add_hours/2, add_minutes/2, add_seconds/2, add_milliseconds/2,
-    op_addition/2, op_subtraction/2,
-    specify_kind/2, to_local_time/1, to_universal_time/1,
-    compare/2, equals/2,
+    year/1,
+    month/1,
+    day/1,
+    hour/1,
+    minute/1,
+    second/1,
+    millisecond/1,
+    microsecond/1,
+    ticks/1,
+    kind/1,
+    day_of_week/1,
+    day_of_year/1,
+    date/1,
+    now/0,
+    utc_now/0,
+    today/0,
+    min_value/0,
+    max_value/0,
+    is_leap_year/1,
+    days_in_month/2,
+    add/2,
+    subtract/2,
+    add_years/2,
+    add_months/2,
+    add_days/2,
+    add_hours/2,
+    add_minutes/2,
+    add_seconds/2,
+    add_milliseconds/2,
+    op_addition/2,
+    op_subtraction/2,
+    specify_kind/2,
+    to_local_time/1,
+    to_universal_time/1,
+    compare/2,
+    equals/2,
     to_string/1, to_string/2, to_string/3,
-    to_short_date_string/1, to_long_date_string/1,
-    to_short_time_string/1, to_long_time_string/1,
+    to_short_date_string/1,
+    to_long_date_string/1,
+    to_short_time_string/1,
+    to_long_time_string/1,
     parse/1, parse/2,
     try_parse/2, try_parse/3, try_parse/4
 ]).
@@ -26,9 +52,22 @@
 
 -spec create(integer(), integer(), integer()) -> datetime().
 -spec create(integer(), integer(), integer(), integer(), integer(), integer()) -> datetime().
--spec create(integer(), integer(), integer(), integer(), integer(), integer(), integer()) -> datetime().
--spec create(integer(), integer(), integer(), integer(), integer(), integer(), integer(), integer()) -> datetime().
--spec create(integer(), integer(), integer(), integer(), integer(), integer(), integer(), integer(), integer()) -> datetime().
+-spec create(integer(), integer(), integer(), integer(), integer(), integer(), integer()) ->
+    datetime().
+-spec create(
+    integer(), integer(), integer(), integer(), integer(), integer(), integer(), integer()
+) -> datetime().
+-spec create(
+    integer(),
+    integer(),
+    integer(),
+    integer(),
+    integer(),
+    integer(),
+    integer(),
+    integer(),
+    integer()
+) -> datetime().
 -spec from_ticks(integer()) -> datetime().
 -spec from_ticks(integer(), integer()) -> datetime().
 -spec year(datetime()) -> integer().
@@ -203,7 +242,8 @@ kind({_Ticks, Kind}) -> Kind.
 day_of_week({Ticks, _Kind}) ->
     {Y, M, D, _, _, _, _} = ticks_to_datetime(Ticks),
     ErlDow = calendar:day_of_the_week({Y, M, D}),
-    ErlDow rem 7.  % 7(Sun)->0, 1(Mon)->1, ..., 6(Sat)->6
+    % 7(Sun)->0, 1(Mon)->1, ..., 6(Sat)->6
+    ErlDow rem 7.
 
 day_of_year({Ticks, _Kind}) ->
     {Y, M, D, _, _, _, _} = ticks_to_datetime(Ticks),
@@ -275,10 +315,11 @@ add_months({Ticks, Kind}, Months) ->
     NewY = TotalMonths div 12,
     NewM = (TotalMonths rem 12) + 1,
     %% Handle negative remainder
-    {FinalY, FinalM} = case NewM =< 0 of
-        true -> {NewY - 1, NewM + 12};
-        false -> {NewY, NewM}
-    end,
+    {FinalY, FinalM} =
+        case NewM =< 0 of
+            true -> {NewY - 1, NewM + 12};
+            false -> {NewY, NewM}
+        end,
     MaxDay = calendar:last_day_of_the_month(FinalY, FinalM),
     NewD = min(D, MaxDay),
     BaseTicks = ticks_from_components(FinalY, FinalM, NewD, H, Min, S, 0, 0),
@@ -353,20 +394,22 @@ to_string({Ticks, Kind}, Format, _Provider) ->
     {Y, M, D, H, Min, S, SubSecondTicks} = ticks_to_datetime(Ticks),
     Ms = SubSecondTicks div ?TICKS_PER_MILLISECOND,
     Mc = (SubSecondTicks rem ?TICKS_PER_MILLISECOND) div ?TICKS_PER_MICROSECOND,
-    FmtStr = case Format of
-        B when is_binary(B) -> binary_to_list(B);
-        L when is_list(L) -> L
-    end,
-    Result = case FmtStr of
-        "" -> format_default(Y, M, D, H, Min, S, Ms, Mc, Kind);
-        "d" -> format_short_date(Y, M, D);
-        "D" -> format_long_date(Y, M, D);
-        "t" -> format_short_time(H, Min);
-        "T" -> format_long_time(H, Min, S);
-        "O" -> format_roundtrip(Y, M, D, H, Min, S, SubSecondTicks, Kind);
-        "o" -> format_roundtrip(Y, M, D, H, Min, S, SubSecondTicks, Kind);
-        _ -> format_custom(FmtStr, Y, M, D, H, Min, S, SubSecondTicks, Kind)
-    end,
+    FmtStr =
+        case Format of
+            B when is_binary(B) -> binary_to_list(B);
+            L when is_list(L) -> L
+        end,
+    Result =
+        case FmtStr of
+            "" -> format_default(Y, M, D, H, Min, S, Ms, Mc, Kind);
+            "d" -> format_short_date(Y, M, D);
+            "D" -> format_long_date(Y, M, D);
+            "t" -> format_short_time(H, Min);
+            "T" -> format_long_time(H, Min, S);
+            "O" -> format_roundtrip(Y, M, D, H, Min, S, SubSecondTicks, Kind);
+            "o" -> format_roundtrip(Y, M, D, H, Min, S, SubSecondTicks, Kind);
+            _ -> format_custom(FmtStr, Y, M, D, H, Min, S, SubSecondTicks, Kind)
+        end,
     iolist_to_binary(Result).
 
 format_default(Y, M, D, H, Min, S, _Ms, _Mc, _Kind) ->
@@ -387,12 +430,15 @@ format_long_time(H, Min, S) ->
     io_lib:format("~2..0B:~2..0B:~2..0B", [H, Min, S]).
 
 format_roundtrip(Y, M, D, H, Min, S, SubSecondTicks, Kind) ->
-    KindSuffix = case Kind of
-        ?KIND_UTC -> "Z";
-        _ -> ""
-    end,
-    io_lib:format("~4..0B-~2..0B-~2..0BT~2..0B:~2..0B:~2..0B.~7..0B~s",
-                  [Y, M, D, H, Min, S, SubSecondTicks, KindSuffix]).
+    KindSuffix =
+        case Kind of
+            ?KIND_UTC -> "Z";
+            _ -> ""
+        end,
+    io_lib:format(
+        "~4..0B-~2..0B-~2..0BT~2..0B:~2..0B:~2..0B.~7..0B~s",
+        [Y, M, D, H, Min, S, SubSecondTicks, KindSuffix]
+    ).
 
 %% Short helper methods
 to_short_date_string(DT) -> to_string(DT, <<"d">>).
@@ -407,8 +453,18 @@ to_long_time_string(DT) -> to_string(DT, <<"T">>).
 format_custom(FmtStr, Y, M, D, H, Min, S, SubSecondTicks, Kind) ->
     Ms = SubSecondTicks div ?TICKS_PER_MILLISECOND,
     Mc = (SubSecondTicks rem ?TICKS_PER_MILLISECOND) div ?TICKS_PER_MICROSECOND,
-    Ctx = #{y => Y, m => M, d => D, h => H, min => Min, s => S,
-            ms => Ms, mc => Mc, sub_ticks => SubSecondTicks, kind => Kind},
+    Ctx = #{
+        y => Y,
+        m => M,
+        d => D,
+        h => H,
+        min => Min,
+        s => S,
+        ms => Ms,
+        mc => Mc,
+        sub_ticks => SubSecondTicks,
+        kind => Kind
+    },
     parse_format(FmtStr, Ctx, []).
 
 parse_format([], _Ctx, Acc) ->
@@ -436,11 +492,21 @@ parse_format([$% | Rest], Ctx, Acc) ->
         [] ->
             parse_format([], Ctx, Acc)
     end;
-parse_format([C | Rest], Ctx, Acc) when C =:= $d; C =:= $f; C =:= $F;
-                                          C =:= $g; C =:= $h; C =:= $H;
-                                          C =:= $K; C =:= $m; C =:= $M;
-                                          C =:= $s; C =:= $t; C =:= $y;
-                                          C =:= $z ->
+parse_format([C | Rest], Ctx, Acc) when
+    C =:= $d;
+    C =:= $f;
+    C =:= $F;
+    C =:= $g;
+    C =:= $h;
+    C =:= $H;
+    C =:= $K;
+    C =:= $m;
+    C =:= $M;
+    C =:= $s;
+    C =:= $t;
+    C =:= $y;
+    C =:= $z
+->
     %% Count consecutive same characters
     {Count, Rest2} = count_repeat(C, Rest, 1),
     Token = format_token(C, Count, Ctx),
@@ -498,10 +564,11 @@ format_token($g, _Count, _Ctx) ->
     "A.D.";
 format_token($h, Count, Ctx) ->
     #{h := H} = Ctx,
-    H12 = case H rem 12 of
-        0 -> 12;
-        V -> V
-    end,
+    H12 =
+        case H rem 12 of
+            0 -> 12;
+            V -> V
+        end,
     if
         Count =:= 1 -> integer_to_list(H12);
         Count >= 2 -> io_lib:format("~2..0B", [H12])
@@ -540,10 +607,11 @@ format_token($s, Count, Ctx) ->
     end;
 format_token($t, Count, Ctx) ->
     #{h := H} = Ctx,
-    AmPm = case H < 12 of
-        true -> "AM";
-        false -> "PM"
-    end,
+    AmPm =
+        case H < 12 of
+            true -> "AM";
+            false -> "PM"
+        end,
     if
         Count =:= 1 -> [hd(AmPm)];
         Count >= 2 -> AmPm
@@ -551,14 +619,17 @@ format_token($t, Count, Ctx) ->
 format_token($y, Count, Ctx) ->
     #{y := Y} = Ctx,
     if
-        Count =:= 1 -> integer_to_list(Y rem 100);
-        Count =:= 2 -> io_lib:format("~2..0B", [Y rem 100]);
+        Count =:= 1 ->
+            integer_to_list(Y rem 100);
+        Count =:= 2 ->
+            io_lib:format("~2..0B", [Y rem 100]);
         Count =:= 3 ->
             case Y < 1000 of
                 true -> io_lib:format("~3..0B", [Y]);
                 false -> integer_to_list(Y)
             end;
-        Count =:= 4 -> io_lib:format("~4..0B", [Y]);
+        Count =:= 4 ->
+            io_lib:format("~4..0B", [Y]);
         Count >= 5 ->
             Fmt = lists:flatten(io_lib:format("~~~B..0B", [Count])),
             io_lib:format(Fmt, [Y])
@@ -567,13 +638,19 @@ format_token($z, Count, Ctx) ->
     #{kind := Kind} = Ctx,
     %% For UTC kind, offset is 0
     %% For Local/Unspecified, we'd need timezone info; use 0 for UTC
-    OffsetMinutes = case Kind of
-        ?KIND_UTC -> 0;
-        _ -> 0  % Simplified: treat as UTC offset
-    end,
+    OffsetMinutes =
+        case Kind of
+            ?KIND_UTC -> 0;
+            % Simplified: treat as UTC offset
+            _ -> 0
+        end,
     OffsetH = abs(OffsetMinutes) div 60,
     OffsetM = abs(OffsetMinutes) rem 60,
-    Sign = case OffsetMinutes >= 0 of true -> "+"; false -> "-" end,
+    Sign =
+        case OffsetMinutes >= 0 of
+            true -> "+";
+            false -> "-"
+        end,
     if
         Count =:= 1 -> io_lib:format("~s~B", [Sign, OffsetH]);
         Count =:= 2 -> io_lib:format("~s~2..0B", [Sign, OffsetH]);
@@ -643,23 +720,25 @@ parse(Str, _Provider) when is_binary(Str) ->
 parse_string(S, OrigStr) ->
     %% Try ISO 8601 first: "2014-09-10T13:50:34.0000000"
     case try_parse_iso(S) of
-        {ok, DT} -> DT;
+        {ok, DT} ->
+            DT;
         error ->
             %% Try US date format: "9/10/2014 1:50:34 PM" or "9/10/2014 13:50:34"
             case try_parse_us(S) of
-                {ok, DT} -> DT;
+                {ok, DT} ->
+                    DT;
                 error ->
                     %% Try time-only: "13:50:34" or "1:5:34 AM"
                     case try_parse_time_only(S) of
                         {ok, DT} -> DT;
-                        error ->
-                            parse_error(OrigStr)
+                        error -> parse_error(OrigStr)
                     end
             end
     end.
 
 try_parse_iso(S) ->
-    Pattern = "^(\\d{4})-(\\d{1,2})-(\\d{1,2})T(\\d{1,2}):(\\d{1,2}):(\\d{1,2})(?:\\.(\\d+))?([Zz])?$",
+    Pattern =
+        "^(\\d{4})-(\\d{1,2})-(\\d{1,2})T(\\d{1,2}):(\\d{1,2}):(\\d{1,2})(?:\\.(\\d+))?([Zz])?$",
     case re:run(S, Pattern, [{capture, all, list}]) of
         {match, Groups} ->
             Y = list_to_integer(lists:nth(2, Groups)),
@@ -671,11 +750,12 @@ try_parse_iso(S) ->
             FracStr = safe_group(8, Groups),
             SubSecondTicks = parse_frac_to_ticks(FracStr),
             KindStr = safe_group(9, Groups),
-            Kind = case KindStr of
-                "Z" -> ?KIND_UTC;
-                "z" -> ?KIND_UTC;
-                _ -> ?KIND_UNSPECIFIED
-            end,
+            Kind =
+                case KindStr of
+                    "Z" -> ?KIND_UTC;
+                    "z" -> ?KIND_UTC;
+                    _ -> ?KIND_UNSPECIFIED
+                end,
             BaseTicks = ticks_from_components(Y, M, D, H, Min, Sec, 0, 0),
             {ok, {BaseTicks + SubSecondTicks, Kind}};
         nomatch ->
@@ -683,7 +763,8 @@ try_parse_iso(S) ->
     end.
 
 try_parse_us(S) ->
-    Pattern = "^(\\d{1,2})/(\\d{1,2})/(\\d{4})(?:\\s+(\\d{1,2}):(\\d{1,2})(?::(\\d{1,2}))?(?:\\s+(AM|PM|am|pm))?)?$",
+    Pattern =
+        "^(\\d{1,2})/(\\d{1,2})/(\\d{4})(?:\\s+(\\d{1,2}):(\\d{1,2})(?::(\\d{1,2}))?(?:\\s+(AM|PM|am|pm))?)?$",
     case re:run(S, Pattern, [{capture, all, list}]) of
         {match, Groups} ->
             M = list_to_integer(lists:nth(2, Groups)),
@@ -691,20 +772,24 @@ try_parse_us(S) ->
             Y = list_to_integer(lists:nth(4, Groups)),
             %% Validate month and day
             case M >= 1 andalso M =< 12 andalso D >= 1 andalso D =< 31 of
-                false -> error;
+                false ->
+                    error;
                 true ->
-                    H0 = case safe_group(5, Groups) of
-                        "" -> 0;
-                        HS -> list_to_integer(HS)
-                    end,
-                    Min = case safe_group(6, Groups) of
-                        "" -> 0;
-                        MS -> list_to_integer(MS)
-                    end,
-                    Sec = case safe_group(7, Groups) of
-                        "" -> 0;
-                        SS -> list_to_integer(SS)
-                    end,
+                    H0 =
+                        case safe_group(5, Groups) of
+                            "" -> 0;
+                            HS -> list_to_integer(HS)
+                        end,
+                    Min =
+                        case safe_group(6, Groups) of
+                            "" -> 0;
+                            MS -> list_to_integer(MS)
+                        end,
+                    Sec =
+                        case safe_group(7, Groups) of
+                            "" -> 0;
+                            SS -> list_to_integer(SS)
+                        end,
                     AmPm = safe_group(8, Groups),
                     H = adjust_ampm(H0, AmPm),
                     {ok, {ticks_from_components(Y, M, D, H, Min, Sec, 0, 0), ?KIND_UNSPECIFIED}}
@@ -719,10 +804,11 @@ try_parse_time_only(S) ->
         {match, Groups} ->
             H0 = list_to_integer(lists:nth(2, Groups)),
             Min = list_to_integer(lists:nth(3, Groups)),
-            Sec = case safe_group(4, Groups) of
-                "" -> 0;
-                SS -> list_to_integer(SS)
-            end,
+            Sec =
+                case safe_group(4, Groups) of
+                    "" -> 0;
+                    SS -> list_to_integer(SS)
+                end,
             AmPm = safe_group(5, Groups),
             H = adjust_ampm(H0, AmPm),
             %% Use current date
@@ -745,10 +831,12 @@ adjust_ampm(H, AmPm) ->
                 true -> H - 12;
                 false -> H
             end;
-        _ -> H
+        _ ->
+            H
     end.
 
-parse_frac_to_ticks("") -> 0;
+parse_frac_to_ticks("") ->
+    0;
 parse_frac_to_ticks(FracStr) ->
     Len = length(FracStr),
     if
@@ -764,7 +852,9 @@ safe_group(N, List) when N > length(List) -> "";
 safe_group(N, List) -> lists:nth(N, List).
 
 parse_error(Str) ->
-    Msg = iolist_to_binary(io_lib:format("String '~s' was not recognized as a valid DateTime.", [Str])),
+    Msg = iolist_to_binary(
+        io_lib:format("String '~s' was not recognized as a valid DateTime.", [Str])
+    ),
     erlang:error(Msg).
 
 %% ============================================================

--- a/src/fable-library-beam/fable_date_offset.erl
+++ b/src/fable-library-beam/fable_date_offset.erl
@@ -3,18 +3,32 @@
     create/7, create/8,
     from_date/2,
     from_ticks/2,
-    year/1, month/1, day/1, hour/1, minute/1, second/1,
-    millisecond/1, ticks/1, offset/1, date_time/1,
-    now/0, utc_now/0, min_value/0,
-    to_local_time/1, to_universal_time/1,
+    year/1,
+    month/1,
+    day/1,
+    hour/1,
+    minute/1,
+    second/1,
+    millisecond/1,
+    ticks/1,
+    offset/1,
+    date_time/1,
+    now/0,
+    utc_now/0,
+    min_value/0,
+    to_local_time/1,
+    to_universal_time/1,
     try_parse/2,
     to_string/1, to_string/2, to_string/3
 ]).
 
 -type datetimeoffset() :: {integer(), 0 | 1 | 2, integer()}.
 
--spec create(integer(), integer(), integer(), integer(), integer(), integer(), integer()) -> datetimeoffset().
--spec create(integer(), integer(), integer(), integer(), integer(), integer(), integer(), integer()) -> datetimeoffset().
+-spec create(integer(), integer(), integer(), integer(), integer(), integer(), integer()) ->
+    datetimeoffset().
+-spec create(
+    integer(), integer(), integer(), integer(), integer(), integer(), integer(), integer()
+) -> datetimeoffset().
 -spec from_date({integer(), integer()}, integer()) -> datetimeoffset().
 -spec from_ticks(integer(), integer()) -> datetimeoffset().
 -spec year(datetimeoffset()) -> integer().
@@ -58,20 +72,24 @@
 create(Y, M, D, H, Min, S, OffsetTicks) when is_integer(OffsetTicks) ->
     DT = fable_date:create(Y, M, D, H, Min, S),
     {Ticks, _Kind} = DT,
-    Kind = case OffsetTicks of
-        0 -> 1; % UTC
-        _ -> 0  % Unspecified
-    end,
+    Kind =
+        case OffsetTicks of
+            % UTC
+            0 -> 1;
+            % Unspecified
+            _ -> 0
+        end,
     {Ticks, Kind, OffsetTicks}.
 
 %% create(Y, M, D, H, Min, S, Ms, OffsetTimeSpan)
 create(Y, M, D, H, Min, S, Ms, OffsetTicks) when is_integer(OffsetTicks) ->
     DT = fable_date:create(Y, M, D, H, Min, S, Ms),
     {Ticks, _Kind} = DT,
-    Kind = case OffsetTicks of
-        0 -> 1;
-        _ -> 0
-    end,
+    Kind =
+        case OffsetTicks of
+            0 -> 1;
+            _ -> 0
+        end,
     {Ticks, Kind, OffsetTicks}.
 
 %% from_date(DateTime, OffsetTimeSpan)
@@ -80,10 +98,11 @@ from_date({Ticks, Kind}, OffsetTicks) ->
 
 %% from_ticks(Ticks, OffsetTimeSpan)
 from_ticks(Ticks, OffsetTicks) ->
-    Kind = case OffsetTicks of
-        0 -> 1;
-        _ -> 0
-    end,
+    Kind =
+        case OffsetTicks of
+            0 -> 1;
+            _ -> 0
+        end,
     {Ticks, Kind, OffsetTicks}.
 
 %% ============================================================
@@ -168,7 +187,11 @@ to_string({Ticks, Kind, OffsetTicks}, Format, Provider) ->
     end.
 
 format_offset(OffsetTicks) ->
-    Sign = case OffsetTicks >= 0 of true -> <<"+">>;  false -> <<"-">> end,
+    Sign =
+        case OffsetTicks >= 0 of
+            true -> <<"+">>;
+            false -> <<"-">>
+        end,
     AbsTicks = abs(OffsetTicks),
     H = AbsTicks div ?TICKS_PER_HOUR,
     M = (AbsTicks rem ?TICKS_PER_HOUR) div ?TICKS_PER_MINUTE,

--- a/src/fable-library-beam/fable_decimal.erl
+++ b/src/fable-library-beam/fable_decimal.erl
@@ -114,7 +114,8 @@ from_parts(Low, Mid, High, IsNegative, Scale) ->
         false -> Adjusted
     end.
 
-pow10(0) -> 1;
+pow10(0) ->
+    1;
 pow10(N) when N > 0 -> 10 * pow10(N - 1);
 pow10(N) when N < 0 ->
     %% Should not happen with valid .NET decimals (scale 0..28)

--- a/src/fable-library-beam/fable_dictionary.erl
+++ b/src/fable-library-beam/fable_dictionary.erl
@@ -1,10 +1,18 @@
 -module(fable_dictionary).
 -export([
-    create_empty/0, create_from_list/1,
-    add/3, get_item/2, set_item/3,
-    try_get_value/2, try_get_value/3, contains_key/2, contains_value/2,
-    remove/2, clear/1,
-    get_count/1, get_keys/1, get_values/1,
+    create_empty/0,
+    create_from_list/1,
+    add/3,
+    get_item/2,
+    set_item/3,
+    try_get_value/2, try_get_value/3,
+    contains_key/2,
+    contains_value/2,
+    remove/2,
+    clear/1,
+    get_count/1,
+    get_keys/1,
+    get_values/1,
     get_enumerator/1
 ]).
 
@@ -76,11 +84,11 @@ add(DictRef, Key, Value) ->
 get_item(DictRef, Key) ->
     Map = get(DictRef),
     case Map of
-       #{Key := Value} ->
-           Value;
-       #{} ->
-           erlang:error({badkey, Key})
-   end.
+        #{Key := Value} ->
+            Value;
+        #{} ->
+            erlang:error({badkey, Key})
+    end.
 
 %% set_Item: upsert (add or update)
 set_item(DictRef, Key, Value) ->
@@ -91,11 +99,11 @@ set_item(DictRef, Key, Value) ->
 try_get_value(DictRef, Key) ->
     Map = get(DictRef),
     case Map of
-       #{Key := Value} ->
-           {true, Value};
-       #{} ->
-           {false, undefined}
-   end.
+        #{Key := Value} ->
+            {true, Value};
+        #{} ->
+            {false, undefined}
+    end.
 
 %% TryGetValue (3-arg): sets OutRef and returns just bool
 %% F# desugars `let ok, v = dic.TryGetValue(k)` using an out-ref

--- a/src/fable-library-beam/fable_guid.erl
+++ b/src/fable-library-beam/fable_guid.erl
@@ -1,5 +1,7 @@
 -module(fable_guid).
--export([new_guid/0, parse/1, try_parse/1, try_parse/2, from_bytes/1, to_byte_array/1, to_string_format/2]).
+-export([
+    new_guid/0, parse/1, try_parse/1, try_parse/2, from_bytes/1, to_byte_array/1, to_string_format/2
+]).
 
 -spec new_guid() -> binary().
 -spec parse(binary()) -> binary().
@@ -18,15 +20,18 @@ new_guid() ->
     %% Set variant: top 2 bits of D = 10
     D = (D0 band 16#3FFF) bor 16#8000,
     list_to_binary(
-        io_lib:format("~8.16.0b-~4.16.0b-~4.16.0b-~4.16.0b-~12.16.0b",
-                       [A, B, C, D, E])).
+        io_lib:format(
+            "~8.16.0b-~4.16.0b-~4.16.0b-~4.16.0b-~12.16.0b",
+            [A, B, C, D, E]
+        )
+    ).
 
 %% Construct a GUID from a 16-byte array (binary or list of integers).
 %% .NET uses mixed-endian: first 3 groups are little-endian, last 2 are big-endian.
 from_bytes({byte_array, _, _} = BA) ->
     from_bytes(list_to_binary(fable_utils:byte_array_to_list(BA)));
 from_bytes(Bytes) when is_binary(Bytes), byte_size(Bytes) =:= 16 ->
-    <<B0,B1,B2,B3, B4,B5, B6,B7, B8,B9, B10,B11,B12,B13,B14,B15>> = Bytes,
+    <<B0, B1, B2, B3, B4, B5, B6, B7, B8, B9, B10, B11, B12, B13, B14, B15>> = Bytes,
     %% Group 1 (4 bytes, little-endian in .NET)
     A = (B3 bsl 24) bor (B2 bsl 16) bor (B1 bsl 8) bor B0,
     %% Group 2 (2 bytes, little-endian)
@@ -38,8 +43,11 @@ from_bytes(Bytes) when is_binary(Bytes), byte_size(Bytes) =:= 16 ->
     %% Group 5 (6 bytes, big-endian)
     E = (B10 bsl 40) bor (B11 bsl 32) bor (B12 bsl 24) bor (B13 bsl 16) bor (B14 bsl 8) bor B15,
     list_to_binary(
-        io_lib:format("~8.16.0b-~4.16.0b-~4.16.0b-~4.16.0b-~12.16.0b",
-                       [A, B, C, D, E])).
+        io_lib:format(
+            "~8.16.0b-~4.16.0b-~4.16.0b-~4.16.0b-~12.16.0b",
+            [A, B, C, D, E]
+        )
+    ).
 
 %% Parse a GUID string, accepting various formats:
 %% "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" (D format)
@@ -83,11 +91,14 @@ try_parse(Bin, OutRef) ->
     end.
 
 extract_hex(Str) ->
-    lists:filter(fun(C) ->
-        (C >= $0 andalso C =< $9) orelse
-        (C >= $a andalso C =< $f) orelse
-        (C >= $A andalso C =< $F)
-    end, Str).
+    lists:filter(
+        fun(C) ->
+            (C >= $0 andalso C =< $9) orelse
+                (C >= $a andalso C =< $f) orelse
+                (C >= $A andalso C =< $F)
+        end,
+        Str
+    ).
 
 %% Convert a GUID string to a byte array (16 bytes binary).
 %% .NET uses mixed-endian: first 3 groups little-endian, last 2 big-endian.
@@ -95,14 +106,17 @@ to_byte_array(Guid) when is_binary(Guid) ->
     Hex = extract_hex(binary_to_list(Guid)),
     AllBytes = hex_to_bytes(Hex, []),
     %% AllBytes is [B0..B15] in big-endian order from the GUID string
-    [B0,B1,B2,B3, B4,B5, B6,B7, B8,B9, B10,B11,B12,B13,B14,B15] = AllBytes,
+    [B0, B1, B2, B3, B4, B5, B6, B7, B8, B9, B10, B11, B12, B13, B14, B15] = AllBytes,
     %% Group 1 (4 bytes): little-endian swap
     %% Group 2 (2 bytes): little-endian swap
     %% Group 3 (2 bytes): little-endian swap
     %% Groups 4+5 (8 bytes): big-endian (no swap)
-    fable_utils:new_byte_array([B3,B2,B1,B0, B5,B4, B7,B6, B8,B9, B10,B11,B12,B13,B14,B15]).
+    fable_utils:new_byte_array([
+        B3, B2, B1, B0, B5, B4, B7, B6, B8, B9, B10, B11, B12, B13, B14, B15
+    ]).
 
-hex_to_bytes([], Acc) -> lists:reverse(Acc);
+hex_to_bytes([], Acc) ->
+    lists:reverse(Acc);
 hex_to_bytes([H1, H2 | Rest], Acc) ->
     Byte = list_to_integer([H1, H2], 16),
     hex_to_bytes(Rest, [Byte | Acc]).

--- a/src/fable-library-beam/fable_hashset.erl
+++ b/src/fable-library-beam/fable_hashset.erl
@@ -1,11 +1,19 @@
 -module(fable_hashset).
 -export([
-    create_empty/0, create_from_list/1,
-    add/2, remove/2, contains/2,
-    get_count/1, clear/1,
-    union_with/2, intersect_with/2, except_with/2,
-    is_subset_of/2, is_superset_of/2,
-    is_proper_subset_of/2, is_proper_superset_of/2,
+    create_empty/0,
+    create_from_list/1,
+    add/2,
+    remove/2,
+    contains/2,
+    get_count/1,
+    clear/1,
+    union_with/2,
+    intersect_with/2,
+    except_with/2,
+    is_subset_of/2,
+    is_superset_of/2,
+    is_proper_subset_of/2,
+    is_proper_superset_of/2,
     copy_to/2,
     get_enumerator/1
 ]).

--- a/src/fable-library-beam/fable_list.erl
+++ b/src/fable-library-beam/fable_list.erl
@@ -1,27 +1,80 @@
 -module(fable_list).
--compile({no_auto_import,[ref_to_list/1]}).
--export([fold/3, fold_back/3, fold2/4, fold_back2/4,
-         reduce/2, reduce_back/2, map_indexed/2,
-         sort_by/2, sort_by_descending/2, sort_with/2,
-         find/2, try_find/2, find_index/2, try_find_index/2,
-         find_back/2, try_find_back/2,
-         find_index_back/2, try_find_index_back/2,
-         choose/2, collect/2,
-         sum_by/2, min_by/2, max_by/2, indexed/1, zip/2, zip3/3,
-         init/2, replicate/2, scan/3, scan_back/3,
-         try_head/1, try_last/1, try_item/2, exactly_one/1, try_exactly_one/1,
-         distinct/1, distinct_by/2, pairwise/1,
-         exists2/3, forall2/3, map2/3, map3/4, mapi2/3,
-         iter2/3, iteri/2, iteri2/3, iter_indexed/2,
-         average/1, average_by/2, count_by/2, group_by/2,
-         unfold/2, split_at/2, chunk_by_size/2, windowed/2,
-         split_into/2, except/2, all_pairs/2, permute/2,
-         map_fold/3, map_fold_back/3, pick/2, try_pick/2,
-         transpose/1, compare_with/3,
-         update_at/3, insert_at/3, insert_many_at/3,
-         remove_at/2, remove_many_at/3,
-         index_of_value/2, get_slice/3,
-         take/2]).
+-compile({no_auto_import, [ref_to_list/1]}).
+-export([
+    fold/3,
+    fold_back/3,
+    fold2/4,
+    fold_back2/4,
+    reduce/2,
+    reduce_back/2,
+    map_indexed/2,
+    sort_by/2,
+    sort_by_descending/2,
+    sort_with/2,
+    find/2,
+    try_find/2,
+    find_index/2,
+    try_find_index/2,
+    find_back/2,
+    try_find_back/2,
+    find_index_back/2,
+    try_find_index_back/2,
+    choose/2,
+    collect/2,
+    sum_by/2,
+    min_by/2,
+    max_by/2,
+    indexed/1,
+    zip/2,
+    zip3/3,
+    init/2,
+    replicate/2,
+    scan/3,
+    scan_back/3,
+    try_head/1,
+    try_last/1,
+    try_item/2,
+    exactly_one/1,
+    try_exactly_one/1,
+    distinct/1,
+    distinct_by/2,
+    pairwise/1,
+    exists2/3,
+    forall2/3,
+    map2/3,
+    map3/4,
+    mapi2/3,
+    iter2/3,
+    iteri/2,
+    iteri2/3,
+    iter_indexed/2,
+    average/1,
+    average_by/2,
+    count_by/2,
+    group_by/2,
+    unfold/2,
+    split_at/2,
+    chunk_by_size/2,
+    windowed/2,
+    split_into/2,
+    except/2,
+    all_pairs/2,
+    permute/2,
+    map_fold/3,
+    map_fold_back/3,
+    pick/2,
+    try_pick/2,
+    transpose/1,
+    compare_with/3,
+    update_at/3,
+    insert_at/3,
+    insert_many_at/3,
+    remove_at/2,
+    remove_many_at/3,
+    index_of_value/2,
+    get_slice/3,
+    take/2
+]).
 
 -spec fold(fun(), term(), list() | reference() | map()) -> term().
 -spec fold_back(fun(), list(), term()) -> term().
@@ -113,8 +166,10 @@ fold(Fn, State, Map) when is_map(Map) ->
 ref_to_list(Ref) ->
     Inner = get(Ref),
     case Inner of
-        L when is_list(L) -> L;         %% ResizeArray
-        M when is_map(M) -> maps:keys(M) %% HashSet
+        %% ResizeArray
+        L when is_list(L) -> L;
+        %% HashSet
+        M when is_map(M) -> maps:keys(M)
     end.
 
 fold_back(Fn, List, State) ->
@@ -148,27 +203,33 @@ sort_with(Fn, List) ->
 
 find(Fn, List) ->
     case lists:dropwhile(fun(E) -> not Fn(E) end, List) of
-        [H|_] -> H;
+        [H | _] -> H;
         [] -> erlang:error(<<"key_not_found">>)
     end.
 
 try_find(Fn, List) ->
     case lists:dropwhile(fun(E) -> not Fn(E) end, List) of
-        [H|_] -> fable_option:some(H);
+        [H | _] -> fable_option:some(H);
         [] -> undefined
     end.
 
 find_index(Fn, List) ->
     find_index(Fn, List, 0).
-find_index(Fn, [H|T], I) ->
-    case Fn(H) of true -> I; false -> find_index(Fn, T, I + 1) end;
+find_index(Fn, [H | T], I) ->
+    case Fn(H) of
+        true -> I;
+        false -> find_index(Fn, T, I + 1)
+    end;
 find_index(_Fn, [], _I) ->
     erlang:error(<<"key_not_found">>).
 
 try_find_index(Fn, List) ->
     try_find_index(Fn, List, 0).
-try_find_index(Fn, [H|T], I) ->
-    case Fn(H) of true -> I; false -> try_find_index(Fn, T, I + 1) end;
+try_find_index(Fn, [H | T], I) ->
+    case Fn(H) of
+        true -> I;
+        false -> try_find_index(Fn, T, I + 1)
+    end;
 try_find_index(_Fn, [], _I) ->
     undefined.
 
@@ -179,7 +240,15 @@ try_find_back(Fn, List) ->
     try_find(Fn, lists:reverse(List)).
 
 choose(Fn, List) ->
-    lists:filtermap(fun(E) -> case Fn(E) of undefined -> false; V -> {true, fable_option:unwrap(V)} end end, List).
+    lists:filtermap(
+        fun(E) ->
+            case Fn(E) of
+                undefined -> false;
+                V -> {true, fable_option:unwrap(V)}
+            end
+        end,
+        List
+    ).
 
 collect(Fn, List) ->
     lists:append(lists:map(Fn, List)).
@@ -209,20 +278,28 @@ replicate(Count, Value) ->
     lists:duplicate(Count, Value).
 
 scan(Fn, State, List) ->
-    {Result, _} = lists:mapfoldl(fun(Item, Acc) ->
-        New = (Fn(Acc))(Item),
-        {New, New}
-    end, State, List),
+    {Result, _} = lists:mapfoldl(
+        fun(Item, Acc) ->
+            New = (Fn(Acc))(Item),
+            {New, New}
+        end,
+        State,
+        List
+    ),
     [State | Result].
 
 scan_back(Fn, List, State) ->
-    {Result, _} = lists:mapfoldr(fun(Item, Acc) ->
-        New = (Fn(Item))(Acc),
-        {New, New}
-    end, State, List),
+    {Result, _} = lists:mapfoldr(
+        fun(Item, Acc) ->
+            New = (Fn(Item))(Acc),
+            {New, New}
+        end,
+        State,
+        List
+    ),
     Result ++ [State].
 
-try_head([H|_]) -> fable_option:some(H);
+try_head([H | _]) -> fable_option:some(H);
 try_head([]) -> undefined.
 
 try_last([]) -> undefined;
@@ -241,8 +318,9 @@ try_exactly_one(_) -> undefined.
 
 distinct(List) ->
     distinct(List, #{}).
-distinct([], _Seen) -> [];
-distinct([H|T], Seen) ->
+distinct([], _Seen) ->
+    [];
+distinct([H | T], Seen) ->
     case maps:is_key(H, Seen) of
         true -> distinct(T, Seen);
         false -> [H | distinct(T, Seen#{H => true})]
@@ -250,8 +328,9 @@ distinct([H|T], Seen) ->
 
 distinct_by(Fn, List) ->
     distinct_by(Fn, List, #{}).
-distinct_by(_Fn, [], _Seen) -> [];
-distinct_by(Fn, [H|T], Seen) ->
+distinct_by(_Fn, [], _Seen) ->
+    [];
+distinct_by(Fn, [H | T], Seen) ->
     Key = Fn(H),
     case maps:is_key(Key, Seen) of
         true -> distinct_by(Fn, T, Seen);
@@ -260,7 +339,7 @@ distinct_by(Fn, [H|T], Seen) ->
 
 pairwise([]) -> [];
 pairwise([_]) -> [];
-pairwise([A,B|T]) -> [{A, B} | pairwise([B|T])].
+pairwise([A, B | T]) -> [{A, B} | pairwise([B | T])].
 
 exists2(Fn, L1, L2) ->
     lists:any(fun({A, B}) -> (Fn(A))(B) end, lists:zip(L1, L2)).
@@ -282,12 +361,26 @@ iter2(Fn, L1, L2) ->
     lists:foreach(fun({A, B}) -> (Fn(A))(B) end, lists:zip(L1, L2)).
 
 iteri(Fn, List) ->
-    lists:foldl(fun(E, I) -> (Fn(I))(E), I + 1 end, 0, List),
+    lists:foldl(
+        fun(E, I) ->
+            (Fn(I))(E),
+            I + 1
+        end,
+        0,
+        List
+    ),
     ok.
 
 iteri2(Fn, L1, L2) ->
     Zipped = lists:zip(L1, L2),
-    lists:foldl(fun({A, B}, I) -> ((Fn(I))(A))(B), I + 1 end, 0, Zipped),
+    lists:foldl(
+        fun({A, B}, I) ->
+            ((Fn(I))(A))(B),
+            I + 1
+        end,
+        0,
+        Zipped
+    ),
     ok.
 
 iter_indexed(Fn, List) -> iteri(Fn, List).
@@ -299,19 +392,27 @@ average_by(Fn, List) ->
     lists:sum(lists:map(Fn, List)) / length(List).
 
 count_by(Fn, List) ->
-    Grouped = lists:foldl(fun(E, Acc) ->
-        Key = Fn(E),
-        Count = maps:get(Key, Acc, 0),
-        Acc#{Key => Count + 1}
-    end, #{}, List),
+    Grouped = lists:foldl(
+        fun(E, Acc) ->
+            Key = Fn(E),
+            Count = maps:get(Key, Acc, 0),
+            Acc#{Key => Count + 1}
+        end,
+        #{},
+        List
+    ),
     maps:to_list(Grouped).
 
 group_by(Fn, List) ->
-    Grouped = lists:foldl(fun(E, Acc) ->
-        Key = Fn(E),
-        Vals = maps:get(Key, Acc, []),
-        Acc#{Key => Vals ++ [E]}
-    end, #{}, List),
+    Grouped = lists:foldl(
+        fun(E, Acc) ->
+            Key = Fn(E),
+            Vals = maps:get(Key, Acc, []),
+            Acc#{Key => Vals ++ [E]}
+        end,
+        #{},
+        List
+    ),
     maps:to_list(Grouped).
 
 unfold(Fn, State) ->
@@ -325,18 +426,20 @@ split_at(Index, List) ->
 
 chunk_by_size(Size, List) ->
     chunk_by_size(Size, List, []).
-chunk_by_size(_Size, [], Acc) -> lists:reverse(Acc);
+chunk_by_size(_Size, [], Acc) ->
+    lists:reverse(Acc);
 chunk_by_size(Size, List, Acc) ->
-    {Chunk, Rest} = case length(List) >= Size of
-        true -> {lists:sublist(List, Size), lists:nthtail(Size, List)};
-        false -> {List, []}
-    end,
+    {Chunk, Rest} =
+        case length(List) >= Size of
+            true -> {lists:sublist(List, Size), lists:nthtail(Size, List)};
+            false -> {List, []}
+        end,
     chunk_by_size(Size, Rest, [Chunk | Acc]).
 
 windowed(Size, List) ->
     windowed(Size, List, []).
 windowed(Size, List, Acc) when length(List) < Size -> lists:reverse(Acc);
-windowed(Size, [_|T] = List, Acc) ->
+windowed(Size, [_ | T] = List, Acc) ->
     Window = lists:sublist(List, Size),
     windowed(Size, T, [Window | Acc]).
 
@@ -346,9 +449,15 @@ split_into(Count, List) ->
     Base = Len div ActualCount,
     Extra = Len rem ActualCount,
     split_into(ActualCount, List, Base, Extra, []).
-split_into(0, _, _, _, Acc) -> lists:reverse(Acc);
+split_into(0, _, _, _, Acc) ->
+    lists:reverse(Acc);
 split_into(N, List, Base, Extra, Acc) ->
-    Size = Base + (case Extra > 0 of true -> 1; false -> 0 end),
+    Size =
+        Base +
+            (case Extra > 0 of
+                true -> 1;
+                false -> 0
+            end),
     {Chunk, Rest} = {lists:sublist(List, Size), lists:nthtail(Size, List)},
     split_into(N - 1, Rest, Base, max(Extra - 1, 0), [Chunk | Acc]).
 
@@ -363,23 +472,35 @@ permute(IndexFn, List) ->
     Arr = list_to_tuple(List),
     Len = tuple_size(Arr),
     Result = erlang:make_tuple(Len, undefined),
-    Result2 = lists:foldl(fun(I, Acc) ->
-        TargetIdx = IndexFn(I),
-        setelement(TargetIdx + 1, Acc, element(I + 1, Arr))
-    end, Result, lists:seq(0, Len - 1)),
+    Result2 = lists:foldl(
+        fun(I, Acc) ->
+            TargetIdx = IndexFn(I),
+            setelement(TargetIdx + 1, Acc, element(I + 1, Arr))
+        end,
+        Result,
+        lists:seq(0, Len - 1)
+    ),
     tuple_to_list(Result2).
 
 map_fold(Fn, State, List) ->
-    lists:mapfoldl(fun(Item, Acc) ->
-        {Mapped, NewAcc} = (Fn(Acc))(Item),
-        {Mapped, NewAcc}
-    end, State, List).
+    lists:mapfoldl(
+        fun(Item, Acc) ->
+            {Mapped, NewAcc} = (Fn(Acc))(Item),
+            {Mapped, NewAcc}
+        end,
+        State,
+        List
+    ).
 
 map_fold_back(Fn, List, State) ->
-    lists:mapfoldr(fun(Item, Acc) ->
-        {Mapped, NewAcc} = (Fn(Item))(Acc),
-        {Mapped, NewAcc}
-    end, State, List).
+    lists:mapfoldr(
+        fun(Item, Acc) ->
+            {Mapped, NewAcc} = (Fn(Item))(Acc),
+            {Mapped, NewAcc}
+        end,
+        State,
+        List
+    ).
 
 pick(Fn, List) ->
     case try_pick(Fn, List) of
@@ -387,8 +508,9 @@ pick(Fn, List) ->
         V -> V
     end.
 
-try_pick(_Fn, []) -> undefined;
-try_pick(Fn, [H|T]) ->
+try_pick(_Fn, []) ->
+    undefined;
+try_pick(Fn, [H | T]) ->
     case Fn(H) of
         undefined -> try_pick(Fn, T);
         V -> V
@@ -402,31 +524,37 @@ find_index_back(Fn, List) ->
 
 try_find_index_back(Fn, List) ->
     try_find_index_back(Fn, lists:reverse(List), length(List) - 1).
-try_find_index_back(_Fn, [], _Idx) -> undefined;
-try_find_index_back(Fn, [H|T], Idx) ->
+try_find_index_back(_Fn, [], _Idx) ->
+    undefined;
+try_find_index_back(Fn, [H | T], Idx) ->
     case Fn(H) of
         true -> Idx;
         false -> try_find_index_back(Fn, T, Idx - 1)
     end.
 
-transpose([]) -> [];
-transpose([[] | _]) -> [];
+transpose([]) ->
+    [];
+transpose([[] | _]) ->
+    [];
 transpose(Lists) ->
     Heads = [hd(L) || L <- Lists],
     Tails = [tl(L) || L <- Lists],
     [Heads | transpose(Tails)].
 
-compare_with(_Fn, [], []) -> 0;
-compare_with(_Fn, [], _) -> -1;
-compare_with(_Fn, _, []) -> 1;
-compare_with(Fn, [H1|T1], [H2|T2]) ->
+compare_with(_Fn, [], []) ->
+    0;
+compare_with(_Fn, [], _) ->
+    -1;
+compare_with(_Fn, _, []) ->
+    1;
+compare_with(Fn, [H1 | T1], [H2 | T2]) ->
     case (Fn(H1))(H2) of
         0 -> compare_with(Fn, T1, T2);
         N -> N
     end.
 
 update_at(Idx, Value, List) ->
-    {Before, [_|After]} = lists:split(Idx, List),
+    {Before, [_ | After]} = lists:split(Idx, List),
     Before ++ [Value | After].
 
 insert_at(Idx, Value, List) ->
@@ -438,7 +566,7 @@ insert_many_at(Idx, Values, List) ->
     Before ++ Values ++ After.
 
 remove_at(Idx, List) ->
-    {Before, [_|After]} = lists:split(Idx, List),
+    {Before, [_ | After]} = lists:split(Idx, List),
     Before ++ After.
 
 remove_many_at(Idx, Count, List) ->
@@ -449,12 +577,20 @@ remove_many_at(Idx, Count, List) ->
 index_of_value(Value, List) ->
     index_of_value(Value, List, 0).
 index_of_value(_Value, [], _Idx) -> -1;
-index_of_value(Value, [Value|_], Idx) -> Idx;
-index_of_value(Value, [_|T], Idx) -> index_of_value(Value, T, Idx + 1).
+index_of_value(Value, [Value | _], Idx) -> Idx;
+index_of_value(Value, [_ | T], Idx) -> index_of_value(Value, T, Idx + 1).
 
 get_slice(Lower, Upper, List) ->
-    Start = case Lower of undefined -> 0; _ -> Lower end,
-    End = case Upper of undefined -> erlang:length(List) - 1; _ -> Upper end,
+    Start =
+        case Lower of
+            undefined -> 0;
+            _ -> Lower
+        end,
+    End =
+        case Upper of
+            undefined -> erlang:length(List) - 1;
+            _ -> Upper
+        end,
     lists:sublist(List, Start + 1, End - Start + 1).
 
 -spec take(non_neg_integer(), list()) -> list().

--- a/src/fable-library-beam/fable_mailbox.erl
+++ b/src/fable-library-beam/fable_mailbox.erl
@@ -1,7 +1,12 @@
 -module(fable_mailbox).
--export([default/1, default/2, start/1, start/2,
-         start_instance/1, receive_msg/1,
-         post/2, post_and_async_reply/2]).
+-export([
+    default/1, default/2,
+    start/1, start/2,
+    start_instance/1,
+    receive_msg/1,
+    post/2,
+    post_and_async_reply/2
+]).
 
 -spec default(fun()) -> map().
 -spec default(fun(), term()) -> map().
@@ -65,9 +70,11 @@ post(Agent, Msg) ->
 post_and_async_reply(Agent, BuildMessage) ->
     fable_async:from_continuations(fun({OnSuccess, _OnError, _OnCancel}) ->
         ReplyRef = make_ref(),
-        ReplyChannel = #{reply => fun(Value) ->
-            put({reply_result, ReplyRef}, Value)
-        end},
+        ReplyChannel = #{
+            reply => fun(Value) ->
+                put({reply_result, ReplyRef}, Value)
+            end
+        },
         Msg = BuildMessage(ReplyChannel),
         post(Agent, Msg),
         Value = erase({reply_result, ReplyRef}),
@@ -79,8 +86,10 @@ process_events(Agent) ->
     Ref = maps:get(ref, Agent),
     State = get(Ref),
     case {maps:get(continuation, State), maps:get(messages, State)} of
-        {undefined, _} -> ok;
-        {_, []} -> ok;
+        {undefined, _} ->
+            ok;
+        {_, []} ->
+            ok;
         {Cont, [Msg | Rest]} ->
             put(Ref, State#{messages => Rest, continuation => undefined}),
             Cont(Msg)

--- a/src/fable-library-beam/fable_map.erl
+++ b/src/fable-library-beam/fable_map.erl
@@ -1,8 +1,23 @@
 -module(fable_map).
--export([try_find/2, fold/3, fold_back/3, map/2, filter/2,
-         exists/2, forall/2, iterate/2, find_key/2, try_find_key/2,
-         partition/2, try_get_value/2, try_get_value/3,
-         pick/2, try_pick/2, min_key_value/1, max_key_value/1, change/3]).
+-export([
+    try_find/2,
+    fold/3,
+    fold_back/3,
+    map/2,
+    filter/2,
+    exists/2,
+    forall/2,
+    iterate/2,
+    find_key/2,
+    try_find_key/2,
+    partition/2,
+    try_get_value/2, try_get_value/3,
+    pick/2,
+    try_pick/2,
+    min_key_value/1,
+    max_key_value/1,
+    change/3
+]).
 
 -spec try_find(term(), map()) -> term() | undefined.
 -spec fold(fun((term()) -> fun((term()) -> fun((term()) -> term()))), term(), map()) -> term().
@@ -29,11 +44,11 @@
 
 try_find(Key, Map) ->
     case Map of
-       #{Key := V} ->
-           fable_option:some(V);
-       #{} ->
-           undefined
-   end.
+        #{Key := V} ->
+            fable_option:some(V);
+        #{} ->
+            undefined
+    end.
 
 fold(Fn, State, Map) ->
     maps:fold(fun(K, V, Acc) -> ((Fn(Acc))(K))(V) end, State, Map).
@@ -58,33 +73,38 @@ iterate(Fn, Map) ->
 
 find_key(Fn, Map) ->
     case lists:dropwhile(fun({K, V}) -> not (Fn(K))(V) end, maps:to_list(Map)) of
-        [{K, _}|_] -> K;
+        [{K, _} | _] -> K;
         [] -> erlang:error(<<"key_not_found">>)
     end.
 
 try_find_key(Fn, Map) ->
     case lists:dropwhile(fun({K, V}) -> not (Fn(K))(V) end, maps:to_list(Map)) of
-        [{K, _}|_] -> fable_option:some(K);
+        [{K, _} | _] -> fable_option:some(K);
         [] -> undefined
     end.
 
 partition(Fn, Map) ->
-    {maps:filter(fun(K, V) -> (Fn(K))(V) end, Map),
-     maps:filter(fun(K, V) -> not (Fn(K))(V) end, Map)}.
+    {
+        maps:filter(fun(K, V) -> (Fn(K))(V) end, Map),
+        maps:filter(fun(K, V) -> not (Fn(K))(V) end, Map)
+    }.
 
 try_get_value(Key, Map) ->
     case Map of
-       #{Key := V} ->
-           {true, V};
-       #{} ->
-           {false, undefined}
-   end.
+        #{Key := V} ->
+            {true, V};
+        #{} ->
+            {false, undefined}
+    end.
 
 %% TryGetValue with out-parameter: sets the out-ref and returns bool.
 try_get_value(Key, Map, OutRef) ->
     case maps:find(Key, Map) of
-        {ok, V} -> put(OutRef, V), true;
-        error -> false
+        {ok, V} ->
+            put(OutRef, V),
+            true;
+        error ->
+            false
     end.
 
 pick(Fn, Map) ->
@@ -93,8 +113,9 @@ pick(Fn, Map) ->
         V -> V
     end.
 
-try_pick(_Fn, []) -> undefined;
-try_pick(Fn, [{K, V}|T]) ->
+try_pick(_Fn, []) ->
+    undefined;
+try_pick(Fn, [{K, V} | T]) ->
     case (Fn(K))(V) of
         undefined -> try_pick(Fn, T);
         Result -> Result
@@ -110,14 +131,14 @@ max_key_value(Map) ->
 
 change(Key, Fn, Map) ->
     case Map of
-       #{Key := V} ->
-           case Fn(V) of
+        #{Key := V} ->
+            case Fn(V) of
                 undefined -> maps:remove(Key, Map);
                 NewV -> maps:put(Key, NewV, Map)
             end;
-       #{} ->
-           case Fn(undefined) of
+        #{} ->
+            case Fn(undefined) of
                 undefined -> Map;
                 NewV -> maps:put(Key, NewV, Map)
             end
-   end.
+    end.

--- a/src/fable-library-beam/fable_observable.erl
+++ b/src/fable-library-beam/fable_observable.erl
@@ -1,10 +1,22 @@
 -module(fable_observable).
--export([subscribe/2, add/2, choose/2, filter/2, map/2,
-         merge/2, pairwise/1, partition/2, scan/3, split/2]).
+-export([
+    subscribe/2,
+    add/2,
+    choose/2,
+    filter/2,
+    map/2,
+    merge/2,
+    pairwise/1,
+    partition/2,
+    scan/3,
+    split/2
+]).
 
 %% Subscribe callback to observable, return IDisposable map.
 subscribe(Callback, Source) ->
-    Observer = #{on_next => Callback, on_error => fun(_) -> ok end, on_completed => fun() -> ok end},
+    Observer = #{
+        on_next => Callback, on_error => fun(_) -> ok end, on_completed => fun() -> ok end
+    },
     call_subscribe(Source, Observer).
 
 %% Add callback (same as subscribe).
@@ -21,167 +33,202 @@ protect(F, Succeed, Fail) ->
 
 %% Choose (filter+map via Option).
 choose(Chooser, Source) ->
-    #{subscribe => fun(Observer) ->
-        OnNext = fun(T) ->
-            protect(
-                fun() -> Chooser(T) end,
-                fun(U) ->
-                    case U of
-                        undefined -> ok;
-                        _ -> (maps:get(on_next, Observer))(U)
-                    end
-                end,
-                maps:get(on_error, Observer)
-            )
-        end,
-        Obv = #{on_next => OnNext,
+    #{
+        subscribe => fun(Observer) ->
+            OnNext = fun(T) ->
+                protect(
+                    fun() -> Chooser(T) end,
+                    fun(U) ->
+                        case U of
+                            undefined -> ok;
+                            _ -> (maps:get(on_next, Observer))(U)
+                        end
+                    end,
+                    maps:get(on_error, Observer)
+                )
+            end,
+            Obv = #{
+                on_next => OnNext,
                 on_error => maps:get(on_error, Observer),
-                on_completed => maps:get(on_completed, Observer)},
-        call_subscribe(Source, Obv)
-    end}.
+                on_completed => maps:get(on_completed, Observer)
+            },
+            call_subscribe(Source, Obv)
+        end
+    }.
 
 %% Filter by predicate.
 filter(Predicate, Source) ->
-    choose(fun(X) ->
-        case Predicate(X) of
-            true -> X;
-            false -> undefined
-        end
-    end, Source).
+    choose(
+        fun(X) ->
+            case Predicate(X) of
+                true -> X;
+                false -> undefined
+            end
+        end,
+        Source
+    ).
 
 %% Map/transform values.
 map(Mapping, Source) ->
-    #{subscribe => fun(Observer) ->
-        OnNext = fun(Value) ->
-            protect(
-                fun() -> Mapping(Value) end,
-                maps:get(on_next, Observer),
-                maps:get(on_error, Observer)
-            )
-        end,
-        Obv = #{on_next => OnNext,
+    #{
+        subscribe => fun(Observer) ->
+            OnNext = fun(Value) ->
+                protect(
+                    fun() -> Mapping(Value) end,
+                    maps:get(on_next, Observer),
+                    maps:get(on_error, Observer)
+                )
+            end,
+            Obv = #{
+                on_next => OnNext,
                 on_error => maps:get(on_error, Observer),
-                on_completed => maps:get(on_completed, Observer)},
-        call_subscribe(Source, Obv)
-    end}.
+                on_completed => maps:get(on_completed, Observer)
+            },
+            call_subscribe(Source, Obv)
+        end
+    }.
 
 %% Merge two observables.
 merge(Source1, Source2) ->
-    #{subscribe => fun(Observer) ->
-        Stopped = fable_utils:new_ref(false),
-        Completed1 = fable_utils:new_ref(false),
-        Completed2 = fable_utils:new_ref(false),
-        OnNext = fun(Value) ->
-            case get(Stopped) of
-                true -> ok;
-                false -> (maps:get(on_next, Observer))(Value)
-            end
-        end,
-        OnError = fun(Error) ->
-            case get(Stopped) of
-                true -> ok;
-                false ->
-                    put(Stopped, true),
-                    (maps:get(on_error, Observer))(Error)
-            end
-        end,
-        OnCompleted1 = fun() ->
-            case get(Stopped) of
-                true -> ok;
-                false ->
-                    put(Completed1, true),
-                    case get(Completed2) of
-                        true ->
-                            put(Stopped, true),
-                            (maps:get(on_completed, Observer))();
-                        false -> ok
-                    end
-            end
-        end,
-        Obv1 = #{on_next => OnNext, on_error => OnError, on_completed => OnCompleted1},
-        H1 = call_subscribe(Source1, Obv1),
-        OnCompleted2 = fun() ->
-            case get(Stopped) of
-                true -> ok;
-                false ->
-                    put(Completed2, true),
-                    case get(Completed1) of
-                        true ->
-                            put(Stopped, true),
-                            (maps:get(on_completed, Observer))();
-                        false -> ok
-                    end
-            end
-        end,
-        Obv2 = #{on_next => OnNext, on_error => OnError, on_completed => OnCompleted2},
-        H2 = call_subscribe(Source2, Obv2),
-        #{dispose => fun() ->
-            fable_utils:safe_dispose(H1),
-            fable_utils:safe_dispose(H2)
-        end}
-    end}.
+    #{
+        subscribe => fun(Observer) ->
+            Stopped = fable_utils:new_ref(false),
+            Completed1 = fable_utils:new_ref(false),
+            Completed2 = fable_utils:new_ref(false),
+            OnNext = fun(Value) ->
+                case get(Stopped) of
+                    true -> ok;
+                    false -> (maps:get(on_next, Observer))(Value)
+                end
+            end,
+            OnError = fun(Error) ->
+                case get(Stopped) of
+                    true ->
+                        ok;
+                    false ->
+                        put(Stopped, true),
+                        (maps:get(on_error, Observer))(Error)
+                end
+            end,
+            OnCompleted1 = fun() ->
+                case get(Stopped) of
+                    true ->
+                        ok;
+                    false ->
+                        put(Completed1, true),
+                        case get(Completed2) of
+                            true ->
+                                put(Stopped, true),
+                                (maps:get(on_completed, Observer))();
+                            false ->
+                                ok
+                        end
+                end
+            end,
+            Obv1 = #{on_next => OnNext, on_error => OnError, on_completed => OnCompleted1},
+            H1 = call_subscribe(Source1, Obv1),
+            OnCompleted2 = fun() ->
+                case get(Stopped) of
+                    true ->
+                        ok;
+                    false ->
+                        put(Completed2, true),
+                        case get(Completed1) of
+                            true ->
+                                put(Stopped, true),
+                                (maps:get(on_completed, Observer))();
+                            false ->
+                                ok
+                        end
+                end
+            end,
+            Obv2 = #{on_next => OnNext, on_error => OnError, on_completed => OnCompleted2},
+            H2 = call_subscribe(Source2, Obv2),
+            #{
+                dispose => fun() ->
+                    fable_utils:safe_dispose(H1),
+                    fable_utils:safe_dispose(H2)
+                end
+            }
+        end
+    }.
 
 %% Pairwise: emit pairs of consecutive values.
 pairwise(Source) ->
-    #{subscribe => fun(Observer) ->
-        Last = fable_utils:new_ref(undefined),
-        HasLast = fable_utils:new_ref(false),
-        OnNext = fun(Value) ->
-            case get(HasLast) of
-                true ->
-                    Prev = get(Last),
-                    put(Last, Value),
-                    (maps:get(on_next, Observer))({Prev, Value});
-                false ->
-                    put(Last, Value),
-                    put(HasLast, true)
-            end
-        end,
-        Obv = #{on_next => OnNext,
+    #{
+        subscribe => fun(Observer) ->
+            Last = fable_utils:new_ref(undefined),
+            HasLast = fable_utils:new_ref(false),
+            OnNext = fun(Value) ->
+                case get(HasLast) of
+                    true ->
+                        Prev = get(Last),
+                        put(Last, Value),
+                        (maps:get(on_next, Observer))({Prev, Value});
+                    false ->
+                        put(Last, Value),
+                        put(HasLast, true)
+                end
+            end,
+            Obv = #{
+                on_next => OnNext,
                 on_error => maps:get(on_error, Observer),
-                on_completed => maps:get(on_completed, Observer)},
-        call_subscribe(Source, Obv)
-    end}.
+                on_completed => maps:get(on_completed, Observer)
+            },
+            call_subscribe(Source, Obv)
+        end
+    }.
 
 %% Partition by predicate: returns {TrueObservable, FalseObservable}.
 partition(Predicate, Source) ->
-    {filter(Predicate, Source),
-     filter(fun(X) -> not Predicate(X) end, Source)}.
+    {filter(Predicate, Source), filter(fun(X) -> not Predicate(X) end, Source)}.
 
 %% Scan: stateful accumulation.
 scan(Collector, State, Source) ->
-    #{subscribe => fun(Observer) ->
-        StateRef = fable_utils:new_ref(State),
-        OnNext = fun(T) ->
-            protect(
-                fun() -> Collector(get(StateRef), T) end,
-                fun(U) ->
-                    put(StateRef, U),
-                    (maps:get(on_next, Observer))(U)
-                end,
-                maps:get(on_error, Observer)
-            )
-        end,
-        Obv = #{on_next => OnNext,
+    #{
+        subscribe => fun(Observer) ->
+            StateRef = fable_utils:new_ref(State),
+            OnNext = fun(T) ->
+                protect(
+                    fun() -> Collector(get(StateRef), T) end,
+                    fun(U) ->
+                        put(StateRef, U),
+                        (maps:get(on_next, Observer))(U)
+                    end,
+                    maps:get(on_error, Observer)
+                )
+            end,
+            Obv = #{
+                on_next => OnNext,
                 on_error => maps:get(on_error, Observer),
-                on_completed => maps:get(on_completed, Observer)},
-        call_subscribe(Source, Obv)
-    end}.
+                on_completed => maps:get(on_completed, Observer)
+            },
+            call_subscribe(Source, Obv)
+        end
+    }.
 
 %% Split by Choice discriminator: returns {Choice1Observable, Choice2Observable}.
 split(Splitter, Source) ->
-    {choose(fun(V) ->
-        case Splitter(V) of
-            {choice1_of2, X} -> X;
-            _ -> undefined
-        end
-    end, Source),
-     choose(fun(V) ->
-        case Splitter(V) of
-            {choice2_of2, X} -> X;
-            _ -> undefined
-        end
-    end, Source)}.
+    {
+        choose(
+            fun(V) ->
+                case Splitter(V) of
+                    {choice1_of2, X} -> X;
+                    _ -> undefined
+                end
+            end,
+            Source
+        ),
+        choose(
+            fun(V) ->
+                case Splitter(V) of
+                    {choice2_of2, X} -> X;
+                    _ -> undefined
+                end
+            end,
+            Source
+        )
+    }.
 
 %% Internal: call the subscribe function on an observable.
 %% Handles both map-based observables (from this module) and

--- a/src/fable-library-beam/fable_option.erl
+++ b/src/fable-library-beam/fable_option.erl
@@ -1,13 +1,27 @@
 -module(fable_option).
 -export([
-    default_value/2, default_with/2, map/2, bind/2,
-    or_else/2, or_else_with/2, iter/2,
-    map2/3, map3/4,
-    contains/2, filter/2,
-    fold/3, fold_back/3,
-    to_array/1, to_list/1, flatten/1,
-    count/1, for_all/2, exists/2,
-    some/1, unwrap/1, value/1
+    default_value/2,
+    default_with/2,
+    map/2,
+    bind/2,
+    or_else/2,
+    or_else_with/2,
+    iter/2,
+    map2/3,
+    map3/4,
+    contains/2,
+    filter/2,
+    fold/3,
+    fold_back/3,
+    to_array/1,
+    to_list/1,
+    flatten/1,
+    count/1,
+    for_all/2,
+    exists/2,
+    some/1,
+    unwrap/1,
+    value/1
 ]).
 
 %% Option type: undefined = None, {some, V} = Some(wrapped), V = Some(unwrapped).
@@ -24,7 +38,8 @@
 -spec or_else_with(option(), fun((ok) -> option())) -> option().
 -spec iter(fun((term()) -> term()), option()) -> ok.
 -spec map2(fun((term()) -> fun((term()) -> term())), option(), option()) -> option().
--spec map3(fun((term()) -> fun((term()) -> fun((term()) -> term()))), option(), option(), option()) -> option().
+-spec map3(fun((term()) -> fun((term()) -> fun((term()) -> term()))), option(), option(), option()) ->
+    option().
 -spec contains(term(), option()) -> boolean().
 -spec filter(fun((term()) -> boolean()), option()) -> option().
 -spec fold(fun((term()) -> fun((term()) -> term())), term(), option()) -> term().
@@ -52,25 +67,49 @@ value({some, V}) -> V;
 value(V) -> V.
 
 default_value(Opt, DefVal) ->
-    case Opt of undefined -> DefVal; _ -> Opt end.
+    case Opt of
+        undefined -> DefVal;
+        _ -> Opt
+    end.
 
 default_with(Opt, DefFn) ->
-    case Opt of undefined -> DefFn(ok); _ -> Opt end.
+    case Opt of
+        undefined -> DefFn(ok);
+        _ -> Opt
+    end.
 
 map(Fn, Opt) ->
-    case Opt of undefined -> undefined; _ -> some(Fn(unwrap(Opt))) end.
+    case Opt of
+        undefined -> undefined;
+        _ -> some(Fn(unwrap(Opt)))
+    end.
 
 bind(Fn, Opt) ->
-    case Opt of undefined -> undefined; _ -> Fn(unwrap(Opt)) end.
+    case Opt of
+        undefined -> undefined;
+        _ -> Fn(unwrap(Opt))
+    end.
 
 or_else(Opt, IfNone) ->
-    case Opt of undefined -> IfNone; _ -> Opt end.
+    case Opt of
+        undefined -> IfNone;
+        _ -> Opt
+    end.
 
 or_else_with(Opt, IfNoneFn) ->
-    case Opt of undefined -> IfNoneFn(ok); _ -> Opt end.
+    case Opt of
+        undefined -> IfNoneFn(ok);
+        _ -> Opt
+    end.
 
 iter(Fn, Opt) ->
-    case Opt of undefined -> ok; _ -> Fn(unwrap(Opt)), ok end.
+    case Opt of
+        undefined ->
+            ok;
+        _ ->
+            Fn(unwrap(Opt)),
+            ok
+    end.
 
 map2(Fn, Opt1, Opt2) ->
     case {Opt1, Opt2} of
@@ -88,34 +127,66 @@ map3(Fn, Opt1, Opt2, Opt3) ->
     end.
 
 contains(Value, Opt) ->
-    case Opt of undefined -> false; _ -> unwrap(Opt) =:= Value end.
+    case Opt of
+        undefined -> false;
+        _ -> unwrap(Opt) =:= Value
+    end.
 
 filter(Fn, Opt) ->
     case Opt of
-        undefined -> undefined;
-        _ -> case Fn(unwrap(Opt)) of true -> Opt; false -> undefined end
+        undefined ->
+            undefined;
+        _ ->
+            case Fn(unwrap(Opt)) of
+                true -> Opt;
+                false -> undefined
+            end
     end.
 
 fold(Fn, State, Opt) ->
-    case Opt of undefined -> State; _ -> (Fn(State))(unwrap(Opt)) end.
+    case Opt of
+        undefined -> State;
+        _ -> (Fn(State))(unwrap(Opt))
+    end.
 
 fold_back(Fn, Opt, State) ->
-    case Opt of undefined -> State; _ -> (Fn(unwrap(Opt)))(State) end.
+    case Opt of
+        undefined -> State;
+        _ -> (Fn(unwrap(Opt)))(State)
+    end.
 
 to_array(Opt) ->
-    case Opt of undefined -> []; _ -> [unwrap(Opt)] end.
+    case Opt of
+        undefined -> [];
+        _ -> [unwrap(Opt)]
+    end.
 
 to_list(Opt) ->
-    case Opt of undefined -> []; _ -> [unwrap(Opt)] end.
+    case Opt of
+        undefined -> [];
+        _ -> [unwrap(Opt)]
+    end.
 
 flatten(Opt) ->
-    case Opt of undefined -> undefined; _ -> unwrap(Opt) end.
+    case Opt of
+        undefined -> undefined;
+        _ -> unwrap(Opt)
+    end.
 
 count(Opt) ->
-    case Opt of undefined -> 0; _ -> 1 end.
+    case Opt of
+        undefined -> 0;
+        _ -> 1
+    end.
 
 for_all(Fn, Opt) ->
-    case Opt of undefined -> true; _ -> Fn(unwrap(Opt)) end.
+    case Opt of
+        undefined -> true;
+        _ -> Fn(unwrap(Opt))
+    end.
 
 exists(Fn, Opt) ->
-    case Opt of undefined -> false; _ -> Fn(unwrap(Opt)) end.
+    case Opt of
+        undefined -> false;
+        _ -> Fn(unwrap(Opt))
+    end.

--- a/src/fable-library-beam/fable_queue.erl
+++ b/src/fable-library-beam/fable_queue.erl
@@ -1,10 +1,17 @@
 -module(fable_queue).
 -export([
-    create_empty/0, create_from_list/1,
-    enqueue/2, dequeue/1, try_dequeue/1, try_dequeue/2,
-    peek/1, try_peek/1, try_peek/2,
-    contains/2, get_count/1, clear/1,
-    to_array/1, trim_excess/1,
+    create_empty/0,
+    create_from_list/1,
+    enqueue/2,
+    dequeue/1,
+    try_dequeue/1, try_dequeue/2,
+    peek/1,
+    try_peek/1, try_peek/2,
+    contains/2,
+    get_count/1,
+    clear/1,
+    to_array/1,
+    trim_excess/1,
     get_enumerator/1
 ]).
 

--- a/src/fable-library-beam/fable_resize_array.erl
+++ b/src/fable-library-beam/fable_resize_array.erl
@@ -1,16 +1,25 @@
 -module(fable_resize_array).
 -export([
     set_item/3,
-    remove/2, remove_all/2, remove_at/2, remove_range/3,
-    insert/3, insert_range/3,
+    remove/2,
+    remove_all/2,
+    remove_at/2,
+    remove_range/3,
+    insert/3,
+    insert_range/3,
     get_range/3,
     index_of/2, index_of/3,
-    find/3, find_last/2, find_all/2, find_index/2, find_last_index/2,
+    find/3,
+    find_last/2,
+    find_all/2,
+    find_index/2,
+    find_last_index/2,
     exists/2,
     sort_with/2,
     for_each/2,
     convert_all/2,
-    fill/4, blit/5
+    fill/4,
+    blit/5
 ]).
 
 -spec set_item(list() | binary(), non_neg_integer(), term()) -> list() | binary().
@@ -56,12 +65,16 @@ remove_first([H | Rest], Item, Acc) ->
 
 %% Remove all matching predicate, return count removed
 remove_all(List, Pred) ->
-    {Kept, Count} = lists:foldl(fun(X, {Acc, C}) ->
-        case Pred(X) of
-            true -> {Acc, C + 1};
-            false -> {[X | Acc], C}
-        end
-    end, {[], 0}, List),
+    {Kept, Count} = lists:foldl(
+        fun(X, {Acc, C}) ->
+            case Pred(X) of
+                true -> {Acc, C + 1};
+                false -> {[X | Acc], C}
+            end
+        end,
+        {[], 0},
+        List
+    ),
     {Count, lists:reverse(Kept)}.
 
 %% Remove at index
@@ -105,7 +118,8 @@ index_of_impl([Item | _], Item, Idx) -> Idx;
 index_of_impl([_ | Rest], Item, Idx) -> index_of_impl(Rest, Item, Idx + 1).
 
 %% Find first matching predicate, return Default when not found
-find(_Pred, [], Default) -> Default;
+find(_Pred, [], Default) ->
+    Default;
 find(Pred, [H | T], Default) ->
     case Pred(H) of
         true -> H;
@@ -116,7 +130,8 @@ find(Pred, [H | T], Default) ->
 find_last(List, Pred) ->
     find_last_impl(lists:reverse(List), Pred).
 
-find_last_impl([], _Pred) -> erlang:error(<<"Key not found">>);
+find_last_impl([], _Pred) ->
+    erlang:error(<<"Key not found">>);
 find_last_impl([H | T], Pred) ->
     case Pred(H) of
         true -> H;
@@ -131,7 +146,8 @@ find_all(List, Pred) ->
 find_index(List, Pred) ->
     find_index_impl(List, Pred, 0).
 
-find_index_impl([], _Pred, _Idx) -> -1;
+find_index_impl([], _Pred, _Idx) ->
+    -1;
 find_index_impl([H | T], Pred, Idx) ->
     case Pred(H) of
         true -> Idx;
@@ -142,7 +158,8 @@ find_index_impl([H | T], Pred, Idx) ->
 find_last_index(List, Pred) ->
     find_last_index_impl(lists:reverse(List), Pred, length(List) - 1).
 
-find_last_index_impl([], _Pred, _Idx) -> -1;
+find_last_index_impl([], _Pred, _Idx) ->
+    -1;
 find_last_index_impl([H | T], Pred, Idx) ->
     case Pred(H) of
         true -> Idx;
@@ -155,12 +172,15 @@ exists(List, Pred) ->
 
 %% Sort with comparison function (Comparison<T> delegate = 2-arg function)
 sort_with(List, CompareFn) ->
-    lists:sort(fun(A, B) ->
-        case CompareFn(A, B) of
-            R when R =< 0 -> true;
-            _ -> false
-        end
-    end, List).
+    lists:sort(
+        fun(A, B) ->
+            case CompareFn(A, B) of
+                R when R =< 0 -> true;
+                _ -> false
+            end
+        end,
+        List
+    ).
 
 %% ForEach
 for_each(List, Fn) ->

--- a/src/fable-library-beam/fable_result.erl
+++ b/src/fable-library-beam/fable_result.erl
@@ -1,8 +1,23 @@
 -module(fable_result).
--export([map/2, map_error/2, bind/2, is_ok/1, is_error/1,
-         contains/2, count/1, default_value/2, default_with/2,
-         exists/2, fold/3, fold_back/3, forall/2, iter/2,
-         to_array/1, to_list/1, to_option/1]).
+-export([
+    map/2,
+    map_error/2,
+    bind/2,
+    is_ok/1,
+    is_error/1,
+    contains/2,
+    count/1,
+    default_value/2,
+    default_with/2,
+    exists/2,
+    fold/3,
+    fold_back/3,
+    forall/2,
+    iter/2,
+    to_array/1,
+    to_list/1,
+    to_option/1
+]).
 
 -type result() :: {ok, term()} | {error, term()}.
 
@@ -69,8 +84,11 @@ fold_back(_Fn, _, State) -> State.
 forall(Fn, {ok, V}) -> Fn(V);
 forall(_Fn, _) -> true.
 
-iter(Fn, {ok, V}) -> Fn(V), ok;
-iter(_Fn, _) -> ok.
+iter(Fn, {ok, V}) ->
+    Fn(V),
+    ok;
+iter(_Fn, _) ->
+    ok.
 
 to_array({ok, V}) -> [V];
 to_array(_) -> [].

--- a/src/fable-library-beam/fable_set.erl
+++ b/src/fable-library-beam/fable_set.erl
@@ -1,7 +1,18 @@
 -module(fable_set).
--export([fold/3, fold_back/3, map/2, filter/2, exists/2, forall/2,
-         iterate/2, partition/2, union_many/1, intersect_many/1,
-         is_proper_subset/2, is_proper_superset/2]).
+-export([
+    fold/3,
+    fold_back/3,
+    map/2,
+    filter/2,
+    exists/2,
+    forall/2,
+    iterate/2,
+    partition/2,
+    union_many/1,
+    intersect_many/1,
+    is_proper_subset/2,
+    is_proper_superset/2
+]).
 
 -spec fold(fun(), term(), list()) -> term().
 -spec fold_back(fun(), list(), term()) -> term().
@@ -47,7 +58,7 @@ partition(Fn, Set) ->
 union_many(Sets) ->
     lists:foldl(fun ordsets:union/2, [], Sets).
 
-intersect_many([H|T]) ->
+intersect_many([H | T]) ->
     lists:foldl(fun ordsets:intersection/2, H, T).
 
 is_proper_subset(A, B) ->

--- a/src/fable-library-beam/fable_stack.erl
+++ b/src/fable-library-beam/fable_stack.erl
@@ -1,9 +1,15 @@
 -module(fable_stack).
 -export([
-    create_empty/0, create_from_list/1,
-    push/2, pop/1, try_pop/1, try_pop/2,
-    peek/1, try_peek/1, try_peek/2,
-    contains/2, get_count/1, clear/1,
+    create_empty/0,
+    create_from_list/1,
+    push/2,
+    pop/1,
+    try_pop/1, try_pop/2,
+    peek/1,
+    try_peek/1, try_peek/2,
+    contains/2,
+    get_count/1,
+    clear/1,
     to_array/1,
     get_enumerator/1
 ]).

--- a/src/fable-library-beam/fable_stopwatch.erl
+++ b/src/fable-library-beam/fable_stopwatch.erl
@@ -1,6 +1,15 @@
 -module(fable_stopwatch).
--export([create/0, start_new/0, start/1, stop/1, reset/1,
-         is_running/1, elapsed_milliseconds/1, elapsed_ticks/1, elapsed/1]).
+-export([
+    create/0,
+    start_new/0,
+    start/1,
+    stop/1,
+    reset/1,
+    is_running/1,
+    elapsed_milliseconds/1,
+    elapsed_ticks/1,
+    elapsed/1
+]).
 
 -spec create() -> reference().
 -spec start_new() -> reference().
@@ -25,7 +34,8 @@ start_new() ->
 start(Ref) ->
     State = get(Ref),
     case maps:get(is_running, State) of
-        true -> ok;
+        true ->
+            ok;
         false ->
             put(Ref, State#{start_time => erlang:monotonic_time(microsecond), is_running => true}),
             ok
@@ -34,7 +44,8 @@ start(Ref) ->
 stop(Ref) ->
     State = get(Ref),
     case maps:get(is_running, State) of
-        false -> ok;
+        false ->
+            ok;
         true ->
             Now = erlang:monotonic_time(microsecond),
             Start = maps:get(start_time, State),

--- a/src/fable-library-beam/fable_string.erl
+++ b/src/fable-library-beam/fable_string.erl
@@ -1,25 +1,54 @@
 -module(fable_string).
--export([insert/3, remove/2, remove/3, starts_with/2, ends_with/2,
-         pad_left/2, pad_left/3, pad_right/2, pad_right/3,
-         replace/3, join/2, join/4, join_strings/2, concat/1, replicate/2,
-         is_null_or_empty/1, is_null_or_white_space/1,
-         forall/2, exists/2, init/2, collect/2,
-         iter/2, iteri/2, map/2, mapi/2, filter/2,
-         index_of/2, index_of/3, index_of_any/2, index_of_any/3,
-         last_index_of/2, last_index_of/3,
-         contains/2, trim_chars/2, trim_start_chars/2, trim_end_chars/2,
-         to_char_array/1, to_char_array/3,
-         compare/2, compare_ignore_case/2,
-         string_ctor_chars/1, string_ctor_char_count/2, string_ctor_chars_range/3,
-         split/2, split/3, split_remove_empty/2, split_with_count/3,
-         to_string/1,
-         printf/1,
-         to_text/1, to_text/2, to_text/3, to_text/4, to_text/5,
-         to_console/1, to_console/2, to_console/3, to_console/4, to_console/5,
-         to_console_error/1, to_console_error/2, to_console_error/3,
-         to_fail/1, to_fail/2, to_fail/3,
-         interpolate/2, format/2,
-         console_writeline/1, console_write/1]).
+-export([
+    insert/3,
+    remove/2, remove/3,
+    starts_with/2,
+    ends_with/2,
+    pad_left/2, pad_left/3,
+    pad_right/2, pad_right/3,
+    replace/3,
+    join/2, join/4,
+    join_strings/2,
+    concat/1,
+    replicate/2,
+    is_null_or_empty/1,
+    is_null_or_white_space/1,
+    forall/2,
+    exists/2,
+    init/2,
+    collect/2,
+    iter/2,
+    iteri/2,
+    map/2,
+    mapi/2,
+    filter/2,
+    index_of/2, index_of/3,
+    index_of_any/2, index_of_any/3,
+    last_index_of/2, last_index_of/3,
+    contains/2,
+    trim_chars/2,
+    trim_start_chars/2,
+    trim_end_chars/2,
+    to_char_array/1, to_char_array/3,
+    compare/2,
+    compare_ignore_case/2,
+    string_ctor_chars/1,
+    string_ctor_char_count/2,
+    string_ctor_chars_range/3,
+    split/2, split/3,
+    split_remove_empty/2,
+    split_with_count/3,
+    to_string/1,
+    printf/1,
+    to_text/1, to_text/2, to_text/3, to_text/4, to_text/5,
+    to_console/1, to_console/2, to_console/3, to_console/4, to_console/5,
+    to_console_error/1, to_console_error/2, to_console_error/3,
+    to_fail/1, to_fail/2, to_fail/3,
+    interpolate/2,
+    format/2,
+    console_writeline/1,
+    console_write/1
+]).
 
 -spec insert(binary(), non_neg_integer(), binary()) -> binary().
 -spec remove(binary(), non_neg_integer()) -> binary().
@@ -32,7 +61,8 @@
 -spec pad_right(binary(), non_neg_integer(), integer()) -> binary().
 -spec replace(binary(), binary() | integer(), binary() | integer()) -> binary().
 -spec join(binary(), list() | reference() | map()) -> binary().
--spec join(binary(), list() | reference() | map(), non_neg_integer(), non_neg_integer()) -> binary().
+-spec join(binary(), list() | reference() | map(), non_neg_integer(), non_neg_integer()) ->
+    binary().
 -spec join_strings(binary(), list() | reference() | map()) -> binary().
 -spec concat(list() | reference() | map()) -> binary().
 -spec replicate(non_neg_integer(), binary()) -> binary().
@@ -98,8 +128,10 @@ remove(Str, StartIdx) ->
     binary:part(Str, 0, StartIdx).
 
 remove(Str, StartIdx, Count) ->
-    iolist_to_binary([binary:part(Str, 0, StartIdx),
-                      binary:part(Str, StartIdx + Count, byte_size(Str) - StartIdx - Count)]).
+    iolist_to_binary([
+        binary:part(Str, 0, StartIdx),
+        binary:part(Str, StartIdx + Count, byte_size(Str) - StartIdx - Count)
+    ]).
 
 starts_with(Str, Prefix) ->
     binary:match(Str, Prefix) =:= {0, byte_size(Prefix)}.
@@ -202,7 +234,8 @@ iteri(Fn, Str) ->
     iteri_loop(Fn, Chars, 0),
     ok.
 
-iteri_loop(_Fn, [], _Idx) -> ok;
+iteri_loop(_Fn, [], _Idx) ->
+    ok;
 iteri_loop(Fn, [C | Rest], Idx) ->
     ((Fn)(Idx))(C),
     iteri_loop(Fn, Rest, Idx + 1).
@@ -210,17 +243,17 @@ iteri_loop(Fn, [C | Rest], Idx) ->
 map(Fn, Str) ->
     Chars = binary_to_list(Str),
     Mapped = lists:map(Fn, Chars),
-    << <<C/utf8>> || C <- Mapped >>.
+    <<<<C/utf8>> || C <- Mapped>>.
 
 mapi(Fn, Str) ->
     Chars = binary_to_list(Str),
     {Mapped, _} = lists:mapfoldl(fun(C, I) -> {((Fn)(I))(C), I + 1} end, 0, Chars),
-    << <<C/utf8>> || C <- Mapped >>.
+    <<<<C/utf8>> || C <- Mapped>>.
 
 filter(Fn, Str) ->
     Chars = binary_to_list(Str),
     Filtered = lists:filter(Fn, Chars),
-    << <<C/utf8>> || C <- Filtered >>.
+    <<<<C/utf8>> || C <- Filtered>>.
 
 %% IndexOf/LastIndexOf with offset support
 
@@ -245,7 +278,8 @@ index_of_any(Str, Chars, StartIdx) ->
     Bytes = binary_to_list(Str),
     index_of_any_loop(Bytes, CharSet, 0, StartIdx).
 
-index_of_any_loop([], _CharSet, _Idx, _StartIdx) -> -1;
+index_of_any_loop([], _CharSet, _Idx, _StartIdx) ->
+    -1;
 index_of_any_loop([_C | Rest], CharSet, Idx, StartIdx) when Idx < StartIdx ->
     index_of_any_loop(Rest, CharSet, Idx + 1, StartIdx);
 index_of_any_loop([C | Rest], CharSet, Idx, StartIdx) ->
@@ -309,14 +343,14 @@ compare_ignore_case(A, B) ->
 %% String constructors
 
 string_ctor_chars(Chars) ->
-    << <<C/utf8>> || C <- Chars >>.
+    <<<<C/utf8>> || C <- Chars>>.
 
 string_ctor_char_count(Char, Count) ->
-    << <<Char/utf8>> || _ <- lists:seq(1, Count) >>.
+    <<<<Char/utf8>> || _ <- lists:seq(1, Count)>>.
 
 string_ctor_chars_range(Chars, Start, Len) ->
     SubChars = lists:sublist(Chars, Start + 1, Len),
-    << <<C/utf8>> || C <- SubChars >>.
+    <<<<C/utf8>> || C <- SubChars>>.
 
 %% Split functions
 
@@ -368,7 +402,10 @@ to_string(V) when is_float(V) ->
     end;
 to_string(V) when is_atom(V) -> atom_to_binary(V, utf8);
 to_string(V) when is_boolean(V) ->
-    case V of true -> <<"true">>; false -> <<"false">> end;
+    case V of
+        true -> <<"true">>;
+        false -> <<"false">>
+    end;
 to_string(V) ->
     iolist_to_binary(io_lib:format(binary_to_list(<<"~p">>), [V])).
 
@@ -401,7 +438,10 @@ to_text(FmtObj, A1, A2, A3, A4) -> apply_curried(to_text(FmtObj), [A1, A2, A3, A
 %% to_console — printfn: prints to stdout with newline.
 to_console(FmtObj) when is_map(FmtObj) ->
     Cont = maps:get(cont, FmtObj),
-    Cont(fun(X) -> io:format("~ts~n", [X]), ok end);
+    Cont(fun(X) ->
+        io:format("~ts~n", [X]),
+        ok
+    end);
 to_console(Str) when is_binary(Str) ->
     io:format("~ts~n", [Str]),
     ok.
@@ -413,7 +453,10 @@ to_console(FmtObj, A1, A2, A3, A4) -> apply_curried(to_console(FmtObj), [A1, A2,
 %% to_console_error — eprintfn: prints to stderr with newline.
 to_console_error(FmtObj) when is_map(FmtObj) ->
     Cont = maps:get(cont, FmtObj),
-    Cont(fun(X) -> io:format(standard_error, "~ts~n", [X]), ok end);
+    Cont(fun(X) ->
+        io:format(standard_error, "~ts~n", [X]),
+        ok
+    end);
 to_console_error(Str) when is_binary(Str) ->
     io:format(standard_error, "~ts~n", [Str]),
     ok.
@@ -433,7 +476,11 @@ to_fail(FmtObj, A1, A2) -> apply_curried(to_fail(FmtObj), [A1, A2]).
 interpolate(Str, Values) when is_reference(Values) ->
     interpolate(Str, get(Values));
 interpolate(Str, Values) ->
-    ValList = case is_list(Values) of true -> Values; false -> [Values] end,
+    ValList =
+        case is_list(Values) of
+            true -> Values;
+            false -> [Values]
+        end,
     interpolate_loop(Str, ValList, []).
 
 interpolate_loop(<<>>, _Values, Acc) ->
@@ -469,13 +516,17 @@ extract_spec_before_placeholder(<<C, Rest/binary>>, SpecAcc) ->
 format(FmtStr, Args) when is_reference(Args) ->
     format(FmtStr, get(Args));
 format(FmtStr, Args) ->
-    ArgList = case is_list(Args) of true -> Args; false -> [Args] end,
+    ArgList =
+        case is_list(Args) of
+            true -> Args;
+            false -> [Args]
+        end,
     format_dotnet(FmtStr, ArgList, []).
 
 format_dotnet(<<>>, _Args, Acc) ->
     iolist_to_binary(lists:reverse(Acc));
 format_dotnet(<<"{{", Rest/binary>>, Args, Acc) ->
-    format_dotnet(Rest, Args, [<<"{" >> | Acc]);
+    format_dotnet(Rest, Args, [<<"{">> | Acc]);
 format_dotnet(<<"}}", Rest/binary>>, Args, Acc) ->
     format_dotnet(Rest, Args, [<<"}">> | Acc]);
 format_dotnet(<<"{", Rest/binary>>, Args, Acc) ->
@@ -525,7 +576,7 @@ parse_format(<<C/utf8, Rest/binary>>, Current, Parts, Specs) ->
 
 %% parse_spec/2 — Parse a single format specifier after the %.
 %% Handles flags (0, -, +, space), width, precision (.N), and type char.
-parse_spec(<<C, Rest/binary>>, Acc) when C =:= $0; C =:= $-; C =:= $+; C =:= $  ->
+parse_spec(<<C, Rest/binary>>, Acc) when C =:= $0; C =:= $-; C =:= $+; C =:= $\s ->
     parse_spec(Rest, [C | Acc]);
 parse_spec(<<C, Rest/binary>>, Acc) when C >= $0, C =< $9 ->
     parse_spec_width(Rest, [C | Acc]);
@@ -576,7 +627,11 @@ format_value(Spec, Value) ->
 
 %% apply_sign_flag/3 — Apply '+' or ' ' flag for numeric values.
 apply_sign_flag(Flags, Raw, Value) ->
-    IsNeg = case Raw of <<$-, _/binary>> -> true; _ -> false end,
+    IsNeg =
+        case Raw of
+            <<$-, _/binary>> -> true;
+            _ -> false
+        end,
     case {IsNeg, lists:member($+, Flags)} of
         {false, true} when is_number(Value) -> <<$+, Raw/binary>>;
         {false, false} ->
@@ -584,7 +639,8 @@ apply_sign_flag(Flags, Raw, Value) ->
                 true when is_number(Value) -> <<$\s, Raw/binary>>;
                 _ -> Raw
             end;
-        _ -> Raw
+        _ ->
+            Raw
     end.
 
 %% parse_spec_parts/1 — Parse "%[flags][width][.prec]type" into components.
@@ -593,7 +649,7 @@ parse_spec_parts([$% | Rest]) ->
 parse_spec_parts(Rest) ->
     parse_spec_flags(Rest, []).
 
-parse_spec_flags([C | Rest], Flags) when C =:= $0; C =:= $-; C =:= $+; C =:= $  ->
+parse_spec_flags([C | Rest], Flags) when C =:= $0; C =:= $-; C =:= $+; C =:= $\s ->
     parse_spec_flags(Rest, [C | Flags]);
 parse_spec_flags(Rest, Flags) ->
     parse_spec_width_part(Rest, lists:reverse(Flags), 0).
@@ -622,7 +678,11 @@ format_raw($s, _Prec, Value) when is_binary(Value) ->
 format_raw($s, _Prec, Value) ->
     to_string(Value);
 format_raw($f, Prec, Value) ->
-    P = if Prec < 0 -> 6; true -> Prec end,
+    P =
+        if
+            Prec < 0 -> 6;
+            true -> Prec
+        end,
     F = float(Value),
     case P of
         0 ->
@@ -635,14 +695,22 @@ format_raw($f, Prec, Value) ->
 format_raw($F, Prec, Value) ->
     format_raw($f, Prec, Value);
 format_raw($e, Prec, Value) ->
-    P = if Prec < 0 -> 6; true -> Prec end,
+    P =
+        if
+            Prec < 0 -> 6;
+            true -> Prec
+        end,
     iolist_to_binary(io_lib:format("~.*e", [P, float(Value)]));
 format_raw($E, Prec, Value) ->
     S = format_raw($e, Prec, Value),
     string:uppercase(S);
 format_raw(Type, Prec, Value) when Type =:= $g; Type =:= $G ->
     %% %g: use shortest of %e and %f (default precision 6 significant digits)
-    P = if Prec < 0 -> 6; true -> Prec end,
+    P =
+        if
+            Prec < 0 -> 6;
+            true -> Prec
+        end,
     F = float(Value),
     Abs = abs(F),
     Threshold = math:pow(10, P),
@@ -651,10 +719,16 @@ format_raw(Type, Prec, Value) when Type =:= $g; Type =:= $G ->
             <<"0">>;
         Abs < 0.0001 ->
             S = format_raw($e, P - 1, F),
-            case Type of $G -> string:uppercase(S); _ -> S end;
+            case Type of
+                $G -> string:uppercase(S);
+                _ -> S
+            end;
         Abs >= Threshold ->
             S = format_raw($e, P - 1, F),
-            case Type of $G -> string:uppercase(S); _ -> S end;
+            case Type of
+                $G -> string:uppercase(S);
+                _ -> S
+            end;
         true ->
             %% Use fixed notation, trim trailing zeros
             S = format_raw($f, P, F),
@@ -685,22 +759,26 @@ format_raw(_, _Prec, Value) ->
 trim_trailing_zeros(Bin) ->
     S = binary_to_list(Bin),
     case lists:member($., S) of
-        false -> Bin;
+        false ->
+            Bin;
         true ->
             Trimmed = lists:reverse(drop_zeros(lists:reverse(S))),
             iolist_to_binary(Trimmed)
     end.
 
 drop_zeros([$0 | Rest]) -> drop_zeros(Rest);
-drop_zeros([$. | Rest]) -> Rest; %% Remove trailing dot too
+%% Remove trailing dot too
+drop_zeros([$. | Rest]) -> Rest;
 drop_zeros(Other) -> Other.
 
 %% apply_width/3 — Apply width padding and flags.
-apply_width(_Flags, 0, Str) -> Str;
+apply_width(_Flags, 0, Str) ->
+    Str;
 apply_width(Flags, Width, Str) when Width > 0 ->
     Len = byte_size(Str),
     if
-        Len >= Width -> Str;
+        Len >= Width ->
+            Str;
         true ->
             Pad = Width - Len,
             ZeroPad = lists:member($0, Flags),
@@ -731,7 +809,8 @@ apply_width(Flags, Width, Str) when Width > 0 ->
                     <<PadStr/binary, Str/binary>>
             end
     end;
-apply_width(_, _, Str) -> Str.
+apply_width(_, _, Str) ->
+    Str.
 
 %% Console.WriteLine / Console.Write
 console_writeline(Value) when is_binary(Value) ->

--- a/src/fable-library-beam/fable_timespan.erl
+++ b/src/fable-library-beam/fable_timespan.erl
@@ -2,13 +2,31 @@
 -export([
     create/1, create/3, create/4, create/5, create/6,
     from_ticks/1,
-    from_days/1, from_hours/1, from_minutes/1, from_seconds/1,
-    from_milliseconds/1, from_microseconds/1,
-    days/1, hours/1, minutes/1, seconds/1, milliseconds/1,
-    microseconds/1, ticks/1,
-    total_days/1, total_hours/1, total_minutes/1, total_seconds/1,
-    total_milliseconds/1, total_microseconds/1,
-    add/2, subtract/2, negate/1, duration/1, multiply/2, divide/2,
+    from_days/1,
+    from_hours/1,
+    from_minutes/1,
+    from_seconds/1,
+    from_milliseconds/1,
+    from_microseconds/1,
+    days/1,
+    hours/1,
+    minutes/1,
+    seconds/1,
+    milliseconds/1,
+    microseconds/1,
+    ticks/1,
+    total_days/1,
+    total_hours/1,
+    total_minutes/1,
+    total_seconds/1,
+    total_milliseconds/1,
+    total_microseconds/1,
+    add/2,
+    subtract/2,
+    negate/1,
+    duration/1,
+    multiply/2,
+    divide/2,
     parse/1, parse/2,
     try_parse/2, try_parse/3,
     to_string/1, to_string/2, to_string/3,
@@ -85,32 +103,32 @@ create(Ticks) when is_float(Ticks) -> trunc(Ticks).
 %% create(Hours, Minutes, Seconds)
 create(Hours, Minutes, Seconds) ->
     Hours * ?TICKS_PER_HOUR +
-    Minutes * ?TICKS_PER_MINUTE +
-    Seconds * ?TICKS_PER_SECOND.
+        Minutes * ?TICKS_PER_MINUTE +
+        Seconds * ?TICKS_PER_SECOND.
 
 %% create(Days, Hours, Minutes, Seconds)
 create(Days, Hours, Minutes, Seconds) ->
     Days * ?TICKS_PER_DAY +
-    Hours * ?TICKS_PER_HOUR +
-    Minutes * ?TICKS_PER_MINUTE +
-    Seconds * ?TICKS_PER_SECOND.
+        Hours * ?TICKS_PER_HOUR +
+        Minutes * ?TICKS_PER_MINUTE +
+        Seconds * ?TICKS_PER_SECOND.
 
 %% create(Days, Hours, Minutes, Seconds, Milliseconds)
 create(Days, Hours, Minutes, Seconds, Milliseconds) ->
     Days * ?TICKS_PER_DAY +
-    Hours * ?TICKS_PER_HOUR +
-    Minutes * ?TICKS_PER_MINUTE +
-    Seconds * ?TICKS_PER_SECOND +
-    Milliseconds * ?TICKS_PER_MILLISECOND.
+        Hours * ?TICKS_PER_HOUR +
+        Minutes * ?TICKS_PER_MINUTE +
+        Seconds * ?TICKS_PER_SECOND +
+        Milliseconds * ?TICKS_PER_MILLISECOND.
 
 %% create(Days, Hours, Minutes, Seconds, Milliseconds, Microseconds)
 create(Days, Hours, Minutes, Seconds, Milliseconds, Microseconds) ->
     Days * ?TICKS_PER_DAY +
-    Hours * ?TICKS_PER_HOUR +
-    Minutes * ?TICKS_PER_MINUTE +
-    Seconds * ?TICKS_PER_SECOND +
-    Milliseconds * ?TICKS_PER_MILLISECOND +
-    Microseconds * ?TICKS_PER_MICROSECOND.
+        Hours * ?TICKS_PER_HOUR +
+        Minutes * ?TICKS_PER_MINUTE +
+        Seconds * ?TICKS_PER_SECOND +
+        Milliseconds * ?TICKS_PER_MILLISECOND +
+        Microseconds * ?TICKS_PER_MICROSECOND.
 
 %% ============================================================
 %% Static factory methods
@@ -207,7 +225,11 @@ to_string(Ticks) -> to_string(Ticks, <<"c">>).
 to_string(Ticks, Format) -> to_string(Ticks, Format, undefined).
 
 to_string(Ticks, Format, _Provider) ->
-    Sign = case Ticks < 0 of true -> <<"-">>; false -> <<"">> end,
+    Sign =
+        case Ticks < 0 of
+            true -> <<"-">>;
+            false -> <<"">>
+        end,
     ATicks = erlang:abs(Ticks),
     D = ATicks div ?TICKS_PER_DAY,
     H = (ATicks rem ?TICKS_PER_DAY) div ?TICKS_PER_HOUR,
@@ -224,32 +246,36 @@ to_string(Ticks, Format, _Provider) ->
 
 %% Format "c": [-][d.]hh:mm:ss[.fffffff]
 format_c(Sign, D, H, M, S, SubSecondTicks) ->
-    DayStr = case D of
-        0 -> <<"">>;
-        _ -> iolist_to_binary(io_lib:format("~B.", [D]))
-    end,
+    DayStr =
+        case D of
+            0 -> <<"">>;
+            _ -> iolist_to_binary(io_lib:format("~B.", [D]))
+        end,
     HourStr = iolist_to_binary(io_lib:format("~2..0B", [H])),
     MinStr = iolist_to_binary(io_lib:format("~2..0B", [M])),
     SecStr = iolist_to_binary(io_lib:format("~2..0B", [S])),
-    FracStr = case SubSecondTicks of
-        0 -> <<"">>;
-        _ -> iolist_to_binary(io_lib:format(".~7..0B", [SubSecondTicks]))
-    end,
+    FracStr =
+        case SubSecondTicks of
+            0 -> <<"">>;
+            _ -> iolist_to_binary(io_lib:format(".~7..0B", [SubSecondTicks]))
+        end,
     iolist_to_binary([Sign, DayStr, HourStr, <<":">>, MinStr, <<":">>, SecStr, FracStr]).
 
 %% Format "g": [-][d:]h:mm:ss[.fff]
 format_g(Sign, D, H, M, S, Ms) ->
-    DayStr = case D of
-        0 -> <<"">>;
-        _ -> iolist_to_binary(io_lib:format("~B:", [D]))
-    end,
+    DayStr =
+        case D of
+            0 -> <<"">>;
+            _ -> iolist_to_binary(io_lib:format("~B:", [D]))
+        end,
     HourStr = iolist_to_binary(io_lib:format("~B", [H])),
     MinStr = iolist_to_binary(io_lib:format("~2..0B", [M])),
     SecStr = iolist_to_binary(io_lib:format("~2..0B", [S])),
-    FracStr = case Ms of
-        0 -> <<"">>;
-        _ -> iolist_to_binary(io_lib:format(".~3..0B", [Ms]))
-    end,
+    FracStr =
+        case Ms of
+            0 -> <<"">>;
+            _ -> iolist_to_binary(io_lib:format(".~3..0B", [Ms]))
+        end,
     iolist_to_binary([Sign, DayStr, HourStr, <<":">>, MinStr, <<":">>, SecStr, FracStr]).
 
 %% Format "G": [-]d:hh:mm:ss.fffffff
@@ -284,7 +310,8 @@ parse(Str, _Provider) when is_binary(Str) ->
     end.
 
 parse_with_regex(Trimmed, OrigStr) ->
-    Pattern = "^(-?)((\\d+)\\.)?(?:0*)([0-9]|0[0-9]|1[0-9]|2[0-3]):(?:0*)([0-5][0-9]|[0-9])(:(?:0*)([0-5][0-9]|[0-9]))?\\.?(\\d+)?$",
+    Pattern =
+        "^(-?)((\\d+)\\.)?(?:0*)([0-9]|0[0-9]|1[0-9]|2[0-3]):(?:0*)([0-5][0-9]|[0-9])(:(?:0*)([0-5][0-9]|[0-9]))?\\.?(\\d+)?$",
     case re:run(Trimmed, Pattern, [{capture, all, list}]) of
         {match, Groups} ->
             parse_groups(Groups, OrigStr);
@@ -295,16 +322,39 @@ parse_with_regex(Trimmed, OrigStr) ->
 parse_groups(Groups, OrigStr) ->
     %% Groups: [Full, Sign, DayDot, DayNum, Hours, Minutes, SecColon, Seconds, Frac]
     %% Indices:  0     1     2       3       4      5         6        7        8
-    Sign = case safe_nth(1, Groups) of "-" -> -1; _ -> 1 end,
-    D = case safe_nth(3, Groups) of "" -> 0; DS -> list_to_integer(DS) end,
-    H = case safe_nth(4, Groups) of "" -> parse_error(OrigStr); HS -> list_to_integer(HS) end,
-    M = case safe_nth(5, Groups) of "" -> parse_error(OrigStr); MS -> list_to_integer(MS) end,
-    S = case safe_nth(7, Groups) of "" -> 0; SS -> list_to_integer(SS) end,
-    FracTicks = case safe_nth(8, Groups) of
-        "" -> 0;
-        FracStr -> parse_frac_to_ticks(FracStr, OrigStr)
-    end,
-    Ticks = D * ?TICKS_PER_DAY + H * ?TICKS_PER_HOUR + M * ?TICKS_PER_MINUTE + S * ?TICKS_PER_SECOND + FracTicks,
+    Sign =
+        case safe_nth(1, Groups) of
+            "-" -> -1;
+            _ -> 1
+        end,
+    D =
+        case safe_nth(3, Groups) of
+            "" -> 0;
+            DS -> list_to_integer(DS)
+        end,
+    H =
+        case safe_nth(4, Groups) of
+            "" -> parse_error(OrigStr);
+            HS -> list_to_integer(HS)
+        end,
+    M =
+        case safe_nth(5, Groups) of
+            "" -> parse_error(OrigStr);
+            MS -> list_to_integer(MS)
+        end,
+    S =
+        case safe_nth(7, Groups) of
+            "" -> 0;
+            SS -> list_to_integer(SS)
+        end,
+    FracTicks =
+        case safe_nth(8, Groups) of
+            "" -> 0;
+            FracStr -> parse_frac_to_ticks(FracStr, OrigStr)
+        end,
+    Ticks =
+        D * ?TICKS_PER_DAY + H * ?TICKS_PER_HOUR + M * ?TICKS_PER_MINUTE + S * ?TICKS_PER_SECOND +
+            FracTicks,
     Sign * Ticks.
 
 %% Convert fractional seconds string to ticks by padding/truncating to 7 digits
@@ -320,10 +370,13 @@ parse_frac_to_ticks(FracStr, OrigStr) ->
     end.
 
 safe_nth(N, List) when N >= length(List) -> "";
-safe_nth(N, List) -> lists:nth(N + 1, List).  %% 0-indexed to 1-indexed
+%% 0-indexed to 1-indexed
+safe_nth(N, List) -> lists:nth(N + 1, List).
 
 parse_error(Str) ->
-    Msg = iolist_to_binary(io_lib:format("String '~s' was not recognized as a valid TimeSpan.", [Str])),
+    Msg = iolist_to_binary(
+        io_lib:format("String '~s' was not recognized as a valid TimeSpan.", [Str])
+    ),
     erlang:error(Msg).
 
 %% ============================================================

--- a/src/fable-library-beam/fable_uri.erl
+++ b/src/fable-library-beam/fable_uri.erl
@@ -2,9 +2,16 @@
 -export([
     create/1, create/2, create/3,
     try_create/3, try_create/4,
-    is_absolute_uri/1, scheme/1, host/1, absolute_path/1,
-    absolute_uri/1, path_and_query/1, query/1, fragment/1,
-    original_string/1, port/1,
+    is_absolute_uri/1,
+    scheme/1,
+    host/1,
+    absolute_path/1,
+    absolute_uri/1,
+    path_and_query/1,
+    query/1,
+    fragment/1,
+    original_string/1,
+    port/1,
     to_string/1,
     unescape_data_string/1
 ]).
@@ -59,7 +66,8 @@ create(UriStr, Kind) when is_binary(UriStr), is_integer(Kind) ->
     %% create(string, UriKind)
     S = binary_to_list(UriStr),
     Parsed = uri_string:parse(S),
-    IsAbsolute = is_map(Parsed) andalso is_map_key(scheme, Parsed) andalso maps:get(scheme, Parsed) =/= [],
+    IsAbsolute =
+        is_map(Parsed) andalso is_map_key(scheme, Parsed) andalso maps:get(scheme, Parsed) =/= [],
     case Kind of
         ?URI_KIND_ABSOLUTE when not IsAbsolute ->
             erlang:error(<<"Invalid URI: The format of the URI could not be determined.">>);
@@ -111,7 +119,6 @@ try_create(UriStr, Kind, OutRef) when is_binary(UriStr), is_integer(Kind) ->
     catch
         _:_ -> false
     end;
-
 %% try_create(BaseUri, RelativeUriOrString, OutRef)
 try_create(BaseUri, RelOrStr, OutRef) when is_map(BaseUri) ->
     try
@@ -161,7 +168,8 @@ absolute_uri(Uri) ->
 
 path_and_query(Uri) ->
     case maps:get(is_absolute_uri, Uri) of
-        false -> erlang:error(<<"This operation is not supported for a relative URI.">>);
+        false ->
+            erlang:error(<<"This operation is not supported for a relative URI.">>);
         true ->
             Path = maps:get(path, Uri, <<"/">>),
             Q = maps:get(query, Uri, <<>>),
@@ -202,12 +210,13 @@ build_uri(OrigStr, Parsed, true) ->
     %% Absolute URI
     Scheme = list_to_binary(string:lowercase(get_parsed(scheme, Parsed, ""))),
     Host = list_to_binary(get_parsed(host, Parsed, "")),
-    Port = case Parsed of
-       #{port := P} ->
-           P;
-       #{} ->
-           undefined
-   end,
+    Port =
+        case Parsed of
+            #{port := P} ->
+                P;
+            #{} ->
+                undefined
+        end,
     Path = list_to_binary(get_parsed(path, Parsed, "/")),
     Query = list_to_binary(get_parsed(query, Parsed, "")),
     Fragment = list_to_binary(get_parsed(fragment, Parsed, "")),
@@ -237,51 +246,59 @@ build_uri(OrigStr, _Parsed, false) ->
 
 get_parsed(Key, Map, Default) ->
     case Map of
-       #{Key := V} ->
-           V;
-       #{} ->
-           Default
-   end.
+        #{Key := V} ->
+            V;
+        #{} ->
+            Default
+    end.
 
 %% Recompose absolute URI (for AbsoluteUri property)
 recompose_absolute(Scheme, Host, Port, Path, Query, Fragment) ->
-    PortStr = case Port of
-        undefined -> <<>>;
-        _ ->
-            %% Omit default ports
-            case is_default_port(Scheme, Port) of
-                true -> <<>>;
-                false -> iolist_to_binary([<<":">>, integer_to_binary(Port)])
-            end
-    end,
-    QueryStr = case Query of
-        <<>> -> <<>>;
-        _ -> iolist_to_binary([<<"?">>, Query])
-    end,
-    FragStr = case Fragment of
-        <<>> -> <<>>;
-        _ -> iolist_to_binary([<<"#">>, Fragment])
-    end,
+    PortStr =
+        case Port of
+            undefined ->
+                <<>>;
+            _ ->
+                %% Omit default ports
+                case is_default_port(Scheme, Port) of
+                    true -> <<>>;
+                    false -> iolist_to_binary([<<":">>, integer_to_binary(Port)])
+                end
+        end,
+    QueryStr =
+        case Query of
+            <<>> -> <<>>;
+            _ -> iolist_to_binary([<<"?">>, Query])
+        end,
+    FragStr =
+        case Fragment of
+            <<>> -> <<>>;
+            _ -> iolist_to_binary([<<"#">>, Fragment])
+        end,
     iolist_to_binary([Scheme, <<"://">>, Host, PortStr, Path, QueryStr, FragStr]).
 
 %% Recompose for display (ToString) - with decoded path
 recompose_display(Scheme, Host, Port, DecodedPath, Query, Fragment) ->
-    PortStr = case Port of
-        undefined -> <<>>;
-        _ ->
-            case is_default_port(Scheme, Port) of
-                true -> <<>>;
-                false -> iolist_to_binary([<<":">>, integer_to_binary(Port)])
-            end
-    end,
-    QueryStr = case Query of
-        <<>> -> <<>>;
-        _ -> iolist_to_binary([<<"?">>, Query])
-    end,
-    FragStr = case Fragment of
-        <<>> -> <<>>;
-        _ -> iolist_to_binary([<<"#">>, Fragment])
-    end,
+    PortStr =
+        case Port of
+            undefined ->
+                <<>>;
+            _ ->
+                case is_default_port(Scheme, Port) of
+                    true -> <<>>;
+                    false -> iolist_to_binary([<<":">>, integer_to_binary(Port)])
+                end
+        end,
+    QueryStr =
+        case Query of
+            <<>> -> <<>>;
+            _ -> iolist_to_binary([<<"?">>, Query])
+        end,
+    FragStr =
+        case Fragment of
+            <<>> -> <<>>;
+            _ -> iolist_to_binary([<<"#">>, Fragment])
+        end,
     iolist_to_binary([Scheme, <<"://">>, Host, PortStr, DecodedPath, QueryStr, FragStr]).
 
 is_default_port(<<"http">>, 80) -> true;


### PR DESCRIPTION
- Format hand-written erlang files
- Suppress build warnings for unused or shadowed vars