### PR TITLE
fix(beam): namespace module-level mutable state keys by module

### DIFF
--- a/src/Fable.Transforms/Beam/FABLE-BEAM.md
+++ b/src/Fable.Transforms/Beam/FABLE-BEAM.md
@@ -1113,10 +1113,15 @@ alone eliminates the single hardest piece of the Fable.Python runtime.
 - **OperationCanceledException**: Added to the exception type pattern in Beam Replacements
   alongside `BuiltinSystemException` and `KeyNotFoundException`.
 - **Module-level mutable variables**: `let mutable x = v` at module level is routed through
-  the process dictionary (same mechanism as local mutable `let` bindings). The declaration
-  emits a `main/0` fragment that initialises the value (`put(x, v)`); reads of the ident emit
-  `get(x)` and writes (`x <- e`) emit `put(x, e)` (see the `IdentExpr`/`Set` branches and the
-  `MemberDeclaration` value case in `Fable2Beam.fs`). All `main/0` fragments — mutable inits,
+  the process dictionary (same mechanism as local mutable `let` bindings). The process-dict
+  key is namespaced by the emitting Erlang module name — `<module>_<name>` (e.g. `x` in module
+  `foo` → key `foo_x`) — so identically-named mutables in different modules don't collide in
+  the shared, process-local process dictionary. The key is built by the single `mutableStateKey`
+  helper (`Fable2Beam.Util.fs`) and used at every site so reads, writes and the initialiser
+  always agree. The declaration emits a `main/0` fragment that initialises the value
+  (`put(foo_x, v)`); reads of the ident emit `get(foo_x)` and writes (`x <- e`) emit
+  `put(foo_x, e)` (see the `IdentExpr`/`Set` branches and the `MemberDeclaration` value case in
+  `Fable2Beam.fs`). All `main/0` fragments — mutable inits,
   snapshot inits (below), and `do` actions — are merged in declaration order, so module
   initialisation runs as a single ordered sequence, mirroring F#. A value initialiser that
   lowers to a multi-statement block (e.g. it contains a `let`) is stored as `put(x, <block>)`
@@ -1129,9 +1134,10 @@ alone eliminates the single hardest piece of the Fable.Python runtime.
       binding time, because F# evaluates module bindings once, in order, before any later
       reassignment. Compiled naively as a lazy 0-arity accessor it would re-read the *live*
       process-dict value and observe later writes. Such values are therefore also eagerly
-      initialised in `main/0` (`put(c, <value>)`, emitted in declaration order so it captures
-      the mutable's value at that point) plus an accessor that reads the snapshot (`c() ->
-      get(c)`). Detection is `readsFreeMutable`, which walks the Fable body tracking locally
+      initialised in `main/0` (`put(foo_c, <value>)`, using the same module-namespaced key and
+      emitted in declaration order so it captures the mutable's value at that point) plus an
+      accessor — named by the bare value name — that reads the snapshot (`c() -> get(foo_c)`).
+      Detection is `readsFreeMutable`, which walks the Fable body tracking locally
       bound names and triggers only on a *free* (module-level) mutable reference —
       self-contained bodies whose only mutables are local stay lazy, so they don't gain a
       spurious dependency on `main/0`.
@@ -1157,6 +1163,10 @@ reads the state:
   module's `main/0` having run — its module-level mutables/snapshots read `undefined`. Reads
   from a **different process** than the one that ran `main/0` also see `undefined`, since the
   process dictionary is process-local.
+
+Keys are namespaced by module (`<module>_<name>`), so multiple modules' mutables with the same
+name running in the **same** process no longer collide — the remaining limitation is purely the
+process-locality above, not naming.
 
 This matches the broader Beam design (mutation is single-process by design; see "Class instance
 representation" and "Mutable Collections" above), but it means module-level mutable global state

--- a/src/Fable.Transforms/Beam/Fable2Beam.Util.fs
+++ b/src/Fable.Transforms/Beam/Fable2Beam.Util.fs
@@ -360,3 +360,11 @@ let wrapWithHoisted (hoisted: Beam.ErlExpr list) (expr: Beam.ErlExpr) : Beam.Erl
 
 let atomLit name =
     Beam.ErlExpr.Literal(Beam.ErlLiteral.AtomLit(Beam.Atom name))
+
+/// Process-dictionary key (atom name) for a module-level mutable or snapshot value.
+/// Namespaced by the emitting Erlang module so identically-named values in different
+/// modules don't collide in the shared, process-local process dictionary. Reads, writes
+/// and the declaration/initializer must all derive their key through this helper or state
+/// silently breaks.
+let mutableStateKey (moduleName: string) (name: string) =
+    moduleName + "_" + Naming.sanitizeErlangName name

--- a/src/Fable.Transforms/Beam/Fable2Beam.fs
+++ b/src/Fable.Transforms/Beam/Fable2Beam.fs
@@ -79,6 +79,7 @@ type IBeamCompiler =
 type Context =
     {
         File: string
+        ModuleName: string // Emitting Erlang module name (namespaces module-level mutable state keys)
         UsedNames: Set<string>
         DecisionTargets: (Ident list * Expr) list
         RecursiveBindings: Set<string>
@@ -242,7 +243,7 @@ let rec transformExpr (com: IBeamCompiler) (ctx: Context) (expr: Expr) : Beam.Er
                     Beam.ErlExpr.Variable(capitalizeFirst ident.Name |> sanitizeErlangVar)
                 elif ident.IsMutable then
                     // Module-level mutable: read current value from process dictionary
-                    Beam.ErlExpr.Call(None, "get", [ atomLit (sanitizeErlangName ident.Name) ])
+                    Beam.ErlExpr.Call(None, "get", [ atomLit (mutableStateKey ctx.ModuleName ident.Name) ])
                 else
                     // Module-level function reference: call as 0-arity function
                     Beam.ErlExpr.Call(None, sanitizeErlangName ident.Name, [])
@@ -551,7 +552,14 @@ let rec transformExpr (com: IBeamCompiler) (ctx: Context) (expr: Expr) : Beam.Er
             Beam.ErlExpr.Call(None, "put", [ erlExpr; transformExpr com ctx value ])
         | IdentExpr ident when ident.IsMutable ->
             // Module-level mutable: update via process dictionary using name atom
-            Beam.ErlExpr.Call(None, "put", [ atomLit (sanitizeErlangName ident.Name); transformExpr com ctx value ])
+            Beam.ErlExpr.Call(
+                None,
+                "put",
+                [
+                    atomLit (mutableStateKey ctx.ModuleName ident.Name)
+                    transformExpr com ctx value
+                ]
+            )
         | IdentExpr ident -> Beam.ErlExpr.Match(Beam.PVar(capitalizeFirst ident.Name), transformExpr com ctx value)
         | _ ->
             com.WarnOnlyOnce("Set with non-identifier target is not supported for Beam target")
@@ -3319,6 +3327,8 @@ and transformDeclaration (com: IBeamCompiler) (ctx: Context) (decl: Declaration)
             |> Option.defaultWith (fun () -> com.GetMember(memDecl.MemberRef))
 
         let name = sanitizeErlangName memDecl.Name
+        // Process-dict key for module-level mutable/snapshot values, namespaced by module.
+        let stateKey = mutableStateKey ctx.ModuleName memDecl.Name
 
         // Look up constructor parameter names for the owning class so method bodies
         // can detect field-stored function invokes (e.g., ctor param `add: int -> int -> int`
@@ -3533,7 +3543,7 @@ and transformDeclaration (com: IBeamCompiler) (ctx: Context) (decl: Declaration)
             // instead of a constant-returning function — the main/0 merges with the
             // ActionDeclaration main/0 so the initialization runs before use.
             if info.IsValue && info.IsMutable && arity = 0 then
-                let initStmt = Beam.ErlExpr.Call(None, "put", [ atomLit name; initValue ])
+                let initStmt = Beam.ErlExpr.Call(None, "put", [ atomLit stateKey; initValue ])
 
                 let funcDef: Beam.ErlFunctionDef =
                     {
@@ -3556,7 +3566,7 @@ and transformDeclaration (com: IBeamCompiler) (ctx: Context) (decl: Declaration)
                 // mutable, so it must be snapshotted. Emit a main/0 fragment that stores the
                 // value in the process dictionary (in declaration order, so it captures the
                 // mutable's value at this point) plus an accessor that reads the snapshot.
-                let initStmt = Beam.ErlExpr.Call(None, "put", [ atomLit name; initValue ])
+                let initStmt = Beam.ErlExpr.Call(None, "put", [ atomLit stateKey; initValue ])
 
                 let initDef: Beam.ErlFunctionDef =
                     {
@@ -3581,7 +3591,7 @@ and transformDeclaration (com: IBeamCompiler) (ctx: Context) (decl: Declaration)
                                 {
                                     Patterns = []
                                     Guard = []
-                                    Body = [ Beam.ErlExpr.Call(None, "get", [ atomLit name ]) ]
+                                    Body = [ Beam.ErlExpr.Call(None, "get", [ atomLit stateKey ]) ]
                                 }
                             ]
                     }
@@ -3642,6 +3652,7 @@ let transformFile (com: Fable.Compiler) (file: File) : Beam.ErlModule =
     let ctx =
         {
             File = com.CurrentFile
+            ModuleName = moduleName
             UsedNames = file.UsedNamesInRootScope
             DecisionTargets = []
             RecursiveBindings = Set.empty

--- a/tests/Beam/Fable.Tests.Beam.fsproj
+++ b/tests/Beam/Fable.Tests.Beam.fsproj
@@ -89,6 +89,8 @@
     <Compile Include="InterfaceTests.fs" />
     <Compile Include="MiscTests2.fs" />
     <Compile Include="QuotationTests.fs" />
+    <Compile Include="ModuleMutableOneTests.fs" />
+    <Compile Include="ModuleMutableTwoTests.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
 </Project>

--- a/tests/Beam/ModuleMutableOneTests.fs
+++ b/tests/Beam/ModuleMutableOneTests.fs
@@ -1,0 +1,13 @@
+module Fable.Tests.ModuleMutableOne
+
+// Companion module for ModuleMutableTwoTests. It declares a module-level mutable with
+// the *same* name (`shared`) as the one in Fable.Tests.ModuleMutableTwo. On the BEAM
+// target module-level mutables are backed by the (process-local) Erlang process
+// dictionary, so their keys must be namespaced by module or the two `shared` values
+// collide. The cross-module assertions live in ModuleMutableTwoTests.fs.
+
+let mutable shared = 0
+
+let setShared (v: int) = shared <- v
+
+let getShared () = shared

--- a/tests/Beam/ModuleMutableTwoTests.fs
+++ b/tests/Beam/ModuleMutableTwoTests.fs
@@ -1,0 +1,28 @@
+module Fable.Tests.ModuleMutableTwo
+
+open Util.Testing
+
+// A module-level mutable with the same name (`shared`) as the one in
+// Fable.Tests.ModuleMutableOne. On the BEAM target both are stored in the Erlang
+// process dictionary; before keys were namespaced by module they shared the bare key
+// `shared` and overwrote each other when both modules' state was used in the same
+// process (as the test runner does). The fix namespaces the key by module name.
+
+let mutable shared = 0
+
+let setShared (v: int) = shared <- v
+
+let getShared () = shared
+
+let ``test module-level mutables with the same name don't collide across modules`` () =
+    // Write distinct values through each module's own mutable, then read them back.
+    // If the process-dict keys collided, the second write would clobber the first.
+    ModuleMutableOne.setShared 111
+    setShared 222
+    equal 111 (ModuleMutableOne.getShared ())
+    equal 222 (getShared ())
+    // Reassign in the opposite order to make sure either module can win last.
+    setShared 333
+    ModuleMutableOne.setShared 444
+    equal 444 (ModuleMutableOne.getShared ())
+    equal 333 (getShared ())

--- a/tests/Beam/erl_test_runner.erl
+++ b/tests/Beam/erl_test_runner.erl
@@ -19,7 +19,12 @@ main([Dir]) ->
         case lists:member({main, 0}, Exports) of
             true ->
                 try Mod:main()
-                catch _:_ -> ok
+                catch InitClass:InitReason ->
+                    %% Don't abort the run on a broken initializer, but log it so a
+                    %% failing main/0 is diagnosable instead of surfacing later as
+                    %% silent `undefined` reads of module-level state.
+                    io:format("  WARN init failed ~s:main/0 - ~p:~p~n", [Mod, InitClass, InitReason]),
+                    ok
                 end;
             false -> ok
         end,


### PR DESCRIPTION
## Problem

PR #4676 added support for module-level mutable variables on the Erlang/BEAM target, backed by the Erlang process dictionary. A value's state is keyed by an atom derived from its name via `sanitizeErlangName`, with reads/writes/initializers emitting `get(key)` / `put(key, v)`.

The process-dict key was the **bare** sanitized value name with no module qualifier. Within a single F# file this is safe — nested modules are already disambiguated. But across different Erlang modules (separate F# files) the bare name collides:

- Two files each with `let mutable counter = 0` both produce key `counter`.
- The Erlang process dictionary is process-local, and the test runner (`erl_test_runner.erl`) runs every module's `main/0` and all tests in a single process — so the two counters overwrite each other. The same hazard exists for any real program where multiple modules' init runs in one process.

This was documented as a known limitation in `FABLE-BEAM.md`.

## Fix

Namespace the process-dict key by the emitting Erlang module name — `<module>_<name>`, matching the existing nested-module mangling style — so state from different modules can't collide. A single helper `mutableStateKey moduleName name` (in `Fable2Beam.Util.fs`) builds the key and is used at **every** site so reads, writes and the initializer always agree:

- the `IdentExpr` read branch (mutable ident → `get`),
- the `Set(IdentExpr, …)` write branch (mutable ident → `put`),
- the `MemberDeclaration` mutable-init and snapshot-init `put`s,
- the snapshot accessor (`name() -> get(key)`; the accessor *function* name stays bare).

The module name is threaded through `Context` (set once in `transformFile`) rather than recomputed.

Other targets (Python/Rust/Dart/JS) get per-module isolation for free because each file is a real module namespace; BEAM is unique in using a flat process-dict namespace, so this aligns BEAM with their behavior.

Cross-process reads still legitimately return `undefined` (the process dict is process-local) — that's a separate, documented limitation and is untouched here. This PR only fixes same-process cross-module collisions. `FABLE-BEAM.md` is updated to reflect the now module-qualified keys.

## Generated output (after fix)

```erlang
% module_mutable_one_tests.erl
erlang:put(module_mutable_one_tests_shared, V)
% module_mutable_two_tests.erl
erlang:put(module_mutable_two_tests_shared, V)
```

## Secondary: diagnosable init failures

The test runner swallowed init failures with `catch _:_ -> ok`, which masked a real bug during #4676. It now logs the caught module and reason (`WARN init failed <mod>:main/0 - <class>:<reason>`) so a broken `main/0` is diagnosable rather than surfacing later as silent `undefined` reads. The run still does not abort on a broken initializer.

## Tests

- Added two BEAM test modules (`ModuleMutableOneTests.fs` / `ModuleMutableTwoTests.fs`) that each define a module-level mutable named `shared`, write distinct values through each, and assert each module sees its own value (in both write orders). This **fails before the fix** (both keys are `shared`, so the second write clobbers the first) and **passes after**.
- Existing multi-statement-initializer regression tests in `MiscTests.fs` stay green.
- `./build.sh test beam`: **2462 passed, 0 failed**.
- `dotnet fantomas` run on changed F# files (CI Fantomas check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)