### PR TITLE
fix(js/ts): DateTime.ToString() and %A are now consistent across all DateTimeKind values

### DIFF
--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -358,7 +358,7 @@ let toString com (ctx: Context) r (args: Expr list) =
         | String -> head
         | Char -> TypeCast(head, String)
         | Builtin BclGuid when tail.IsEmpty -> head
-        | Builtin(BclGuid | BclTimeSpan | BclTimeOnly | BclDateOnly as bt) ->
+        | Builtin(BclGuid | BclTimeSpan | BclTimeOnly | BclDateOnly | BclDateTime | BclDateTimeOffset as bt) ->
             Helper.LibCall(com, coreModFor bt, "toString", String, args)
         | Number(Int16, _) -> Helper.LibCall(com, "Util", "int16ToString", String, args)
         | Number(Int32, _) -> Helper.LibCall(com, "Util", "int32ToString", String, args)

--- a/src/fable-library-ts/Date.ts
+++ b/src/fable-library-ts/Date.ts
@@ -509,7 +509,7 @@ function dateToString_Y(date: IDateTime) {
 function dateToStringWithKind(date: IDateTime, format?: string) {
   const utc = date.kind === DateTimeKind.Utc;
   if (typeof format !== "string") {
-    return utc ? date.toUTCString() : date.toLocaleString();
+    return dateToString_d(date) + " " + dateToString_T(date);
   } else if (format.length === 1) {
     switch (format) {
       case "D": return dateToString_D(date);

--- a/tests/Js/Main/DateTimeTests.fs
+++ b/tests/Js/Main/DateTimeTests.fs
@@ -1231,4 +1231,14 @@ let tests =
         let str = utc.ToString("yyyy-MM-dd HH:mm")
 
         str |> equal "2024-12-31 23:00"
+
+    testCase "DateTime.ToString without format is consistent across kinds" <| fun () ->
+        let local = DateTime(2020, 2, 20, 20, 20, 20, DateTimeKind.Local)
+        let utc = DateTime(2020, 2, 20, 20, 20, 20, DateTimeKind.Utc)
+        local.ToString() |> equal (utc.ToString())
+
+    testCase "DateTime %A format is consistent across kinds" <| fun () ->
+        let local = DateTime(2020, 2, 20, 20, 20, 20, DateTimeKind.Local)
+        let utc = DateTime(2020, 2, 20, 20, 20, 20, DateTimeKind.Utc)
+        sprintf "%A" local |> equal (sprintf "%A" utc)
   ]


### PR DESCRIPTION
Fix #2408