### PR TITLE
Fix --noRestore not skipping MSBuildCracker restores

### DIFF
--- a/src/Fable.Compiler/MSBuildCrackerResolver.fs
+++ b/src/Fable.Compiler/MSBuildCrackerResolver.fs
@@ -142,8 +142,10 @@ Exception:
             let targets =
                 "ResolveAssemblyReferencesDesignTime,ResolveProjectReferencesDesignTime,ResolvePackageDependenciesDesignTime,FindReferenceAssembliesForReferences,_GenerateCompileDependencyCache,_ComputeNonExistentFileProperty,BeforeBuild,BeforeCompile,CoreCompile"
 
+            let restoreArg = if options.NoRestore then "" else "/restore"
+
             let arguments =
-                $"/restore /t:%s{targets} %s{properties} --getItem:FscCommandLineArgs --getItem:ProjectReference --getProperty:OutputType -warnAsMessage:NU1608"
+                $"%s{restoreArg} /t:%s{targets} %s{properties} --getItem:FscCommandLineArgs --getItem:ProjectReference --getProperty:OutputType -warnAsMessage:NU1608"
 
             let! json =
                 dotnet_msbuild_with_defines options.RootDir fsproj.FullName arguments options.FableOptions.Define


### PR DESCRIPTION
Fixes #4527

## Problem

The `--noRestore` CLI flag is parsed and stored in `CrackerOptions.NoRestore`, but `MSBuildCrackerResolver.mkOptionsFromDesignTimeBuildAux` hardcodes `/restore` in the `dotnet msbuild` arguments, ignoring the flag.

This causes sequential per-project restores during project cracking, adding ~20s to every Fable compilation for projects with many transitive references (~25 in our case), even when the user explicitly passes `--noRestore`.

## Fix

One-line change: conditionally include `/restore` based on `options.NoRestore`.

```fsharp
// Before:
let arguments =
    $"/restore /t:%s{targets} ..."

// After:
let restoreArg = if options.NoRestore then "" else "/restore"
let arguments =
    $"%s{restoreArg} /t:%s{targets} ..."
```

## Testing

Tested on a monorepo with 1577 source files across ~25 transitive project references:

- **Before**: Parsing phase ~44s (includes ~22s of sequential restores)
- **After with `--noRestore`**: Parsing phase ~28s (restores skipped)
- Default behavior (without `--noRestore`) is unchanged