### PR TITLE
fix(js/ts): implicit DateTime to DateTimeOffset conversion

### DIFF
--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -3296,6 +3296,9 @@ let dateTimeOffset (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: E
                 |> addError com ctx.InlinePath r
 
                 None
+    | "op_Implicit" ->
+        Helper.LibCall(com, moduleName, "fromDate", t, args, i.SignatureArgTypes, ?loc = r)
+        |> Some
     | "ToString" ->
         Helper.LibCall(com, "Date", "toString", t, args, i.SignatureArgTypes, ?thisArg = thisArg, ?loc = r)
         |> Some

--- a/tests/Js/Main/DateTimeOffsetTests.fs
+++ b/tests/Js/Main/DateTimeOffsetTests.fs
@@ -885,5 +885,10 @@ let tests =
             let source = DateTimeOffset(2007, 9, 1, 14, 30, 0, TimeSpan.Zero)
             (fun _ -> source.ToOffset(TimeSpan(0, 0, -10)))
             |> Util.throwsErrorContaining "Offset must be specified in whole minutes"
+
+        testCase "Implicit conversion from DateTime preserves value" <| fun () ->
+            let d = DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Utc)
+            let dto: DateTimeOffset = d
+            dto.UtcDateTime |> equal d
     ]
   ]


### PR DESCRIPTION
Fix #3908