### PR TITLE
perf(python): emit union field reads via `narrow` helper instead of `typing.cast`

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -9,9 +9,9 @@
   "reportConstantRedefinition": false, // Fable preserves casing for variables starting with uppercase
   "reportUnnecessaryIsInstance": false, // Not a problem in generated code (look into this later)
   "reportUnnecessaryComparison": false, // Generated tests do this on purpose
-  "reportUnnecessaryCast": false, // Generated code for union case field need addional cast otherwise Pyrigh cannot infer the resolved typed
   "reportImportCycles": true,
   "reportMissingImports": true,
+  "reportUnnecessaryCast": true,
   "reportDuplicateImport": true,
   "reportOverlappingOverload": true,
   "reportInconsistentConstructor": true,

--- a/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
@@ -1466,12 +1466,13 @@ let transformGet (com: IPythonCompiler) ctx range typ (fableExpr: Fable.Expr) ki
             let field = uci.UnionCaseFields |> List.item i.FieldIndex
             let fieldName = field.Name |> Naming.toFieldSnakeCase |> Helpers.clean
             // `fableExpr` is statically typed as the union base, which doesn't declare this
-            // field, so tell Pyright which case class we're reading from (cast is a no-op
-            // at runtime). See reportUnnecessaryCast in pyrightconfig.json.
+            // field, so tell Pyright which case class we're reading from via the library's
+            // `narrow` helper (a no-op at runtime). Keeping the "cast" inside `narrow`
+            // leaves generated code cast-free and preserves reportUnnecessaryCast.
             let caseRef = getUnionCaseRef com ctx i.Entity ent uci
-            let cast = com.GetImportExpr(ctx, "typing", "cast")
-            let castedExpr = Expression.call (cast, [ caseRef; baseExpr ])
-            let! finalExpr = getExpr com ctx range castedExpr (Expression.stringConstant fieldName)
+            let narrow = libValue com ctx "union" "narrow"
+            let narrowedExpr = Expression.call (narrow, [ caseRef; baseExpr ])
+            let! finalExpr = getExpr com ctx range narrowedExpr (Expression.stringConstant fieldName)
             return finalExpr
         }
 

--- a/src/fable-library-py/fable_library/union.py
+++ b/src/fable-library-py/fable_library/union.py
@@ -101,6 +101,24 @@ class Union(StringableBase, EquatableBase, ComparableBase, HashableBase, ICompar
         return -1 if self.tag < other.tag else 1
 
 
+def narrow[T](case: type[T], value: object) -> T:
+    """Narrow a union value to one of its case classes for the type checker.
+
+    F# discriminated unions compile to a base ``Union`` class plus one case
+    class per case (e.g. ``Tree`` -> ``Tree_Leaf | Tree_Node``). Reading a
+    case-specific field such as ``x.left_`` requires the value to be typed as
+    that case class, but after a ``match`` on ``tag`` it is still statically
+    typed as the union. ``narrow(Tree_Node, x)`` re-types ``x`` so the field
+    read resolves, playing the same role as ``typing.cast`` but scoped to
+    unions. Keeping it in the library (instead of emitting ``cast`` inline)
+    lets generated code stay ``cast``-free and preserves ``reportUnnecessaryCast``.
+
+    ``case`` is only used by the type checker to bind ``T``; this is an identity
+    function at runtime.
+    """
+    return value  # pyright: ignore[reportReturnType]
+
+
 @dataclass_transform()
 def tagged_union(tag: int):
     """Decorator for union case classes.
@@ -135,4 +153,4 @@ def tagged_union(tag: int):
     return decorator
 
 
-__all__ = ["Union", "tagged_union"]
+__all__ = ["Union", "narrow", "tagged_union"]


### PR DESCRIPTION
## Summary

Follow-up to #4725, targeting its branch.

#4725 speeds up union case field reads by emitting `cast(Case, x).field` instead of the `.fields`-rebuild property. To make Pyright accept those casts it disables `reportUnnecessaryCast` **globally**, because some sites (single-case unions, already-narrowed values) make the cast redundant from Pyright's point of view.

This PR moves that "cast" into a tiny library helper so generated code stays `cast`-free and the global rule can stay on.

## Changes

- **`fable_library/union.py`** — add `narrow[T](case: type[T], value: object) -> T`, a typed identity function (documented, exported in `__all__`). It plays the same role as `typing.cast` but is scoped to unions.
- **`Fable2Python.Transforms.fs`** — union field reads now emit `narrow(Case, x).field` instead of `cast(Case, x).field`.
- **`pyrightconfig.json`** — revert `reportUnnecessaryCast` back to `true`; `narrow` is not `typing.cast`, so the rule no longer fires on these reads (and still guards the rest of the generated code).

Generated output before → after:
```python
# before (#4725)
return cast(Tree_Node, t).left_
# after (this PR)
return narrow(Tree_Node, t).left_
```

## Why not `cast(T, value)` inside `narrow`?

`narrow`'s body is `return value  # pyright: ignore[reportReturnType]` rather than `return cast(T, value)`. `typing.cast` is a plain Python function (`return val`), so routing through it would make **two** calls per field read instead of one — a needless regression on the exact hot path this optimization targets (~8M reads in the #4725 benchmark). The ignore is targeted, and `reportUnnecessaryTypeIgnoreComment` (enabled) confirms it's genuinely necessary.

## Verification

- Pyright on `union.py`: 0 errors/warnings; the ignore is not flagged as unnecessary.
- Call-site check: `narrow(Tree_Leaf, x).value_` resolves to the field's real type (`int`).
- Quicktest compiles and emits `narrow(...)` for both user unions and library unions (`Result`/`Choice`); the only remaining `cast` in output is a legitimately-necessary one that `reportUnnecessaryCast: true` accepts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)