### PR TITLE
fix(beam): preserve element type through Option.Value for interface dispatch

### DIFF
--- a/src/Fable.Transforms/Beam/Replacements.fs
+++ b/src/Fable.Transforms/Beam/Replacements.fs
@@ -1173,7 +1173,11 @@ let private options
     match info.CompiledName, thisArg with
     | "Some", _ -> NewOption(List.tryHead _args, t.Generics.Head, false) |> makeValue r |> Some
     | "get_None", _ -> NewOption(None, t.Generics.Head, false) |> makeValue r |> Some
-    | "get_Value", Some c -> Some c
+    // Option is erased (Some x → x), so `.Value` is runtime-identity. Cast to
+    // the element type `t` so the result carries the unwrapped type (e.g. an
+    // interface) rather than `Option<t>`, which downstream codegen needs (e.g.
+    // interface method dispatch).
+    | "get_Value", Some c -> TypeCast(c, t) |> Some
     | "get_IsSome", Some c -> Test(c, OptionTest true, r) |> Some
     | "get_IsNone", Some c -> Test(c, OptionTest false, r) |> Some
     // Static methods on ValueOption type (Bind, Map, DefaultValue, etc.)

--- a/tests/Beam/InterfaceTests.fs
+++ b/tests/Beam/InterfaceTests.fs
@@ -86,3 +86,24 @@ let ``test Interface generic interface constraints work`` () =
     let w = AdderWrapper2(a)
     let res = (w :> IConstrained<_>).AddThroughCaptured 2 5
     res |> equal 6
+
+// Regression: calling an interface member on `option.Value` must go through
+// dynamic interface dispatch. On BEAM, options are erased so `.Value` is
+// runtime-identity; previously the receiver lost its interface type and the
+// backend emitted an unqualified (undefined) direct call instead of iface_get.
+type IRunner =
+    abstract member Run: unit -> int
+
+type Runner(n: int) =
+    interface IRunner with
+        member _.Run() = n + 1
+
+[<Fact>]
+let ``test Interface method call via Option.Value works`` () =
+    let s: IRunner option = Some(Runner(41) :> IRunner)
+    let res =
+        if s.IsSome then
+            s.Value.Run()
+        else
+            0
+    res |> equal 42


### PR DESCRIPTION
## Problem

On the BEAM backend, calling an interface member on `option.Value` emitted an unqualified direct call to an undefined Erlang function instead of dynamic interface dispatch.

For `s.Value.Run()` where `s: IThing option`, Fable emitted `run(S)` — an undefined `run/1` function — so `rebar3 compile` failed with `function run/1 undefined`. The same call on an interface-typed local (`thing.Run()`) or a pattern-bound value (`match s with Some t -> t.Run()`) correctly emitted `(fable_utils:iface_get(run, 0, X))()`. The F# is well-typed and works on .NET, JS, and Python; only BEAM mis-emitted.

## Root cause

Options are erased on BEAM (`Some x` → `x`), so the `get_Value` replacement in `Beam/Replacements.fs` returned the receiver unchanged. But the returned expression still carried type `Option<IThing>` rather than `IThing`. The interface-method-call path in `Fable2Beam.fs` inspected the receiver's type, saw an `Option` instead of an interface `DeclaredType`, and fell through to the catch-all direct-call branch.

## Fix

Wrap the erased value in a `TypeCast` to the element type `t`. `TypeCast` is runtime-identity on BEAM (stripped at emission), but the expression now carries the unwrapped type, so the existing `iface_get` dispatch fires.

This is the targeted fix (preserve the interface type through `Option.Value`) rather than changing the direct-call fallback, since that branch is legitimately used for non-interface instance methods.

## Testing

- Added a regression test `test Interface method call via Option.Value works` to the BEAM interface test suite.
- Full BEAM suite passes: **2447 passed, 0 failed**.
- Verified the original repro (all of caseB/C/D plus control/caseE) now emits `iface_get` and compiles cleanly under `rebar3 compile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)