### PR TITLE
[CI] Fix analyzer failures by restricting SDK rollForward policy

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "10.0.100",
-    "rollForward": "latestFeature"
+    "rollForward": "latestPatch"
   }
 }


### PR DESCRIPTION
## Summary

- The GitHub runner image was updated (~March 27) to include .NET SDK **10.0.201** (a newer feature band). With `"rollForward": "latestMajor"` in `global.json`, the runtime used this newer SDK which ships FSharp.Core **10.1.201** (FSharp.Core version is decoupled from SDK version)
- The `fsharp-analyzers` tool (v0.36.0) requires `FSharp.Core = 10.0.101`, and the 10.0→10.1 jump causes it to silently crash at runtime (the MSBuild target has `ContinueOnError=true` and `IgnoreExitCode=true`)
- No SARIF reports are generated, so the `upload-sarif` step fails with `Path does not exist: src/reports`
- Changed `rollForward` from `"latestMajor"` to `"latestPatch"` — this stays within the 10.0.1xx feature band where FSharp.Core remains at 10.0.x. (`latestFeature` was also tried but still rolled forward to SDK 10.0.201 which ships FSharp.Core 10.1.201)

## Test plan

- [x] Verify the `analyzers` CI jobs pass on this PR
- [x] Verify other CI jobs (build-javascript, build-python, etc.) are not affected by the rollForward change

🤖 Generated with [Claude Code](https://claude.com/claude-code)