### PR TITLE
ci: tighten PR scope rules to enforce js/ts as one unit

### DIFF
--- a/.github/workflows/conventional-pr-title.yml
+++ b/.github/workflows/conventional-pr-title.yml
@@ -21,10 +21,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           scopes: |
-            js
-            ts
-            dart
-            python
-            rust
-            beam
-            js/ts
+            ^(?:all|(?:js/ts|dart|python|rust|beam)(?:/(?:js/ts|dart|python|rust|beam))*)$

--- a/.github/workflows/repo-assist.md
+++ b/.github/workflows/repo-assist.md
@@ -301,7 +301,7 @@ Update memory with labels applied and cursor position.
     e. Add a test for the bug if feasible.
     f. DO NOT update the changelogs, they are automatically generated based on the commit history
     g. Create a draft PR with: AI disclosure, `Closes #N`, root cause, fix rationale, and trade-offs. CI will validate the build and tests.
-        The PR title should follow the Conventional Commits format (e.g., `fix: ...`, `feat: ...`, `perf: ...`) with a target prefix if applicable (e.g., `fix(python): ...`, `feat(js): ...`).
+        The PR title should follow the Conventional Commits format (e.g., `fix: ...`, `feat: ...`, `perf: ...`) with a target scope if applicable. Allowed scopes: `js/ts`, `dart`, `python`, `rust`, `beam`, `all`. JS and TS must always be combined as `js/ts` (never used separately). Multi-target changes use slash-separated combinations such as `fix(js/ts/python): ...` or `fix(python/beam): ...`. Use `all` for changes affecting every target, and omit the scope entirely for non-target-specific changes.
     h. Post a single brief comment on the issue linking to the PR.
 3. Update memory with fix attempts and outcomes.
 


### PR DESCRIPTION
## Summary

- Replace the flat `scopes:` allowlist in `conventional-pr-title.yml` with a regex that enforces `js/ts` as a single inseparable atom and accepts any slash-separated combination of valid targets (e.g. `js/ts/python`, `python/beam`), plus `all` for cross-cutting changes.
- Update the repo-assist prompt (`repo-assist.md:304`) so generated PR titles match the new rule. Removes the old `feat(js): ...` example which would now be rejected.

## Why

Repo-assist regularly produces multi-target fixes (e.g. `[JS/TS/Python/Beam] Fix ResizeArray equality`) but the previous flat allowlist had no way to express combinations, so those titles either skipped Conventional Commits or used scopes the linter would reject. The regex form covers the combinatorial space without enumeration.

## Test plan

- [ ] Verify the linter accepts: `fix(js/ts): ...`, `fix(python): ...`, `fix(js/ts/python): ...`, `fix(all): ...`, and a no-scope `fix: ...`
- [ ] Verify the linter rejects: `fix(js): ...`, `fix(ts): ...`, `fix(js/python): ...`
- [ ] Confirm next repo-assist run produces a title matching the new pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)