### PR TITLE
[Beam] Fix System.String.Concat with 4+ arguments

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* [Beam] Fix `System.String.Concat` with 4+ arguments not being supported (by @dbrattli)
 * [TS/Python] Fix invalid `this` argument type in structs (#4453) (by @ncave)
 * [JS/TS] Fix `N` format specifier (`ToString("N0")`, `String.Format("{0:N0}", ...)`) producing a trailing dot when precision is 0 (fix #2582) (by @MangelMaxime)
 * [JS/TS] Fix `C0` and `P0` format specifiers producing trailing dot (e.g., `"¤1,000."` → `"¤1,000"`) (by @MangelMaxime)

--- a/src/Fable.Compiler/CHANGELOG.md
+++ b/src/Fable.Compiler/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* [Beam] Fix `System.String.Concat` with 4+ arguments not being supported (by @dbrattli)
 * [TS/Python] Fix invalid `this` argument type in structs (#4453) (by @ncave)
 * [JS/TS] Fix `N` format specifier (`ToString("N0")`, `String.Format("{0:N0}", ...)`) producing a trailing dot when precision is 0 (fix #2582) (by @MangelMaxime)
 * [JS/TS] Fix `C0` and `P0` format specifiers producing trailing dot (e.g., `"¤1,000."` → `"¤1,000"`) (by @MangelMaxime)

--- a/src/Fable.Transforms/Beam/Replacements.fs
+++ b/src/Fable.Transforms/Beam/Replacements.fs
@@ -940,7 +940,14 @@ let private strings
         | [ items ] -> emitExpr r t [ items ] "fable_string:concat($0)" |> Some
         | [ a; b ] -> emitExpr r t [ a; b ] "iolist_to_binary([$0, $1])" |> Some
         | [ a; b; c ] -> emitExpr r t [ a; b; c ] "iolist_to_binary([$0, $1, $2])" |> Some
-        | _ -> None
+        | _ ->
+            let argsList =
+                List.foldBack
+                    (fun arg acc -> Value(NewList(Some(arg, acc), String), None))
+                    args
+                    (Value(NewList(None, String), None))
+
+            emitExpr r t [ argsList ] "fable_string:concat($0)" |> Some
     // String.Compare
     | "Compare", None, [ a; b ] -> Helper.LibCall(com, "fable_string", "compare", t, [ a; b ]) |> Some
     | "Compare", None, [ a; b; compType ] ->

--- a/tests/Beam/StringTests.fs
+++ b/tests/Beam/StringTests.fs
@@ -410,6 +410,10 @@ let ``test String.Compare with StringComparison works`` () =
 let ``test System.String.Concat works`` () =
     String.Concat("a", "b", "c") |> equal "abc"
 
+[<Fact>]
+let ``test System.String.Concat with 4 args works`` () =
+    String.Concat("a", "b", "c", "d") |> equal "abcd"
+
 // --- String constructors ---
 
 [<Fact>]


### PR DESCRIPTION
## Summary
- Fix `System.String.Concat` with 4+ arguments returning "not supported" error on the BEAM target
- The handler only matched 1, 2, and 3 args explicitly — the catch-all returned `None`. Now builds an Erlang list from all args and passes it to `fable_string:concat/1`
- Added test for 4-arg `String.Concat`

## Test plan
- [x] `./build.sh quicktest beam` — verifies 4-arg concat outputs correctly
- [x] `./build.sh test beam` — all 2278 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)