### PR TITLE
refactor(python): rename FormattableString field from str to fmt

### DIFF
--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -1678,8 +1678,8 @@ let formattableString
     (args: Expr list)
     =
     match i.CompiledName, thisArg, args with
-    | "Create", None, [ str; args ] -> objExpr [ "str", str; "args", args ] |> Some
-    | "get_Format", Some x, _ -> getFieldWith r t x "str" |> Some
+    | "Create", None, [ str; args ] -> objExpr [ "fmt", str; "args", args ] |> Some
+    | "get_Format", Some x, _ -> getFieldWith r t x "fmt" |> Some
     | "get_ArgumentCount", Some x, _ ->
         // Use int32(len()) to ensure consistent return type
         let lenExpr =


### PR DESCRIPTION
## Problem

The Python representation of `FormattableString` used a field literally named `str`, so a `$"...{x}..."` interpolation typed as `FormattableString` compiled to an object expression with a `@property def str`:

```python
class ObjectExpr2405:
    @property
    def str(self, __unit: Unit=UNIT) -> str:   # <- field named `str`
        return "You owe: {0:N5} {1} {2}"
    @property
    def args(self, __unit: Unit=UNIT) -> Array[Any]:
        return Array[Any]([int32(100), int32.THREE, True])
```

This **runs correctly** and Pyright accepts it — under PEP 563 (`from __future__ import annotations`) the `-> str` return annotation resolves to the builtin (`get_type_hints` confirms `{'return': <class 'str'>}`), and the property never shadows the builtin since attribute names live in a separate namespace.

However, Astral's [`ty`](https://github.com/astral-sh/ty) resolves the annotation against the class-scoped `str` property and reports a false positive:

```
error[invalid-type-form]: Variable of type `property` is not allowed in a return type annotation
    --> temp/tests/Python/test_string.py:1039:45
1039 |         def str(self, __unit: Unit=UNIT) -> str:
```

## Fix

Rename the internal field `str` → `fmt` in the Python `formattableString` replacement. The field is internal to that one function (written by `Create`, read by `get_Format`), so the change is fully self-contained — `GetArgument`/`GetArguments`/`ArgumentCount` use the separate `args` field, and `GetStrings()` is JS-only.

## Verification

- All 2350 Python tests pass (`./build.sh test python`)
- `ty check temp/tests/Python/test_string.py` → `All checks passed!`
- Pyright remains clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)