### PR TITLE
fix(js/ts): pass TypeInfo to getRecordFields to handle None fields in anonymous records

### DIFF
--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -4270,7 +4270,13 @@ let fsharpValue com methName (r: SourceLocation option) t (i: CallInfo) (args: E
         // concept the runtime helpers don't accept.
         let args =
             match methName with
-            | "GetRecordFields" -> List.truncate 1 args
+            | "GetRecordFields" ->
+                let recordArg = List.head args
+                // For anonymous records, None fields are omitted from the JS object so
+                // Object.keys cannot enumerate them. Pass the TypeInfo so the runtime can
+                // use field names from the type instead of from the object's own keys.
+                let (MaybeCasted innerArg) = recordArg
+                [ recordArg; makeTypeInfo r innerArg.Type ]
             | "GetUnionFields"
             | "MakeUnion"
             | "MakeRecord" -> List.truncate 2 args

--- a/src/fable-library-ts/Reflection.ts
+++ b/src/fable-library-ts/Reflection.ts
@@ -477,8 +477,14 @@ export function getUnionCaseFields(uci: CaseInfo): FieldInfo[] {
 
 // This is used as replacement of `FSharpValue.GetRecordFields`
 // For `FSharpTypes.GetRecordFields` see `getRecordElements`
-// Object.keys returns keys in the order they were added to the object
-export function getRecordFields(v: any): MutableArray<any> {
+// TypeInfo is used when available to enumerate fields by name: anonymous record None fields
+// are omitted from the JS object, so Object.keys alone would miss them.
+// Boxed anonymous record would are still not covered but this is the best we can do for now
+// without adding a __fields__ to every anonymous record being created
+export function getRecordFields(v: any, t: TypeInfo): MutableArray<any> {
+  if (t.fields != null) {
+    return t.fields().map(([key, _]) => v[key]);
+  }
   return Object.keys(v).map((k) => v[k]);
 }
 

--- a/tests/Js/Main/ReflectionTests.fs
+++ b/tests/Js/Main/ReflectionTests.fs
@@ -381,6 +381,13 @@ let reflectionTests = [
     let all = isRecord && matchRecordFields && matchIndividualRecordFields && canMakeSameRecord
     all |> equal true
 
+  testCase "FSharpValue.GetRecordFields with anonymous record returns all fields including None" <| fun () ->
+    let fields = FSharpValue.GetRecordFields {| a = 3; b = (None: int option); c = Some 89 |}
+    fields.Length |> equal 3
+    fields.[0] |> equal (box 3)
+    fields.[1] |> equal (box None)
+    fields.[2] |> equal (box (Some 89))
+
   testCase "Reflection functions accept allowAccessToPrivateRepresentation" <| fun () ->
     let recordType = typeof<TestRecord>
     let record = { String = "a"; Int = 1 }


### PR DESCRIPTION
Fix #3477

There is still a limitation which is if people box the anonymous record we can't/don't retrieve the type information. But this still provide a better coverage hopefully.