### PR TITLE
[Python] Fix modulo with negative numbers for bigint

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* [Python] Fix modulo with negative numbers using Python floored semantics instead of .NET truncated semantics for bigint (fixes #4462) (by @dbrattli)
 * [Beam] Fix `System.String.Concat` with 4+ arguments not being supported (by @dbrattli)
 * [TS/Python] Fix invalid `this` argument type in structs (#4453) (by @ncave)
 * [JS/TS] Fix `N` format specifier (`ToString("N0")`, `String.Format("{0:N0}", ...)`) producing a trailing dot when precision is 0 (fix #2582) (by @MangelMaxime)

--- a/src/Fable.Compiler/CHANGELOG.md
+++ b/src/Fable.Compiler/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* [Python] Fix modulo with negative numbers using Python floored semantics instead of .NET truncated semantics for bigint (fixes #4462) (by @dbrattli)
 * [Beam] Fix `System.String.Concat` with 4+ arguments not being supported (by @dbrattli)
 * [TS/Python] Fix invalid `this` argument type in structs (#4453) (by @ncave)
 * [JS/TS] Fix `N` format specifier (`ToString("N0")`, `String.Format("{0:N0}", ...)`) producing a trailing dot when precision is 0 (fix #2582) (by @MangelMaxime)

--- a/src/fable-library-py/fable_library/big_int.py
+++ b/src/fable-library-py/fable_library/big_int.py
@@ -81,7 +81,12 @@ def op_division(a: int, b: int) -> int:
 
 
 def op_modulus(a: int, b: int) -> int:
-    return a % b
+    # .NET uses truncated remainder, Python uses floored remainder.
+    # They differ when the dividend and divisor have different signs.
+    r = a % b
+    if r != 0 and ((a < 0) != (b < 0)):
+        r -= b
+    return r
 
 
 def op_right_shift(a: int, num_bits: int) -> int:

--- a/tests/Python/TestArithmetic.fs
+++ b/tests/Python/TestArithmetic.fs
@@ -60,6 +60,12 @@ let ``test Integer division doesn't produce floats`` () =
 let ``test Infix modulo can be generated`` () =
     4 % 3 |> equal 1
 
+[<Fact>]
+let ``test Infix modulo with negative numbers`` () =
+    -5 % 3 |> equal -2
+    5 % -3 |> equal 2
+    -5 % -3 |> equal -2
+
 // [<Fact>]
 // let ``test Math.DivRem works with bytes`` () =
 //     Math.DivRem(5y, 2y) |> equal struct (2y, 1y)
@@ -385,6 +391,12 @@ let ``test Int64 Infix modulo can be generated`` () =
     4L % 3L |> equal 1L
 
 [<Fact>]
+let ``test Int64 Infix modulo with negative numbers`` () =
+    -5L % 3L |> equal -2L
+    5L % -3L |> equal 2L
+    -5L % -3L |> equal -2L
+
+[<Fact>]
 let ``test Int64 Evaluation order is preserved by generated code`` () =
     (4L - 2L) * 2L + 1L |> equal 5L
 
@@ -445,6 +457,12 @@ let ``test BigInt Integer division doesn't produce floats`` () =
 [<Fact>]
 let ``test BigInt Infix modulo can be generated`` () =
     4I % 3I |> equal 1I
+
+[<Fact>]
+let ``test BigInt Infix modulo with negative numbers`` () =
+    -5I % 3I |> equal -2I
+    5I % -3I |> equal 2I
+    -5I % -3I |> equal -2I
 
 // [<Fact>]
 // let ``test BigInt.DivRem works`` () = // See #1744


### PR DESCRIPTION
## Summary
- Fix `bigint` modulo (`%`) with negative numbers returning Python floored remainder instead of .NET truncated remainder (fixes #4462)
- `-5I % 3I` now correctly returns `-2I` instead of `1I`
- `int` and `int64` were already correct thanks to Rust wrapper types whose `__mod__` uses Rust's native `%` (truncated)
- Added tests for negative modulo on `int`, `int64`, and `bigint`

## Test plan
- [x] `./build.sh test python --skip-fable-library-core` — all 2107 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)