### PR TITLE
fix(js/ts): date arithmetic: PM parsing, AddMonths day clamp, AddYears offset

### DIFF
--- a/src/fable-library-ts/Date.ts
+++ b/src/fable-library-ts/Date.ts
@@ -636,7 +636,9 @@ export function parseRaw(input: string): [Date, Offset] {
           parseInt(timeParts[1] || "0", 10) * 60 +
           parseFloat(timeParts[2] || "0");
         if (m[3] != null && m[3].toUpperCase() === "PM" && hourPart < 12) {
-          timeInSeconds += 720;
+          timeInSeconds += 12 * 3600;
+        } else if (m[3] != null && m[3].toUpperCase() === "AM" && hourPart === 12) {
+          timeInSeconds -= 12 * 3600;
         }
       }
       if (m[4] != null) { // There's an offset, parse as UTC
@@ -854,18 +856,9 @@ export function addYears(d: IDateTime, v: number) {
 }
 
 export function addMonths(d: IDateTime, v: number) {
-  let newMonth = month(d) + v;
-  let newMonth_ = 0;
-  let yearOffset = 0;
-  if (newMonth > 12) {
-    newMonth_ = newMonth % 12;
-    yearOffset = Math.floor(newMonth / 12);
-    newMonth = newMonth_;
-  } else if (newMonth < 1) {
-    newMonth_ = 12 + newMonth % 12;
-    yearOffset = Math.floor(newMonth / 12) + (newMonth_ === 12 ? -1 : 0);
-    newMonth = newMonth_;
-  }
+  const totalMonths = month(d) + v;
+  const newMonth = ((totalMonths - 1) % 12 + 12) % 12 + 1;
+  const yearOffset = Math.floor((totalMonths - 1) / 12);
   const newYear = year(d) + yearOffset;
   const _daysInMonth = daysInMonth(newYear, newMonth);
   const newDay = Math.min(_daysInMonth, day(d));

--- a/src/fable-library-ts/DateOffset.ts
+++ b/src/fable-library-ts/DateOffset.ts
@@ -249,28 +249,20 @@ export function addTicks(d: IDateTimeOffset, v: int64) {
 }
 
 export function addYears(d: IDateTimeOffset, v: number) {
-  const newMonth = d.getUTCMonth() + 1;
-  const newYear = d.getUTCFullYear() + v;
+  const d2 = new Date(d.getTime() + offset(d));
+  const newMonth = d2.getUTCMonth() + 1;
+  const newYear = d2.getUTCFullYear() + v;
   const _daysInMonth = daysInMonth(newYear, newMonth);
-  const newDay = Math.min(_daysInMonth, d.getUTCDate());
-  return create(newYear, newMonth, newDay, d.getUTCHours(), d.getUTCMinutes(),
-    d.getUTCSeconds(), d.getUTCMilliseconds(), offset(d));
+  const newDay = Math.min(_daysInMonth, d2.getUTCDate());
+  return create(newYear, newMonth, newDay, d2.getUTCHours(), d2.getUTCMinutes(),
+    d2.getUTCSeconds(), d2.getUTCMilliseconds(), offset(d));
 }
 
 export function addMonths(d: IDateTimeOffset, v: number) {
   const d2 = new Date(d.getTime() + offset(d));
-  let newMonth = d2.getUTCMonth() + 1 + v;
-  let newMonth_ = 0;
-  let yearOffset = 0;
-  if (newMonth > 12) {
-    newMonth_ = newMonth % 12;
-    yearOffset = Math.floor(newMonth / 12);
-    newMonth = newMonth_;
-  } else if (newMonth < 1) {
-    newMonth_ = 12 + newMonth % 12;
-    yearOffset = Math.floor(newMonth / 12) + (newMonth_ === 12 ? -1 : 0);
-    newMonth = newMonth_;
-  }
+  const totalMonths = d2.getUTCMonth() + 1 + v;
+  const newMonth = ((totalMonths - 1) % 12 + 12) % 12 + 1;
+  const yearOffset = Math.floor((totalMonths - 1) / 12);
   const newYear = d2.getUTCFullYear() + yearOffset;
   const _daysInMonth = daysInMonth(newYear, newMonth);
   const newDay = Math.min(_daysInMonth, d2.getUTCDate());

--- a/tests/Js/Main/DateTimeOffsetTests.fs
+++ b/tests/Js/Main/DateTimeOffsetTests.fs
@@ -412,6 +412,20 @@ let tests =
         test -20 2050
         test -100 2046
 
+    testCase "DateTimeOffset.AddMonths keeps last day when delta is a multiple of 12" <| fun () ->
+        let dt = DateTimeOffset(2020, 12, 31, 0, 0, 0, TimeSpan.Zero).AddMonths(12)
+        dt.Year |> equal 2021
+        dt.Month |> equal 12
+        dt.Day |> equal 31
+
+    testCase "DateTimeOffset.AddYears keeps offset-local wall clock" <| fun () ->
+        let dt = DateTimeOffset(2020, 1, 1, 2, 0, 0, TimeSpan.FromHours 5.).AddYears(1)
+        dt.Year |> equal 2021
+        dt.Month |> equal 1
+        dt.Day |> equal 1
+        dt.Hour |> equal 2
+        dt.Offset |> equal (TimeSpan.FromHours 5.)
+
     testCase "DateTimeOffset.AddDays works" <| fun () ->
         let test v expected =
             let dt = DateTimeOffset(2014,9,12,0,0,0,TimeSpan.Zero).AddDays(v)

--- a/tests/Js/Main/DateTimeTests.fs
+++ b/tests/Js/Main/DateTimeTests.fs
@@ -848,7 +848,7 @@ let tests =
         d3.Hour + d3.Minute + d3.Second |> equal 54
 
 
-    testCase "DateTime.Parse handles AM/PM designator correctly" <| fun () -> // PM = 12 hours, not 720 seconds
+    testCase "DateTime.Parse handles AM/PM designator correctly" <| fun () ->
         // Time-only strings parse to clock fields that are timezone-independent
         let d = DateTime.Parse("1:05:34 PM", CultureInfo.InvariantCulture)
         d.Hour |> equal 13

--- a/tests/Js/Main/DateTimeTests.fs
+++ b/tests/Js/Main/DateTimeTests.fs
@@ -848,6 +848,19 @@ let tests =
         d3.Hour + d3.Minute + d3.Second |> equal 54
 
 
+    testCase "DateTime.Parse handles AM/PM designator correctly" <| fun () -> // PM = 12 hours, not 720 seconds
+        // Time-only strings parse to clock fields that are timezone-independent
+        let d = DateTime.Parse("1:05:34 PM", CultureInfo.InvariantCulture)
+        d.Hour |> equal 13
+        d.Minute |> equal 5
+        d.Second |> equal 34
+        let d = DateTime.Parse("12:05 AM", CultureInfo.InvariantCulture)
+        d.Hour |> equal 0
+        d.Minute |> equal 5
+        let d = DateTime.Parse("12:05 PM", CultureInfo.InvariantCulture)
+        d.Hour |> equal 12
+        d.Minute |> equal 5
+
     testCase "DateTime.TryParse works" <| fun () ->
         let (isSuccess, _) = DateTime.TryParse("foo", CultureInfo.InvariantCulture, DateTimeStyles.None)
         isSuccess |> equal false
@@ -1004,6 +1017,12 @@ let tests =
         test -5 2054
         test -20 2050
         test -100 2046
+
+    testCase "DateTime.AddMonths keeps last day when delta is a multiple of 12" <| fun () ->
+        let dt = DateTime(2020, 12, 31, 0, 0, 0, DateTimeKind.Utc).AddMonths(12)
+        dt.Year |> equal 2021
+        dt.Month |> equal 12
+        dt.Day |> equal 31
 
     testCase "DateTime.AddDays works" <| fun () ->
         let test v expected =


### PR DESCRIPTION
- The fallback parser added the PM designator as 720 seconds (12 minutes instead of 12 hours), so Parse("3:30 PM") gave 3:42; also added the missing 12 AM -> 00 handling
- AddMonths landed one day early whenever month+delta was a positive multiple of 12 (newMonth % 12 = 0 made daysInMonth clamp day 31 to 30); normalization rewritten in canonical modular form in both Date and DateOffset
- DateTimeOffset.AddYears read raw UTC fields instead of offset-adjusted ones, shifting the wall clock by the offset

(split from #4738)