### PR TITLE
fix(ts): filter class type params from attached let-binding methods

### DIFF
--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -1412,7 +1412,9 @@ module Util =
 
                 let declaredTypeParams =
                     if isAttached && kind <> Attached(isStatic = true) then
+                        // Instance attached methods inherit class type params; only declare method-specific ones
                         info.GenericParameters
+                        |> List.filter (fun g -> entGenParams |> List.forall (fun e -> e.Name <> g.Name))
                     else
                         entGenParams @ info.GenericParameters
                     |> List.map (fun g -> Fable.GenericParam(g.Name, g.IsMeasure, g.Constraints))

--- a/tests/Js/Main/TypeTests.fs
+++ b/tests/Js/Main/TypeTests.fs
@@ -765,6 +765,16 @@ let genericByrefFunc(n: byref<'t[]>) =
 type GenericClassWithStaticMember<'T>() =
     static member Length(xs: 'T list) = xs.Length
 
+[<Fable.Core.AttachMembers>]
+type GenericClassWithLetBinding<'TKey, 'TItem when 'TKey: comparison>(maker: 'TKey -> 'TItem) =
+    let mutable cache = Map.empty
+    let makeForKey key =
+        let v = maker key
+        cache <- cache.Add(key, v)
+        v
+    member _.Get(key: 'TKey) : 'TItem =
+        cache.TryFind key |> Option.defaultWith (fun () -> makeForKey key)
+
 [<AttachMembersAttribute>]
 type MyOptionalClass(?arg1: float, ?arg2: string, ?arg3: int) =
     member val P1 = defaultArg arg1 1.0
@@ -1548,6 +1558,11 @@ let tests =
 
     testCase "Generic static member on generic attached class re-declares type param" <| fun () ->
         GenericClassWithStaticMember<int>.Length([1; 2; 3]) |> equal 3
+
+    testCase "Generic attached class with let-binding helper does not shadow class type params" <| fun () ->
+        let src = GenericClassWithLetBinding<string, int>(fun k -> k.Length)
+        src.Get("hello") |> equal 5
+        src.Get("hi") |> equal 2
 
     testCase "Two unions of different type with same shape are not equal" <| fun () ->
         areEqual (MyUnion1.Foo(1,2)) (MyUnion2.Foo(1,2)) |> equal false


### PR DESCRIPTION
Fix #3503