### PR TITLE
[All] Fix --noRestore not skipping MSBuildCracker restores (#4527)

### DIFF
--- a/src/Fable.Cli/CHANGELOG.md
+++ b/src/Fable.Cli/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [Python] Fix `DateTime.TryParse` incorrectly assigning `DateTimeKind.Local` to naive datetime strings (should be `DateTimeKind.Unspecified`) (fixes #3654)
 * [JS/TS] Fix `String.Contains` ignoring `StringComparison` argument (second argument was silently discarded)
 * [Python] Fix `String.Contains` ignoring `StringComparison` argument (second argument was silently discarded)
+* [All] Fix `--noRestore` not skipping MSBuildCracker restores (by @ randrag)
 
 ## 5.0.0-rc.7 - 2026-04-07
 

--- a/src/Fable.Compiler/CHANGELOG.md
+++ b/src/Fable.Compiler/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [Python] Fix `DateTime.TryParse` incorrectly assigning `DateTimeKind.Local` to naive datetime strings (should be `DateTimeKind.Unspecified`) (fixes #3654)
 * [JS/TS] Fix `String.Contains` ignoring `StringComparison` argument (second argument was silently discarded)
 * [Python] Fix `String.Contains` ignoring `StringComparison` argument (second argument was silently discarded)
+* [All] Fix `--noRestore` not skipping MSBuildCracker restores (by @ randrag)
 
 ## 5.0.0-rc.13 - 2026-04-07
 

--- a/src/Fable.Compiler/MSBuildCrackerResolver.fs
+++ b/src/Fable.Compiler/MSBuildCrackerResolver.fs
@@ -142,8 +142,10 @@ Exception:
             let targets =
                 "ResolveAssemblyReferencesDesignTime,ResolveProjectReferencesDesignTime,ResolvePackageDependenciesDesignTime,FindReferenceAssembliesForReferences,_GenerateCompileDependencyCache,_ComputeNonExistentFileProperty,BeforeBuild,BeforeCompile,CoreCompile"
 
+            let restoreArg = if options.NoRestore then "" else "/restore"
+
             let arguments =
-                $"/restore /t:%s{targets} %s{properties} --getItem:FscCommandLineArgs --getItem:ProjectReference --getProperty:OutputType -warnAsMessage:NU1608"
+                $"%s{restoreArg} /t:%s{targets} %s{properties} --getItem:FscCommandLineArgs --getItem:ProjectReference --getProperty:OutputType -warnAsMessage:NU1608"
 
             let! json =
                 dotnet_msbuild_with_defines options.RootDir fsproj.FullName arguments options.FableOptions.Define

--- a/src/Fable.Compiler/MSBuildCrackerResolver.fs
+++ b/src/Fable.Compiler/MSBuildCrackerResolver.fs
@@ -142,7 +142,11 @@ Exception:
             let targets =
                 "ResolveAssemblyReferencesDesignTime,ResolveProjectReferencesDesignTime,ResolvePackageDependenciesDesignTime,FindReferenceAssembliesForReferences,_GenerateCompileDependencyCache,_ComputeNonExistentFileProperty,BeforeBuild,BeforeCompile,CoreCompile"
 
-            let restoreArg = if options.NoRestore then "" else "/restore"
+            let restoreArg =
+                if options.NoRestore then
+                    ""
+                else
+                    "/restore"
 
             let arguments =
                 $"%s{restoreArg} /t:%s{targets} %s{properties} --getItem:FscCommandLineArgs --getItem:ProjectReference --getProperty:OutputType -warnAsMessage:NU1608"


### PR DESCRIPTION
Replace https://github.com/fable-compiler/Fable/pull/4528 because I could not push to the fork repo...