### PR TITLE
feat(beam): add !^ erased-cast operator to BeamInterop

### DIFF
--- a/src/Fable.Core/Fable.Core.BeamInterop.fs
+++ b/src/Fable.Core/Fable.Core.BeamInterop.fs
@@ -2,6 +2,10 @@ module Fable.Core.BeamInterop
 
 open Fable.Core
 
+/// Implicit cast for erased unions (U2, U3...)
+let inline (!^) (x: ^t1) : ^t2 =
+    ((^t1 or ^t2): (static member op_ErasedCast: ^t1 -> ^t2) x)
+
 /// Destructure a tuple of arguments and apply to literal Erlang code as with EmitAttribute.
 /// E.g. `emitErlExpr (arg1, arg2) "$0 + $1"` in Erlang becomes `arg1 + arg2`
 let emitErlExpr<'T> (args: obj) (erlCode: string) : 'T = nativeOnly

--- a/src/Fable.Transforms/Beam/Replacements.fs
+++ b/src/Fable.Transforms/Beam/Replacements.fs
@@ -5208,6 +5208,8 @@ let tryCall
     : Expr option
     =
     match info.DeclaringEntityFullName with
+    // Implicit cast for erased unions (U2, U3...) via `!^`; the cast is erased.
+    | _ when info.CompiledName = "op_ErasedCast" -> List.tryHead args
     | "Microsoft.FSharp.Core.Operators"
     | "Microsoft.FSharp.Core.Operators.Checked"
     | "Microsoft.FSharp.Core.ExtraTopLevelOperators"
@@ -5486,7 +5488,9 @@ let tryCall
                 let args = destructureTupleArgs [ args ]
                 let isStatement = rest = "Statement"
                 emitTemplate r t args isStatement template |> Some
+        // Dynamic casting (op_BangBang) and implicit erased-union cast (op_BangHat), both erased
         | "op_BangBang", [ arg ] -> Some arg
+        | "op_BangHat", [ arg ] -> Some arg
         | _ -> None
     | "Fable.Core.BeamInterop.Erlang" ->
         match info.CompiledName, args with

--- a/tests/Beam/InteropTests.fs
+++ b/tests/Beam/InteropTests.fs
@@ -393,6 +393,21 @@ let ``test Erased unions with multiple fields work`` () =
 #endif
 
 [<Fact>]
+let ``test !^ implicit cast for erased unions works`` () =
+#if FABLE_COMPILER
+    let strify (x: U2<int, string>) =
+        match x with
+        | U2.Case1 i -> "i: " + string i
+        | U2.Case2 s -> "s: " + s
+    let i: U2<int, string> = !^42
+    let s: U2<int, string> = !^"foo"
+    strify i |> equal "i: 42"
+    strify s |> equal "s: foo"
+#else
+    ()
+#endif
+
+[<Fact>]
 let ``test StringEnum works`` () =
 #if FABLE_COMPILER
     let value = Vertical


### PR DESCRIPTION
## Summary

Adds the `!^` implicit erased-cast operator to `Fable.Core.BeamInterop`, bringing the Beam target in line with the JS, Python, Rust, and PHP interop modules which already expose it.

`!^` is the implicit cast for erased unions (`U2`, `U3`, …):

```fsharp
let x: U2<int, string> = !^42      // U2.Case1 42
let y: U2<int, string> = !^"foo"   // U2.Case2 "foo"
```

This unblocks simplifying `ServerName`-style erased-union call sites in the Fable.Beam repo.

## Changes

- **`Fable.Core.BeamInterop.fs`** — add the `!^` operator, identical to the definition already in `JsInterop`/`PyInterop`/`RustInterop`/`PhpInterop`.
- **`Beam/Replacements.fs`** — the Beam backend also lacked the lowering, so wire up the two cases other targets already handle:
  - `op_BangHat` in the `Fable.Core.BeamInterop` arm (the `!^` call, erased to its argument).
  - `op_ErasedCast` (the static member the operator resolves to on the `U`-types), erased to its argument. JS/Rust get this for free via `UniversalFableCoreHelpers`, which Beam's dispatcher doesn't route through.
- **`tests/Beam/InteropTests.fs`** — add a test mirroring the JS `U2<int,string>` pattern.

## Testing

`./build.sh test beam` — all 2446 tests pass, including the new `test !^ implicit cast for erased unions works`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)