### PR TITLE
chore: ignore Fable Beam generated files for Beam quicktest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ src/quicktest/**/*.js
 src/quicktest-py/**/*.py
 src/quicktest-rust/**/*.rs
 src/quicktest-dart/**/*.dart
+src/quicktest-beam/**/*.beam
+src/quicktest-beam/**/*.erl
+src/quicktest-beam/src/*.src
+src/quicktest-beam/rebar.config
 **/fable_modules/**
 
 ## Ignore Visual Studio temporary files, build results, and


### PR DESCRIPTION
@dbrattli 

It seems like these files were not ignored when building quicktest project for BEAM.

If I understand, these files will also be generated for User project, and he will need to ignore most (if not all) of them.

From a UX perspective, it would be nice if they could be placed in `fable_modules` to get auto ignored. But I am not sure if this is possible ?