### PR TITLE
fix(ts/js): `Regex.Replace` count/substitutions and `Regex.Split` semantics

### DIFF
--- a/src/fable-library-ts/RegExp.ts
+++ b/src/fable-library-ts/RegExp.ts
@@ -117,28 +117,32 @@ export function replace(
     input = tmp;
     limit = undefined;
   }
-  if (typeof replacement === "function") {
-    limit = limit == null ? -1 : limit;
-    return input.substring(0, offset) + input.substring(offset).replace(reg as RegExp, replacer);
-  } else {
-    replacement =
-      replacement
-      // $0 doesn't work with JS regex, see #1155
-      .replace(/\$0/g, (_s) => "$&")
-      // named groups in replacement are `${name}` in .Net, but `$<name>` in JS (in regex: groups are `(?<name>...)` in both)
-      .replace(/\${([^}]+)}/g, "\$<$1>")
-      ;
-    if (limit != null) {
-      let m: RegExpExecArray;
-      const sub1 = input.substring(offset);
-      const _matches = matches(reg, sub1);
-      const sub2 = matches.length > limit ? (m = _matches[limit - 1], sub1.substring(0, m.index + m[0].length)) : sub1;
-      return input.substring(0, offset) + sub2.replace(reg as RegExp, replacement as string)
-        + input.substring(offset + sub2.length);
-    } else {
-      return input.replace(reg as RegExp, replacement as string);
-    }
+  if (typeof replacement === "string") {
+    const rep = replacement as string;
+    // .NET replacement patterns cannot be rewritten as JS replacement strings unambiguously
+    // (e.g. `$$0` must stay literal "$0", `$0` doesn't work with JS regex (see #1155), and
+    // `${1}` followed by a digit must not become `$1` + digit), so interpret them with an
+    // evaluator instead, honoring the `$$` escape left-to-right
+    replacement = (match: any): string =>
+      rep.replace(/\$(?:(\$)|(&)|(`)|(')|(\d+)|\{(\d+)\}|\{([^}]+)\})/g,
+        (s, dollar?: string, and?: string, before?: string, after?: string, num?: string, numBraced?: string, name?: string) => {
+          if (dollar != null) { return "$"; }
+          if (and != null) { return match[0]; }
+          if (before != null) { return match.input.substring(0, match.index); }
+          if (after != null) { return match.input.substring(match.index + match[0].length); }
+          const n = num ?? numBraced;
+          if (n != null) {
+            const i = parseInt(n, 10);
+            // Same as .NET: an unmatched group is replaced by an empty string,
+            // a nonexistent group number keeps the substitution pattern literally
+            return i < match.length ? (match[i] ?? "") : s;
+          }
+          // Named groups are `${name}` in .NET (in regex: groups are `(?<name>...)` in both)
+          return match.groups != null && (name as string) in match.groups ? (match.groups[name as string] ?? "") : s;
+        });
   }
+  limit = limit == null ? -1 : limit;
+  return input.substring(0, offset) + input.substring(offset).replace(reg as RegExp, replacer);
 }
 
 export function split(reg: string | RegExp, input: string, limit?: number, offset: number = 0) {
@@ -148,6 +152,26 @@ export function split(reg: string | RegExp, input: string, limit?: number, offse
     input = tmp;
     limit = undefined;
   }
-  input = input.substring(offset);
-  return input.split(reg as RegExp, limit);
+  // JS String.split(regex, limit) truncates the result and discards the remainder,
+  // whereas .NET keeps it in the last element (`limit` is the max number of elements),
+  // keeps the text before `offset` in the first element and includes the values of
+  // matched capture groups, so iterate the matches manually like .NET Regex.Split does
+  const result: string[] = [];
+  let prev = 0;
+  let count = limit == null ? -1 : limit - 1;
+  for (const m of matches(reg as RegExp, input, offset)) {
+    if (count === 0) {
+      break;
+    }
+    result.push(input.substring(prev, m.index));
+    prev = m.index + m[0].length;
+    for (let i = 1; i < m.length; i++) {
+      if (m[i] !== undefined) {
+        result.push(m[i]);
+      }
+    }
+    count--;
+  }
+  result.push(input.substring(prev));
+  return result;
 }

--- a/tests/Js/Main/RegexTests.fs
+++ b/tests/Js/Main/RegexTests.fs
@@ -298,6 +298,33 @@ let tests =
         let s = Regex.Replace("1234567890", ".{2}", "$0-")
         equal "12-34-56-78-90-" s
 
+    testCase "Regex.Replace with count limit replaces exactly count matches" <| fun _ ->
+        let r = Regex("a")
+        r.Replace("aaaa", "b", 1) |> equal "baaa"
+        r.Replace("aaaa", "b", 2) |> equal "bbaa"
+        r.Replace("aaaa", "b", 3) |> equal "bbba"
+
+    testCase "Regex.Replace with numbered group substitution works" <| fun _ ->
+        Regex.Replace("abc", "(b)", "[${1}]") |> equal "a[b]c"
+        Regex.Replace("abc", "(b)", "[$1]") |> equal "a[b]c"
+
+    testCase "Regex.Replace with $$ escape works" <| fun _ ->
+        Regex.Replace("abc", "b", "$$") |> equal "a$c"
+        Regex.Replace("abc", "b", "$$0") |> equal "a$0c"
+
+    testCase "Regex.Replace with whole match works" <| fun _ ->
+        Regex.Replace("abc", "b", "$0") |> equal "abc"
+        Regex.Replace("abc", "b", "[$&]") |> equal "a[b]c"
+
+    testCase "Regex.Split with count keeps remainder" <| fun _ ->
+        Regex(",").Split("a,b,c", 2) |> equal [| "a"; "b,c" |]
+
+    testCase "Regex.Split without count works" <| fun _ ->
+        Regex.Split("1a2b3", "[a-z]") |> equal [| "1"; "2"; "3" |]
+
+    testCase "Regex.Split with capturing group includes captures" <| fun _ ->
+        Regex.Split("a1b2c", "([0-9])") |> equal [| "a"; "1"; "b"; "2"; "c" |]
+
     // See #838
     testCase "Group values are correct and empty when not being matched" <| fun _ ->
         Regex.Matches("\n\n\n", @"(?:([^\n\r]+)|\r\n|\n\r|\n|\r)")

--- a/tests/Js/Main/RegexTests.fs
+++ b/tests/Js/Main/RegexTests.fs
@@ -325,6 +325,36 @@ let tests =
     testCase "Regex.Split with capturing group includes captures" <| fun _ ->
         Regex.Split("a1b2c", "([0-9])") |> equal [| "a"; "1"; "b"; "2"; "c" |]
 
+    testCase "Regex.Replace with $` and $' works" <| fun _ ->
+        Regex.Replace("abc", "b", "[$`]") |> equal "a[a]c"
+        Regex.Replace("abc", "b", "[$']") |> equal "a[c]c"
+
+    testCase "Regex.Replace with ambiguous multi-digit group number keeps it literal" <| fun _ ->
+        // .NET does not shrink an ambiguous multi-digit group number down to a valid prefix:
+        // since group 12 doesn't exist, the whole token is kept literally, both for $12 and $11
+        // (even though group 1 exists in both cases)
+        Regex.Replace("ab", "(a)b", "$12") |> equal "$12"
+        Regex.Replace("ab", "(a)b", "$11") |> equal "$11"
+        Regex.Replace("ab", "(a)b", "[${12}]") |> equal "[${12}]"
+        // a non-digit right after the number is not part of it, so it substitutes normally
+        Regex.Replace("ab", "(a)b", "$1x") |> equal "ax"
+
+    testCase "Regex.Replace with nonexistent group number keeps it literal" <| fun _ ->
+        Regex.Replace("abc", "b", "$99") |> equal "a$99c"
+        Regex.Replace("abc", "b", "[${99}]") |> equal "a[${99}]c"
+
+    testCase "Regex.Replace with nonexistent named group keeps it literal" <| fun _ ->
+        Regex.Replace("abc", "(a)", "[${foo}]") |> equal "[${foo}]bc"
+
+    testCase "Regex.Replace with count 0 makes no replacements" <| fun _ ->
+        Regex("a").Replace("aaaa", "b", 0) |> equal "aaaa"
+
+    testCase "Regex.Split with count 0 is unlimited" <| fun _ ->
+        Regex(",").Split("a,b,c", 0) |> equal [| "a"; "b"; "c" |]
+
+    testCase "Regex.Split with count 1 makes no split" <| fun _ ->
+        Regex(",").Split("a,b,c", 1) |> equal [| "a,b,c" |]
+
     // See #838
     testCase "Group values are correct and empty when not being matched" <| fun _ ->
         Regex.Matches("\n\n\n", @"(?:([^\n\r]+)|\r\n|\n\r|\n|\r)")


### PR DESCRIPTION
- Replace with count compared against the imported matches function's arity instead of the match array, so any count >= 2 replaced ALL matches; string replacements now route through the evaluator path which counts the limit down correctly
- .NET substitution patterns are interpreted with a single left-to-right pass: $$ escapes are honored ($$0 stays literal $0), numbered ${n} groups substitute correctly, unmatched groups yield ""
- Split discarded the remainder when a count was given and dropped the prefix before startat; it now iterates matches manually with .NET semantics (remainder kept, prefix kept, capture group values included, zero-length edge matches preserved)

(split from #4738)