### PR TITLE
fix(js/ts): Fix Decimal.GetBits returning incorrect mantissa after round arithmetic result

### DIFF
--- a/src/fable-library-ts/Decimal.ts
+++ b/src/fable-library-ts/Decimal.ts
@@ -248,14 +248,16 @@ export function fromParts(low: number, mid: number, high: number, isNegative: bo
 
 export function getBits(d: Decimal) {
   const bitSize = 96;
-  const decDigits = Uint8Array.from(d.c);
+  const decStr = d.toString();
+  const absStr = decStr[0] === "-" ? decStr.slice(1) : decStr;
+  const dotPos = absStr.indexOf(".");
+  const scale = dotPos < 0 ? 0 : absStr.length - dotPos - 1;
+  const mantissaStr = dotPos < 0 ? absStr : absStr.slice(0, dotPos) + absStr.slice(dotPos + 1);
+  const decDigits = Uint8Array.from(mantissaStr, ch => ch.charCodeAt(0) - 48);
   const hexDigits = decimalToHex(decDigits, bitSize);
   const low = getInt32Bits(hexDigits, 0);
   const mid = getInt32Bits(hexDigits, 8);
   const high = getInt32Bits(hexDigits, 16);
-  const decStr = d.toString();
-  const dotPos = decStr.indexOf(".");
-  const scale = dotPos < 0 ? 0 : decStr.length - dotPos - 1;
   const signExp = ((scale & 0x7F) << 16) | (d.s < 0 ? 0x80000000 : 0);
   return [low, mid, high, signExp];
 }

--- a/src/fable-library-ts/Decimal.ts
+++ b/src/fable-library-ts/Decimal.ts
@@ -252,7 +252,7 @@ export function getBits(d: Decimal) {
   const absStr = decStr[0] === "-" ? decStr.slice(1) : decStr;
   const dotPos = absStr.indexOf(".");
   const scale = dotPos < 0 ? 0 : absStr.length - dotPos - 1;
-  const mantissaStr = dotPos < 0 ? absStr : absStr.slice(0, dotPos) + absStr.slice(dotPos + 1);
+  const mantissaStr = absStr.replace(".", "");
   const decDigits = Uint8Array.from(mantissaStr, ch => ch.charCodeAt(0) - 48);
   const hexDigits = decimalToHex(decDigits, bitSize);
   const low = getInt32Bits(hexDigits, 0);

--- a/tests/Js/Main/ArithmeticTests.fs
+++ b/tests/Js/Main/ArithmeticTests.fs
@@ -253,6 +253,18 @@ let tests =
         d2 |> equal d
         d3 |> equal -d
 
+    testCase "Decimal GetBits works with arithmetic operations" <| fun () ->
+        let check (d: decimal) =
+            let bits = Decimal.GetBits(d)
+            Decimal(bits) |> equal d
+
+        check (10M + 10M)
+        check (100.5M - 0.5M)
+        check (5M * 200M)
+        check (-0.1M * 100M)
+        check (2000M / 10M)
+        check (1.5M + 0.5M)
+
     testCase "Decimal abs works" <| fun () ->
         abs -4M |> equal 4M
 


### PR DESCRIPTION
## Problem
`Decimal.GetBits` returned incorrect bits for any decimal value produced by arithmetic that yields a round result (e.g. 1M * 10M, 10M + 10M). Reconstructing a decimal from these bits via `Decimal(GetBits(d))` would give a value off by some power of 10.

**Root cause:** big.js normalizes its internal representation by stripping trailing zeros from `d.c` and compensating via `d.e`. The old implementation read `d.c` directly as the mantissa digit array, so for 10 (stored as `c=[1], e=1`), it would extract mantissa 1 instead of 10.

## Repro

Following code snippet can be used for repro.

```fsharp
open System

let check (d: decimal) =
    let bits = Decimal.GetBits(d)
    let d2 = Decimal(bits)
    printfn "original=%A reconstructed=%A match=%A" d d2 (d = d2)

check (10M + 10M) // Expected 20, gets 2
check (100.5M - 0.5M) // Expected 100 gets 1
check (-0.1M * 100M) // Expected -10 gets -1 

```
Also, [Repl](https://fable.io/repl/#?code=PYBwpgdgBAygngZwC5gLYCh0BsxKgYwAsx8BrKACgBMAuKKkgS1QEMsBKKAXnSj6hx4ARoyQJuUACJNWWAHQBxXACFRCau179B9AEwTp+Zmwoixm-lBAAnRhCQAzaACJgtgOZ22XAKQBBKGsSYAhkawBXfBQqXwDWJCJY53o9SioJKl1NdCIScgoARgAGAFkoAGooYpLNXLJKYqK5AFYygFooJtba4nqKNqaCsoAqKqLS9iA&html=Q&css=Q)

## Fix

Derive the mantissa from `d.toString()` instead of `d.c`. Strip the sign and decimal point from the string representation to get the mantissa digits, and compute scale from the dot position. This approach should be less prone to big.js internal representation changes.

## Notes
- The inverse direction `(fromParts → big.js)` seems to be unaffected; only reading back via getBits was broken
- Searched for other use cases of `d.c` part of big.js representation where it could be prone to the same normalization issue, did not find any.

