### PR TITLE
fix(all): include return type in overload suffix for op_Implicit/op_Explicit

### DIFF
--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -687,9 +687,17 @@ module Helpers =
         | _ ->
             let entGenParams = ent.GenericParameters |> Seq.mapToList TypeHelpers.genParamName
 
-            memb.CurriedParameterGroups
-            |> Seq.mapToList (Seq.mapToList (fun p -> TypeHelpers.makeType Map.empty p.Type))
-            |> OverloadSuffix.getHash entGenParams
+            let paramTypeGroups =
+                memb.CurriedParameterGroups
+                |> Seq.mapToList (Seq.mapToList (fun p -> TypeHelpers.makeType Map.empty p.Type))
+
+            // op_Implicit/op_Explicit can be overloaded by return type, so include it in the hash
+            match memb.CompiledName with
+            | "op_Implicit"
+            | "op_Explicit" ->
+                let returnType = TypeHelpers.makeType Map.empty memb.ReturnParameter.Type
+                OverloadSuffix.getHashWithReturnType entGenParams paramTypeGroups returnType
+            | _ -> OverloadSuffix.getHash entGenParams paramTypeGroups
 
     let private getMemberMangledName trimRootModule (memb: FSharpMemberOrFunctionOrValue) =
         if memb.IsExtensionMember then

--- a/src/Fable.Transforms/OverloadSuffix.fs
+++ b/src/Fable.Transforms/OverloadSuffix.fs
@@ -194,6 +194,21 @@ let getHash (entityGenericParams: string list) (curriedParamTypeGroups: Fable.Ty
     // but I don't know how to identify them in the AST
     | _ -> ""
 
+/// For op_Implicit/op_Explicit, the return type is part of the overload signature.
+/// This function includes the return type in the hash to distinguish overloads that differ only by return type.
+let getHashWithReturnType
+    (entityGenericParams: string list)
+    (curriedParamTypeGroups: Fable.Type list list)
+    (returnType: Fable.Type)
+    =
+    match curriedParamTypeGroups with
+    | [ paramTypes ] ->
+        let genParams =
+            entityGenericParams |> List.mapi (fun i p -> p, string<int> i) |> dict
+
+        getHashPrivate (paramTypes @ [ returnType ]) genParams
+    | _ -> ""
+
 /// Used for extension members
 let getExtensionHash (curriedParamTypeGroups: Fable.Type list list) =
     match curriedParamTypeGroups with

--- a/tests/Js/Main/ApplicativeTests.fs
+++ b/tests/Js/Main/ApplicativeTests.fs
@@ -355,6 +355,11 @@ let implicitMethod (arg: ImplicitType<string, int>) (i: int) =
     | ImplicitType.Case1 _ -> 1
     | ImplicitType.Case2 _ -> 2
 
+type ImplicitReturnTypeOverload =
+    { Field: int }
+    static member op_Implicit(s: string) : int = s.Length
+    static member op_Implicit(s: string) : float = float s.Length + 0.5
+
 type ArityRecord = { arity2: int->int->string }
 
 type RecordB = {
@@ -515,6 +520,12 @@ let tests5 = [
     testCase "TraitCall can resolve overloads with a single generic argument" <| fun () ->
         implicitMethod !+"hello" 5 |> equal 1
         implicitMethod !+6       5 |> equal 2
+
+    testCase "op_Implicit overloads can be distinguished by return type" <| fun () ->
+        let i: int = ImplicitReturnTypeOverload.op_Implicit "hello"
+        let f: float = ImplicitReturnTypeOverload.op_Implicit "hello"
+        i |> equal 5
+        f |> equal 5.5
 
     testCase "NestedLambdas" <| fun () ->
         let mutable m = 0


### PR DESCRIPTION
Fix #2564