### PR TITLE
fix(ts): strip byref annotation from compiler-generated copy-update locals

### DIFF
--- a/src/Fable.Transforms/Fable2Babel.fs
+++ b/src/Fable.Transforms/Fable2Babel.fs
@@ -2647,8 +2647,18 @@ but thanks to the optimisation done below we get
         transformBindingExprBody com ctx var value |> assign var.Range (identAsExpr var)
 
     let transformBindingAsStatements (com: IBabelCompiler) ctx (var: Fable.Ident) (value: Fable.Expr) =
+        // Compiler-generated copy-update locals (inputRecord, copyOfStruct) are treated as plain
+        // values at runtime even though their Fable type is byref. Strip the wrapper for TS annotation.
+        let varType =
+            if var.IsCompilerGenerated then
+                match var.Type with
+                | Replacements.Util.IsByRefType com innerType -> innerType
+                | typ -> typ
+            else
+                var.Type
+
         if isJsStatement ctx false value then
-            let ta, tp = makeTypeAnnotationWithParametersIfTypeScript com ctx var.Type None
+            let ta, tp = makeTypeAnnotationWithParametersIfTypeScript com ctx varType None
 
             let decl =
                 Statement.variableDeclaration (Let, var.Name, ?annotation = ta, typeParameters = tp, ?loc = var.Range)
@@ -2660,7 +2670,7 @@ but thanks to the optimisation done below we get
             let value = transformBindingExprBody com ctx var value
 
             let ta, tp =
-                makeTypeAnnotationWithParametersIfTypeScript com ctx var.Type (Some value)
+                makeTypeAnnotationWithParametersIfTypeScript com ctx varType (Some value)
 
             let kind =
                 if var.IsMutable then

--- a/tests/Js/Main/TypeTests.fs
+++ b/tests/Js/Main/TypeTests.fs
@@ -278,7 +278,11 @@ type ValueTypeR =
 type StructUnion = Value of string
 
 [<Struct>]
-type SimpleRecord = { A: string; B: string }
+type SimpleRecord =
+    { A: string; B: string }
+    member this.WithA(a: string) =
+        let this = this
+        { this with A = a }
 
 type Point2D =
    struct
@@ -1411,6 +1415,12 @@ let tests =
         simpleRecord.B |> equal "B"
         simple.A |> equal ""
         simple.B |> equal "B"
+
+    testCase "copy-update expression on this in struct member works" <| fun () -> // See #3828
+        let r : SimpleRecord = { A = "hello"; B = "world" }
+        let r2 = r.WithA("foo")
+        r2.A |> equal "foo"
+        r2.B |> equal "world"
 
     testCase "Custom F# exceptions work" <| fun () ->
         try


### PR DESCRIPTION
Fix #3828