### PR TITLE
[Rust] Fixes bug with async return! behavior

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [JS/TS] Fix invalid syntax emitted when negating negative literals (fix #4251) (by @MangelMaxime)
 * [Rust] Fix negative counting in CallInfo.GenericArgs (by @ncave)
 * [Rust] Fix inline bindings and captured idents tracking (by @ncave)
+* [Rust] Fix `return!` in async computation expressions so inner async workflows are returned and awaited correctly (by @mizzle-mo)
 * [JS/TS] Improve `Regex.Escape` and `Regex.Unescape` handling (by @MangelMaxime)
 * [All] Fix allow plugins to target .NET6 target framework (by @MangelMaxime)
 * [Python] Fix function references passed as arguments inside tail-call optimised functions gaining unnecessary default parameters for outer TCO variables they don't reference (fix #3877)

--- a/src/Fable.Compiler/CHANGELOG.md
+++ b/src/Fable.Compiler/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [JS/TS] Fix invalid syntax emitted when negating negative literals (fix #4251) (by @MangelMaxime)
 * [Rust] Fix negative counting in CallInfo.GenericArgs (by @ncave)
 * [Rust] Fix inline bindings and captured idents tracking (by @ncave)
+* [Rust] Fix `return!` in async computation expressions so inner async workflows are returned and awaited correctly (by @mizzle-mo)
 * [JS/TS] Improve `Regex.Escape` and `Regex.Unescape` handling (by @MangelMaxime)
 * [All] Fix allow plugins to target .NET6 target framework (by @MangelMaxime)
 * [Python] Fix function references passed as arguments inside tail-call optimised functions gaining unnecessary default parameters for outer TCO variables they don't reference (fix #3877)

--- a/src/Fable.Transforms/Rust/Replacements.fs
+++ b/src/Fable.Transforms/Rust/Replacements.fs
@@ -3023,6 +3023,9 @@ let asyncBuilder (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Exp
     | "Return", _, _ ->
         Helper.LibCall(com, "AsyncBuilder", "r_return", t, args, i.SignatureArgTypes, ?loc = r)
         |> Some
+    | "ReturnFrom", _, _ ->
+        Helper.LibCall(com, "AsyncBuilder", "return_from", t, args, i.SignatureArgTypes, ?loc = r)
+        |> Some
     | "Zero", _, _ ->
         Helper.LibCall(com, "AsyncBuilder", "zero", t, args, i.SignatureArgTypes, ?loc = r)
         |> Some

--- a/src/fable-library-rust/src/Async.rs
+++ b/src/fable-library-rust/src/Async.rs
@@ -129,6 +129,10 @@ pub mod AsyncBuilder_ {
         })
     }
 
+    pub fn return_from<T: Send + Sync + 'static>(computation: Arc<Async<T>>) -> Arc<Async<T>> {
+        computation
+    }
+
     pub fn zero<T: Send + Sync + 'static>() -> Arc<Async<()>> {
         r_return(())
     }

--- a/tests/Rust/tests/src/AsyncTests.fs
+++ b/tests/Rust/tests/src/AsyncTests.fs
@@ -33,6 +33,55 @@ let shouldConvertTaskToASyncAndEvalCorrectly () =
     let t = task { return 1 } |> Async.AwaitTask
     t |> Async.RunSynchronously |> equal 1
 
+[<Fact>]
+let ``return! should compile in async CE`` () =
+    let inner () = async { return 42 }
+    let outer () = async { return! inner () }
+    let result = Async.RunSynchronously (outer ())
+    result |> equal 42
+
+[<Fact>]
+let ``return! works in recursive async CE`` () =
+    let rec loop n = async {
+        if n <= 0 then return 0
+        else return! loop (n - 1)
+    }
+    let result = Async.RunSynchronously (loop 5)
+    result |> equal 0
+
+[<Fact>]
+let ``return! is transparent through multiple layers`` () =
+    // Verifies return_from is identity: chaining return! does not double-wrap the computation
+    // or alter the value in any way.
+    let inner () = async { return 7 }
+    let passthrough (comp: Async<int>) = async { return! comp }
+    let result =
+        inner ()
+        |> passthrough
+        |> passthrough
+        |> passthrough
+        |> Async.RunSynchronously
+    result |> equal 7
+
+[<Fact>]
+let ``return! propagates value from async built with bind`` () =
+    // Verifies that a computation produced via let! / return is correctly
+    // passed through return!, not just a literal return value.
+    let doubled x = async {
+        let! v = async { return x }
+        return v * 2
+    }
+    let outer () = async { return! doubled 21 }
+    Async.RunSynchronously (outer ()) |> equal 42
+
+[<Fact>]
+let ``return! propagates error Result from inner async`` () =
+    // Both Ok and Error variants must flow through return! unchanged.
+    let inner (result: Result<int, string>) = async { return result }
+    let outer (result: Result<int, string>) = async { return! inner result }
+    Async.RunSynchronously (outer (Ok 99)) |> equal (Ok 99)
+    Async.RunSynchronously (outer (Error "oops")) |> equal (Error "oops")
+
 // [<Fact>]
 // let shouldExecAsParallelStructurallyCorrect () =
 //     let t = Async.Parallel [


### PR DESCRIPTION
Hey Team,

I used to hang out in the Gitter back in the day! I am just getting back into the .NET/F# ecosystem after many years away. F# is still by far my favorite language and community, and I figured I would get back up to speed by experimenting with the Rust support.

**What this PR does:**

* Fixes bug with using `return!` in an async CE
* Adds return_from runtime function that passes the existing computation through unchanged, avoiding double-wrapping
* Adds regression tests

**Context & Feedback Request:**

My F# is pretty rusty, so I am leaning on Claude and friends as a tutor to help me get reacquainted with the syntax and idioms. I’ve tested the logic locally and it works, but I want to be completely transparent: I am still re-learning what makes for "good" F#.

I opened this as a Draft because the last thing I want is to burden you with ugly code. If you have the bandwidth, I would hugely appreciate any feedback. If you prefer I work on my F# skills locally before contributing, just say the word and I will happily close this—no hard feelings at all! I just figured collaborating openly is the fastest way to learn while hopefully providing value.

Thanks for your time and for keeping this awesome project going!  