### PR TITLE
[Beam] Unify receive overloads and fix String.Compare codegen

### DIFF
--- a/src/Fable.Core/Fable.Core.BeamInterop.fs
+++ b/src/Fable.Core/Fable.Core.BeamInterop.fs
@@ -22,10 +22,10 @@ let importMember<'T> (path: string) : 'T = nativeOnly
 /// Imports all exports from an Erlang module
 let importAll<'T> (path: string) : 'T = nativeOnly
 
-module Erlang =
+type Erlang =
     /// Selective receive with timeout. Returns Some(msg) on match, None on timeout.
     /// Each DU case maps to a receive clause with the case's CompiledName (or snake_case name)
     /// as the Erlang atom tag.
-    let receive<'T> (timeoutMs: int) : 'T option = nativeOnly
+    static member receive<'T>(timeoutMs: int) : 'T option = nativeOnly
     /// Blocking selective receive (no timeout). Blocks until a matching message arrives.
-    let receiveForever<'T> () : 'T = nativeOnly
+    static member receive<'T>() : 'T = nativeOnly

--- a/src/Fable.Transforms/Beam/Fable2Beam.fs
+++ b/src/Fable.Transforms/Beam/Fable2Beam.fs
@@ -1684,8 +1684,8 @@ and transformReceive (com: IBeamCompiler) (ctx: Context) (emitInfo: EmitInfo) (t
     let isForever = emitInfo.Macro = "__fable_beam_receive_forever__"
 
     // Extract DU entity ref from type:
-    // receive<'T> : 'T option  →  Option(DeclaredType(ref, _), _)
-    // receiveForever<'T> : 'T  →  DeclaredType(ref, _)
+    // receive<'T>(timeoutMs) : 'T option  →  Option(DeclaredType(ref, _), _)
+    // receive<'T>() : 'T  →  DeclaredType(ref, _)
     let entityRef =
         match typ with
         | Option(DeclaredType(ref, _), _) -> Some ref
@@ -1694,7 +1694,7 @@ and transformReceive (com: IBeamCompiler) (ctx: Context) (emitInfo: EmitInfo) (t
 
     match entityRef with
     | None ->
-        com.WarnOnlyOnce("Erlang.receive/receiveForever requires a DU type parameter")
+        com.WarnOnlyOnce("Erlang.receive requires a DU type parameter")
         Beam.ErlExpr.Literal(Beam.ErlLiteral.AtomLit(Beam.Atom "undefined"))
     | Some ref ->
         match com.TryGetEntity(ref) with
@@ -1747,7 +1747,7 @@ and transformReceive (com: IBeamCompiler) (ctx: Context) (emitInfo: EmitInfo) (t
                 )
 
             if isForever then
-                // receiveForever: no after clause, returns DU directly
+                // receive() (no timeout): no after clause, returns DU directly
                 Beam.ErlExpr.Receive(clauses, None)
             else
                 // receive: has after clause, returns Option (Some = DU value, None = undefined)

--- a/src/Fable.Transforms/Beam/Replacements.fs
+++ b/src/Fable.Transforms/Beam/Replacements.fs
@@ -902,13 +902,7 @@ let private strings
     // String.Compare
     | "Compare", None, [ a; b ] -> Helper.LibCall(com, "fable_string", "compare", t, [ a; b ]) |> Some
     | "Compare", None, [ a; b; compType ] ->
-        // Dispatch on ignoreCase bool (true) or StringComparison enum (5=OrdinalIgnoreCase)
-        emitExpr
-            r
-            t
-            [ a; b; compType ]
-            "(fun() -> case $2 of true -> fable_string:compare_ignore_case($0, $1); 5 -> fable_string:compare_ignore_case($0, $1); _ -> fable_string:compare($0, $1) end end)()"
-        |> Some
+        Helper.LibCall(com, "fable_string", "compare", t, [ a; b; compType ]) |> Some
     | "Compare", None, [ a; startA; b; startB; len ] ->
         // String.Compare(a, startA, b, startB, len) — substring comparison
         emitExpr
@@ -923,7 +917,7 @@ let private strings
             r
             t
             [ a; startA; b; startB; len; compType ]
-            "(fun() -> case $5 of true -> fable_string:compare_ignore_case(binary:part($0, $1, $4), binary:part($2, $3, $4)); 5 -> fable_string:compare_ignore_case(binary:part($0, $1, $4), binary:part($2, $3, $4)); _ -> fable_string:compare(binary:part($0, $1, $4), binary:part($2, $3, $4)) end end)()"
+            "fable_string:compare(binary:part($0, $1, $4), binary:part($2, $3, $4), $5)"
         |> Some
     // String.IsNullOrEmpty / IsNullOrWhiteSpace (static on System.String)
     | "IsNullOrEmpty", None, [ str ] -> Helper.LibCall(com, "fable_string", "is_null_or_empty", t, [ str ]) |> Some
@@ -4803,7 +4797,7 @@ let tryCall
     | "Fable.Core.BeamInterop.Erlang" ->
         match info.CompiledName, args with
         | "receive", [ timeoutArg ] -> emitExpr r t [ timeoutArg ] "__fable_beam_receive__($0)" |> Some
-        | "receiveForever", _ -> emitExpr r t [] "__fable_beam_receive_forever__" |> Some
+        | "receive", [] -> emitExpr r t [] "__fable_beam_receive_forever__" |> Some
         | _ -> None
     // Testing assertions (used by our test framework)
     | "Fable.Core.Testing.Assert" ->

--- a/src/fable-library-beam/fable_string.erl
+++ b/src/fable-library-beam/fable_string.erl
@@ -30,7 +30,7 @@
     trim_start_chars/2,
     trim_end_chars/2,
     to_char_array/1, to_char_array/3,
-    compare/2,
+    compare/2, compare/3,
     compare_ignore_case/2,
     string_ctor_chars/1,
     string_ctor_char_count/2,
@@ -339,6 +339,13 @@ compare_ignore_case(A, B) ->
     LA = string:lowercase(A),
     LB = string:lowercase(B),
     compare(LA, LB).
+
+%% compare/3 — dispatch on ignoreCase (bool) or StringComparison enum (int)
+compare(A, B, true) -> compare_ignore_case(A, B);
+compare(A, B, 1) -> compare_ignore_case(A, B);   % CurrentCultureIgnoreCase
+compare(A, B, 3) -> compare_ignore_case(A, B);   % InvariantCultureIgnoreCase
+compare(A, B, 5) -> compare_ignore_case(A, B);   % OrdinalIgnoreCase
+compare(A, B, _) -> compare(A, B).
 
 %% String constructors
 

--- a/tests/Beam/InteropTests.fs
+++ b/tests/Beam/InteropTests.fs
@@ -300,11 +300,11 @@ let ``test Erlang receive with multi-field DU case`` () =
 #endif
 
 [<Fact>]
-let ``test Erlang receiveForever with self-send`` () =
+let ``test Erlang receive blocking with self-send`` () =
 #if FABLE_COMPILER
-    // Send a message before calling receiveForever so it doesn't block
+    // Send a message before calling receive so it doesn't block
     emitErlExpr () "erlang:self() ! ping"
-    let msg = Erlang.receiveForever<RecvMsg> ()
+    let msg = Erlang.receive<RecvMsg> ()
     match msg with
     | Ping -> equal 1 1
     | _ -> equal 0 1 // fail


### PR DESCRIPTION
## Summary
- **Erlang.receive overloads**: Changed `Erlang` from a module with `receive`/`receiveForever` to a type with overloaded static `receive` methods — `receive<'T>(timeoutMs)` returns `'T option`, `receive<'T>()` blocks forever and returns `'T`
- **String.Compare fix**: Moved comparison type dispatch from inline emitted Erlang case expressions to a new `fable_string:compare/3` library function, eliminating erlc warnings about unreachable clauses caused by mixing boolean and integer patterns in the same `case` expression
- The new `compare/3` handles all `StringComparison` ignore-case variants (1, 3, 5) plus the `true` boolean overload via Erlang pattern matching

## Test plan
- [x] Verify existing Beam interop tests pass (`./build.sh test beam`)
- [x] Check that the `string_tests.erl` "clause cannot match" warnings are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)