### PR TITLE
chore: fetch tags so PyPI publish resolves the real version

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -15,6 +15,11 @@ jobs:
         UV_LINK_MODE: copy
       steps:
       - uses: actions/checkout@v6
+        with:
+          # Fetch the full history including tags so `dunamai --latest-tag`
+          # can resolve the release version. Without this, the default shallow
+          # checkout has no tags and dunamai falls back to 0.0.0.
+          fetch-depth: 0
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:


### PR DESCRIPTION
## Problem

A manually triggered PyPI publish shipped version **0.0.0** to PyPI (https://pypi.org/project/fable-library/0.0.0/).

## Root cause

The `build-fable-library` job derives the package version with:

```bash
VERSION=$(dunamai from git --format "..." --pattern "..." --latest-tag)
```

`actions/checkout` defaults to a shallow clone (`fetch-depth: 1`) that does **not** fetch tags. With no tags available, `dunamai --latest-tag` falls back to its default base version `0.0.0`, which then gets built into the wheels and published.

## Fix

Set `fetch-depth: 0` on the checkout in the `build-fable-library` job so the full tag history is available and `dunamai` resolves the actual release version. Only this job runs `dunamai` — the wheel-building jobs just download the produced artifact — so no other checkout needs changing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)