### PR TITLE
fix(cli): fable clean command crash when output directory doesn't exist

### DIFF
--- a/src/Fable.Cli/Entry.fs
+++ b/src/Fable.Cli/Entry.fs
@@ -453,7 +453,10 @@ let clean (args: CliArgs) language rootDir =
                 recClean subdir
         )
 
-    recClean cleanDir
+    if IO.Directory.Exists(cleanDir) then
+        recClean cleanDir
+    else
+        Log.always ($"Directory does not exist: {cleanDir}")
 
     if fileCount = 0 && not fableModulesDeleted then
         Log.always ("No files have been deleted. If Fable output is in another directory, pass it as argument.")


### PR DESCRIPTION
The clean command would crash with DirectoryNotFoundException if the specified output directory (via -o flag) didn't exist. Now it gracefully handles this case by checking if the directory exists before attempting to clean it.