### PR TITLE
chore: trigger PyPI publish workflow after creating a release

### DIFF
--- a/src/Fable.Build/GithubRelease.fs
+++ b/src/Fable.Build/GithubRelease.fs
@@ -34,6 +34,21 @@ let createGithubRelease (version: LastVersionFinder.Version) =
             |> CmdLine.toString
         )
 
+        // Creating the release above with the default GITHUB_TOKEN does not
+        // trigger the `release: published` event in other workflows (GitHub
+        // suppresses it to avoid recursive runs). `workflow_dispatch` is one of
+        // the two exceptions that CAN be triggered by GITHUB_TOKEN, so we
+        // explicitly dispatch the PyPI publish workflow for the freshly created tag.
+        Command.Run(
+            "gh",
+            CmdLine.empty
+            |> CmdLine.appendRaw "workflow"
+            |> CmdLine.appendRaw "run"
+            |> CmdLine.appendRaw "publish-pypi.yml"
+            |> CmdLine.appendPrefix "--ref" versionText
+            |> CmdLine.toString
+        )
+
 let private createReleaseCommitAndPush (version: LastVersionFinder.Version) =
     let versionText = version.Version.ToString()
 


### PR DESCRIPTION
## Problem

The automated release flow (EasyBuild ShipIt) creates a GitHub release but does **not** trigger `publish-pypi.yml`, so the PyPI publish had to be dispatched manually.

## Root cause

`publish-pypi.yml` listens for `release: types: [published]`. The release is created with `gh release create` (`GithubRelease.fs`), authenticated in CI via the default `GITHUB_TOKEN`. GitHub deliberately suppresses events triggered by `GITHUB_TOKEN` from starting other workflow runs (to prevent recursive runs) — **except** `workflow_dispatch` and `repository_dispatch`. So the `release: published` event fires but is silently ignored by downstream workflows.

## Fix

After a release is created, explicitly dispatch `publish-pypi.yml` for the freshly created tag via `gh workflow run publish-pypi.yml --ref <tag>`. Since `workflow_dispatch` is one of the two events that *can* be triggered by `GITHUB_TOKEN`, this works with the token already present in the workflow — no new PAT/secret needed.

The call sits inside the existing `if not releaseExists` guard, so it only fires for genuinely new releases, and dispatches against the new tag so `dunamai --latest-tag` resolves the correct version. No changes to `publish-pypi.yml` are required (it already has `workflow_dispatch`).

Note: a local `./build.sh github-release` will now also dispatch the PyPI workflow when it creates a release, which is consistent with creating a release meaning "publish all packages".

🤖 Generated with [Claude Code](https://claude.com/claude-code)