### PR TITLE
refactor(all): mark enum-like DUs [<Struct>] to satisfy StructDiscriminatedUnionAnalyzer

### DIFF
--- a/src/Fable.Compiler/Globbing.fs
+++ b/src/Fable.Compiler/Globbing.fs
@@ -18,11 +18,12 @@ module Glob =
     let inline normalizePath (path: string) =
         path.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar)
 
+    [<Struct>]
     type private SearchOption =
-        | Directory of string
-        | Drive of string
+        | Directory of dir: string
+        | Drive of drive: string
         | Recursive
-        | FilePattern of string
+        | FilePattern of pattern: string
 
     let private checkSubDirs absolute (dir: string) root =
         if dir.Contains "*" then

--- a/src/Fable.Compiler/Globbing.fsi
+++ b/src/Fable.Compiler/Globbing.fsi
@@ -15,11 +15,12 @@ module Glob =
 
     val inline normalizePath: path: string -> string
 
+    [<Struct>]
     type private SearchOption =
-        | Directory of string
-        | Drive of string
+        | Directory of dir: string
+        | Drive of drive: string
         | Recursive
-        | FilePattern of string
+        | FilePattern of pattern: string
 
     val internal getRoot: baseDirectory: string -> pattern: string -> string
     val internal search: baseDir: string -> originalInput: string -> string list

--- a/src/Fable.Compiler/Util.fs
+++ b/src/Fable.Compiler/Util.fs
@@ -705,11 +705,12 @@ module Json =
     open Fable.AST
 
     // TODO: Check which other parameters are accepted by attributes (arrays?)
+    [<Struct>]
     type AttParam =
-        | Int of int
-        | Float of float
-        | Bool of bool
-        | String of string
+        | Int of intValue: int
+        | Float of floatValue: float
+        | Bool of boolValue: bool
+        | String of stringValue: string
 
         static member From(values: obj list) =
             (Ok [], values)

--- a/src/Fable.Transforms/Dart/Dart.fs
+++ b/src/Fable.Transforms/Dart/Dart.fs
@@ -1,10 +1,12 @@
 // Loosely based on https://pub.dev/documentation/analyzer/latest/dart_ast_ast/dart_ast_ast-library.html
 module rec Fable.AST.Dart
 
+[<Struct>]
 type UpdateOperator =
     | UpdateMinus
     | UpdatePlus
 
+[<Struct>]
 type AssignmentOperator =
     | AssignEqual
     | AssignMinus
@@ -259,6 +261,7 @@ type Expression =
     static member throwExpression(value, typ) = ThrowExpression(value, typ)
     static member rethrowExpression(typ) = RethrowExpression typ
 
+[<Struct>]
 type VariableDeclarationKind =
     | Final
     | Const
@@ -378,6 +381,7 @@ type InstanceVariable(ident, ?value, ?kind, ?isOverride, ?isLate) =
     member _.IsOverride = defaultArg isOverride false
     member _.IsLate = defaultArg isLate false
 
+[<Struct>]
 type MethodKind =
     | IsMethod
     | IsGetter

--- a/src/Fable.Transforms/Dart/DartPrinter.fs
+++ b/src/Fable.Transforms/Dart/DartPrinter.fs
@@ -6,6 +6,7 @@ open Fable.AST
 open Fable.AST.Dart
 open Fable.Transforms.Printer
 
+[<Struct>]
 type ListPos =
     | IsFirst
     | IsMiddle

--- a/src/Fable.Transforms/Dart/Fable2Dart.fs
+++ b/src/Fable.Transforms/Dart/Fable2Dart.fs
@@ -62,6 +62,7 @@ type Context =
 
         { this with EntityAndMemberGenericParams = this.EntityAndMemberGenericParams @ genParams }
 
+[<Struct>]
 type MemberKind =
     | ClassConstructor
     | NonAttached of funcName: string

--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -105,10 +105,11 @@ type FsField(fi: FSharpField) =
             | n -> name + "_" + (string<int> n)
 
 [<RequireQualifiedAccess>]
+[<Struct>]
 type CompiledValue =
-    | Integer of int
-    | Float of float
-    | Boolean of bool
+    | Integer of intValue: int
+    | Float of floatValue: float
+    | Boolean of boolValue: bool
 
 type FsUnionCase(uci: FSharpUnionCase) =
     /// FSharpUnionCase.CompiledName doesn't give the value of CompiledNameAttribute

--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -13,6 +13,7 @@ type ReturnStrategy =
     | Assign of Expression
     | Target of Identifier
 
+[<Struct>]
 type ConstructorRef =
     | Annotation
     | ActualConsRef
@@ -1329,6 +1330,7 @@ module Util =
 
         scopedTypeParams, typeParams
 
+    [<Struct>]
     type MemberKind =
         | ClassConstructor
         | NonAttached of funcName: string

--- a/src/Fable.Transforms/Global/Babel.fs
+++ b/src/Fable.Transforms/Global/Babel.fs
@@ -3,10 +3,12 @@ namespace rec Fable.AST.Babel
 
 open Fable.AST
 
+[<Struct>]
 type UpdateOperator =
     | UpdateMinus
     | UpdatePlus
 
+[<Struct>]
 type AssignmentOperator =
     | AssignEqual
     | AssignMinus
@@ -204,6 +206,7 @@ type Declaration =
 
 /// A directive prologue as defined in ECMA specification
 /// https://tc39.es/ecma262/#sec-directive-prologues-and-the-use-strict-directive
+[<Struct>]
 type DirectivePrologue = | DirectivePrologue of text: string
 
 /// A module import or export declaration.
@@ -300,6 +303,7 @@ type VariableDeclarator =
         init: Expression option *
         loc: SourceLocation option
 
+[<Struct>]
 type VariableDeclarationKind =
     | Var
     | Let
@@ -412,6 +416,7 @@ type ObjectMember =
 //    let shorthand = defaultArg shorthand_ false
 //    member _.Shorthand: bool = shorthand
 
+[<Struct>]
 type ObjectMethodKind =
     | ObjectGetter
     | ObjectSetter
@@ -440,6 +445,7 @@ type ObjectMethodKind =
 
 
 // Classes
+[<Struct>]
 type AccessModifier =
     | Public
     | Private

--- a/src/Fable.Transforms/Global/Compiler.fs
+++ b/src/Fable.Transforms/Global/Compiler.fs
@@ -35,12 +35,14 @@ type CompilerOptionsHelper =
         }
 
 [<RequireQualifiedAccess>]
+[<Struct>]
 type Severity =
     | Warning
     | Error
     | Info
 
 [<RequireQualifiedAccess>]
+[<Struct>]
 type OutputType =
     | Library
     | Exe

--- a/src/Fable.Transforms/Php/Fable2Php.fs
+++ b/src/Fable.Transforms/Php/Fable2Php.fs
@@ -756,15 +756,16 @@ let convertRecord (com: IPhpCompiler) (decl: Fable.ClassDecl) (info: Fable.Entit
 /// F# is expression based, but some constructs have to be transpiled as
 /// statements in other languages. This types indicates how the result
 /// should be passed to the resto of the code.
+[<Struct>]
 type ReturnStrategy =
     /// The statement should return the value
     | Return
     /// The statement should define a new variable and assign it
-    | Let of string
+    | Let of varName: string
     /// No return value
     | Do
     /// used in decision tree when multiple cases result in the same code
-    | Target of string
+    | Target of targetName: string
 
 let nsreplacement (ns: string) =
     match ns.Replace(".", @"\") with

--- a/src/Fable.Transforms/Php/Php.fs
+++ b/src/Fable.Transforms/Php/Php.fs
@@ -1,15 +1,17 @@
 namespace rec Fable.AST.Php
 
+[<Struct>]
 type PhpConst =
-    | PhpConstNumber of float
-    | PhpConstString of string
-    | PhpConstBool of bool
+    | PhpConstNumber of number: float
+    | PhpConstString of str: string
+    | PhpConstBool of flag: bool
     | PhpConstNull
 
+[<Struct>]
 type PhpArrayIndex =
     | PhpArrayNoIndex
-    | PhpArrayInt of int
-    | PhpArrayString of string
+    | PhpArrayInt of index: int
+    | PhpArrayString of key: string
 
 type PhpField =
     {
@@ -17,9 +19,10 @@ type PhpField =
         Type: string
     }
 
+[<Struct>]
 type Capture =
-    | ByValue of string
-    | ByRef of string
+    | ByValue of valueName: string
+    | ByRef of refName: string
 
 type Prop =
     | Field of PhpField
@@ -70,9 +73,9 @@ and PhpStatement =
     | PhpFor of ident: string * start: PhpExpr * limit: PhpExpr * isUp: bool * body: PhpStatement list
     | PhpDo of PhpExpr
 
-and PhpCase =
-    | IntCase of int
-    | StringCase of string
+and [<Struct>] PhpCase =
+    | IntCase of intValue: int
+    | StringCase of strValue: string
     | DefaultCase
 
 and PhpTypeRef =

--- a/src/Fable.Transforms/Python/Fable2Python.Types.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.Types.fs
@@ -25,6 +25,7 @@ type ITailCallOpportunity =
     abstract Args: Arg list
     abstract IsRecursiveRef: Fable.Expr -> bool
 
+[<Struct>]
 type MemberKind =
     | ClassConstructor
     | NonAttached of funcName: string

--- a/src/Fable.Transforms/Python/Python.AST.fs
+++ b/src/Fable.Transforms/Python/Python.AST.fs
@@ -133,6 +133,7 @@ type Literal =
     | TupleLiteral of Literal list
     | FrozensetLiteral of Literal list
 
+[<Struct>]
 type Operator =
     | Add
     | Sub
@@ -148,10 +149,12 @@ type Operator =
     | BitAnd
     | MatMult
 
+[<Struct>]
 type BoolOperator =
     | And
     | Or
 
+[<Struct>]
 type ComparisonOperator =
     | Eq
     | NotEq
@@ -164,17 +167,20 @@ type ComparisonOperator =
     | In
     | NotIn
 
+[<Struct>]
 type UnaryOperator =
     | Invert
     | Not
     | UAdd
     | USub
 
+[<Struct>]
 type ExpressionContext =
     | Load
     | Del
     | Store
 
+[<Struct>]
 type Identifier =
     | Identifier of name: string
 

--- a/src/Fable.Transforms/Rust/AST/Rust.AST.Parser.fs
+++ b/src/Fable.Transforms/Rust/AST/Rust.AST.Parser.fs
@@ -66,6 +66,7 @@ type AssocOp =
 
 //#[derive(PartialEq, Debug)]
 [<RequireQualifiedAccess>]
+[<Struct>]
 type Fixity =
     /// The operator is left-associative
     | Left

--- a/src/Fable.Transforms/Rust/AST/Rust.AST.Pretty.fs
+++ b/src/Fable.Transforms/Rust/AST/Rust.AST.Pretty.fs
@@ -141,6 +141,7 @@ open type Macros
 
 /// How to break. Described in more detail in the module docs.
 [<RequireQualifiedAccess>]
+[<Struct>]
 type Breaks =
     | Consistent
     | Inconsistent

--- a/src/Fable.Transforms/Rust/AST/Rust.AST.State.fs
+++ b/src/Fable.Transforms/Rust/AST/Rust.AST.State.fs
@@ -52,6 +52,7 @@ type AsmArg =
 type SourceMap() = class end
 
 [<RequireQualifiedAccess>]
+[<Struct>]
 type CommentStyle =
     /// No code on either side of each line of the comment
     | Isolated
@@ -117,6 +118,7 @@ type State =
     }
 
 [<RequireQualifiedAccess>]
+[<Struct>]
 type Edition =
     /// The 2015 edition
     | Edition2015

--- a/src/Fable.Transforms/Rust/AST/Rust.AST.Types.fs
+++ b/src/Fable.Transforms/Rust/AST/Rust.AST.Types.fs
@@ -30,11 +30,13 @@ open Fable.Transforms.Rust.AST.Spans
 module token =
 
     [<RequireQualifiedAccess>]
+    [<Struct>]
     type CommentKind =
         | Line
         | Block
 
     [<RequireQualifiedAccess>]
+    [<Struct>]
     type BinOpToken =
         | Plus
         | Minus
@@ -49,6 +51,7 @@ module token =
 
     /// A delimiter token.
     [<RequireQualifiedAccess>]
+    [<Struct>]
     type DelimToken =
         /// A round parenthesis (i.e., `(` or `)`).
         | Paren
@@ -187,6 +190,7 @@ module token =
     type TreeAndSpacing = (TokenTree * Spacing)
 
     [<RequireQualifiedAccess>]
+    [<Struct>]
     type Spacing =
         | Alone
         | Joint
@@ -319,6 +323,7 @@ type ParenthesizedArgs =
 ///
 /// Negative bounds should also be handled here.
 [<RequireQualifiedAccess>]
+[<Struct>]
 type TraitBoundModifier =
     /// No modifiers
     | None
@@ -349,6 +354,7 @@ type GenericBounds = Vec<GenericBound>
 /// if we wanted to relax this order, we could override `PartialEq` and
 /// `PartialOrd`, to allow the kinds to be unordered.
 [<RequireQualifiedAccess>]
+[<Struct>]
 type ParamKindOrd =
     | Lifetime
     | Type
@@ -553,6 +559,7 @@ type RangeEnd =
     | Excluded
 
 [<RequireQualifiedAccess>]
+[<Struct>]
 type RangeSyntax =
     /// `...`
     | DotDotDot
@@ -626,6 +633,7 @@ type PatKind =
     | MacCall of MacCall
 
 [<RequireQualifiedAccess>]
+[<Struct>]
 type Mutability =
     | Mut
     | Not
@@ -633,6 +641,7 @@ type Mutability =
 /// The kind of borrow in an `AddrOf` expression,
 /// e.g., `&place` or `&raw const place`.
 [<RequireQualifiedAccess>]
+[<Struct>]
 type BorrowKind =
     /// A normal borrow, `&$expr` or `&mut $expr`.
     /// The resulting type is either `&'a T` or `&'a mut T`
@@ -644,6 +653,7 @@ type BorrowKind =
     | Raw
 
 [<RequireQualifiedAccess>]
+[<Struct>]
 type BinOpKind =
     /// The `+` operator (addition)
     | Add
@@ -688,6 +698,7 @@ type BinOp = Spanned<BinOpKind>
 ///
 /// Note that `&data` is not an operator, it's an `AddrOf` expression.
 [<RequireQualifiedAccess>]
+[<Struct>]
 type UnOp =
     /// The `*` operator for dereferencing
     | Deref
@@ -728,6 +739,7 @@ type MacCallStmt =
     }
 
 [<RequireQualifiedAccess>]
+[<Struct>]
 type MacStmtStyle =
     /// The macro statement had a trailing semicolon (e.g., `foo! { ... };`
     /// `foo!(...);`, `foo![...];`).
@@ -794,6 +806,7 @@ type BlockCheckMode =
     | Unsafe of UnsafeSource
 
 [<RequireQualifiedAccess>]
+[<Struct>]
 type UnsafeSource =
     | CompilerGenerated
     | UserProvided
@@ -821,6 +834,7 @@ type Expr =
 
 /// Limit types of a range (inclusive or exclusive)
 [<RequireQualifiedAccess>]
+[<Struct>]
 type RangeLimits =
     /// Inclusive at the beginning, exclusive at the end
     | HalfOpen
@@ -1018,6 +1032,7 @@ type QSelf =
 
 /// A capture clause used in closures and `async` blocks.
 [<RequireQualifiedAccess>]
+[<Struct>]
 type CaptureBy =
     /// `move |x| y + x`.
     | Value
@@ -1027,6 +1042,7 @@ type CaptureBy =
 /// The movability of a generator / closure literal:
 /// whether a generator contains self-references, causing it to be `!Unpin`.
 [<RequireQualifiedAccess>]
+[<Struct>]
 type Movability =
     /// May contain self-references, `!Unpin`.
     | Static
@@ -1057,6 +1073,7 @@ type MacArgs =
         token.Token
 
 [<RequireQualifiedAccess>]
+[<Struct>]
 type MacDelimiter =
     | Parenthesis
     | Bracket
@@ -1162,11 +1179,13 @@ type FnSig =
     }
 
 [<RequireQualifiedAccess>]
+[<Struct>]
 type FloatTy =
     | F32
     | F64
 
 [<RequireQualifiedAccess>]
+[<Struct>]
 type IntTy =
     | Isize
     | I8
@@ -1176,6 +1195,7 @@ type IntTy =
     | I128
 
 [<RequireQualifiedAccess>]
+[<Struct>]
 type UintTy =
     | Usize
     | U8
@@ -1272,6 +1292,7 @@ type TyKind =
 
 /// Syntax used to declare a trait object.
 [<RequireQualifiedAccess>]
+[<Struct>]
 type TraitObjectSyntax =
     | Dyn
     | None
@@ -1327,6 +1348,7 @@ type InlineAsm =
 ///
 /// E.g., `"intel"` as in `llvm_asm!("mov eax, 2" : "={eax}"(result) : : : "intel")`.
 [<RequireQualifiedAccess>]
+[<Struct>]
 type LlvmAsmDialect =
     | Att
     | Intel
@@ -1398,6 +1420,7 @@ type FnDecl =
 
 /// Is the trait definition an auto trait?
 [<RequireQualifiedAccess>]
+[<Struct>]
 type IsAuto =
     | Yes
     | No
@@ -1442,6 +1465,7 @@ type FnRetTy =
     | Ty of P<Ty>
 
 [<RequireQualifiedAccess>]
+[<Struct>]
 type Inline =
     | Yes
     | No
@@ -1524,6 +1548,7 @@ type UseTree =
 /// are contained as statements within items. These two cases need to be
 /// distinguished for pretty-printing.
 [<RequireQualifiedAccess>]
+[<Struct>]
 type AttrStyle =
     | Outer
     | Inner
@@ -1590,6 +1615,7 @@ type PolyTraitRef =
     }
 
 [<RequireQualifiedAccess>]
+[<Struct>]
 type CrateSugar =
     /// Source is `pub(crate)`.
     | PubCrate

--- a/src/Fable.Transforms/Rust/Fable2Rust.fs
+++ b/src/Fable.Transforms/Rust/Fable2Rust.fs
@@ -965,6 +965,7 @@ module TypeInfo =
         )
         |> Option.toValueOption
 
+    [<Struct>]
     type PointerType =
         | Lrc
         | Rc


### PR DESCRIPTION
## Summary

Resolves the editable **IONIDE-012** (`StructDiscriminatedUnionAnalyzer`) code scanning alerts by marking the flagged discriminated unions `[<Struct>]` — the same pattern already used for `FieldNamingKind`, `ClassStyle`, and `Atom`.

**62 alerts** across 20 files are addressed:
- The majority are enum-like / single-case / already-named-field DUs needing only the `[<Struct>]` attribute (bulk in `Rust.AST.Types.fs` ×26, `Python.AST.fs` ×6, `Global/Babel.fs` ×6, `Dart/Dart.fs` ×4, …).
- **8 multicase DUs with unnamed fields** also required unique field names to satisfy the struct-union rule (`FS3585`). Positional pattern matching is preserved, so call sites are unaffected:
  - `Php.fs`: `PhpConst`, `PhpArrayIndex`, `Capture`, `PhpCase`
  - `Fable2Php.fs`: `ReturnStrategy`
  - `FSharp2Fable.Util.fs`: `CompiledValue`
  - `Globbing.fs` (+ its `.fsi` signature): `SearchOption`
  - `Util.fs`: `AttParam`

## Left untouched

The **8 IONIDE-012 alerts in `src/Fable.AST/`** (`Common.fs`, `Fable.fs`, `Plugins.fs`) are intentionally not changed. Adding `[<Struct>]` there would flip a public type from a reference type to a value type — a breaking change disallowed for that project.

## Verification

- `Fable.Cli` (→ `Fable.Transforms` + `Fable.Compiler`) and `Fable.Standalone` build clean.
- No reference-identity / `null` / `Unchecked.defaultof` usages on the changed compiler-logic types (the only behavioral axis `[<Struct>]` affects).
- JavaScript quicktest compiles and runs end-to-end with the freshly built compiler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)