### PR TITLE
chore: replace deprecated maturin upload with uv publish

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -30,14 +30,14 @@ jobs:
           python-version: '3.12'
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-      - name: Install Uv and Maturin
-        run: |
-          pipx install uv
-          pipx install maturin
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8
+      - name: Install Maturin
+        run: uv tool install maturin
       - name: Transpile F# to Python
         run: ./build.sh fable-library --python
       - name: Install Dunamai
-        run: pipx install dunamai
+        run: uv tool install dunamai
       - name: Set version
         run: |
           VERSION=$(dunamai from git --format "{base}{stage}{revision}" --pattern "^(?P<base>\d+\.\d+\.\d+)((-(?P<stage>alpha|beta|rc))\.(?P<revision>\d+))?$" --latest-tag)
@@ -74,8 +74,8 @@ jobs:
             python-version: ${{ matrix.python-version }}
         - name: Install Rust
           uses: dtolnay/rust-toolchain@stable
-        - name: Install Uv
-          run: pipx install uv
+        - name: Install uv
+          uses: astral-sh/setup-uv@v8
         - name: Download fable-library-py
           uses: actions/download-artifact@v8
           with:
@@ -281,11 +281,12 @@ jobs:
           uses: actions/attest-build-provenance@v4
           with:
             subject-path: 'wheels-*/*'
+        - name: Install uv
+          uses: astral-sh/setup-uv@v8
         - name: Publish to PyPI
           if: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
-          uses: PyO3/maturin-action@v1
+          # `maturin upload` is deprecated (PyO3/maturin#2334); use `uv publish`.
+          # `--check-url` skips files already on PyPI (replaces `--skip-existing`).
           env:
-            MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-          with:
-            command: upload
-            args: --non-interactive --skip-existing wheels-*/*
+            UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+          run: uv publish --check-url https://pypi.org/simple/ wheels-*/*


### PR DESCRIPTION
## Summary

`maturin upload`/`publish` are deprecated ([PyO3/maturin#2334](https://github.com/PyO3/maturin/issues/2334)) — maturin recommends delegating publishing to dedicated tools like `uv` or `twine`. This switches the PyPI publish step to `uv publish` and standardizes uv installation across the workflow.

## Changes

- **Publish step:** `maturin upload --skip-existing` → `uv publish --check-url https://pypi.org/simple/`. `--check-url` skips files already present on PyPI (equivalent to `--skip-existing`). Token is read from `UV_PUBLISH_TOKEN` (same `PYPI_API_TOKEN` secret).
- **uv install:** all three jobs now use the official `astral-sh/setup-uv@v8` action instead of `pipx install uv` (faster prebuilt binary + caching).
- **maturin / dunamai:** installed via `uv tool install` (the uv equivalent of `pipx install`); they stay on PATH so the `maturin` call in `build.sh` and the `dunamai from git ...` invocation are unchanged.

## Notes

- The remaining `PyO3/maturin-action@v1` steps are untouched — only the `upload`/`publish` commands are deprecated; using the action to **build** wheels is still supported.
- Token-based auth is retained. A future follow-up could drop the token and use PyPI [trusted publishing](https://docs.pypi.org/trusted-publishers/) (the job already has `id-token: write`), but that requires PyPI-side configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)