### PR TITLE
fix: add type specifiers to interpolated strings

### DIFF
--- a/src/Fable.Compiler/ProjectCracker.fs
+++ b/src/Fable.Compiler/ProjectCracker.fs
@@ -706,7 +706,7 @@ let getFableLibraryPath (opts: CrackerOptions) (shouldCopy: bool) =
                 |}
             |> Option.defaultWith (fun () ->
                 Fable.FableError
-                    $"Cannot find [temp/]{buildDir} from {baseDir}.\nPlease, make sure you build {buildDir}"
+                    $"Cannot find [temp/]%s{buildDir} from %s{baseDir}.\nPlease, make sure you build %s{buildDir}"
                 |> raise
             )
 
@@ -786,7 +786,7 @@ let loadPrecompiledInfo (opts: CrackerOptions) otherOptions sourceFiles =
         // Check if precompiled compiler version and options match
         if info.CompilerVersion <> Literals.VERSION then
             Fable.FableError(
-                $"Library was precompiled using Fable v{info.CompilerVersion} but you're using v{Literals.VERSION}. Please use same version."
+                $"Library was precompiled using Fable v%s{info.CompilerVersion} but you're using v%s{Literals.VERSION}. Please use same version."
             )
             |> raise
 
@@ -816,7 +816,7 @@ let loadPrecompiledInfo (opts: CrackerOptions) otherOptions sourceFiles =
                         |> List.map (fun f -> "    " + File.relPathToCurDir f)
                         |> String.concat Log.newLine
                     // TODO: This should likely be an error but make it a warning for now
-                    Log.warning ($"Detected outdated files in precompiled lib:{Log.newLine}{outdated}")
+                    Log.warning ($"Detected outdated files in precompiled lib:%s{Log.newLine}%s{outdated}")
         with er ->
             Log.warning ("Cannot check timestamp of precompiled files: " + er.Message)
 
@@ -849,7 +849,7 @@ let getFullProjectOpts (resolver: ProjectCrackerResolver) (opts: CrackerOptions)
                 if not isOlder then
                     Log.verbose (
                         lazy
-                            $"Cached project info ({cacheTimestamp}) will be discarded because {File.relPathToCurDir filePath} ({fileTimestamp}) is newer"
+                            $"Cached project info (%O{cacheTimestamp}) will be discarded because %s{File.relPathToCurDir filePath} (%O{fileTimestamp}) is newer"
                     )
 
                 isOlder
@@ -911,7 +911,7 @@ let getFullProjectOpts (resolver: ProjectCrackerResolver) (opts: CrackerOptions)
                                 else
                                     "Debug"
 
-                            $"Won't reuse compiled files because last compilation was for {otherMode} mode"
+                            $"Won't reuse compiled files because last compilation was for %s{otherMode} mode"
                     )
 
                 isMostRecent

--- a/src/Fable.Compiler/Util.fs
+++ b/src/Fable.Compiler/Util.fs
@@ -316,16 +316,16 @@ module File =
                             let creationTime = File.GetCreationTime(lockFile)
 
                             if (DateTime.Now - creationTime).TotalMilliseconds > float timeoutMs then
-                                Log.always $"Found old lock file {relPathToCurDir lockFile} ({creationTime})"
+                                Log.always $"Found old lock file %s{relPathToCurDir lockFile} (%O{creationTime})"
 
                                 try
                                     File.Delete(lockFile)
                                 with _ ->
                                     ()
                             else
-                                Log.always $"Directory is locked, waiting for max {timeoutMs / 1000}s"
+                                Log.always $"Directory is locked, waiting for max %d{timeoutMs / 1000}s"
 
-                                Log.always $"If compiler gets stuck, delete {relPathToCurDir lockFile}"
+                                Log.always $"If compiler gets stuck, delete %s{relPathToCurDir lockFile}"
                         elif waitedMs >= timeoutMs then
                             Fable.AST.Fable.FableError "LockTimeOut" |> raise
 
@@ -348,7 +348,7 @@ module File =
                 if fileCreated then
                     File.Delete(lockFile)
             with e ->
-                Log.always $"Could not delete lock file: {lockFile} ({e.Message})"
+                Log.always $"Could not delete lock file: %s{lockFile} (%s{e.Message})"
 
 [<RequireQualifiedAccess>]
 module Process =
@@ -388,7 +388,7 @@ module Process =
     let findInPath (exec: string) =
         match tryFindInPath exec with
         | Some exec -> exec
-        | None -> failwith $"Cannot find {exec} in PATH"
+        | None -> failwith $"Cannot find %s{exec} in PATH"
 
     let getCurrentAssembly () = typeof<TypeInThisAssembly>.Assembly
 
@@ -413,7 +413,7 @@ module Process =
         // TODO: We should use cliArgs.RootDir instead of Directory.GetCurrentDirectory here but it's only informative
         // so let's leave it as is for now to avoid having to pass the cliArgs through all the call sites
         if not redirectOutput then
-            Log.always $"""{File.relPathToCurDir workingDir}> {exePath} {String.concat " " args}"""
+            Log.always $"""%s{File.relPathToCurDir workingDir}> %s{exePath} %s{String.concat " " args}"""
 
         let psi = ProcessStartInfo(exePath)
 
@@ -616,7 +616,7 @@ module Imports =
             let importPath = Path.Combine(projDir, importPath)
             let targetDir = Path.GetDirectoryName(targetPath)
             getRelativePath targetDir importPath
-        | Some macro, _ -> failwith $"Unknown import macro: {macro}"
+        | Some macro, _ -> failwith $"Unknown import macro: %s{macro}"
         | None, None ->
             if isAbsolutePath importPath then
                 let sourceDir = Path.GetDirectoryName(sourcePath)
@@ -934,7 +934,7 @@ type PrecompiledInfoImpl(fableModulesDir: string, info: PrecompiledInfoJson) =
         IO.Path.Combine(fableModulesDir, "precompiled_info.json")
 
     static member GetInlineExprsPath(fableModulesDir, index: int) =
-        IO.Path.Combine(fableModulesDir, "inline_exprs", $"inline_exprs_{index}.json")
+        IO.Path.Combine(fableModulesDir, "inline_exprs", $"inline_exprs_%d{index}.json")
 
     static member Load(fableModulesDir: string) =
         try

--- a/src/Fable.Transforms/BabelPrinter.fs
+++ b/src/Fable.Transforms/BabelPrinter.fs
@@ -450,7 +450,7 @@ module PrinterExtensions =
                 |> List.iter (
                     function
                     | _, NullOrUndefinedOrVoid -> ()
-                    | key, StringConstant value -> printProp (fun () -> printer.Print($"{key}=\"{value}\""))
+                    | key, StringConstant value -> printProp (fun () -> printer.Print($"%s{key}=\"%s{value}\""))
                     | key, value ->
                         printProp (fun () ->
                             printer.Print(key + "={")

--- a/src/Fable.Transforms/Dart/Fable2Dart.fs
+++ b/src/Fable.Transforms/Dart/Fable2Dart.fs
@@ -180,7 +180,7 @@ module Util =
             match transformAndCaptureExpr com ctx entRef with
             | [], IdentExpression ident -> Some ident
             | _ ->
-                addError com [] None $"Unexpected, entity ref for {ent.FullName} is not an identifier"
+                addError com [] None $"Unexpected, entity ref for %s{ent.FullName} is not an identifier"
 
                 None
         )
@@ -1956,17 +1956,17 @@ module Util =
             match transformCallArgs com ctx (CallInfo info) with
             | [], args -> args
             | _, args ->
-                $"Rewrite base arguments for {classDecl.Entity.FullName} so they can be compiled as Dart expressions"
+                $"Rewrite base arguments for %s{classDecl.Entity.FullName} so they can be compiled as Dart expressions"
                 |> addWarning com [] e.Range
 
                 args
         | Some(Fable.Value _ as e) ->
-            $"Ignoring base call for {classDecl.Entity.FullName}"
+            $"Ignoring base call for %s{classDecl.Entity.FullName}"
             |> addWarning com [] e.Range
 
             []
         | Some e ->
-            $"Unexpected base call for {classDecl.Entity.FullName}"
+            $"Unexpected base call for %s{classDecl.Entity.FullName}"
             |> addError com [] e.Range
 
             []
@@ -2316,7 +2316,7 @@ module Util =
                 let name =
                     match p.Name with
                     | Some name -> name
-                    | None -> $"arg{i}$"
+                    | None -> $"arg%d{i}$"
 
                 let t = transformType com ctx p.Type
                 FunctionArg(makeImmutableIdent t name) // TODO, isOptional=p.IsOptional, isNamed=p.IsNamed)
@@ -2391,7 +2391,7 @@ module Util =
         =
         match implementsIterable, baseType with
         | Some iterable, Some _ ->
-            $"Types implementing IEnumerable cannot inherit from another class: {classEnt.FullName}"
+            $"Types implementing IEnumerable cannot inherit from another class: %s{classEnt.FullName}"
             |> addError com [] None
 
             Some iterable

--- a/src/Fable.Transforms/Dart/Replacements.fs
+++ b/src/Fable.Transforms/Dart/Replacements.fs
@@ -640,7 +640,7 @@ let tryEntityIdent (com: Compiler) entFullName =
     | BuiltinDefinition(FSharpReference _) -> makeImportLib com MetaType "FSharpRef" "Types" |> Some
     | BuiltinDefinition(FSharpResult _) -> makeImportLib com MetaType "FSharpResult$2" "Result" |> Some
     | BuiltinDefinition(FSharpChoice genArgs) ->
-        let membName = $"FSharpChoice${List.length genArgs}"
+        let membName = $"FSharpChoice$%d{List.length genArgs}"
         makeImportLib com MetaType membName "Choice" |> Some
     // | BuiltinDefinition BclGuid -> jsTypeof "string" expr
     | BuiltinDefinition(BclHashSet _)
@@ -1387,7 +1387,7 @@ let strings (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr opt
     | "GetEnumerator", Some c, _ -> stringToCharSeq c |> getEnumerator com r t |> Some
     | ("Contains" | "StartsWith" | "EndsWith" as meth), Some c, arg :: _ ->
         if List.isMultiple args then
-            addWarning com ctx.InlinePath r $"String.{meth}: second argument is ignored"
+            addWarning com ctx.InlinePath r $"String.%s{meth}: second argument is ignored"
 
         Helper.InstanceCall(c, Naming.lowerFirst meth, t, [ arg ], ?loc = r) |> Some
     | ReplaceName [ "ToUpper", "toUpperCase"
@@ -3158,7 +3158,7 @@ let random (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr opti
     | meth, Some thisArg ->
         let meth =
             if meth = "Next" then
-                $"Next{List.length args}"
+                $"Next%d{List.length args}"
             else
                 meth
 
@@ -3273,7 +3273,7 @@ let regex com (ctx: Context) r t (i: CallInfo) (thisArg: Expr option) (args: Exp
         match thisArg, args with
         | Some thisArg, args ->
             if args.Length > 2 then
-                $"Regex.{meth} doesn't support more than 2 arguments"
+                $"Regex.%s{meth} doesn't support more than 2 arguments"
                 |> addError com ctx.InlinePath r
 
             thisArg :: args |> Some
@@ -4194,6 +4194,6 @@ let tryType typ =
         | FSharpMap(key, value) -> Some(Types.fsharpMap, maps, [ key; value ])
         | FSharpSet genArg -> Some(Types.fsharpSet, sets, [ genArg ])
         | FSharpResult(genArg1, genArg2) -> Some(Types.result, results, [ genArg1; genArg2 ])
-        | FSharpChoice genArgs -> Some($"{Types.choiceNonGeneric}`{List.length genArgs}", results, genArgs)
+        | FSharpChoice genArgs -> Some($"%s{Types.choiceNonGeneric}`%d{List.length genArgs}", results, genArgs)
         | FSharpReference genArg -> Some(Types.refCell, refCells, [ genArg ])
     | _ -> None

--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -2580,16 +2580,19 @@ module Util =
     let failReplace (com: IFableCompiler) ctx r (info: Fable.ReplaceCallInfo) (thisArg: Fable.Expr option) =
         let msg =
             if info.DeclaringEntityFullName.StartsWith("Fable.Core.", StringComparison.Ordinal) then
-                $"{info.DeclaringEntityFullName}.{info.CompiledName} is not supported, try updating fable tool"
+                $"%s{info.DeclaringEntityFullName}.%s{info.CompiledName} is not supported, try updating fable tool"
             else
                 com.WarnOnlyOnce(
                     "Fable only supports a subset of standard .NET API, please check https://fable.io/docs/dotnet/compatibility.html. For external libraries, check whether they are Fable-compatible in the package docs."
                 )
 
-                $"""{info.DeclaringEntityFullName}.{info.CompiledName}{if Option.isSome thisArg then
-                                                                           ""
-                                                                       else
-                                                                           " (static)"} is not supported by Fable"""
+                let staticSuffix =
+                    if Option.isSome thisArg then
+                        ""
+                    else
+                        " (static)"
+
+                $"%s{info.DeclaringEntityFullName}.%s{info.CompiledName}%s{staticSuffix} is not supported by Fable"
 
         msg |> addErrorAndReturnNull com ctx.InlinePath r
 

--- a/src/Fable.Transforms/FSharp2Fable.fs
+++ b/src/Fable.Transforms/FSharp2Fable.fs
@@ -111,7 +111,7 @@ let private transformNewUnion com ctx r fsType (unionCase: FSharpUnionCase) (arg
         match argExprs with
         | [] -> transformStringEnum rule unionCase
         | _ ->
-            $"StringEnum types cannot have fields: {tdef.TryFullName}"
+            $"StringEnum types cannot have fields: %O{tdef.TryFullName}"
             |> addErrorAndReturnNull com ctx.InlinePath r
 
     | OptionUnion(typ, isStruct) ->
@@ -723,7 +723,7 @@ let private transformExpr (com: IFableCompiler) (ctx: Context) appliedGenArgs fs
                 let! limit = transformExpr com ctx [] limit
                 let! body = transformExpr com newContext [] body
                 return makeForLoop r isUp ident start limit body
-            | _ -> return failwithf $"Unexpected loop {r}: %A{fsExpr}"
+            | _ -> return failwithf $"Unexpected loop %O{r}: %A{fsExpr}"
 
         | FSharpExprPatterns.WhileLoop(guardExpr, bodyExpr, _) ->
             let! guardExpr = transformExpr com ctx [] guardExpr
@@ -1686,7 +1686,7 @@ let private applyJsPyDecorators
             let parameters =
                 memb.CurriedParameterGroups
                 |> Seq.collect id
-                |> Seq.mapi (fun i p -> defaultArg p.Name $"arg{i}", makeType Map.empty p.Type)
+                |> Seq.mapi (fun i p -> defaultArg p.Name $"arg%d{i}", makeType Map.empty p.Type)
                 |> Seq.toList
 
             Replacements.Api.makeMethodInfo com None name parameters returnType
@@ -2760,7 +2760,7 @@ type FableCompiler(com: Compiler) =
         |> List.filter (fun (i, v) ->
             if ctx.CapturedBindings.Contains(i.Name) && canHaveSideEffects com v then
                 if isIdentUsed i.Name resolved then
-                    $"Inlined argument {i.Name} is being captured but is also used somewhere else. "
+                    $"Inlined argument %s{i.Name} is being captured but is also used somewhere else. "
                     + "There's a risk of double evaluation."
                     |> addWarning com [] i.Range
 

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -754,10 +754,10 @@ module Annotation =
         | Replacements.Util.FSharpMap(key, value) ->
             makeFableLibImportTypeAnnotation com ctx [ key; value ] "Map" "FSharpMap"
         | Replacements.Util.FSharpResult(ok, err) ->
-            $"FSharpResult$2{Util.UnionHelpers.UNION_SUFFIX}"
+            $"FSharpResult$2%s{Util.UnionHelpers.UNION_SUFFIX}"
             |> makeFableLibImportTypeAnnotation com ctx [ ok; err ] "Result"
         | Replacements.Util.FSharpChoice genArgs ->
-            $"FSharpChoice${List.length genArgs}{Util.UnionHelpers.UNION_SUFFIX}"
+            $"FSharpChoice$%d{List.length genArgs}%s{Util.UnionHelpers.UNION_SUFFIX}"
             |> makeFableLibImportTypeAnnotation com ctx genArgs "Choice"
         | Replacements.Util.FSharpReference genArg ->
             if isInRefOrAnyType com typ then
@@ -772,7 +772,7 @@ module Annotation =
             | _ -> argTypes
             |> List.mapi (fun i argType ->
                 FunctionTypeParam.functionTypeParam (
-                    Identifier.identifier ($"arg{i}"),
+                    Identifier.identifier ($"arg%d{i}"),
                     makeTypeAnnotation com ctx argType
                 )
             )
@@ -1034,7 +1034,7 @@ module Util =
                         if selector.StartsWith("*", StringComparison.Ordinal) then
                             selector
                         else
-                            $"default as {selector}"
+                            $"default as %s{selector}"
 
                     com.GetImportExpr(ctx, selector, path, r, noMangle = true) |> ignore
 
@@ -1631,7 +1631,7 @@ module Util =
                         Expression.callExpression (helperRef, values, typeArguments = typeParams)
                     | None -> callConstructor (Some case)
                 | None ->
-                    $"Unmatched union case tag: {tag} for {ent.FullName}" |> addWarning com [] r
+                    $"Unmatched union case tag: %d{tag} for %s{ent.FullName}" |> addWarning com [] r
 
                     callConstructor None
             else
@@ -2676,7 +2676,8 @@ but thanks to the optimisation done below we get
                 match List.tryItem tag ent.UnionCases with
                 | Some case -> Some case.Name
                 | None ->
-                    $"Unmatched union case tag: {tag} for {ent.FullName}" |> addWarning com [] range
+                    $"Unmatched union case tag: %d{tag} for %s{ent.FullName}"
+                    |> addWarning com [] range
 
                     None
             | _ -> None
@@ -4742,7 +4743,7 @@ but thanks to the optimisation done below we get
                     let noConflict = ctx.UsedNames.RootScope.Add(alias)
 
                     if not noConflict then
-                        com.WarnOnlyOnce($"Import {alias} conflicts with existing identifier in root scope")
+                        com.WarnOnlyOnce($"Import %s{alias} conflicts with existing identifier in root scope")
 
                     alias
                 else

--- a/src/Fable.Transforms/FableTransforms.fs
+++ b/src/Fable.Transforms/FableTransforms.fs
@@ -599,7 +599,7 @@ module private Transforms =
                 match expr with
                 | IdentExpr _ -> None, expr
                 | arg ->
-                    let ident = makeTypedIdent argType $"anonRec{com.IncrementCounter()}"
+                    let ident = makeTypedIdent argType $"anonRec%d{com.IncrementCounter()}"
 
                     Some(ident, arg), IdentExpr ident
 

--- a/src/Fable.Transforms/OverloadSuffix.fs
+++ b/src/Fable.Transforms/OverloadSuffix.fs
@@ -60,7 +60,7 @@ let rec private getTypeFastFullName (genParams: IDictionary<_, _>) (t: Fable.Typ
         let typeName = getTypeFastFullName genParams genArg
 
         if isStruct then
-            $"System.Nullable<{typeName}>"
+            $"System.Nullable<%s{typeName}>"
         else
             // there is no overload distinction for nullable reference types,
             // so the name and overload suffix are the same as the inner type

--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -2001,7 +2001,7 @@ let arrayModule (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (_: Ex
             let value = value |> Option.defaultWith (fun () -> getZero com ctx t2)
             Helper.LibCall(com, "array", "create", t, [ size; value ])
         | _ ->
-            $"Expecting an array type but got {t}"
+            $"Expecting an array type but got %O{t}"
             |> addErrorAndReturnNull com ctx.InlinePath r
 
     match i.CompiledName, args with
@@ -3473,7 +3473,7 @@ let regex com (ctx: Context) r t (i: CallInfo) (thisArg: Expr option) (args: Exp
         match thisArg, args with
         | Some thisArg, args ->
             if args.Length > 2 then
-                $"Regex.{meth} doesn't support more than 2 arguments"
+                $"Regex.%s{meth} doesn't support more than 2 arguments"
                 |> addError com ctx.InlinePath r
 
             thisArg :: args |> Some
@@ -4291,7 +4291,7 @@ let tryType typ =
         | FSharpMap(key, value) -> Some(Types.fsharpMap, maps, [ key; value ])
         | FSharpSet genArg -> Some(Types.fsharpSet, sets, [ genArg ])
         | FSharpResult(genArg1, genArg2) -> Some(Types.result, results, [ genArg1; genArg2 ])
-        | FSharpChoice genArgs -> Some($"{Types.choiceNonGeneric}`{List.length genArgs}", results, genArgs)
+        | FSharpChoice genArgs -> Some($"%s{Types.choiceNonGeneric}`%d{List.length genArgs}", results, genArgs)
         | FSharpReference genArg -> Some(Types.refCell, refCells, [ genArg ])
         | BclDateOnly -> Some(Types.dateOnly, dateOnly, [])
         | BclTimeOnly -> Some(Types.timeOnly, timeOnly, [])

--- a/src/Fable.Transforms/Replacements.Util.fs
+++ b/src/Fable.Transforms/Replacements.Util.fs
@@ -380,7 +380,7 @@ let getElementType =
     | _ -> Any
 
 let genericTypeInfoError (name: string) =
-    $"Cannot get type info of generic parameter {name}. Fable erases generics at runtime, try inlining the functions so generics can be resolved at compile time."
+    $"Cannot get type info of generic parameter %s{name}. Fable erases generics at runtime, try inlining the functions so generics can be resolved at compile time."
 
 // This is mainly intended for typeof errors because we want to show the user where the function is originally called
 let changeRangeToCallSite (inlinePath: InlinePath list) (range: SourceLocation option) =
@@ -615,7 +615,7 @@ let partialApplyAtRuntime (com: Compiler) t arity (expr: Expr) (partialArgs: Exp
             | partialArgs -> curriedApply None t curried partialArgs
     | _ ->
         // Check if argTypes.Length < arity?
-        let makeArgIdent i typ = makeTypedIdent typ $"a{i}" // $"a{com.IncrementCounter()}$"
+        let makeArgIdent i typ = makeTypedIdent typ $"a%d{i}" // $"a{com.IncrementCounter()}$"
         let argTypes, returnType = uncurryLambdaType arity [] t
         let argIdents = argTypes |> List.mapi makeArgIdent
         let args = argIdents |> List.map Fable.IdentExpr
@@ -684,7 +684,7 @@ let uncurryExprAtRuntime (com: Compiler) arity (expr: Expr) =
                 | Fable.DelegateType(argTypes, returnType) -> argTypes, returnType
                 | _ -> [], expr.Type
 
-            let makeArgIdent i typ = makeTypedIdent typ $"b{i}" // $"a{com.IncrementCounter()}$"
+            let makeArgIdent i typ = makeTypedIdent typ $"b%d{i}" // $"a{com.IncrementCounter()}$"
             let argIdents = argTypes |> List.mapi makeArgIdent
             let args = argIdents |> List.map Fable.IdentExpr
             let body = curriedApply None returnType expr args
@@ -1027,7 +1027,7 @@ let (|UniversalFableCoreHelpers|_|) (com: ICompiler) (ctx: Context) r t (i: Call
             com
             ctx.InlinePath
             r
-            $"{i.CompiledName} is being compiled without replacement, this will fail at runtime."
+            $"%s{i.CompiledName} is being compiled without replacement, this will fail at runtime."
 
         let runtimeMsg =
             "A function supposed to be replaced by native code has been called, please check."
@@ -1248,10 +1248,10 @@ module AnonRecords =
             | [] -> unreachable ()
             | [ expectedType ] ->
                 let expectedType = expectedType |> formatType
-                $"Object doesn't contain field '{fieldName}' of type '{expectedType}' required by interface '{interfaceName}'"
+                $"Object doesn't contain field '%s{fieldName}' of type '%s{expectedType}' required by interface '%s{interfaceName}'"
             | _ ->
                 let expectedTypes = expectedTypes |> formatTypes
-                $"Object doesn't contain field '{fieldName}' of any type [{expectedTypes}] required by interface '{interfaceName}'"
+                $"Object doesn't contain field '%s{fieldName}' of any type [%s{expectedTypes}] required by interface '%s{interfaceName}'"
 
         (range, fieldName, msg)
 
@@ -1279,10 +1279,10 @@ module AnonRecords =
                 | [] -> unreachable ()
                 | [ expectedType ] ->
                     let expectedType = expectedType |> formatType
-                    $"Expected type '{expectedType}' for field '{fieldName}' in interface '{interfaceName}', but is '{actualType}'"
+                    $"Expected type '%s{expectedType}' for field '%s{fieldName}' in interface '%s{interfaceName}', but is '%s{actualType}'"
                 | _ ->
                     let expectedTypes = expectedTypes |> formatTypes
-                    $"Expected any type of [{expectedTypes}] for field '{fieldName}' in interface '{interfaceName}', but is '{actualType}'"
+                    $"Expected any type of [%s{expectedTypes}] for field '%s{fieldName}' in interface '%s{interfaceName}', but is '%s{actualType}'"
             | Some indexers ->
                 assert (indexers |> List.isEmpty |> not)
 
@@ -1295,10 +1295,10 @@ module AnonRecords =
                     | [] -> unreachable ()
                     | [ expectedType ] ->
                         let expectedType = expectedType |> formatType
-                        $"Expected type '{expectedType}' for field '{fieldName}' because of Indexer '{indexerName}' in interface '{interfaceName}', but is '{actualType}'"
+                        $"Expected type '%s{expectedType}' for field '%s{fieldName}' because of Indexer '%s{indexerName}' in interface '%s{interfaceName}', but is '%s{actualType}'"
                     | _ ->
                         let expectedTypes = expectedTypes |> formatTypes
-                        $"Expected any type of [{expectedTypes}] for field '{fieldName}' because of Indexer '{indexerName}' in interface '{interfaceName}', but is '{actualType}'"
+                        $"Expected any type of [%s{expectedTypes}] for field '%s{fieldName}' because of Indexer '%s{indexerName}' in interface '%s{interfaceName}', but is '%s{actualType}'"
                 | _ ->
                     let indexerNames = indexers |> List.map (quote) |> String.concat "; "
 
@@ -1306,10 +1306,10 @@ module AnonRecords =
                     | [] -> unreachable ()
                     | [ expectedType ] ->
                         let expectedType = expectedType |> formatType
-                        $"Expected type '{expectedType}' for field '{fieldName}' because of Indexers [{indexerNames}] in interface '{interfaceName}', but is '{actualType}'"
+                        $"Expected type '%s{expectedType}' for field '%s{fieldName}' because of Indexers [%s{indexerNames}] in interface '%s{interfaceName}', but is '%s{actualType}'"
                     | _ ->
                         let expectedTypes = expectedTypes |> formatTypes
-                        $"Expected any type of [{expectedTypes}] for field '{fieldName}' because of Indexers [{indexerNames}] in interface '{interfaceName}', but is '{actualType}'"
+                        $"Expected any type of [%s{expectedTypes}] for field '%s{fieldName}' because of Indexers [%s{indexerNames}] in interface '%s{interfaceName}', but is '%s{actualType}'"
 
         let r = r |> Option.orElse range // fall back to anon record range
 

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -688,7 +688,7 @@ let tryEntityIdent (com: Compiler) entFullName =
     | BuiltinDefinition(FSharpReference _) -> makeImportLib com Any "FSharpRef" "Types" |> Some
     | BuiltinDefinition(FSharpResult _) -> makeImportLib com Any "FSharpResult$2" "Result" |> Some
     | BuiltinDefinition(FSharpChoice genArgs) ->
-        let membName = $"FSharpChoice${List.length genArgs}"
+        let membName = $"FSharpChoice$%d{List.length genArgs}"
         makeImportLib com Any membName "Choice" |> Some
     // | BuiltinDefinition BclGuid -> jsTypeof "string" expr
     // | BuiltinDefinition BclTimeSpan -> jsTypeof "number" expr
@@ -3531,7 +3531,7 @@ let random (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr opti
     | meth, Some thisArg ->
         let meth =
             if meth = "Next" then
-                $"Next{List.length args}"
+                $"Next%d{List.length args}"
             else
                 meth
 
@@ -3663,7 +3663,7 @@ let regex com (ctx: Context) r t (i: CallInfo) (thisArg: Expr option) (args: Exp
         match thisArg, args with
         | Some thisArg, args ->
             if args.Length > 2 then
-                $"Regex.{meth} doesn't support more than 2 arguments"
+                $"Regex.%s{meth} doesn't support more than 2 arguments"
                 |> addError com ctx.InlinePath r
 
             thisArg :: args |> Some
@@ -4489,6 +4489,6 @@ let tryType typ =
         | FSharpMap(key, value) -> Some(Types.fsharpMap, maps, [ key; value ])
         | FSharpSet genArg -> Some(Types.fsharpSet, sets, [ genArg ])
         | FSharpResult(genArg1, genArg2) -> Some(Types.result, results, [ genArg1; genArg2 ])
-        | FSharpChoice genArgs -> Some($"{Types.choiceNonGeneric}`{List.length genArgs}", results, genArgs)
+        | FSharpChoice genArgs -> Some($"%s{Types.choiceNonGeneric}`%d{List.length genArgs}", results, genArgs)
         | FSharpReference genArg -> Some(Types.refCell, refCells, [ genArg ])
     | _ -> None

--- a/src/Fable.Transforms/Rust/Fable2Rust.fs
+++ b/src/Fable.Transforms/Rust/Fable2Rust.fs
@@ -3197,7 +3197,7 @@ module Util =
             | Fable.Option(genArg, _) ->
                 match evalName with
                 | Some idName ->
-                    let fieldName = $"{idName}_{caseIndex}_{0}"
+                    let fieldName = $"%s{idName}_%d{caseIndex}_%d{0}"
                     [ (fieldName, idName, genArg) ]
                 | _ -> []
             | Fable.DeclaredType(entRef, genArgs) ->
@@ -3210,7 +3210,7 @@ module Util =
                     | Some idName ->
                         unionCase.UnionCaseFields
                         |> List.mapi (fun i field ->
-                            let fieldName = $"{idName}_{caseIndex}_{i}"
+                            let fieldName = $"%s{idName}_%d{caseIndex}_%d{i}"
                             let fieldType = FableTransforms.uncurryType field.FieldType
                             (fieldName, idName, fieldType)
                         )
@@ -5673,9 +5673,9 @@ module Compiler =
                         import
 
                 if isMacro then
-                    $"{import.LocalIdent}!"
+                    $"%s{import.LocalIdent}!"
                 else
-                    $"{import.LocalIdent}"
+                    $"%s{import.LocalIdent}"
 
             member _.GetAllImports(ctx) =
                 imports.Values

--- a/src/Fable.Transforms/Rust/Replacements.fs
+++ b/src/Fable.Transforms/Rust/Replacements.fs
@@ -326,7 +326,7 @@ let toSeq com t (expr: Expr) =
         Helper.LibCall(com, "Seq", "ofArray", t, [ chars ])
     | _ -> TypeCast(expr, t)
 
-let emitRawString (s: string) = $"\"{s}\"" |> emitExpr None String []
+let emitRawString (s: string) = $"\"%s{s}\"" |> emitExpr None String []
 
 let emitFormat (com: ICompiler) r t (args: Expr list) macro =
     let args =
@@ -3648,6 +3648,6 @@ let tryType typ =
         | FSharpMap(key, value) -> Some(Types.fsharpMap, maps, [ key; value ])
         | FSharpSet genArg -> Some(Types.fsharpSet, sets, [ genArg ])
         | FSharpResult(genArg1, genArg2) -> Some(Types.result, results, [ genArg1; genArg2 ])
-        | FSharpChoice genArgs -> Some($"{Types.choiceNonGeneric}`{List.length genArgs}", results, genArgs)
+        | FSharpChoice genArgs -> Some($"%s{Types.choiceNonGeneric}`%d{List.length genArgs}", results, genArgs)
         | FSharpReference genArg -> Some(Types.refCell, refCells, [ genArg ])
     | _ -> None

--- a/src/Fable.Transforms/State.fs
+++ b/src/Fable.Transforms/State.fs
@@ -69,7 +69,7 @@ type Assemblies(getPlugin, fsharpAssemblies: FSharpAssembly list, addLog: Severi
                                 with ex ->
                                     let errorMessage =
                                         [
-                                            $"Error while loading plugin: {e.FullName}"
+                                            $"Error while loading plugin: %s{e.FullName}"
                                             ""
                                             "This error often happens if you are trying to use a plugin that is not compatible with the current version of Fable."
                                             "If you see this error please open an issue at https://github.com/fable-compiler/Fable/"
@@ -353,7 +353,7 @@ type CompilerImpl
                 | Some r -> r, None
                 | None ->
                     let msg =
-                        $"Cannot find root module for {fileName}. If this belongs to a package, make sure it includes the source files."
+                        $"Cannot find root module for %s{fileName}. If this belongs to a package, make sure it includes the source files."
 
                     (this :> Compiler).AddLog(msg, Severity.Warning, fileName = currentFile)
 

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -1099,7 +1099,7 @@ module AST =
         | :? float as x -> NumberConstant(NumberValue.Float64 x, NumberInfo.Empty) |> makeValue None
         | :? decimal as x -> NumberConstant(NumberValue.Decimal x, NumberInfo.Empty) |> makeValue None
         | _ ->
-            FableError $"Cannot create expression for object {value} (%s{value.GetType().FullName})"
+            FableError $"Cannot create expression for object %O{value} (%s{value.GetType().FullName})"
             |> raise
 
     let makeTypeConst r (typ: Type) (value: obj) =
@@ -1157,7 +1157,7 @@ module AST =
 
             NewArray(ArrayValues values, Number(kind, uom), arrayKind) |> makeValue r
         | _ ->
-            FableError $"Unexpected type %A{typ} for literal {value} (%s{value.GetType().FullName})"
+            FableError $"Unexpected type %A{typ} for literal %O{value} (%s{value.GetType().FullName})"
             |> raise
 
     let getLibPath (com: Compiler) (moduleName: string) =
@@ -1280,7 +1280,7 @@ module AST =
             | [] -> ""
             | head :: tail ->
                 ((head, List.length args), tail)
-                ||> List.fold (fun (macro, pos) part -> $"{macro}$%i{pos}{part}", pos + 1)
+                ||> List.fold (fun (macro, pos) part -> $"%s{macro}$%i{pos}%s{part}", pos + 1)
                 |> fst
 
         emit r t (args @ templateValues) isStatement macro
@@ -1528,7 +1528,7 @@ module AST =
 
                 let genArgsLength = List.length genArgs
                 let genArgs = String.concat "," genArgs
-                $"System.{isStruct}Tuple`{genArgsLength}[{genArgs}]"
+                $"System.%s{isStruct}Tuple`%d{genArgsLength}[%s{genArgs}]"
         | Array(gen, _kind) -> // TODO: Check kind
             (getTypeFullName prettify gen) + "[]"
 
@@ -1536,9 +1536,9 @@ module AST =
             let gen = getTypeFullName prettify gen
 
             if isStruct then
-                $"System.Nullable<{gen}>"
+                $"System.Nullable<%s{gen}>"
             else
-                $"{gen} | null"
+                $"%s{gen} | null"
 
         | Option(gen, isStruct) ->
             let gen = getTypeFullName prettify gen


### PR DESCRIPTION
## Summary

Resolves all **127 `GRA-INTERPOLATED-001`** code-scanning alerts — _"missing type specifiers in interpolated strings"_ — across 17 source files in `Fable.Compiler` and `Fable.Transforms`.

Each flagged interpolation hole gets the correct `%`-specifier so the type is checked at compile time. **Output is unchanged**; this only adds compile-time type safety:

- **`%s`** for strings (names, full names, formatted types, paths, error/warning messages) — the majority
- **`%d`** for ints (generated identifiers like `arg{i}`, `FSharpChoice${n}`, union tags, counters, arities)
- **`%O`** for objects whose default formatting already called `ToString()` (`DateTime` timestamps, `Fable.Type`, `obj` values, `string option`)

One site (`FSharp2Fable.Util.fs`) had a multi-line `if/else` inside the hole that went offside once the prefix widened, so it was hoisted into a small `staticSuffix` binding.

## Verification

`dotnet build src/Fable.Cli/Fable.Cli.fsproj -c Release` succeeds with **0 warnings, 0 errors**. The build itself is the safety net: a wrong specifier (`%s` on a non-string, `%d` on a non-int) is a hard compile error, so a clean build confirms every choice is type-correct. The identifier-generating strings (which feed into *generated code*, not just messages) produce byte-identical output, so there is no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)