### PR TITLE
[Python] Fix missing await on else branch of ternary in async closures

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* [Python] Fix missing `await` on else branch of ternary expressions in async closures (by @dbrattli)
 * [Beam] Fix `|> ignore` on cross-module Emit calls generating variable bindings that shadow Emit case-clause variables (by @dbrattli)
 * [Beam] Fix `containsIdentRef` not checking `Call` ThisArg (by @dbrattli)
 * [All] Fix CLI color not resetting after error messages (fixes #3755) (by @MangelMaxime)

--- a/src/Fable.Compiler/CHANGELOG.md
+++ b/src/Fable.Compiler/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* [Python] Fix missing `await` on else branch of ternary expressions in async closures (by @dbrattli)
 * [Beam] Fix `|> ignore` on cross-module Emit calls generating variable bindings that shadow Emit case-clause variables (by @dbrattli)
 * [Beam] Fix `containsIdentRef` not checking `Call` ThisArg (by @dbrattli)
 * [JS/TS] `StringEnum` now respect `CompiledValue` and `CompiledName` (by @shayanhabibi)

--- a/src/Fable.Transforms/Python/PythonPrinter.fs
+++ b/src/Fable.Transforms/Python/PythonPrinter.fs
@@ -816,7 +816,7 @@ module PrinterExtensions =
             | Name ex -> printer.Print(ex)
             | Await ex ->
                 printer.Print("await ")
-                printer.Print(ex)
+                printer.ComplexExpressionWithParens(ex)
             | Yield expr ->
                 printer.Print("yield")
 

--- a/tests/Python/TestTask.fs
+++ b/tests/Python/TestTask.fs
@@ -199,3 +199,23 @@ let ``test async returns in try-with are awaited`` () =
 
     let result2 = wrapper true |> fun tsk -> tsk.GetAwaiter().GetResult()
     equal -1 result2
+
+// Regression: closure with let binding before if/else returning Task emits ternary;
+// both branches of the ternary must be awaited.
+let asyncNone () : Task<int option> = Task.FromResult None
+
+let makeClosure (flag: bool) =
+    let captured = flag
+    fun (value: int) ->
+        let x = value + 1
+        if captured then Task.FromResult(Some x) else asyncNone ()
+
+[<Fact>]
+let ``test async ternary in closure awaits both branches`` () =
+    let fn = makeClosure true
+    let result = fn 41 |> fun tsk -> tsk.GetAwaiter().GetResult()
+    equal (Some 42) result
+
+    let fn2 = makeClosure false
+    let result2 = fn2 41 |> fun tsk -> tsk.GetAwaiter().GetResult()
+    equal None result2


### PR DESCRIPTION
## Summary

- Fix Python `await` operator precedence issue with ternary expressions (`IfExp`). In Python, `await` binds tighter than ternary, so `await x if cond else y` parses as `(await x) if cond else y` — only the true branch gets awaited. The fix uses `ComplexExpressionWithParens` in the `Await` printer to parenthesize complex sub-expressions, producing `await (x if cond else y)`.
- This affected async closures where the compiler emits a ternary instead of an if/else statement (e.g., closures capturing outer variables with a let binding before the if/else).

## Test plan

- [x] Added regression test `test async ternary in closure awaits both branches` in `tests/Python/TestTask.fs`
- [x] Verified test fails without the fix (returns unawaited coroutine object)
- [x] All 2102 Python tests pass with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)