### PR TITLE
fix(js/ts): Fix datetime custom format off by one year

### DIFF
--- a/src/fable-library-ts/Date.ts
+++ b/src/fable-library-ts/Date.ts
@@ -273,13 +273,13 @@ function dateToStringWithCustomFormat(date: Date, format: string, utc: boolean) 
         cursorPos += tokenLength;
         switch (tokenLength) {
           case 1:
-            result += localizedDate.getFullYear() % 100;
+            result += year(localizedDate) % 100;
             break;
           case 2:
-            result += padWithZeros(localizedDate.getFullYear() % 100, 2);
+            result += padWithZeros(year(localizedDate) % 100, 2);
             break;
           default:
-            result += padWithZeros(localizedDate.getFullYear(), tokenLength);
+            result += padWithZeros(year(localizedDate), tokenLength);
             break;
         }
         break;

--- a/tests/Js/Main/DateTimeTests.fs
+++ b/tests/Js/Main/DateTimeTests.fs
@@ -1145,4 +1145,11 @@ let tests =
     testCase "Adding days to a local date works even if daylight saving time changes" <| fun () ->
         let dt = DateTime(2019, 10, 20, 0, 0, 0, DateTimeKind.Local)
         dt.AddDays(9.).Day |> equal 29
+
+    testCase "Using format strings should respect local time" <| fun () ->
+        let dt = DateTime.Parse("2025-01-01T00:00:00+0100")
+        let utc = dt.ToUniversalTime()
+        let str = utc.ToString("yyyy-MM-dd HH:mm")
+
+        str |> equal "2024-12-31 23:00"
   ]


### PR DESCRIPTION
When you use a custom format like "yyyy-MM-dd HH:mm", you can get an edge-case where you get back off by one year string.

So, if you have `localizedDate = Wed Jan 01 2025 00:00:00 GMT+0100 (Central European Standard Time)`, you'll get `2025-12-31 23:00:00`. This is because the functions used for month, day, hour, etc, use the correct helper functions that take `kind` into account.

Using the `year` function should solve it.