### PR TITLE
ci: Add CI concurrency settings to cancel superseded PR runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   id-token: write
   security-events: write


### PR DESCRIPTION
When multiple commits are pushed to the same PR branch in quick
succession, only the latest CI run is needed. The concurrency group
cancels any in-progress run for the same workflow+branch combination
when a new one starts. Main branch pushes are excluded from
cancellation so all merges complete.

Closes #4530

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
