### PR TITLE
fix(python): avoid duplicate captured argument in hoisted guards (#4610)

### DIFF
--- a/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
@@ -3007,6 +3007,16 @@ let transformFunction
     let cleanName (input: string) =
         Regex.Replace(input, @"_mut(_\d+)?$", "")
 
+    // Names of this function's own arguments. TCO capture parameters must not
+    // collide with these, otherwise we emit a duplicate argument (see #4610).
+    let ownArgNames =
+        args
+        |> List.map (fun id ->
+            let (Identifier name) = ident com ctx id
+            name
+        )
+        |> Set.ofList
+
     // For Python we need to append the TC-arguments to any declared (arrow) function inside the while-loop of the
     // TCO. We will set them as default values to themselves e.g `i=i` to capture the value and not the variable.
     let tcArgs, tcDefaults =
@@ -3019,6 +3029,11 @@ let transformFunction
 
                 match name with
                 | "tupled_arg_m" -> None // Remove these arguments (not sure why)
+                // Don't capture a TCO variable as a default parameter when this
+                // function already declares an argument with the same name: the
+                // local argument shadows the outer one and a duplicate parameter
+                // is a Python syntax error. See #4610.
+                | _ when ownArgNames.Contains name -> None
                 // Only capture TCO variables actually referenced in the function body.
                 // This avoids unnecessary default parameters on nested lambdas that don't
                 // use the outer TCO variables. See #3877.

--- a/tests/Python/TestPatternMatch.fs
+++ b/tests/Python/TestPatternMatch.fs
@@ -237,6 +237,22 @@ let ``test guard expression capture with 5 cases`` () =
     guardCaptureMultiple 5 |> equal "small: 5"
     guardCaptureMultiple 0 |> equal "zero or negative"
 
+// Guard that uses the bound value multiple times. The guard is hoisted into a
+// helper function and must not capture the outer argument as a duplicate
+// default parameter (see #4610).
+let mkTag (tag: string option) =
+    match tag with
+    | None -> ""
+    | Some s when s.StartsWith("!") && not (s.StartsWith("!!")) -> s + " "
+    | Some s -> "!<" + s + "> "
+
+[<Fact>]
+let ``test guard reusing binding does not duplicate captured argument`` () =
+    mkTag None |> equal ""
+    mkTag (Some "!foo") |> equal "!foo "
+    mkTag (Some "!!foo") |> equal "!<!!foo> "
+    mkTag (Some "foo") |> equal "!<foo> "
+
 // ----------------------------------------------------------------------------
 // 6. Nested Matching
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Fixes #4610. A pattern-match guard that reuses its bound value generates invalid Python with a duplicate argument:

```fsharp
let mkTag (tag: string option) =
    match tag with
    | None -> ""
    | Some s when s.StartsWith("!") && not (s.StartsWith("!!")) -> s + " "
    | Some s -> "!<" + s + "> "
```

```python
def _arrow0(tag: str, tag: Any=tag) -> bool:  # SyntaxError: duplicate argument 'tag'
```

This regressed in `5.0.0` (worked in `5.0.0-alpha.21`).

## Root cause

When a guard reuses its binding, it is hoisted into a helper function that already takes the scrutinee as its own parameter (`tag`). Fable's tail-call optimization in `transformFunction` appends the enclosing function's arguments as default-valued capture parameters (`x: Any=x`) to nested functions — and it appended `tag` again, even though the helper already declares it.

## Fix

Skip a TCO capture parameter when the function already declares an argument with the same name. The local argument shadows the outer one, so the capture is both redundant and a Python syntax error.

## Testing

- Added `test guard reusing binding does not duplicate captured argument` to `tests/Python/TestPatternMatch.fs` using the exact repro from the issue.
- Full Python test suite passes (2349 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)