### PR TITLE
[Repo Assist] ci: Add timeout-minutes to all build jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
   # Run `dotnet fantomas .` to format all code.
   verify-linting:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v5
@@ -35,6 +36,7 @@ jobs:
   restore-project:
     name: Check that solution can be restored
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v5
@@ -49,6 +51,7 @@ jobs:
 
   # Separate build job for JavaScript
   build-javascript:
+    timeout-minutes: 60
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest]
@@ -76,6 +79,7 @@ jobs:
   # Separate build job for TypeScript
   build-typescript:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v5
@@ -97,6 +101,7 @@ jobs:
   # Separate build job for Integration
   build-integration:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v5
@@ -115,6 +120,7 @@ jobs:
   # Separate build job for Standalone
   build-standalone:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v5
@@ -132,6 +138,7 @@ jobs:
 
   # Separate build job for Python since we use a test matrix (will run in parallell)
   build-python:
+    timeout-minutes: 75
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest]
@@ -176,6 +183,7 @@ jobs:
 
   # Separate build job for Rust (will run in parallel)
   build-rust:
+    timeout-minutes: 75
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -206,6 +214,7 @@ jobs:
   # Separate build job for Dart
   build-dart:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v5
@@ -224,6 +233,7 @@ jobs:
   # Separate build job for Beam (Erlang)
   build-beam:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v5
@@ -245,6 +255,7 @@ jobs:
   # Separate job to run F# analyzers
   analyzers:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

- Without explicit timeouts, GitHub Actions defaults to **6 hours** per job. If any job hangs (e.g. a stuck test, a network stall during tool install), CI minutes are wasted for the full 6 hours before GitHub cancels it.
- This adds `timeout-minutes` to every job in `build.yml`, chosen conservatively based on job type.

| Job | Timeout | Rationale |
|-----|---------|-----------|
| `verify-linting` | 15 min | Just `dotnet fantomas --check` |
| `restore-project` | 15 min | Just `dotnet restore` |
| `build-standalone` | 30 min | Lightweight standalone build |
| `build-typescript`, `build-integration`, `build-dart`, `build-beam`, `analyzers` | 45 min | Single-target builds with tests |
| `build-javascript` | 60 min | Matrix (ubuntu + windows) |
| `build-python`, `build-rust` | 75 min | Include Rust/maturin compilation |

Timeouts apply per matrix instance, so a 2-platform matrix job with `timeout-minutes: 60` allows 60 minutes per platform, not 30 each.

## Trade-offs

The timeouts are deliberately generous to avoid false positives on slow runners. If CI regularly takes longer than the limits on a particular job, the timeout can be raised. The goal is to catch truly hung jobs, not to optimise for the fastest possible run.

> Originally generated by [Repo Assist](https://github.com/fable-compiler/Fable/actions/runs/23124131992) — pushed manually because the patch modifies a protected workflow file.

Closes #4409