### PR TITLE
fix(beam): collapse array-literal process-dict ref round-trips in FFI/Emit calls

### DIFF
--- a/src/Fable.Transforms/Beam/FABLE-BEAM.md
+++ b/src/Fable.Transforms/Beam/FABLE-BEAM.md
@@ -1000,6 +1000,17 @@ alone eliminates the single hardest piece of the Fable.Python runtime.
   `fable_utils:new_ref([...])`. `derefArr`/`wrapArr` helpers in Replacements convert
   between refs and plain lists for bulk operations. Binary comparison operators on arrays
   use `fable_comparison:compare(A, B) op 0`. TypeTest for arrays uses `is_reference`.
+  When an array *literal* flows directly into an FFI/Emit binding that derefs its
+  argument (e.g. `maps:from_list(erlang:get($0))`), the naive output is
+  `...erlang:get(fable_utils:new_ref([...]))` — a pointless process-dict round-trip
+  on an immutable literal (it also leaks an un-erased process-dict entry).
+  `simplifyArrayRefDerefs` in `Fable2Beam.fs` cancels it on the Beam AST when
+  building an `Emit` node: if an argument is an inline `new_ref(list)` and *every*
+  occurrence of its `$N` placeholder in the macro template is deref-wrapped
+  (`erlang:get($N)`/`get($N)`), the deref is dropped from the template and the
+  underlying list is passed directly. Gating on the argument's AST shape (rather than
+  parsing rendered Erlang) keeps it robust; a ref-typed *variable* (a bound/mutable
+  array) keeps its deref.
 - **Byte arrays via atomics**: Byte arrays (`Array<byte>`) use Erlang's `atomics` module
   for true O(1) mutable read/write. Represented as `{byte_array, Size, AtomicsRef}` tuples.
   Runtime helpers in `fable_utils.erl` handle both direct tuples and process-dict

--- a/src/Fable.Transforms/Beam/Fable2Beam.fs
+++ b/src/Fable.Transforms/Beam/Fable2Beam.fs
@@ -19,6 +19,44 @@ let rec mustWrapOption =
     | Option _ -> true
     | _ -> false
 
+/// Simplify the process-dict ref round-trip that arises when an immutable array
+/// *literal* is passed to an FFI/Emit binding that immediately derefs it.
+///
+/// Fable-BEAM materialises an array literal as a fresh, inline process-dict ref
+/// (`fable_utils:new_ref([...])`). A binding that reads it back with `erlang:get($N)`
+/// (or bare `get($N)`) therefore produces `erlang:get(fable_utils:new_ref([...]))` —
+/// a round-trip that yields the literal straight back while leaking a never-erased
+/// process-dict entry.
+///
+/// This is recognised on the Beam AST: when argument N is an inline `new_ref(list)`
+/// and *every* occurrence of `$N` in the (short, authored) macro template is wrapped
+/// by a deref, the deref is dropped from the template and the underlying list is
+/// passed directly. Gating on the argument's AST shape — instead of parsing rendered
+/// Erlang — keeps this robust; a ref-typed *variable* (a bound/mutable array) is left
+/// untouched, so its deref is preserved.
+let private simplifyArrayRefDerefs (macro: string) (args: Beam.ErlExpr list) : string * Beam.ErlExpr list =
+    let folder (macroAcc: string, argsAcc) (i, arg) =
+        match arg with
+        | Beam.ErlExpr.Call(Some "fable_utils", "new_ref", [ inner ]) ->
+            let ph = $"$%d{i}"
+            // A control-char sentinel (never present in a macro template) marks the
+            // deref-wrapped placeholders. `erlang:get` is replaced first so its inner
+            // `get(` isn't consumed by the bare form below.
+            let sentinel = "\u0000"
+
+            let stripped =
+                macroAcc.Replace($"erlang:get(%s{ph})", sentinel).Replace($"get(%s{ph})", sentinel)
+
+            // Collapse only when the placeholder was present and every occurrence was
+            // deref-wrapped — a surviving bare `$N` means some use site still needs the ref.
+            if stripped.Contains(sentinel) && not (stripped.Contains(ph)) then
+                stripped.Replace(sentinel, ph), argsAcc @ [ inner ]
+            else
+                macroAcc, argsAcc @ [ arg ]
+        | _ -> macroAcc, argsAcc @ [ arg ]
+
+    args |> List.indexed |> List.fold folder (macro, [])
+
 let unwrapOptionalArg (arg: Fable.Expr) =
     match arg with
     | Fable.Value(Fable.NewOption(Some inner, _, _), _) -> inner
@@ -741,7 +779,8 @@ let rec transformExpr (com: IBeamCompiler) (ctx: Context) (expr: Expr) : Beam.Er
             transformReceive com ctx emitInfo typ
         else
             let args = emitInfo.CallInfo.Args |> List.map (transformExpr com ctx)
-            Beam.ErlExpr.Emit(emitInfo.Macro, args)
+            let macro, args = simplifyArrayRefDerefs emitInfo.Macro args
+            Beam.ErlExpr.Emit(macro, args)
 
     | TryCatch(body, catch_, finalizer, _range) ->
         let erlBody = transformExpr com ctx body

--- a/tests/Beam/InteropTests.fs
+++ b/tests/Beam/InteropTests.fs
@@ -121,6 +121,16 @@ let boolToString (x: bool) : string = nativeOnly
 [<Emit("case $0 of undefined -> <<\"none\">>; Value -> Value end")>]
 let emitWithValueCaseVar (x: string option) : string = nativeOnly
 
+// FFI binding that derefs its array argument. Fable-BEAM represents arrays as
+// process-dict refs, so an array literal passed here would otherwise generate a
+// `erlang:get(fable_utils:new_ref([...]))` round-trip; the compiler must collapse
+// that to a plain list so the BIF receives `[{...}]` directly.
+[<Emit("maps:from_list(erlang:get($0))")>]
+let mapFromPairs (pairs: (string * int) array) : obj = nativeOnly
+
+[<Emit("maps:get($0, $1)")>]
+let mapGet (key: string) (m: obj) : int = nativeOnly
+
 #endif
 
 // ============================================================
@@ -176,6 +186,17 @@ let ``test emitErlExpr can call Erlang functions`` () =
 #if FABLE_COMPILER
     let result: int = emitErlExpr (3, 4) "erlang:max($0, $1)"
     equal 4 result
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test array literal passed to deref FFI binding round-trips correctly`` () =
+#if FABLE_COMPILER
+    // The literal flows straight into maps:from_list without a process-dict ref.
+    let m = mapFromPairs [| ("a", 1); ("b", 2) |]
+    equal 1 (mapGet "a" m)
+    equal 2 (mapGet "b" m)
 #else
     ()
 #endif


### PR DESCRIPTION
## Problem

Fable-BEAM represents F# arrays as process-dictionary refs (`fable_utils:new_ref(...)`), so any array-typed value handed to an FFI BIF must be read back with `erlang:get(...)`. When an **array literal** is passed directly to an FFI/Emit binding that derefs its argument — e.g. `[<Emit("maps:from_list(erlang:get($0))")>]` — the compiler emits a pointless round-trip:

```erlang
maps:from_list(erlang:get(fable_utils:new_ref([{<<"content-type">>, <<"text/html">>}])))
```

It allocates a process-dict ref on every call for an immutable literal that never needed mutable-array semantics (and leaks a never-erased process-dict entry). A hand-written handler just writes `maps:from_list([{<<"content-type">>, <<"text/html">>}])`.

Reported by a consumer migrating Fable.Actor's timeflies-beam example to the typed Cowboy API.

## Approach

`fable_utils:new_ref(X)` stores `X` under a fresh inline reference and returns it; an immediately-applied `erlang:get` reads it straight back, so `get(new_ref(X))` ≡ `X`.

This is recognised **on the Beam AST** in `simplifyArrayRefDerefs` (`Fable2Beam.fs`) when an `Emit` node is built: when an argument is an inline `new_ref(list)` **and every occurrence** of its `$N` placeholder in the (short, authored) macro template is deref-wrapped (`erlang:get($N)` / `get($N)`), the deref is stripped from the template and the underlying list is passed directly.

Gating on the **argument's AST shape** — rather than scanning rendered Erlang with balanced-paren matching — keeps it robust:
- A ref-typed **variable** (a bound/mutable array) is left untouched, so its deref is preserved (verified: `maps:from_list(erlang:get(Arr))`).
- The "every occurrence wrapped" check means macros like `put($0, get($0) + 1)` (where `$0` also appears unwrapped) are never miscompiled.
- Lowering array literals to plain lists at `NewArray` was rejected: it would break every binding that derefs with `erlang:get($0)` (you'd get `erlang:get([...])` → `undefined`).

This covers user FFI bindings **and** Fable's own deref-based replacements (`maps:keys`/`values`/`to_list`, `Array.sum`/`min`/`max`/`contains`, `Set.ofArray`, `Map.ofArray`, …) when given literals. Generated output now matches a hand-written handler:

```erlang
maps:from_list([{<<"content-type"/utf8>>, <<"text/html"/utf8>>}])
```

## Changes

- **`Fable2Beam.fs`** — added `simplifyArrayRefDerefs`, applied to the args/macro when constructing `Emit` nodes.
- **`tests/Beam/InteropTests.fs`** — regression test feeding a literal array to a deref-style Emit binding.
- **`FABLE-BEAM.md`** — documented the behavior.

## Testing

Full BEAM suite passes: **2443 passed, 0 failed** (including the new test). Quicktest-verified all paths: `lists:sum([1,2,3])`, `maps:from_list([{...},{...}])`, and a bound+mutated array still emitting `maps:from_list(erlang:get(Arr))`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)