### PR TITLE
chore(rust): widen sleep gap in flaky Async.Sleep test

### DIFF
--- a/tests/Rust/tests/src/AsyncTests.fs
+++ b/tests/Rust/tests/src/AsyncTests.fs
@@ -228,8 +228,8 @@ let ``Async.Sleep works`` () =
     let mutable s = ""
     let a1 =
         async {
-            do! Async.Sleep(300)
-            s <- s + "300"
+            do! Async.Sleep(1000)
+            s <- s + "1000"
         }
     let a2 =
         async {
@@ -240,7 +240,7 @@ let ``Async.Sleep works`` () =
     let t2 = a2 |> Async.StartAsTask
     let r1 = t1.Result
     let r2 = t2.Result
-    s |> equal "100300"
+    s |> equal "1001000"
 
 // type DisposableAction(f) =
 //     interface IDisposable with


### PR DESCRIPTION
## Summary
- The `Async.Sleep works` test in `tests/Rust/tests/src/AsyncTests.fs` is timing-flaky on CI. It relies on `Async.Sleep(100)` finishing before `Async.Sleep(300)`, but on a loaded runner the second task can be queued >200ms after the first, inverting the order (e.g. [build-rust no_std on PR #4571](https://github.com/fable-compiler/Fable/actions/runs/24959688555/job/73084071460?pr=4571) saw `300100` instead of `100300`).
- Widen the gap from 100ms vs 300ms to 100ms vs 1000ms so scheduling jitter on CI doesn't flip the order.

## Test plan
- [ ] CI passes for the `build-rust` jobs (default, threaded, no_std).
- [ ] The test still meaningfully exercises `Async.Sleep` ordering across two concurrent tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)