### PR TITLE
fix(beam): make Emit $N substitution a single left-to-right pass

### DIFF
--- a/src/Fable.Transforms/Beam/ErlangPrinter.fs
+++ b/src/Fable.Transforms/Beam/ErlangPrinter.fs
@@ -466,15 +466,32 @@ module Output =
             sb.Append("end") |> ignore
 
         | Emit(template, args) ->
-            // Substitute $0, $1, etc. with printed argument expressions
-            let mutable result = template
+            // Substitute $0, $1, etc. with printed argument expressions.
+            // Done in a single left-to-right pass so that (a) `$1` does not
+            // corrupt `$10` (the full integer index is parsed) and (b) a `$N`
+            // sequence appearing inside an already-substituted argument (e.g. a
+            // string literal containing "$1") is not re-substituted.
+            let printedArgs =
+                args
+                |> List.map (fun arg ->
+                    let argSb = System.Text.StringBuilder()
+                    printExpr argSb indent arg
+                    argSb.ToString()
+                )
+                |> List.toArray
 
-            args
-            |> List.iteri (fun i arg ->
-                let argSb = System.Text.StringBuilder()
-                printExpr argSb indent arg
-                result <- result.Replace($"$%d{i}", argSb.ToString())
-            )
+            let result =
+                System.Text.RegularExpressions.Regex.Replace(
+                    template,
+                    @"\$\d+",
+                    fun m ->
+                        let idx = int (m.Value.Substring(1))
+
+                        match Array.tryItem idx printedArgs with
+                        | Some printed -> printed
+                        // Out-of-range placeholder: leave the literal text untouched.
+                        | None -> m.Value
+                )
 
             // Erlang has flat variable scoping — variables bound inside case/begin
             // blocks leak into the surrounding function clause. When the same Emit

--- a/tests/Beam/InteropTests.fs
+++ b/tests/Beam/InteropTests.fs
@@ -20,6 +20,30 @@ let listLength (xs: 'a list) : int = nativeOnly
 [<Emit("<<$0/binary, $1/binary>>")>]
 let concatBinaries (a: string) (b: string) : string = nativeOnly
 
+// Substitution must be a single left-to-right pass:
+// a `$N` sequence appearing inside an already-substituted argument
+// (here the string literal "$1") must NOT be re-substituted.
+[<Emit("{$0, $1}")>]
+let emitPair (a: string) (b: int) : string * int = nativeOnly
+
+// `$1` substitution must not corrupt the `$10` placeholder (full integer
+// index is parsed, not a naive textual replace).
+[<Emit("[$0, $1, $10]")>]
+let emitIndex10
+    (a0: int)
+    (a1: int)
+    (a2: int)
+    (a3: int)
+    (a4: int)
+    (a5: int)
+    (a6: int)
+    (a7: int)
+    (a8: int)
+    (a9: int)
+    (a10: int)
+    : int list =
+    nativeOnly
+
 // ============================================================
 // Import tests
 // ============================================================
@@ -147,6 +171,27 @@ let ``test Emit can call Erlang BIFs`` () =
 let ``test Emit can use binary syntax`` () =
 #if FABLE_COMPILER
     concatBinaries "Hello" "World" |> equal "HelloWorld"
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test Emit does not re-substitute $N inside argument text`` () =
+#if FABLE_COMPILER
+    // The string argument "$1" must survive verbatim — the substituter must
+    // not replace the "$1" that appears inside the already-printed argument.
+    let a, b = emitPair "$1" 7
+    equal "$1" a
+    equal 7 b
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test Emit $1 does not corrupt $10 placeholder`` () =
+#if FABLE_COMPILER
+    let result = emitIndex10 0 99 2 3 4 5 6 7 8 9 1010
+    equal [ 0; 99; 1010 ] result
 #else
     ()
 #endif


### PR DESCRIPTION
## Problem

The Erlang/BEAM printer substituted `[<Emit>]` placeholders with naive sequential `String.Replace($"$%d{i}", ...)`. Iterating one placeholder at a time over the mutated string has two correctness bugs:

1. **`$1` corrupts `$10`** (textual prefix match). Replacing `$1` also matches the `$1` prefix of `$10`:
   ```fsharp
   [<Emit("[$0, $1, $10]")>]
   let f a0 a1 ... a10 = nativeOnly
   f 0 99 ... 1010   // produced [0,99,990] instead of [0,99,1010]
   ```
2. **A `$N` sequence inside an already-substituted argument gets re-substituted**:
   ```fsharp
   [<Emit("{$0, $1}")>]
   let pair (a: string) (b: int) = nativeOnly
   pair "$1" 7       // produced {<<"7">>, 7} instead of {<<"$1">>, 7}
   ```

## Fix

Replace the loop with a single `Regex.Replace` over `\$\d+` — the same approach the JS printer (`BabelPrinter.fs`) already uses:

```fsharp
let result =
    System.Text.RegularExpressions.Regex.Replace(
        template,
        @"\$\d+",
        fun m ->
            let idx = int (m.Value.Substring(1))
            match Array.tryItem idx printedArgs with
            | Some printed -> printed
            | None -> m.Value   // out-of-range placeholder: leave literal text untouched
    )
```

This fixes both bugs by construction: `\d+` matches the full integer index (so `$10` isn't clipped by `$1`), and `Regex.Replace` evaluates matches against the original template only, so a `$N` appearing inside a substituted argument is never re-scanned.

Scope is limited to the Erlang printer (`ErlangPrinter.fs`); no other backend is touched.

## Tests

Added two regression tests in `tests/Beam/InteropTests.fs` covering both bugs. Full BEAM suite passes (**2444 passed, 0 failed**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)