### PR TITLE
fix(python): emit wildcard default for union or-patterns (#4649)

### DIFF
--- a/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
@@ -1994,19 +1994,23 @@ let private transformSwitchPatternAsMatch
         else
             let ctx = { ctx with DecisionTargets = targets }
 
-            // Group cases by target index to create or-patterns
+            // Group cases by target index to create or-patterns. Drop cases routing to the
+            // default's target since the always-emitted wildcard already covers them (#4649).
             let groupedCases =
                 convertedCases
                 |> List.groupBy snd
-                |> List.map (fun (targetIndex, patterns) ->
-                    let patterns = patterns |> List.map fst
+                |> List.choose (fun (targetIndex, patterns) ->
+                    if targetIndex = defaultIndex then
+                        None
+                    else
+                        let patterns = patterns |> List.map fst
 
-                    let pattern =
-                        match patterns with
-                        | [ single ] -> single
-                        | multiple -> MatchOr multiple
+                        let pattern =
+                            match patterns with
+                            | [ single ] -> single
+                            | multiple -> MatchOr multiple
 
-                    (pattern, targetIndex)
+                        Some(pattern, targetIndex)
                 )
 
             // Build match cases
@@ -2018,18 +2022,9 @@ let private transformSwitchPatternAsMatch
                     MatchCase.matchCase (pattern, body)
                 )
 
-            // Build default case (wildcard)
+            // Build default case (wildcard) and always append it last
             let defaultCase = buildDefaultMatchCase com ctx returnStrategy targets defaultIndex
-
-            // Check if the default case is already covered by the grouped cases
-            let defaultAlreadyCovered =
-                groupedCases |> List.exists (fun (_, idx) -> idx = defaultIndex)
-
-            let allCases =
-                if defaultAlreadyCovered then
-                    matchCases
-                else
-                    matchCases @ [ defaultCase ]
+            let allCases = matchCases @ [ defaultCase ]
 
             // Transform the evaluation expression
             let subject, stmts = com.TransformAsExpr(ctx, evalExpr)

--- a/tests/Python/TestPatternMatch.fs
+++ b/tests/Python/TestPatternMatch.fs
@@ -135,6 +135,18 @@ let colorMatch3 c =
     | Blue -> "blue"
     | _ -> "other"
 
+type Case =
+    | BestCase
+    | MidCase
+    | WorstCase
+
+// Or-pattern over union cases where the grouped cases share the same target
+// as the default branch. See https://github.com/fable-compiler/Fable/issues/4649
+let atLeastMid c =
+    match c with
+    | BestCase | MidCase -> true
+    | WorstCase -> false
+
 [<Fact>]
 let ``test union match with field extraction`` () =
     unionMatch (Circle 5.0) |> equal "Circle 5"
@@ -158,6 +170,12 @@ let ``test simple union match with 3 cases`` () =
     colorMatch3 Red |> equal "red"
     colorMatch3 Blue |> equal "blue"
     colorMatch3 Green |> equal "other"
+
+[<Fact>]
+let ``test or-pattern over union cases sharing default target`` () =
+    atLeastMid BestCase |> equal true
+    atLeastMid MidCase |> equal true
+    atLeastMid WorstCase |> equal false
 
 // ----------------------------------------------------------------------------
 // 5. Guard Expressions (when clauses)


### PR DESCRIPTION
Fixes #4649

## Problem

Matching against multiple union cases in an or-pattern returned `None` (Python) for one of the cases:

```fsharp
type Case = BestCase | MidCase | WorstCase

let atLeastMid (c: Case) =
    match c with
    | BestCase | MidCase -> true
    | WorstCase -> false
```

transpiled to (tag 0 missing):

```python
def at_least_mid(c: Case) -> bool:
    match c.tag:
        case 1:
            return True
        case 2:
            return False
```

so `atLeastMid BestCase` fell through the match and returned `None` instead of `True`.

## Root cause

In `transformSwitchPatternAsMatch`, FCS lowered the match so `BestCase` (tag 0) became the **default** branch, sharing its target body (`return True`) with `MidCase`. The generator had a `defaultAlreadyCovered` check that **dropped the wildcard `case _:`** whenever the default's target index was already used by an explicit case — leaving the tag only reachable via the default (tag 0) unmatched.

## Fix

Always emit the wildcard default (it's the only thing covering subject values not listed explicitly). Instead, drop the *redundant explicit cases* that route to the default's target, since the wildcard already covers them. The example now generates:

```python
def at_least_mid(c: Case) -> bool:
    match c.tag:
        case 2:
            return False
        case _:
            return True
```

## Testing

- Added regression test `test or-pattern over union cases sharing default target` in `tests/Python/TestPatternMatch.fs`.
- Full Python suite passes (2354 tests).
- No new Pyright type-check errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)