### PR TITLE
fix(js/ts): make Exception.ToString() return the message instead of "Exception"

### DIFF
--- a/src/fable-library-ts/Util.ts
+++ b/src/fable-library-ts/Util.ts
@@ -84,6 +84,10 @@ export class Exception {
   constructor(msg?: string) {
     this.message = msg ?? "";
   }
+
+  toString() {
+    return this.message;
+  }
 }
 
 export function isException(x: any) {

--- a/tests/Js/Main/TypeTests.fs
+++ b/tests/Js/Main/TypeTests.fs
@@ -1393,6 +1393,15 @@ let tests =
         | ex -> (false, "unknown", 0.)
         |> equal (true, "Code: 5", 5.5)
 
+    testCase "Exception ToString contains the message" <| fun () -> // See #4197
+        let msg =
+            try
+                failwith "test message"
+                ""
+            with ex -> ex.ToString()
+        // .NET returns "System.Exception: test message", Fable returns just the message
+        msg.Contains("test message") |> equal true
+
     testCase "reraise works" <| fun () ->
         try
             try


### PR DESCRIPTION
## Fix: `Exception.ToString()` returns `"Exception"` instead of the message (JS/TS)

### Problem

Since v2, calling `ToString()` on a caught exception prints the literal string `"Exception"` instead of the message:

```fsharp
try
    failwith "boom"
with ex ->
    Browser.Dom.console.log(ex.ToString())
// v1: "boom"  →  v2: "Exception"
```

### Cause

PR #4197 ("[JS/TS] Replace Error with Exception") changed `System.Exception` so it compiles to Fable's own `Exception` class (in `Util.ts`) rather than JavaScript's native `Error`. That class — intentionally not derived from `Error` for performance (#2160) — has no `toString()` method, so `ex.ToString()` (routed through `Types.toString`) falls back to returning the constructor name. Previously, native `Error.prototype.toString()` returned `"<name>: <message>"`, so the message was visible.

### Fix

Add a `toString()` to the `Exception` class returning `this.message`. This matches the Dart (`ExceptionBase.toString() => this.message`) and Python (native `__str__`) targets, which were already correct. F# `exception` declarations (`FSharpException`) keep their own record-formatting `toString()`, and the BCL exception subclasses in `System.fs` inherit the new behavior.

Scoped to the JS/TS runtime library only; no compiler changes needed.

### Testing

- Added a regression test in `tests/Js/Main/TypeTests.fs` asserting `ex.ToString()` contains the message (passes on both .NET and Fable).
- Verified via quicktest (`ex.ToString()` now prints `boom`) and the full JS test suite (no regressions).