### PR TITLE
fix(js/ts): Observable/Event dropping null/undefined/unit values

### DIFF
--- a/src/fable-library-ts/Event.ts
+++ b/src/fable-library-ts/Event.ts
@@ -35,8 +35,16 @@ export class Event$2<Delegate extends Function, Args> {
   public Trigger(value: Args): void;
   public Trigger(sender: any, value: Args): void
   public Trigger(senderOrValue: any, valueOrUndefined?: Args): void {
+    // Disambiguate the overloads by arity, not by value: a two-argument call may
+    // legitimately pass `undefined` as the event value (e.g. unit events).
     let sender: any = null;
-    const value = valueOrUndefined === undefined ? senderOrValue as Args : (sender = senderOrValue, valueOrUndefined);
+    let value: Args;
+    if (arguments.length <= 1) {
+      value = senderOrValue as Args;
+    } else {
+      sender = senderOrValue;
+      value = valueOrUndefined as Args;
+    }
     this.delegates.forEach(f => { f(sender, value) });
   }
 }

--- a/src/fable-library-ts/Observable.ts
+++ b/src/fable-library-ts/Observable.ts
@@ -1,6 +1,6 @@
 
 import { FSharpChoice$2_$union, Choice_tryValueIfChoice1Of2, Choice_tryValueIfChoice2Of2 } from "./Choice.ts";
-import { Option, value } from "./Option.ts";
+import { Option, some, value } from "./Option.ts";
 import { IDisposable } from "./Util.ts";
 
 export interface IObserver<T> {
@@ -56,7 +56,7 @@ export function choose<T, U>(chooser: (x: T) => Option<U>, source: IObservable<T
 }
 
 export function filter<T>(predicate: (x: T) => boolean, source: IObservable<T>): IObservable<T> {
-  return choose((x) => predicate(x) ? x : void 0, source);
+  return choose((x) => predicate(x) ? some(x) : undefined, source);
 }
 
 export function map<T, U>(mapping: (x: T) => U, source: IObservable<T>): IObservable<U> {
@@ -120,11 +120,13 @@ export function merge<T>(source1: IObservable<T>, source2: IObservable<T>): IObs
 export function pairwise<T>(source: IObservable<T>): IObservable<[T, T]> {
   return new Observable<[T, T]>((observer) => {
     let last: T;
+    let haveLast = false;
     return source.Subscribe(new Observer<T>((next) => {
-      if (last != null) {
+      if (haveLast) {
         observer.OnNext([last, next]);
       }
       last = next;
+      haveLast = true;
     }, observer.OnError, observer.OnCompleted));
   });
 }

--- a/tests/Js/Main/EventTests.fs
+++ b/tests/Js/Main/EventTests.fs
@@ -250,4 +250,22 @@ let tests =
             test.Trigger(i)
 
         equal 300 counter
+
+    testCase "Event.Trigger delivers zero value" <| fun () ->
+        let mutable result = -1
+        let source = Event<int>()
+        source.Publish |> Event.add (fun n -> result <- n)
+        source.Trigger 0
+        equal 0 result
+
+    testCase "Classes can trigger CLI events with zero value" <| fun () ->
+        let mutable result = -1
+        let mutable actualSender = null
+        let classWithEvent = new ClassWithCLIEvent()
+        classWithEvent.Event.Add(fun (sender, x) ->
+            actualSender <- box sender
+            result <- x)
+        classWithEvent.TestEvent(0)
+        equal 0 result
+        equal (box classWithEvent) actualSender
   ]

--- a/tests/Js/Main/ObservableTests.fs
+++ b/tests/Js/Main/ObservableTests.fs
@@ -120,4 +120,37 @@ let tests =
         Observable.add (equal 12) source2
         source.Trigger 6
         source.Trigger 2
+
+    testCase "Observable.filter delivers unit values when predicate is true" <| fun () ->
+        let mutable count = 0
+        let source = MyObservable()
+        source
+        |> Observable.filter (fun _ -> true)
+        |> Observable.add (fun () -> count <- count + 1)
+        source.Trigger ()
+        source.Trigger ()
+        source.Trigger ()
+        equal 3 count
+
+    testCase "Observable.filter delivers zero values" <| fun () ->
+        let received = ResizeArray()
+        let source = MyObservable()
+        source
+        |> Observable.filter (fun _ -> true)
+        |> Observable.add (fun x -> received.Add x)
+        source.Trigger 0
+        source.Trigger 1
+        source.Trigger 2
+        equal [0; 1; 2] (List.ofSeq received)
+
+    testCase "Observable.pairwise produces all consecutive pairs" <| fun () ->
+        let pairs = ResizeArray()
+        let source = MyObservable()
+        source
+        |> Observable.pairwise
+        |> Observable.add (fun p -> pairs.Add p)
+        source.Trigger 1
+        source.Trigger 2
+        source.Trigger 3
+        equal [(1, 2); (2, 3)] (List.ofSeq pairs)
   ]

--- a/tests/Js/Main/ObservableTests.fs
+++ b/tests/Js/Main/ObservableTests.fs
@@ -153,4 +153,15 @@ let tests =
         source.Trigger 2
         source.Trigger 3
         equal [(1, 2); (2, 3)] (List.ofSeq pairs)
+
+    testCase "Observable.pairwise does not drop pairs around a null element" <| fun () ->
+        let pairs = ResizeArray()
+        let source = MyObservable()
+        source
+        |> Observable.pairwise
+        |> Observable.add (fun p -> pairs.Add p)
+        source.Trigger "a"
+        source.Trigger null
+        source.Trigger "b"
+        equal [("a", null); (null, "b")] (List.ofSeq pairs)
   ]


### PR DESCRIPTION
- Observable.filter passed the raw value to choose instead of wrapping with some(), dropping null/undefined/unit values that satisfied the predicate (Event.filter already did this correctly)
- Observable.pairwise used a null check instead of a have-last flag, suppressing the pair after any null element
- Event.Trigger disambiguated its overloads by value === undefined, misrouting Trigger(sender, undefined) so the handler received the sender as the event value; now disambiguated by arity

(split from #4738)