### PR TITLE
fix(beam): handle string binaries in Seq enumerator

### DIFF
--- a/src/fable-library-beam/fable_utils.erl
+++ b/src/fable-library-beam/fable_utils.erl
@@ -153,6 +153,9 @@ get_enumerator(Map) when is_map(Map) ->
 get_enumerator({group_collection, Items, _Names}) ->
     %% Regex GroupCollection: iterate over the group items list
     get_enumerator(Items);
+get_enumerator(Bin) when is_binary(Bin) ->
+    %% String binary used as seq<char>: enumerate Unicode codepoints.
+    get_enumerator(unicode:characters_to_list(Bin));
 get_enumerator(Other) ->
     %% Fallback: treat as list
     get_enumerator(lists:flatten([Other])).

--- a/tests/Beam/StringTests.fs
+++ b/tests/Beam/StringTests.fs
@@ -1055,3 +1055,25 @@ let ``test String.forall works`` () =
     "aaa" |> String.forall (fun c -> c = 'a') |> equal true
     "aab" |> String.forall (fun c -> c = 'a') |> equal false
     "" |> String.forall (fun c -> c = 'a') |> equal true
+
+[<Fact>]
+let ``test Seq.mapi over string works`` () =
+    "Hello"
+    |> Seq.mapi (fun _ c -> string c)
+    |> String.concat ""
+    |> equal "Hello"
+
+[<Fact>]
+let ``test Seq.map over string works`` () =
+    "abc"
+    |> Seq.map (fun c -> string c)
+    |> String.concat "-"
+    |> equal "a-b-c"
+
+[<Fact>]
+let ``test Seq.toList over string works`` () =
+    "abc" |> Seq.toList |> equal [ 'a'; 'b'; 'c' ]
+
+[<Fact>]
+let ``test Seq.length over string works`` () =
+    "Hello" |> Seq.length |> equal 5


### PR DESCRIPTION
## Summary

- Fix `badarg` crash when applying `Seq.X` operations (e.g. `Seq.mapi`, `Seq.map`, `Seq.toList`) to a string on the BEAM target.
- F# strings are `seq<char>` by language definition, but Fable.Beam lowers them to Erlang binaries. `fable_utils:get_enumerator/1` had no clause for binaries, so the fallback path (`lists:flatten([Other])`) wrapped the binary into a single-element list — the enumerator then handed the whole binary back as one "char", crashing later code paths (e.g. `<<C/utf8>>` from `string c`).
- Add a binary clause that converts to a Unicode codepoint list, matching the existing `to_list/1` handling.

### Minimal repro

```fsharp
"Hello" |> Seq.mapi (fun _ c -> string c) |> String.concat ""
// CLR/JS/Python: "Hello"
// BEAM (before): error:badarg in seq:enumerator_generate_while_some
// BEAM (after):  "Hello"
```

### Stack trace before fix

```
seq:enumerator_generate_while_some/3-fun-2-     (seq.erl:372)
fable_utils:enumerate_to_list_loop/2            (fable_utils.erl:274)
fable_utils:enumerate_to_list/1                 (fable_utils.erl:268)
fable_string:join/2                             (fable_string.erl:171)
```

## Test plan

- [x] Quicktest reproduces the original crash before the fix; returns `"Hello"` after.
- [x] Non-ASCII handled correctly: `"über"` enumerates as 4 codepoints (verified raw output `<<"ü-b-e-r">>`, 8 bytes), not 5 bytes.
- [x] New regression tests in `tests/Beam/StringTests.fs` covering `Seq.mapi`, `Seq.map`, `Seq.toList`, `Seq.length` over strings.
- [x] Full BEAM suite green: 2441 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)