### PR TITLE
fix(js/ts): throw an error when trying to set non-property memeber inside of `jsOptions`

### DIFF
--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -884,6 +884,24 @@ let makePojoFromLambda com (arg: Expr) =
 
                     // This is a nested property
                     groupByGetter updatedAcc tail
+
+                // Assigning to a non-property interface member (a plain abstract method
+                // declared without `with get, set`) is invalid F#: the compiler rejects it
+                // with `FS0971: Undefined value 'copyOfStruct'`. Fable's FCS fork doesn't
+                // surface that diagnostic, instead handing us the address of a throwaway
+                // local (`&copyOfStruct`) compiled as `let addr = FSharpRef(...) in addr.contents <- value`.
+                | Let(addrIdent,
+                      Call(Import(importInfo, _, _), callInfo, _, _),
+                      Set(IdentExpr setIdent, ExprSet _, _, _, r)) when
+                    importInfo.Selector = "FSharpRef"
+                    && List.contains "new" callInfo.Tags
+                    && setIdent.Name = addrIdent.Name
+                    ->
+                    "Cannot set a non-property member in 'jsOptions'. Declare the interface member as a settable property, e.g. `abstract X: T with get, set`."
+                    |> addError com [] r
+
+                    groupByGetter acc tail
+
                 | _ -> groupByGetter acc tail
 
         let root = groupByGetter (MakePojoFromLambdaContext("/")) flattened

--- a/tests/Integration/Compiler/CompilerMessagesTests.fs
+++ b/tests/Integration/Compiler/CompilerMessagesTests.fs
@@ -43,4 +43,36 @@ let tests =
       |> Assert.Exists.warningWith "Incomplete pattern matches on this expression"
       |> Assert.Exists.warningWith "The result of this expression has type 'int' and is implicitly ignored."
       |> ignore
+
+    testCase "Setting a non-property member in jsOptions results in specific error" <| fun _ ->
+      let source =
+        """
+open Fable.Core.JsInterop
+
+type Response =
+    abstract fn: int -> int
+    abstract prop: bool with get, set
+
+let res = jsOptions<Response> (fun o -> o.fn <- (fun i -> i))
+"""
+      compile source
+      |> Assert.Exists.errorWith "Cannot set a non-property member in 'jsOptions'"
+      |> ignore
+
+    testCase "Setting only settable properties in jsOptions succeeds" <| fun _ ->
+      let source =
+        """
+open Fable.Core.JsInterop
+
+type Response =
+    abstract fnProp: (int -> int) with get, set
+    abstract prop: bool with get, set
+
+let res = jsOptions<Response> (fun o ->
+    o.fnProp <- (fun i -> i)
+    o.prop <- false)
+"""
+      compile source
+      |> Assert.Is.success
+      |> ignore
   ]


### PR DESCRIPTION
Fix #3861