### PR TITLE
ci: use astral-sh/setup-uv action for Python CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,10 +160,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install uv
-        run: |
-          pipx install uv
-          pipx install maturin
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install maturin
+        run: uv tool install maturin
 
       - name: Fable Library - Python (linux)
         if: matrix.platform == 'ubuntu-latest'


### PR DESCRIPTION
Replace manual 'pipx install uv' with the official astral-sh/setup-uv@v5
action, which enables package caching (enable-cache: true) and is maintained
by the uv team. Replace 'pipx install maturin' with 'uv tool install maturin'
for consistency with uv tooling.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
