### PR TITLE
fix(beam): make immutable class instances process-portable

### DIFF
--- a/src/Fable.Transforms/Beam/FABLE-BEAM.md
+++ b/src/Fable.Transforms/Beam/FABLE-BEAM.md
@@ -240,6 +240,27 @@ Erlang modules implementing F# core types:
 | **Nested modules**                | Flat module names: `My_Module_Sub`                | One file per module                  |
 | **Computation expressions**       | Transformed at Fable AST level; async/task → CPS  | —                                    |
 
+### Class instance representation: map vs process-dict ref
+
+A class instance has two possible representations, chosen per class at construction:
+
+- **Immutable classes** (no mutable instance fields, no `as self`, no base-class
+  state to merge, and whose stored interface closures / field initializers don't use
+  `this` as a value) are emitted as a **self-contained map** — the instance term *is*
+  the state map, exactly like a non-self-referencing object expression. These are
+  process-portable: an interface or regular method invoked from another process reads
+  fields from the value itself, not from the constructing process's dictionary.
+- **Mutable classes** (any `let mutable` / `val mutable` instance field, self-reference,
+  etc.) keep their state in the **process dictionary**, keyed by a `make_ref()`. The BEAM
+  has no shared mutable memory across processes, so mutation is single-process by design
+  — cross-process object sharing of mutable instances is intentionally unsupported (use
+  actors / message passing for that).
+
+Field reads are decoupled from the representation: `fable_utils:field_get/2` (and
+`iface_get`, `inst_state`, `move_next`, `get_current`, `safe_dispose`) accept both a map
+and a ref, so call sites and runtime helpers work regardless of which form the
+constructor chose. See `transformClassDeclaration` in `Fable2Beam.fs`.
+
 ## Concurrency & Async
 
 This compiler/runtime implements F#'s async and agent model **in-process** (CPS-based),

--- a/src/Fable.Transforms/Beam/Fable2Beam.Util.fs
+++ b/src/Fable.Transforms/Beam/Fable2Beam.Util.fs
@@ -146,7 +146,9 @@ let rec containsThisValue (expr: Expr) : bool =
             |> Option.map (fun (_, e) -> containsThisValue e)
             |> Option.defaultValue false)
         || (finalizer |> Option.map containsThisValue |> Option.defaultValue false)
-    | Emit(emitInfo, _, _) -> emitInfo.CallInfo.Args |> List.exists containsThisValue
+    | Emit(emitInfo, _, _) ->
+        emitInfo.CallInfo.Args |> List.exists containsThisValue
+        || (emitInfo.CallInfo.ThisArg |> Option.exists containsThisValue)
     | ObjectExpr(members, _, baseCall) ->
         members |> List.exists (fun m -> containsThisValue m.Body)
         || (
@@ -228,7 +230,9 @@ let rec thisUsedAsValue (name: string) (expr: Expr) : bool =
             |> Option.map (fun (_, e) -> thisUsedAsValue name e)
             |> Option.defaultValue false)
         || (finalizer |> Option.map (thisUsedAsValue name) |> Option.defaultValue false)
-    | Emit(emitInfo, _, _) -> emitInfo.CallInfo.Args |> List.exists (thisUsedAsValue name)
+    | Emit(emitInfo, _, _) ->
+        emitInfo.CallInfo.Args |> List.exists (thisUsedAsValue name)
+        || (emitInfo.CallInfo.ThisArg |> Option.exists (thisUsedAsValue name))
     | ObjectExpr(members, _, baseCall) ->
         members |> List.exists (fun m -> thisUsedAsValue name m.Body)
         || (

--- a/src/Fable.Transforms/Beam/Fable2Beam.Util.fs
+++ b/src/Fable.Transforms/Beam/Fable2Beam.Util.fs
@@ -85,6 +85,165 @@ let rec containsIdentRef (name: string) (expr: Expr) : bool =
         | Curry _ -> false
     | _ -> false
 
+/// Check whether an expression references the constructor's `this` (the `ThisValue`
+/// value kind — which, per the Fable AST, only appears inside constructors). The
+/// self-contained map representation builds the instance after evaluating field
+/// initializers and `do` bodies, so any such body that references `this` cannot use
+/// that representation and must keep the process-dict ref form.
+let rec containsThisValue (expr: Expr) : bool =
+    match expr with
+    | Value(ThisValue _, _) -> true
+    | Value(value, _) ->
+        match value with
+        | NewAnonymousRecord(values, _, _, _)
+        | NewRecord(values, _, _)
+        | NewUnion(values, _, _, _)
+        | NewTuple(values, _) -> values |> List.exists containsThisValue
+        | NewList(Some(h, t), _) -> containsThisValue h || containsThisValue t
+        | NewOption(Some e, _, _) -> containsThisValue e
+        | NewArray(NewArrayKind.ArrayValues values, _, _) -> values |> List.exists containsThisValue
+        | StringTemplate(_, _, values) -> values |> List.exists containsThisValue
+        | _ -> false
+    | IdentExpr _ -> false
+    | Call(callee, info, _, _) ->
+        containsThisValue callee
+        || info.Args |> List.exists containsThisValue
+        || (info.ThisArg |> Option.exists containsThisValue)
+    | CurriedApply(applied, args, _, _) -> containsThisValue applied || args |> List.exists containsThisValue
+    | Let(_, value, body) -> containsThisValue value || containsThisValue body
+    | LetRec(bindings, body) ->
+        bindings |> List.exists (fun (_, v) -> containsThisValue v)
+        || containsThisValue body
+    | Lambda(_, body, _) -> containsThisValue body
+    | Delegate(_, body, _, _) -> containsThisValue body
+    | IfThenElse(g, t, e, _) -> containsThisValue g || containsThisValue t || containsThisValue e
+    | Sequential exprs -> exprs |> List.exists containsThisValue
+    | TypeCast(e, _) -> containsThisValue e
+    | Operation(kind, _, _, _) ->
+        match kind with
+        | Binary(_, l, r) -> containsThisValue l || containsThisValue r
+        | Unary(_, e) -> containsThisValue e
+        | Logical(_, l, r) -> containsThisValue l || containsThisValue r
+    | DecisionTree(e, targets) ->
+        containsThisValue e
+        || targets |> List.exists (fun (_, t) -> containsThisValue t)
+    | DecisionTreeSuccess(_, values, _) -> values |> List.exists containsThisValue
+    | Test(e, _, _) -> containsThisValue e
+    | Get(e, kind, _, _) ->
+        containsThisValue e
+        || (
+            match kind with
+            | ExprGet idx -> containsThisValue idx
+            | _ -> false
+        )
+    | Set(e, _, _, v, _) -> containsThisValue e || containsThisValue v
+    | WhileLoop(guard, body, _) -> containsThisValue guard || containsThisValue body
+    | ForLoop(_, start, limit, body, _, _) ->
+        containsThisValue start || containsThisValue limit || containsThisValue body
+    | TryCatch(body, catch, finalizer, _) ->
+        containsThisValue body
+        || (catch
+            |> Option.map (fun (_, e) -> containsThisValue e)
+            |> Option.defaultValue false)
+        || (finalizer |> Option.map containsThisValue |> Option.defaultValue false)
+    | Emit(emitInfo, _, _) -> emitInfo.CallInfo.Args |> List.exists containsThisValue
+    | ObjectExpr(members, _, baseCall) ->
+        members |> List.exists (fun m -> containsThisValue m.Body)
+        || (
+            match baseCall with
+            | Some e -> containsThisValue e
+            | None -> false
+        )
+    | Extended(kind, _) ->
+        match kind with
+        | Throw(Some e, _) -> containsThisValue e
+        | Throw(None, _)
+        | Debugger
+        | Curry _ -> false
+    | _ -> false
+
+/// Check whether `name` (an instance's `this`/self identifier) is ever used as a
+/// runtime value, i.e. anywhere other than as the object of a field read
+/// (`this.Field`). Field reads can be compiled to read from the captured instance
+/// map, but using `this` itself as a value (passing it, calling a sibling method on
+/// it, etc.) requires a reference to the whole instance — which a self-contained
+/// immutable map cannot provide to closures stored inside it. Used to decide whether
+/// a class can be represented as a portable map rather than a process-dict ref.
+let rec thisUsedAsValue (name: string) (expr: Expr) : bool =
+    match expr with
+    | IdentExpr ident -> ident.Name = name
+    // `this.Field` — the ident in the object position is a field read, not a value use.
+    | Get(IdentExpr ident, FieldGet _, _, _) when ident.Name = name -> false
+    | Get(e, kind, _, _) ->
+        thisUsedAsValue name e
+        || (
+            match kind with
+            | ExprGet idx -> thisUsedAsValue name idx
+            | _ -> false
+        )
+    | Call(callee, info, _, _) ->
+        thisUsedAsValue name callee
+        || info.Args |> List.exists (thisUsedAsValue name)
+        || (info.ThisArg |> Option.exists (thisUsedAsValue name))
+    | CurriedApply(applied, args, _, _) -> thisUsedAsValue name applied || args |> List.exists (thisUsedAsValue name)
+    | Let(_, value, body) -> thisUsedAsValue name value || thisUsedAsValue name body
+    | LetRec(bindings, body) ->
+        bindings |> List.exists (fun (_, v) -> thisUsedAsValue name v)
+        || thisUsedAsValue name body
+    | Lambda(_, body, _) -> thisUsedAsValue name body
+    | Delegate(_, body, _, _) -> thisUsedAsValue name body
+    | IfThenElse(g, t, e, _) -> thisUsedAsValue name g || thisUsedAsValue name t || thisUsedAsValue name e
+    | Sequential exprs -> exprs |> List.exists (thisUsedAsValue name)
+    | Value(value, _) ->
+        match value with
+        | NewAnonymousRecord(values, _, _, _)
+        | NewRecord(values, _, _)
+        | NewUnion(values, _, _, _)
+        | NewTuple(values, _) -> values |> List.exists (thisUsedAsValue name)
+        | NewList(Some(h, t), _) -> thisUsedAsValue name h || thisUsedAsValue name t
+        | NewOption(Some e, _, _) -> thisUsedAsValue name e
+        | NewArray(NewArrayKind.ArrayValues values, _, _) -> values |> List.exists (thisUsedAsValue name)
+        | StringTemplate(_, _, values) -> values |> List.exists (thisUsedAsValue name)
+        | _ -> false
+    | TypeCast(e, _) -> thisUsedAsValue name e
+    | Operation(kind, _, _, _) ->
+        match kind with
+        | Binary(_, l, r) -> thisUsedAsValue name l || thisUsedAsValue name r
+        | Unary(_, e) -> thisUsedAsValue name e
+        | Logical(_, l, r) -> thisUsedAsValue name l || thisUsedAsValue name r
+    | DecisionTree(e, targets) ->
+        thisUsedAsValue name e
+        || targets |> List.exists (fun (_, t) -> thisUsedAsValue name t)
+    | DecisionTreeSuccess(_, values, _) -> values |> List.exists (thisUsedAsValue name)
+    | Test(e, _, _) -> thisUsedAsValue name e
+    | Set(e, _, _, v, _) -> thisUsedAsValue name e || thisUsedAsValue name v
+    | WhileLoop(guard, body, _) -> thisUsedAsValue name guard || thisUsedAsValue name body
+    | ForLoop(_, start, limit, body, _, _) ->
+        thisUsedAsValue name start
+        || thisUsedAsValue name limit
+        || thisUsedAsValue name body
+    | TryCatch(body, catch, finalizer, _) ->
+        thisUsedAsValue name body
+        || (catch
+            |> Option.map (fun (_, e) -> thisUsedAsValue name e)
+            |> Option.defaultValue false)
+        || (finalizer |> Option.map (thisUsedAsValue name) |> Option.defaultValue false)
+    | Emit(emitInfo, _, _) -> emitInfo.CallInfo.Args |> List.exists (thisUsedAsValue name)
+    | ObjectExpr(members, _, baseCall) ->
+        members |> List.exists (fun m -> thisUsedAsValue name m.Body)
+        || (
+            match baseCall with
+            | Some e -> thisUsedAsValue name e
+            | None -> false
+        )
+    | Extended(kind, _) ->
+        match kind with
+        | Throw(Some e, _) -> thisUsedAsValue name e
+        | Throw(None, _)
+        | Debugger
+        | Curry _ -> false
+    | _ -> false
+
 /// Check if an expression is effectively unit — either a direct UnitConstant
 /// or a Sequential containing only UnitConstants. This pattern arises when F#
 /// inlines `ignore` on a call: `let value = expr in ()` where the body may be

--- a/src/Fable.Transforms/Beam/Fable2Beam.fs
+++ b/src/Fable.Transforms/Beam/Fable2Beam.fs
@@ -1924,16 +1924,13 @@ and transformGet (com: IBeamCompiler) (ctx: Context) (kind: GetKind) (typ: Type)
                 match isThisRef, ctx.CtorFieldExprs.TryFind(info.Name) with
                 | true, Some cachedExpr -> cachedExpr
                 | _ ->
-                    // Class instance: state is stored in process dict, ref is the key
-                    // Use f$ prefix to avoid collision with interface method keys
+                    // Class instance: read via fable_utils:field_get, which supports both
+                    // a self-contained map (immutable class) and a process-dict ref (mutable class).
+                    // Use field_ prefix to avoid collision with interface method keys.
                     let classFieldAtom =
                         Beam.ErlExpr.Literal(Beam.ErlLiteral.AtomLit(Beam.Atom("field_" + fieldName)))
 
-                    Beam.ErlExpr.Call(
-                        Some "maps",
-                        "get",
-                        [ classFieldAtom; Beam.ErlExpr.Call(None, "get", [ erlExpr ]) ]
-                    )
+                    Beam.ErlExpr.Call(Some "fable_utils", "field_get", [ classFieldAtom; erlExpr ])
             | Fable.AST.Fable.Type.DeclaredType(entityRef, _) when isInterfaceType com entityRef ->
                 let fieldName = sanitizeErlangName info.Name
                 let fieldAtom = Beam.ErlExpr.Literal(Beam.ErlLiteral.AtomLit(Beam.Atom fieldName))
@@ -2420,13 +2417,13 @@ and transformCall (com: IBeamCompiler) (ctx: Context) (callee: Expr) (info: Call
         // as a class field). This avoids confusing with method calls on self.
         match info.ThisArg with
         | Some thisExpr when ctx.ThisArgVar.IsSome && ctx.CtorParamNames.Contains(ident.Name) ->
-            // Field-stored function: (maps:get(field_<name>, get(This)))(Args)
+            // Field-stored function: (fable_utils:field_get(field_<name>, This))(Args)
             let erlThis = transformExpr com ctx thisExpr
             let thisH, cleanThis = extractBlock erlThis
             let fieldAtom = atomLit ("field_" + sanitizeErlangName ident.Name)
 
             let lookup =
-                Beam.ErlExpr.Call(Some "maps", "get", [ fieldAtom; Beam.ErlExpr.Call(None, "get", [ cleanThis ]) ])
+                Beam.ErlExpr.Call(Some "fable_utils", "field_get", [ fieldAtom; cleanThis ])
 
             Beam.ErlExpr.Apply(lookup, cleanArgs) |> wrapWithHoisted (hoisted @ thisH)
         | _ ->
@@ -2572,15 +2569,11 @@ and transformCall (com: IBeamCompiler) (ctx: Context) (callee: Expr) (info: Call
                         | _ -> false
 
                     if isCtorFieldInvoke then
-                        // Constructor param field invoke: (maps:get(field_<name>, get(This)))(Args)
+                        // Constructor param field invoke: (fable_utils:field_get(field_<name>, This))(Args)
                         let fieldAtom = atomLit ("field_" + sanitizeErlangName methodName)
 
                         let lookup =
-                            Beam.ErlExpr.Call(
-                                Some "maps",
-                                "get",
-                                [ fieldAtom; Beam.ErlExpr.Call(None, "get", [ cleanCallee ]) ]
-                            )
+                            Beam.ErlExpr.Call(Some "fable_utils", "field_get", [ fieldAtom; cleanCallee ])
 
                         Beam.ErlExpr.Apply(lookup, cleanArgs) |> wrapWithHoisted allHoisted
                     elif isRecordLike then
@@ -2760,7 +2753,11 @@ and transformClassDeclaration
                                     // BaseState = get(BaseRef)
                                     Beam.ErlExpr.Match(
                                         Beam.PVar "BaseState",
-                                        Beam.ErlExpr.Call(None, "get", [ Beam.ErlExpr.Variable "BaseRef" ])
+                                        Beam.ErlExpr.Call(
+                                            Some "fable_utils",
+                                            "inst_state",
+                                            [ Beam.ErlExpr.Variable "BaseRef" ]
+                                        )
                                     )
                                     // erase(BaseRef) — clean up the temporary base ref
                                     Beam.ErlExpr.Call(None, "erase", [ Beam.ErlExpr.Variable "BaseRef" ])
@@ -2772,6 +2769,63 @@ and transformClassDeclaration
                             // — skip the base call, no fields to merge
                             [], []
                     | _ -> [], []
+
+                // Decide the instance representation. An immutable class is emitted as a
+                // self-contained map (the instance term), exactly like a non-self-referencing
+                // object expression — so it is process-portable: field reads and method calls
+                // work in any process, not just the constructing one. A class is map-representable
+                // when it has no mutable instance fields, no `as self` self-reference, no base
+                // class state to merge, and none of its stored interface closures / `do` bodies use
+                // `this` as a value (only as the object of a field read — those become reads from
+                // the captured instance map). Classes with mutable instance fields keep the
+                // process-dict ref representation: BEAM has no shared mutable memory across
+                // processes, so cross-process mutation is intentionally unsupported (use actors).
+                // Interface members are stored as closures inside the instance. They may read
+                // `this.Field` (which we redirect to the captured instance map), but using `this`
+                // itself as a value — passing it, calling a sibling instance method on it — needs a
+                // reference to the whole instance, which a self-contained map cannot give a closure
+                // stored inside it. Such classes keep the process-dict ref representation.
+                let ifaceMembersPortable =
+                    decl.AttachedMembers
+                    |> List.filter (fun m -> m.ImplementedSignatureRef.IsSome)
+                    |> List.forall (fun memb ->
+                        match memb.Args with
+                        | first :: _ when first.IsThisArgument || first.Name = "this" ->
+                            not (Util.thisUsedAsValue first.Name memb.Body)
+                            && not (Util.containsThisValue memb.Body)
+                        | _ -> not (Util.containsThisValue memb.Body)
+                    )
+
+                // Field initializers and `do` bodies reference the constructor's `this` as the
+                // `ThisValue` value kind. The self-contained map is only built after they run, so
+                // any reference to `this` there is unsupportable in the map form — fall back to refs.
+                let fieldsPortable =
+                    fields |> List.forall (fun (_, v) -> not (Util.containsThisValue v))
+
+                let doExprsPortable =
+                    doExprs |> List.forall (fun e -> not (Util.containsThisValue e))
+
+                let hasMutableInstanceFields =
+                    ent.FSharpFields |> List.exists (fun f -> f.IsMutable)
+
+                let useMapRepr =
+                    not hasMutableInstanceFields
+                    && selfRefFieldNames.IsEmpty
+                    && baseEntries.IsEmpty
+                    && baseCallPrelude.IsEmpty
+                    && ifaceMembersPortable
+                    && fieldsPortable
+                    && doExprsPortable
+
+                // The Erlang variable that holds the instance inside the constructor:
+                // the self-contained fields map (`State0`) for map representation, or the
+                // process-dict ref (`Ref`) otherwise. Interface closures read `this.Field`
+                // from this variable via fable_utils:field_get.
+                let instanceVar =
+                    if useMapRepr then
+                        "State0"
+                    else
+                        "Ref"
 
                 // Process fields in order, progressively building a map of field name → Erlang expr.
                 // This allows later fields to reference earlier fields via this.FieldName
@@ -2800,8 +2854,12 @@ and transformClassDeclaration
                         (baseEntries, ctorCtx)
 
                 // Build interface entries from AttachedMembers that implement interfaces.
-                // These are stored in the process dict state map alongside field state,
-                // so interface dispatch (fable_utils:iface_get) can find them.
+                // These are stored in the instance map alongside field state, so interface
+                // dispatch (fable_utils:iface_get) can find them. Inside their closures,
+                // `this` resolves to the instance variable (the captured fields map for the
+                // map representation, or the process-dict ref otherwise).
+                let ifaceCtx = { ctorCtx with ThisArgVar = Some instanceVar }
+
                 let interfaceEntries =
                     decl.AttachedMembers
                     |> List.choose (fun memb ->
@@ -2818,8 +2876,8 @@ and transformClassDeclaration
                                 let ifaceCtorCtx =
                                     match memb.Args with
                                     | first :: _ when first.IsThisArgument || first.Name = "this" ->
-                                        { ctorCtx with ThisIdentNames = Set.singleton first.Name }
-                                    | _ -> ctorCtx
+                                        { ifaceCtx with ThisIdentNames = Set.singleton first.Name }
+                                    | _ -> ifaceCtx
 
                                 let erlBody = transformExpr com ifaceCtorCtx memb.Body
 
@@ -2860,15 +2918,15 @@ and transformClassDeclaration
                                 let ifaceCtorCtx =
                                     let argNames =
                                         nonThisArgs
-                                        |> List.fold (fun (s: Set<string>) a -> s.Add(a.Name)) ctorCtx.LocalVars
+                                        |> List.fold (fun (s: Set<string>) a -> s.Add(a.Name)) ifaceCtx.LocalVars
 
                                     match memb.Args with
                                     | first :: _ when first.IsThisArgument || first.Name = "this" ->
-                                        { ctorCtx with
+                                        { ifaceCtx with
                                             ThisIdentNames = Set.singleton first.Name
                                             LocalVars = argNames
                                         }
-                                    | _ -> { ctorCtx with LocalVars = argNames }
+                                    | _ -> { ifaceCtx with LocalVars = argNames }
 
                                 let erlBody = transformExpr com ifaceCtorCtx memb.Body
 
@@ -2898,57 +2956,84 @@ and transformClassDeclaration
                         | None -> None
                     )
 
-                // Transform constructor `do` expressions (side effects like `do v.Value <- 10`)
+                // Transform constructor `do` expressions (side effects like `do v.Value <- 10`).
+                // Under the map representation these never reference `this` (the gate excludes such
+                // classes), so the base constructor context is sufficient.
                 let erlDoExprs = doExprs |> List.map (transformExpr com ctorCtx)
 
-                // Build the state expression: either a plain map or merged with base state
-                let stateExpr =
-                    if baseCallPrelude.IsEmpty then
-                        Beam.ErlExpr.Map mapEntries
-                    else
-                        // maps:merge(BaseState, #{derived_fields...})
-                        Beam.ErlExpr.Call(
-                            Some "maps",
-                            "merge",
-                            [ Beam.ErlExpr.Variable "BaseState"; Beam.ErlExpr.Map mapEntries ]
-                        )
-
                 let body =
-                    baseCallPrelude
-                    @ [
-                        // Ref = make_ref()
-                        Beam.ErlExpr.Match(Beam.PVar "Ref", Beam.ErlExpr.Call(None, "make_ref", []))
-                        // put(Ref, State) where State is either #{fields} or maps:merge(BaseState, #{fields})
-                        Beam.ErlExpr.Call(None, "put", [ Beam.ErlExpr.Variable "Ref"; stateExpr ])
-                    ]
-                    @ (if interfaceEntries.IsEmpty then
-                           []
-                       else
-                           // Step 2: merge interface entries into state (separate put so getter bodies
-                           // that reference this.SomeField via get(Ref) work correctly)
-                           [
-                               Beam.ErlExpr.Call(
-                                   None,
-                                   "put",
-                                   [
-                                       Beam.ErlExpr.Variable "Ref"
-                                       Beam.ErlExpr.Call(
-                                           Some "maps",
-                                           "merge",
-                                           [
-                                               Beam.ErlExpr.Call(None, "get", [ Beam.ErlExpr.Variable "Ref" ])
-                                               Beam.ErlExpr.Map interfaceEntries
-                                           ]
-                                       )
-                                   ]
-                               )
-                           ])
-                    // Constructor `do` body expressions (side effects)
-                    @ erlDoExprs
-                    @ [
-                        // Return Ref
-                        Beam.ErlExpr.Variable "Ref"
-                    ]
+                    if useMapRepr then
+                        // Immutable class: the instance IS a self-contained map (process-portable).
+                        // Interface closures capture the fields map (`State0`) so they read fields
+                        // from the value itself, never from a per-process dictionary.
+                        if interfaceEntries.IsEmpty && erlDoExprs.IsEmpty then
+                            [ Beam.ErlExpr.Map mapEntries ]
+                        else
+                            [
+                                // State0 = #{fields}
+                                Beam.ErlExpr.Match(Beam.PVar instanceVar, Beam.ErlExpr.Map mapEntries)
+                            ]
+                            @ erlDoExprs
+                            @ [
+                                if interfaceEntries.IsEmpty then
+                                    Beam.ErlExpr.Variable instanceVar
+                                else
+                                    // Return State0 extended with the interface closures.
+                                    Beam.ErlExpr.Call(
+                                        Some "maps",
+                                        "merge",
+                                        [ Beam.ErlExpr.Variable instanceVar; Beam.ErlExpr.Map interfaceEntries ]
+                                    )
+                            ]
+                    else
+                        // Mutable class: state lives in the process dictionary, keyed by a ref.
+                        // Build the state expression: either a plain map or merged with base state.
+                        let stateExpr =
+                            if baseCallPrelude.IsEmpty then
+                                Beam.ErlExpr.Map mapEntries
+                            else
+                                // maps:merge(BaseState, #{derived_fields...})
+                                Beam.ErlExpr.Call(
+                                    Some "maps",
+                                    "merge",
+                                    [ Beam.ErlExpr.Variable "BaseState"; Beam.ErlExpr.Map mapEntries ]
+                                )
+
+                        baseCallPrelude
+                        @ [
+                            // Ref = make_ref()
+                            Beam.ErlExpr.Match(Beam.PVar "Ref", Beam.ErlExpr.Call(None, "make_ref", []))
+                            // put(Ref, State) where State is either #{fields} or maps:merge(BaseState, #{fields})
+                            Beam.ErlExpr.Call(None, "put", [ Beam.ErlExpr.Variable "Ref"; stateExpr ])
+                        ]
+                        @ (if interfaceEntries.IsEmpty then
+                               []
+                           else
+                               // Step 2: merge interface entries into state (separate put so getter bodies
+                               // that reference this.SomeField via get(Ref) work correctly)
+                               [
+                                   Beam.ErlExpr.Call(
+                                       None,
+                                       "put",
+                                       [
+                                           Beam.ErlExpr.Variable "Ref"
+                                           Beam.ErlExpr.Call(
+                                               Some "maps",
+                                               "merge",
+                                               [
+                                                   Beam.ErlExpr.Call(None, "get", [ Beam.ErlExpr.Variable "Ref" ])
+                                                   Beam.ErlExpr.Map interfaceEntries
+                                               ]
+                                           )
+                                       ]
+                                   )
+                               ])
+                        // Constructor `do` body expressions (side effects)
+                        @ erlDoExprs
+                        @ [
+                            // Return Ref
+                            Beam.ErlExpr.Variable "Ref"
+                        ]
 
                 // Use the constructor's compiled name so call sites can find it
                 let ctorFuncName = sanitizeErlangName cons.Name
@@ -3337,7 +3422,7 @@ and transformDeclaration (com: IBeamCompiler) (ctx: Context) (decl: Declaration)
                         Beam.ErlExpr.Match(Beam.PVar "BaseRef", cleanBaseCall)
                         Beam.ErlExpr.Match(
                             Beam.PVar "BaseState",
-                            Beam.ErlExpr.Call(None, "get", [ Beam.ErlExpr.Variable "BaseRef" ])
+                            Beam.ErlExpr.Call(Some "fable_utils", "inst_state", [ Beam.ErlExpr.Variable "BaseRef" ])
                         )
                         Beam.ErlExpr.Call(None, "erase", [ Beam.ErlExpr.Variable "BaseRef" ])
                     ]

--- a/src/fable-library-beam/fable_utils.erl
+++ b/src/fable-library-beam/fable_utils.erl
@@ -201,8 +201,9 @@ move_next(EnumRef) ->
     end.
 
 get_current(Enum) when is_map(Enum) ->
-    %% Map-represented compiled enumerator: call its field_current fun.
-    (maps:get(field_current, Enum))(ok);
+    %% Map-represented compiled enumerator (immutable instance fields): the instance
+    %% map is the state.
+    current_of_state(Enum);
 get_current(EnumRef) ->
     State = get(EnumRef),
     case maps:is_key(current, State) of
@@ -210,8 +211,23 @@ get_current(EnumRef) ->
             %% Simple list-based enumerator
             maps:get(current, State);
         false ->
-            %% Compiled seq.erl enumerator: call field_current fun
-            (maps:get(field_current, State))(ok)
+            current_of_state(State)
+    end.
+
+%% Resolve the "current" value from a compiled enumerator's state map. Two shapes
+%% occur and the representation (map vs ref) is orthogonal to which one applies:
+%%   - compiled seq.erl enumerators store a `field_current` thunk;
+%%   - a class implementing IEnumerator stores its Current getter under the interface
+%%     key as a {getter, Fun} pair (generic IEnumerator<T> and/or non-generic).
+current_of_state(State) ->
+    case maps:is_key(field_current, State) of
+        true ->
+            (maps:get(field_current, State))(ok);
+        false ->
+            case maps:is_key(system_collections_generic_i_enumerator_1_get_current, State) of
+                true -> iface_unwrap(maps:get(system_collections_generic_i_enumerator_1_get_current, State));
+                false -> iface_unwrap(maps:get(system_collections_i_enumerator_get_current, State))
+            end
     end.
 
 %% IEEE 754 special float values.

--- a/src/fable-library-beam/fable_utils.erl
+++ b/src/fable-library-beam/fable_utils.erl
@@ -2,6 +2,8 @@
 -export([
     iface_get/2,
     iface_get/3,
+    field_get/2,
+    inst_state/1,
     apply_curried/2,
     new_ref/1,
     safe_dispose/1,
@@ -32,12 +34,14 @@
 
 -spec iface_get(atom(), map() | reference() | {fable_import_all, atom()}) -> term().
 -spec iface_get(atom(), non_neg_integer(), {fable_import_all, atom()}) -> term().
+-spec field_get(atom(), map() | reference()) -> term().
+-spec inst_state(map() | reference()) -> map().
 -spec apply_curried(fun(), list()) -> term().
 -spec new_ref(term()) -> reference().
 -spec safe_dispose(term()) -> ok.
 -spec get_enumerator(list() | reference() | map() | term()) -> reference().
--spec move_next(reference()) -> boolean().
--spec get_current(reference()) -> term().
+-spec move_next(map() | reference()) -> boolean().
+-spec get_current(map() | reference()) -> term().
 -spec pos_infinity() -> float().
 -spec neg_infinity() -> float().
 -spec nan() -> nan.
@@ -81,6 +85,20 @@ iface_get(Name, Ref) -> iface_unwrap(maps:get(Name, get(Ref))).
 
 iface_unwrap({getter, Fun}) -> Fun();
 iface_unwrap(Val) -> Val.
+
+%% Read an instance field, supporting both representations of a class instance:
+%% an immutable self-contained map (process-portable, like object expressions) and
+%% a process-dict ref (used for classes with mutable instance fields — single-process).
+%% Decoupling the read site from the representation lets the constructor alone decide
+%% which form to emit.
+field_get(Field, Obj) when is_map(Obj) -> maps:get(Field, Obj);
+field_get(Field, Ref) -> maps:get(Field, get(Ref)).
+
+%% Resolve a class instance to its state map, supporting both representations.
+%% Used when merging a base class's state into a derived class: the base
+%% constructor may return a self-contained map or a process-dict ref.
+inst_state(Obj) when is_map(Obj) -> Obj;
+inst_state(Ref) -> get(Ref).
 
 %% Create a new process dictionary ref cell with the given initial value.
 %% Encapsulates make_ref() + put() to avoid variable name collisions in nested constructs.
@@ -160,6 +178,11 @@ get_enumerator(Other) ->
     %% Fallback: treat as list
     get_enumerator(lists:flatten([Other])).
 
+%% A compiled enumerator class can be represented either as a self-contained map
+%% (immutable instance fields) or as a process-dict ref; resolve to the state map.
+move_next(Enum) when is_map(Enum) ->
+    %% Map-represented compiled enumerator: the instance map is the state.
+    (maps:get(system_collections_i_enumerator_move_next, Enum))();
 move_next(EnumRef) ->
     State = get(EnumRef),
     case maps:is_key(items, State) of
@@ -177,6 +200,9 @@ move_next(EnumRef) ->
             (maps:get(system_collections_i_enumerator_move_next, State))()
     end.
 
+get_current(Enum) when is_map(Enum) ->
+    %% Map-represented compiled enumerator: call its field_current fun.
+    (maps:get(field_current, Enum))(ok);
 get_current(EnumRef) ->
     State = get(EnumRef),
     case maps:is_key(current, State) of

--- a/tests/Beam/EnumerableTests.fs
+++ b/tests/Beam/EnumerableTests.fs
@@ -49,26 +49,21 @@ let mkEnumerable someList =
       interface System.Collections.IEnumerable with
         member x.GetEnumerator() = ((someList :> IEnumerable<_>).GetEnumerator() :> System.Collections.IEnumerator) }
 
-// TODO: Custom IEnumerable class with Fibonacci IEnumerator — class IEnumerator implementation
-// doesn't correctly maintain state across MoveNext/Current calls on Beam
-// [<Fact>]
-// let ``test Enumerable class works`` () =
-//     let f1 = Seq.toArray (fib())
-//     let f2 = Seq.toArray (Enumerator(fun () -> upcast new Fibonacci()))
-//     f1 = f2 |> equal true
+[<Fact>]
+let ``test Enumerable class works`` () =
+    let f1 = Seq.toArray (fib())
+    let f2 = Seq.toArray (Enumerator(fun () -> upcast new Fibonacci()))
+    f1 = f2 |> equal true
 
-// TODO: Custom IEnumerable object expression with IEnumerator — same MoveNext/Current issue
-// [<Fact>]
-// let ``test Enumerable object expr works`` () =
-//     let f1 = Seq.toArray (fib())
-//     let f2 = Seq.toArray (toSeq fibGen)
-//     f1 = f2 |> equal true
+[<Fact>]
+let ``test Enumerable object expr works`` () =
+    let f1 = Seq.toArray (fib())
+    let f2 = Seq.toArray (toSeq fibGen)
+    f1 = f2 |> equal true
 
-// TODO: mkEnumerable wrapping list — IEnumerable<T>.GetEnumerator() dispatching through
-// object expression doesn't route correctly to fable_utils enumerator on Beam
-// [<Fact>]
-// let ``test Enumerator can be converted to seq`` () =
-//     mkEnumerable [1..10]
-//     |> Seq.toList
-//     |> List.sum
-//     |> equal 55
+[<Fact>]
+let ``test Enumerator can be converted to seq`` () =
+    mkEnumerable [1..10]
+    |> Seq.toList
+    |> List.sum
+    |> equal 55

--- a/tests/Beam/InterfaceTests.fs
+++ b/tests/Beam/InterfaceTests.fs
@@ -107,3 +107,36 @@ let ``test Interface method call via Option.Value works`` () =
         else
             0
     res |> equal 42
+
+// Regression: a class instance must be process-portable. Its fields live in the
+// instance value itself (a self-contained map), not in the constructing process's
+// dictionary — so an interface or regular method invoked from another (spawned)
+// process reads the correct field value instead of crashing with {badmap,undefined}.
+// Object expressions already behaved this way; classes now match.
+#if FABLE_COMPILER
+// Run a thunk in a freshly spawned process and return its result synchronously.
+[<Fable.Core.Emit("(fun() -> XprocParent = self(), XprocFun = $0, spawn(fun() -> XprocParent ! {xproc_res, case erlang:fun_info(XprocFun, arity) of {arity, 0} -> XprocFun(); _ -> XprocFun(ok) end} end), receive {xproc_res, XprocR} -> XprocR after 5000 -> timeout end end)()")>]
+let private runInSpawnedProcess (f: unit -> 'a) : 'a = Fable.Core.Util.nativeOnly
+#else
+let private runInSpawnedProcess (f: unit -> 'a) : 'a = f ()
+#endif
+
+type IXProcGetter =
+    abstract member Get: unit -> int
+
+type XProcClassGetter(value: int) =
+    interface IXProcGetter with
+        member _.Get() = value
+
+type XProcClassMethod(value: int) =
+    member _.Get() = value
+
+[<Fact>]
+let ``test class interface method is invocable from another process`` () =
+    let o = XProcClassGetter(42) :> IXProcGetter
+    runInSpawnedProcess (fun () -> o.Get()) |> equal 42
+
+[<Fact>]
+let ``test class instance method is invocable from another process`` () =
+    let o = XProcClassMethod(42)
+    runInSpawnedProcess (fun () -> o.Get()) |> equal 42


### PR DESCRIPTION
## Problem

On the BEAM target, a class instance was represented as a bare `make_ref()` with **all** state — instance fields *and* method/interface closures — stored in the **constructing process's** dictionary via `erlang:put(Ref, ...)`. A method (interface or regular) invoked from a *different* process therefore dereferenced `erlang:get(Ref)` against the wrong process dictionary, read `undefined`, and crashed with `{badmap,undefined}`. Single-process use happened to work, which hid the bug.

Object expressions were unaffected because they capture state lexically in their closures.

Real-world manifestation: a `Fable.Reactive` `IAsyncObserver` implemented as a class has `OnNextAsync` invoked from a spawned `safeObserver` process; the field holding the downstream sink read `undefined`, so notifications were silently dropped and the bridge crashed.

### Minimal reproduction (before)

```erlang
class_getter_ctor_...(Value) ->
    Ref = erlang:make_ref(),
    erlang:put(Ref, #{field_value => Value}),
    erlang:put(Ref, maps:merge(erlang:get(Ref), #{get => fun() ->
        maps:get(field_value, erlang:get(Ref))   %% reads the *caller* process's dict
    end})),
    Ref.
```

## Fix

Represent an **immutable-field** class instance as a **self-contained map** (the instance term *is* the state map), exactly like a non-self-referencing object expression — so its fields and methods are readable in any process:

```erlang
class_getter_ctor_...(Value) ->
    State0 = #{field_value => Value},
    maps:merge(State0, #{get => fun() ->
        fable_utils:field_get(field_value, State0)
    end}).
```

Classes with **mutable** instance fields keep the process-dict ref representation. The BEAM has no shared mutable memory across processes, so cross-process mutation stays **unsupported by design** (use actors / message passing) — this preserves single-process mutation semantics unchanged.

### Changes

- **`fable_utils.erl`**: add polymorphic `field_get/2` and `inst_state/1`; make `move_next`/`get_current` accept a map *or* a ref (the same pattern `iface_get`/`safe_dispose` already use), so runtime helpers work for either representation. `get_current` resolves the current value through a shared `current_of_state/1` helper handling both enumerator shapes — the compiled-`seq.erl` `field_current` thunk and a class-implemented `IEnumerator`'s `{getter, Fun}` under the interface key (generic + non-generic). This also fixes a latent ref-path bug where a class `IEnumerator`'s `Current` was looked up under the wrong key.
- **`Fable2Beam.fs`**: route class field reads through `field_get`; choose map vs ref per class in `transformClassDeclaration` (gate: no mutable fields, no `as self`, no base-class state to merge, and no interface closure / field initializer / `do`-body using `this` as a value); base-merge preludes use `inst_state`.
- **`Fable2Beam.Util.fs`**: `containsThisValue` / `thisUsedAsValue` gate helpers; both also scan `Emit`'s `CallInfo.ThisArg` (matching the `Call` case) so an `[<Emit>]` member passing `this` as `ThisArg` cannot slip through the map-representation gate.
- **`FABLE-BEAM.md`**: document the dual representation and the single-process boundary for mutable instances.
- **`InterfaceTests.fs`**: regression tests invoking an immutable class's interface and instance methods from a spawned process (run inline on .NET).
- **`EnumerableTests.fs`**: re-enable three previously-disabled tests covering class- and object-expression `IEnumerator` implementations, now unblocked by the `get_current` fix.

## Verification

- Beam suite: **2453 passed, 0 failed** (including the 2 new cross-process regression tests and the 3 re-enabled enumerator tests).
- Confirmed in generated code that mutable classes (`let mutable`, `member val ... with get, set`, fluent-`this`-returning) still use `make_ref`/process dict, while immutable classes become portable maps.
- Cross-process reproduction now returns `42` for interface method, instance method, and object expression alike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
