### PR TITLE
ci: only run publish-pypi on real releases, not every main merge

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,9 +1,6 @@
 name: Publish to PyPI
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
   release:
     types: [published]


### PR DESCRIPTION
## Summary

`publish-pypi.yml` triggered on every push to `main`, kicking off the full cross-platform wheel build (linux/musllinux/windows/macos/sdist) plus the test matrix — on every merge. The actual `release` publish job was already gated to `release`/`workflow_dispatch`, so pushes built and tested everything only to skip publishing. Wasted CI on every merge.

This removes the `push: branches: [main]` trigger so the workflow only runs on:

- `release: [published]` — a real new release (the intended path)
- `workflow_dispatch` — manual runs

Ordinary build/PR validation is still covered by `build.yml`, which runs on push to `main` and PRs.

Note: version is derived via `dunamai ... --latest-tag`, so releases should continue to be cut by publishing a GitHub Release (which creates the tag) — exactly the `release: published` event that still triggers this workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)