### PR TITLE
fix: [Python] consistent mangled names for generic abstract class members

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* [Python] Fix derived classes of generic abstract classes not being instantiable due to mismatched mangled method names between abstract stubs and overrides (by @dbrattli)
 * [Dart/Rust] Fix `ResizeArray` reference equality (by @ncave)
 * [JS/TS/Python/Beam] Fix `ResizeArray` (`System.Collections.Generic.List`) equality to use reference equality instead of structural equality (fixes #3718)
 * [Beam] Fix `List.Cons` call replacement and test (by @ncave)

--- a/src/Fable.Compiler/CHANGELOG.md
+++ b/src/Fable.Compiler/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* [Python] Fix derived classes of generic abstract classes not being instantiable due to mismatched mangled method names between abstract stubs and overrides (by @dbrattli)
 * [Dart/Rust] Fix `ResizeArray` reference equality (by @ncave)
 * [JS/TS/Python/Beam] Fix `ResizeArray` (`System.Collections.Generic.List`) equality to use reference equality instead of structural equality (fixes #3718)
 * [Beam] Fix `List.Cons` call replacement and test (by @ncave)

--- a/src/Fable.Transforms/Python/Fable2Python.Bases.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.Bases.fs
@@ -335,12 +335,14 @@ module InterfaceNaming =
             |> OverloadSuffix.getHash entityGenericParameters
 
     /// Generates a mangled member name for interfaces/abstract classes.
-    /// Format: EntityFullPath_MemberName + OverloadSuffix (dots replaced with underscores)
+    /// Format: EntityFullName_MemberName + OverloadSuffix (dots and backticks replaced with underscores).
+    /// Uses the entity's FullName (which includes generic arity like ``2``) so the mangled name
+    /// matches the one produced for overrides in derived classes.
     let getMangledMemberName (ent: Fable.Entity) (memb: Fable.MemberFunctionOrValue) =
         let overloadSuffix = getOverloadSuffix ent memb
-        let lastDotIndex = memb.FullName.LastIndexOf '.'
-        let fullNamePath = memb.FullName.Substring(0, lastDotIndex)
-        $"%s{fullNamePath}.%s{memb.CompiledName}%s{overloadSuffix}".Replace(".", "_")
+
+        $"%s{ent.FullName}.%s{memb.CompiledName}%s{overloadSuffix}"
+        |> Fable.Py.Naming.cleanNameAsPyIdentifier
 
 /// Generates abstract method stubs for abstract classes.
 /// Creates stubs for dispatch slots (abstract members) that don't have default implementations.

--- a/tests/Python/TestType.fs
+++ b/tests/Python/TestType.fs
@@ -591,6 +591,22 @@ type AbstractClassWithResizeArrayProp() =
 type ConcreteClass1() =
     inherit MangledAbstractClass5(2)
 
+// Generic abstract class with members - regression test for Python name-mangling
+// where abstract stubs and overrides produced mismatched names for generic arities.
+[<AbstractClass>]
+type GenericAbstractRunner<'A, 'B>() =
+    abstract Encode: 'A -> string
+    abstract Decode: string -> 'A
+    abstract MapAToB: 'A -> 'B
+    abstract SomeProp: int with get
+
+type ConcreteGenericRunner() =
+    inherit GenericAbstractRunner<int, string>()
+    override _.Encode(a: int) = string a
+    override _.Decode(s: string) = int s
+    override _.MapAToB(a: int) = string a
+    override _.SomeProp = 42
+
 type IndexedProps(v: int) =
     let mutable v = v
     member _.Item with get (v2: int) = v + v2 and set v2 (s: string) = v <- v2 + int s
@@ -1793,6 +1809,14 @@ let ``test Unchecked.defaultof works for fields on structs`` () =
     top.A |> equal 0
     top.B.A |> equal 0
     top.B.B |> equal false
+
+[<Fact>]
+let ``test Generic abstract class can be instantiated through derived class`` () =
+    let runner = ConcreteGenericRunner() :> GenericAbstractRunner<int, string>
+    runner.Encode 7 |> equal "7"
+    runner.Decode "42" |> equal 42
+    runner.MapAToB 3 |> equal "3"
+    runner.SomeProp |> equal 42
 
 [<Fact>]
 let ``test Abstract class property backed by captured variable in object expression works`` () =


### PR DESCRIPTION
## Summary

Derived classes of generic abstract classes could not be instantiated in compiled Python due to mismatched mangled method names between the abstract stub and the override.

### Root cause

Two different name-mangling paths:

- **Abstract stubs** (`Fable2Python.Bases.fs`, `InterfaceNaming.getMangledMemberName`) derived the entity prefix from `memb.FullName`, which from the F# compiler does **not** include the backtick generic arity. The code also replaced `.` with `_` but left backticks untouched.
- **Overrides in derived classes** (`FSharp2Fable.Util.fs`, `getMangledAbstractMemberName`) built the prefix from the entity's own `TryFullName`, which **does** include the arity (e.g. `` `2 ``), and downstream sanitization in `Python.Prelude.sanitizeIdentForbiddenChars` replaced both `.` and `` ` `` with `_`.

Result: for `TestRunner<'A, 'B>` the abstract stub was named `TestRunner_get_Encode` while the override was named `TestRunner_2_get_Encode`. Python's ABC then refused to instantiate any derived class:

```
TypeError: Can't instantiate abstract class PythonTestRunner without an implementation for abstract methods
  'Thoth_Json_Tests_Testing_TestRunner_get_Decode',
  'Thoth_Json_Tests_Testing_TestRunner_get_Encode',
  ...
```

### Fix

`getMangledMemberName` now uses `ent.FullName` (entity full name with arity) and `Fable.Py.Naming.cleanNameAsPyIdentifier`, which replaces both `.` and `` ` `` with `_`. This matches the mangled name that derived-class overrides produce.

For non-generic abstract classes the output is unchanged.

## Test plan

- [x] New regression test `Generic abstract class can be instantiated through derived class` in `tests/Python/TestType.fs` covering an abstract method, an abstract property, and an abstract generic mapper.
- [x] Full `tests/Python` suite passes locally (2331 tests).
- [x] Verified externally against Thoth.Json's Python tests (239 tests, previously broken on this branch, now green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)