### PR TITLE
fix(js/ts): BigInteger byte-array corruption, checked conversions, gcd, log2

### DIFF
--- a/src/fable-library-ts/BigInt.ts
+++ b/src/fable-library-ts/BigInt.ts
@@ -135,12 +135,12 @@ export function toIntN_unchecked(bits: number, x: bigint, signed: boolean): bigi
 }
 
 export function toIntN(bits: number, x: bigint, signed: boolean): bigint {
-    let higher_bits = abs(x) >> BigInt(bits);
-    if (higher_bits !== 0n) {
+    const truncated = signed ? BigInt.asIntN(bits, x) : BigInt.asUintN(bits, x);
+    if (truncated !== x) {
         const s = signed ? "a signed" : "an unsigned";
         throw new Exception(`Value was either too large or too small for ${s} ${bits}-bit integer.`);
     }
-    return signed ? BigInt.asIntN(bits, x) : BigInt.asUintN(bits, x);
+    return truncated;
 }
 
 export function toInt8(x: bigint): int8 { return Number(toIntN(8, x, true)); }
@@ -176,6 +176,9 @@ export function toFloat64(x: bigint): float64 { return Number(x); }
 export function toDecimal(x: bigint): decimal {
     const isNegative = x < zero;
     const bits = abs(x);
+    if ((bits >> 96n) !== zero) {
+        throw new Exception("Value was either too large or too small for a Decimal.");
+    }
     const low = Number(BigInt.asUintN(32, bits));
     const mid = Number(BigInt.asUintN(32, bits >> 32n));
     const high = Number(BigInt.asUintN(32, bits >> 64n));
@@ -228,6 +231,8 @@ export function divRem(x: bigint, y: bigint, out?: FSharpRef<bigint>): bigint | 
 }
 
 export function greatestCommonDivisor(x: bigint, y: bigint): bigint {
+    x = abs(x);
+    y = abs(y);
     while (y > zero) {
         const q = x / y;
         const r = x - q * y;
@@ -237,8 +242,17 @@ export function greatestCommonDivisor(x: bigint, y: bigint): bigint {
     return x;
 }
 
+// Number of bits in the binary representation of x (x must be positive)
+function bitLength(x: bigint): number {
+    const hex = x.toString(16);
+    return (hex.length - 1) * 4 + (32 - Math.clz32(fromHexCode(hex.charCodeAt(0))));
+}
+
 export function getBitLength(x: bigint): int64 {
-    return fromFloat64(x === zero ? 1 : log2(abs(x)) + 1);
+    if (x < zero) {
+        x = -x - one; // two's complement bit length excluding the sign bit
+    }
+    return x === zero ? zero : BigInt(bitLength(x));
 }
 
 export function log2(x: bigint): float64 {
@@ -274,7 +288,10 @@ export function log(x: bigint, base: float64): float64 {
 }
 
 export function ilog2(x: bigint): bigint {
-    return BigInt(log2(x));
+    if (x < zero) {
+        throw new Exception("Value must be non-negative.");
+    }
+    return x === zero ? zero : BigInt(bitLength(x) - 1);
 }
 
 // export function copySign
@@ -305,35 +322,20 @@ function fromHexCode(code: number): number {
 
 function toSignedBytes(x: bigint, isBigEndian: boolean): Uint8Array {
     const isNeg = x < 0n;
-    if (isNeg) {
-        const len = log2(-x);
-        const bits = len + (8 - len % 8);
-        const pow2 = (1n << BigInt(bits));
-        x = x + pow2; // two's complement
+    const sentinel = isNeg ? -1n : 0n;
+    const bytes: number[] = []; // little-endian
+    do {
+        bytes.push(Number(BigInt.asUintN(8, x)));
+        x = x >> 8n;
+    } while (x !== sentinel);
+    // extra byte if the top byte's sign bit would misrepresent the sign
+    if (isNeg !== (bytes[bytes.length - 1] > 127)) {
+        bytes.push(isNeg ? 255 : 0);
     }
-    const hex = x.toString(16);
-    const len = hex.length;
-    const odd = len % 2;
-    const first = hex.charCodeAt(0);
-    const isLow = 48 <= first && first <= 55; // 0..7
-    const start = (isNeg && isLow) || (!isNeg && !isLow) ? 1 : 0;
-    const bytes = new Uint8Array(start + (len + odd) / 2);
-    const inc = isBigEndian ? 1 : -1;
-    let pos = isBigEndian ? 0 : bytes.length - 1;
-    if (start > 0) {
-        bytes[pos] = isNeg ? 255 : 0;
-        pos += inc;
+    if (isBigEndian) {
+        bytes.reverse();
     }
-    if (odd > 0) {
-        bytes[pos] = fromHexCode(first);
-        pos += inc;
-    }
-    for (let i = odd; i < len; i += 2, pos += inc) {
-        const a = fromHexCode(hex.charCodeAt(i));
-        const b = fromHexCode(hex.charCodeAt(i + 1));
-        bytes[pos] = (a << 4) | b;
-    }
-    return bytes;
+    return new Uint8Array(bytes);
 }
 
 function fromSignedBytes(bytes: ArrayLike<uint8>, isBigEndian: boolean) {

--- a/tests/Js/Main/ArithmeticTests.fs
+++ b/tests/Js/Main/ArithmeticTests.fs
@@ -816,6 +816,40 @@ let tests =
         Numerics.BigInteger([|231uy; 216uy; 2uy; 164uy; 86uy; 149uy; 8uy; 199uy; 62uy; 0uy; 92uy|]) |> equal 111222333444555666777888999I
         Numerics.BigInteger([|25uy; 39uy; 253uy; 91uy; 169uy; 106uy; 247uy; 56uy; 193uy; 255uy; 163uy|]) |> equal -111222333444555666777888999I
 
+    testCase "Big integer to byte array round-trips negatives" <| fun () ->
+        // See regression where -62837 corrupted the sign extension
+        (bigint -62837).ToByteArray() |> equal [|0x8Buy; 0x0Auy; 0xFFuy|]
+        Numerics.BigInteger((bigint -62837).ToByteArray()) |> equal -62837I
+        (bigint -129).ToByteArray() |> equal [|0x7Fuy; 0xFFuy|]
+        Numerics.BigInteger((bigint -129).ToByteArray()) |> equal -129I
+        (bigint -256).ToByteArray() |> equal [|0x00uy; 0xFFuy|]
+        Numerics.BigInteger((bigint -256).ToByteArray()) |> equal -256I
+        (bigint 255).ToByteArray() |> equal [|0xFFuy; 0x00uy|]
+        Numerics.BigInteger((bigint 255).ToByteArray()) |> equal 255I
+
+    testCase "BigInteger.GreatestCommonDivisor works with negatives" <| fun () ->
+        bigint.GreatestCommonDivisor(-4I, 6I) |> equal 2I
+        bigint.GreatestCommonDivisor(4I, -6I) |> equal 2I
+        bigint.GreatestCommonDivisor(-4I, -6I) |> equal 2I
+        bigint.GreatestCommonDivisor(0I, -5I) |> equal 5I
+
+    testCase "BigInteger.Log2 works for non-powers-of-two" <| fun () ->
+        bigint.Log2 5I |> equal 2I
+        bigint.Log2 8I |> equal 3I
+
+    testCase "BigInteger.GetBitLength works" <| fun () ->
+        (0I).GetBitLength() |> equal 0L
+        (-1I).GetBitLength() |> equal 0L
+        (255I).GetBitLength() |> equal 8L
+        (-8I).GetBitLength() |> equal 3L
+
+    testCase "BigInteger checked conversions throw on overflow" <| fun () ->
+        (fun () -> int8 200I) |> throwsError ""
+        (fun () -> uint8 -1I) |> throwsError ""
+        (fun () -> int32 3000000000I) |> throwsError ""
+        (fun () -> byte 256I) |> throwsError ""
+        (fun () -> sbyte 200I) |> throwsError ""
+
     testCase "Member values of decimal type can be compared" <| fun () -> // See #747
         decimalOne < decimalTwo |> equal true
         decimalOne > decimalTwo |> equal false


### PR DESCRIPTION
- toSignedBytes computed the two's-complement width from fractional Math.log2, undersizing the buffer for some negatives so toByteArray/fromByteArray round-trips corrupted values (e.g. -62837 -> +2699); rewritten via byte-wise iteration
- Checked toIntN conversions used abs(x) >> bits as the bounds test, silently wrapping out-of-range values instead of throwing
- greatestCommonDivisor was wrong for negative arguments
- getBitLength was wrong for zero and negatives; ilog2 crashed on non-powers-of-two; both now derive from the exact bit length
- toDecimal silently truncated to the low 96 bits instead of throwing on overflow

(split from #4738)