### PR TITLE
feat(beam): support Erlang/BEAM target in standalone compiler

### DIFF
--- a/src/Fable.Transforms/Beam/Fable2Beam.fs
+++ b/src/Fable.Transforms/Beam/Fable2Beam.fs
@@ -170,13 +170,13 @@ let resolveImportModuleName (com: IBeamCompiler) (importPath: string) =
     // (e.g., Agent/Types.fs vs Reactive/Types.fs) would both produce module name "types"
     // and the import would be incorrectly treated as a local (self-recursive) call.
     let resolvedImportPath =
-        if System.IO.Path.IsPathRooted(importPath) then
-            System.IO.Path.GetFullPath(importPath)
+        if Path.IsPathRooted(importPath) then
+            Path.GetFullPath(importPath)
         else
-            let currentDir = System.IO.Path.GetDirectoryName(com.CurrentFile)
-            System.IO.Path.GetFullPath(System.IO.Path.Combine(currentDir, importPath))
+            let currentDir = Path.GetDirectoryName(com.CurrentFile)
+            Path.GetFullPath(Path.Combine(currentDir, importPath))
 
-    let currentFileFull = System.IO.Path.GetFullPath(com.CurrentFile)
+    let currentFileFull = Path.GetFullPath(com.CurrentFile)
 
     if resolvedImportPath = currentFileFull then
         None

--- a/src/Fable.Transforms/Beam/Prelude.fs
+++ b/src/Fable.Transforms/Beam/Prelude.fs
@@ -87,7 +87,7 @@ module Naming =
         |> checkErlKeywords
 
     let moduleNameFromFile (filePath: string) =
-        System.IO.Path.GetFileNameWithoutExtension(filePath)
+        Fable.Path.GetFileNameWithoutExtension(filePath)
         |> fun s -> s.Replace(".", "_").Replace("-", "_")
         |> Fable.Naming.applyCaseRule Fable.Core.CaseRules.SnakeCase
 

--- a/src/fable-standalone/src/Fable.Standalone.fsproj
+++ b/src/fable-standalone/src/Fable.Standalone.fsproj
@@ -34,6 +34,7 @@
     <Compile Include="../../Fable.Transforms/Python/Replacements.fs" />
     <Compile Include="../../Fable.Transforms/Rust/Replacements.fs" />
     <Compile Include="../../Fable.Transforms/Dart/Replacements.fs" />
+    <Compile Include="../../Fable.Transforms/Beam/Prelude.fs" />
     <Compile Include="../../Fable.Transforms/Beam/Beam.AST.fs" />
     <Compile Include="../../Fable.Transforms/Beam/Replacements.fs" />
     <Compile Include="../../Fable.Transforms/Replacements.fs" />
@@ -61,6 +62,10 @@
     <Compile Include="../../Fable.Transforms/Dart/DartPrinter.fs" />
     <Compile Include="../../Fable.Transforms/Rust/RustPrinter.fs" />
     <Compile Include="../../Fable.Transforms/Rust/Fable2Rust.fs" />
+    <Compile Include="../../Fable.Transforms/Beam/Fable2Beam.Util.fs" />
+    <Compile Include="../../Fable.Transforms/Beam/Fable2Beam.Reflection.fs" />
+    <Compile Include="../../Fable.Transforms/Beam/Fable2Beam.fs" />
+    <Compile Include="../../Fable.Transforms/Beam/ErlangPrinter.fs" />
     <Compile Include="../../Fable.Transforms/State.fs" />
 
     <!-- Fable.Standalone -->

--- a/src/fable-standalone/src/Main.fs
+++ b/src/fable-standalone/src/Main.fs
@@ -343,6 +343,12 @@ type RustResult(ast: Rust.AST.Types.Crate, errors) =
     interface IFableResult with
         member _.FableErrors = errors
 
+type BeamResult(ast: Fable.AST.Beam.ErlModule, errors) =
+    member _.Ast = ast
+
+    interface IFableResult with
+        member _.FableErrors = errors
+
 let transformToFableAst (com: Compiler) : Fable.File =
     let fileName = com.CurrentFile
 
@@ -379,7 +385,9 @@ let transformToTargetAst (com: CompilerImpl) (fableAst: Fable.File) : IFableResu
     | Rust ->
         let ast = Rust.Fable2Rust.Compiler.transformFile com fableAst
         upcast RustResult(ast, errors)
-    | Beam -> failwith "Beam target is not supported in the standalone compiler"
+    | Beam ->
+        let ast = Fable.Transforms.Beam.Compiler.transformFile com fableAst
+        upcast BeamResult(ast, errors)
 
 let compileToTargetAst (results: IParseAndCheckResults) fileName fableLibrary typedArrays language : IFableResult =
     let res = results :?> ParseAndCheckResults
@@ -415,6 +423,8 @@ let getLanguage (language: string) =
     | "dart" -> Dart
     | "rs"
     | "rust" -> Rust
+    | "beam"
+    | "erlang" -> Beam
     | _ -> failwithf "Unsupported language: %s" language
 
 let init () =
@@ -474,6 +484,7 @@ let init () =
             | :? PhpResult as php -> PhpPrinter.run writer php.Ast
             | :? PythonResult as python -> PythonPrinter.run writer python.Ast
             | :? RustResult as rust -> Rust.RustPrinter.run writer rust.Ast
+            | :? BeamResult as beam -> ErlangPrinter.run writer beam.Ast
             | _ -> failwith "Unexpected Fable result"
 
         member _.FSharpAstToString(results: IParseAndCheckResults, fileName: string) =

--- a/src/fable-standalone/src/Worker/Worker.fs
+++ b/src/fable-standalone/src/Worker/Worker.fs
@@ -55,6 +55,22 @@ type State =
         CurrentResults: Map<string, IParseAndCheckResults>
     }
 
+/// Map a REPL language string to its fable-library directory name (used as the
+/// base path for generated library imports).
+let private fableLibraryDir (language: string) =
+    match language.ToLowerInvariant() with
+    | "ts"
+    | "typescript" -> "fable-library-ts"
+    | "py"
+    | "python" -> "fable-library-py"
+    | "php" -> "fable-library-php"
+    | "dart" -> "fable-library-dart"
+    | "rs"
+    | "rust" -> "fable-library-rust"
+    | "beam"
+    | "erlang" -> "fable-library-beam"
+    | _ -> "fable-library-js"
+
 type SourceWriter(sourceMaps: bool, language: string) =
     let sb = System.Text.StringBuilder()
 
@@ -164,7 +180,7 @@ let private compileCode fable fileName fsharpNames fsharpCodes language otherFSh
                         measureTime
                             (fun () ->
                                 fable.Manager.CompileToTargetAst(
-                                    "fable-library-js",
+                                    fableLibraryDir language,
                                     parseResults,
                                     fileName,
                                     typedArrays,


### PR DESCRIPTION
## Summary

Wires the BEAM/Erlang code generator into the **Fable.Standalone** compiler that powers the online REPL, so Erlang/BEAM can be selected as a target like the other languages (JS, TS, Python, Rust, Dart, PHP). Previously the standalone compiler explicitly threw `"Beam target is not supported in the standalone compiler"`.

The heavyweight BEAM steps (`erlc`, `erl`, rebar3 scaffolding) live in `Fable.Cli` and are **not** on the REPL path — like the other non-JS targets, the REPL only needs to *generate and display* source (only JavaScript is executed in-browser).

## Changes

- **`Fable.Standalone.fsproj`** — add the missing BEAM compile units (`Prelude.fs`, `Fable2Beam.Util.fs`, `Fable2Beam.Reflection.fs`, `Fable2Beam.fs`, `ErlangPrinter.fs`), matching the ordering in `Fable.Transforms.fsproj`.
- **`Main.fs`** — add `BeamResult`, the real `Beam` case in `transformToTargetAst`, `"beam"`/`"erlang"` in `getLanguage`, and the `BeamResult` case in `PrintTargetAst`.
- **`Worker/Worker.fs`** — replace the hardcoded `"fable-library-js"` with a target-aware `fableLibraryDir` mapping.
- **`Beam/Fable2Beam.fs` & `Beam/Prelude.fs`** — the standalone compiler is itself transpiled by Fable to JS, so the BEAM generator must avoid BCL APIs Fable doesn't support in-browser. Replace `System.IO.Path.*` (`IsPathRooted`/`GetFullPath`/`Combine`/`GetDirectoryName`/`GetFileNameWithoutExtension`) with the Fable-compatible `Fable.Path` module (which `Fable2Babel` already uses). No behavioural change on the .NET CLI path — those helpers delegate to `System.IO.Path` outside `FABLE_COMPILER`.

## Testing

- `dotnet build` of both `Fable.Standalone.fsproj` and `Worker.fsproj` — 0 errors.
- `./build.sh standalone` (full Fable→JS transpile + rollup/esbuild bundle) — 0 Fable errors; `dist/bundle.min.js` and `dist/worker.min.js` generated.

## Out of scope

The external `fable.io` REPL **UI** (separate repo) still needs an "Erlang/BEAM" dropdown entry and read-only `.erl` source display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)