### PR TITLE
fix(js/ts): async cancellation propagation and continuation double-resolve

### DIFF
--- a/src/fable-library-ts/Async.ts
+++ b/src/fable-library-ts/Async.ts
@@ -11,11 +11,6 @@ function emptyContinuation<T>(_x: T) {
   // NOP
 }
 
-// see AsyncBuilder.Delay
-function delay<T>(generator: () => Async<T>) {
-  return protectedCont((ctx: IAsyncContext<T>) => generator()(ctx));
-}
-
 // MakeAsync: body:(AsyncActivation<'T> -> AsyncReturn) -> Async<'T>
 export function makeAsync<T>(body: Async<T>) {
   return body;
@@ -60,24 +55,33 @@ export function throwIfCancellationRequested(token: CancellationToken) {
 }
 
 export function startChild<T>(computation: Async<T>, ms?: number): Async<Async<T>> {
-  const promise = startAsPromise(computation);
-  let promiseToRun = promise;
+  return protectedCont((ctx) => {
+    // Share the parent's cancellation token so cancelling the parent
+    // cancels the child, like .NET Async.StartChild
+    const promise = startAsPromise(computation, ctx.cancelToken);
+    let promiseToRun = promise;
 
-  if (ms) {
-    // Race the computation against a timeout: whichever settles first wins.
-    promiseToRun = new Promise<T>((resolve, reject) => {
-      const timeoutId = setTimeout(() => reject(TimeoutException_$ctor()), ms);
-      promise.then(
-        value => { clearTimeout(timeoutId); resolve(value); },
-        error => { clearTimeout(timeoutId); reject(error); }
-      );
-    });
-  }
+    if (ms) {
+      // Race the computation against a timeout: whichever settles first wins.
+      promiseToRun = new Promise<T>((resolve, reject) => {
+        const timeoutId = setTimeout(() => reject(TimeoutException_$ctor()), ms);
+        promise.then(
+          value => { clearTimeout(timeoutId); resolve(value); },
+          error => { clearTimeout(timeoutId); reject(error); }
+        );
+      });
+    }
 
-  // JS Promises are hot, computation has already started
-  // but we delay returning the result
-  return protectedCont((ctx) =>
-    protectedReturn(awaitPromise(promiseToRun))(ctx));
+    // Prevent an unhandled rejection when the child is cancelled or fails
+    // while nobody awaits it (in F# an unobserved child's cancellation or
+    // failure is simply not propagated). awaitPromise attaches its own
+    // handlers to the same promise, so awaiting still observes the result.
+    promiseToRun.catch(emptyContinuation);
+
+    // JS Promises are hot, computation has already started
+    // but we delay returning the result
+    protectedReturn(awaitPromise(promiseToRun))(ctx);
+  });
 }
 
 export function awaitPromise<T>(p: Promise<T>) {
@@ -132,20 +136,24 @@ export function ignore<T>(computation: Async<T>) {
 }
 
 export function parallel<T>(computations: Iterable<Async<T>>) {
-  return delay(() => awaitPromise(Promise.all(Array.from(computations, (w) => startAsPromise(w)))));
+  // Children share the parent's cancellation token, like .NET Async.Parallel
+  return protectedCont((ctx: IAsyncContext<T[]>) =>
+    awaitPromise(Promise.all(Array.from(computations, (w) => startAsPromise(w, ctx.cancelToken))))(ctx));
 }
 
 export function sequential<T>(computations: Iterable<Async<T>>) {
 
-  function _sequential<T>(computations: Iterable<Async<T>>): Promise<T[]> {
+  function _sequential(computations: Iterable<Async<T>>, cancelToken: CancellationToken): Promise<T[]> {
     let pr: Promise<T[]> = Promise.resolve([]);
     for (const c of computations) {
-      pr = pr.then(results => startAsPromise(c).then(r => results.concat([r])))
+      pr = pr.then(results => startAsPromise(c, cancelToken).then(r => results.concat([r])))
     }
     return pr;
   }
 
-  return delay(() => awaitPromise<T[]>(_sequential<T>(computations)));
+  // Children share the parent's cancellation token, like .NET Async.Sequential
+  return protectedCont((ctx: IAsyncContext<T[]>) =>
+    awaitPromise<T[]>(_sequential(computations, ctx.cancelToken))(ctx));
 }
 
 export function sleep(millisecondsDueTime: number) {
@@ -184,10 +192,15 @@ export function startWithContinuations<T>(
   cancelToken?: CancellationToken) {
 
   const trampoline = new Trampoline();
+  // Mark the computation completed as soon as a terminal continuation is entered
+  // so protectedCont lets exceptions from continuation code propagate instead of
+  // routing them to onError (see Trampoline.completed).
+  const done = <U>(cont: Continuation<U>): Continuation<U> =>
+    (x: U) => { trampoline.completed = true; return cont(x); };
   computation({
-    onSuccess: continuation ? continuation as Continuation<T> : emptyContinuation,
-    onError: exceptionContinuation,
-    onCancel: cancellationContinuation,
+    onSuccess: done(continuation ? continuation as Continuation<T> : emptyContinuation),
+    onError: done(exceptionContinuation),
+    onCancel: done(cancellationContinuation),
     cancelToken: cancelToken ? cancelToken : defaultCancellationToken,
     trampoline,
   });

--- a/src/fable-library-ts/AsyncBuilder.ts
+++ b/src/fable-library-ts/AsyncBuilder.ts
@@ -64,8 +64,14 @@ export class Trampoline {
     return 2000;
   }
   private callCount: number;
+  // Set once a terminal continuation of the computation has been entered.
+  // After that point any exception unwinding through protectedCont comes from
+  // user continuation code, not the workflow body, and must propagate instead
+  // of being routed to onError (which would resolve the computation twice).
+  public completed: boolean;
   constructor() {
     this.callCount = 0;
+    this.completed = false;
   }
   public incrementAndCheck() {
     return this.callCount++ > Trampoline.maxTrampolineCallCount;
@@ -96,6 +102,7 @@ export function protectedCont<T>(f: Async<T>) {
         try {
           f(ctx);
         } catch (err) {
+          if (ctx.trampoline.completed) { throw err; }
           ctx.onError(ensureErrorOrException(err));
         }
       });
@@ -103,6 +110,11 @@ export function protectedCont<T>(f: Async<T>) {
       try {
         f(ctx);
       } catch (err) {
+        // Once a terminal continuation has run the computation is complete, so
+        // an exception from user continuation code must propagate rather than be
+        // routed to onError (which would resolve the computation a second time,
+        // e.g. a succeeded try/with body re-entering its with handler).
+        if (ctx.trampoline.completed) { throw err; }
         ctx.onError(ensureErrorOrException(err));
       }
     }
@@ -113,11 +125,17 @@ export function protectedBind<T, U>(computation: Async<T>, binder: (x: T) => Asy
   return protectedCont((ctx: IAsyncContext<U>) => {
     computation({
       onSuccess: (x: T) => {
+        // Only guard the binder evaluation itself: the resulting computation
+        // is protected on its own, and re-catching what it throws would
+        // route continuation exceptions back into onError (double-resolve).
+        let bound: Async<U>;
         try {
-          binder(x)(ctx);
+          bound = binder(x);
         } catch (err) {
           ctx.onError(ensureErrorOrException(err));
+          return;
         }
+        bound(ctx);
       },
       onError: ctx.onError,
       onCancel: ctx.onCancel,
@@ -191,11 +209,15 @@ export class AsyncBuilder {
         cancelToken: ctx.cancelToken,
         trampoline: ctx.trampoline,
         onError: (ex: any) => {
+          // See protectedBind: only guard the handler evaluation itself.
+          let handled: Async<T>;
           try {
-            catchHandler(ex)(ctx);
+            handled = catchHandler(ex);
           } catch (err) {
             ctx.onError(ensureErrorOrException(err));
+            return;
           }
+          handled(ctx);
         },
       });
     });

--- a/tests/Js/Main/AsyncTests.fs
+++ b/tests/Js/Main/AsyncTests.fs
@@ -649,4 +649,57 @@ let tests =
         }, cts.Token)
         cts.Cancel()
         async { equal true cancelCalled }
+
+    testCase "Async try .. with does not run 'with' branch when body succeeds" <| fun () ->
+        let work = async {
+            try
+              return 1
+            with _ ->
+              return 99 }
+        let mutable result = 0
+        Async.StartWithContinuations(work, (fun r -> result <- r), ignore, ignore)
+        equal result 1
+
+    testCaseAsync "Async.StartChild cancels the child when the parent's token is cancelled" <| fun () ->
+        async {
+            let mutable finallyRan = false
+            let mutable completed = false
+            let cts = new System.Threading.CancellationTokenSource()
+            let child = async {
+                try
+                    do! Async.Sleep 500
+                    completed <- true
+                finally
+                    finallyRan <- true
+            }
+            let parent = async {
+                let! childResult = Async.StartChild child
+                do! childResult
+            }
+            Async.StartImmediate(parent, cts.Token)
+            do! Async.Sleep 200
+            cts.Cancel()
+            do! Async.Sleep 600
+            equal true finallyRan
+            equal false completed
+        }
+
+    testCaseAsync "Async.Parallel children are cancelled when the parent's token is cancelled" <| fun () ->
+        async {
+            let mutable completed = 0
+            let cts = new System.Threading.CancellationTokenSource()
+            let mkChild () = async {
+                do! Async.Sleep 500
+                completed <- completed + 1
+            }
+            let work = async {
+                let! _ = Async.Parallel [ mkChild(); mkChild(); mkChild() ]
+                return ()
+            }
+            Async.StartImmediate(work, cts.Token)
+            do! Async.Sleep 200
+            cts.Cancel()
+            do! Async.Sleep 600
+            equal 0 completed
+        }
   ]

--- a/tests/Js/Main/AsyncTests.fs
+++ b/tests/Js/Main/AsyncTests.fs
@@ -660,6 +660,21 @@ let tests =
         Async.StartWithContinuations(work, (fun r -> result <- r), ignore, ignore)
         equal result 1
 
+    testCase "Exception thrown by the continuation is not redirected to the 'with' branch" <| fun () ->
+        let work = async {
+            try
+              return 1
+            with _ ->
+              return 99 }
+        let mutable calls = 0
+        throwsAnyError (fun () ->
+            Async.StartWithContinuations(
+                work,
+                (fun _ -> calls <- calls + 1; failwith "boom from continuation"),
+                ignore,
+                ignore))
+        equal 1 calls
+
     testCaseAsync "Async.StartChild cancels the child when the parent's token is cancelled" <| fun () ->
         async {
             let mutable finallyRan = false
@@ -694,6 +709,25 @@ let tests =
             }
             let work = async {
                 let! _ = Async.Parallel [ mkChild(); mkChild(); mkChild() ]
+                return ()
+            }
+            Async.StartImmediate(work, cts.Token)
+            do! Async.Sleep 200
+            cts.Cancel()
+            do! Async.Sleep 600
+            equal 0 completed
+        }
+
+    testCaseAsync "Async.Sequential children are cancelled when the parent's token is cancelled" <| fun () ->
+        async {
+            let mutable completed = 0
+            let cts = new System.Threading.CancellationTokenSource()
+            let mkChild () = async {
+                do! Async.Sleep 500
+                completed <- completed + 1
+            }
+            let work = async {
+                let! _ = Async.Sequential [ mkChild(); mkChild(); mkChild() ]
                 return ()
             }
             Async.StartImmediate(work, cts.Token)


### PR DESCRIPTION
- StartChild/Parallel/Sequential started children on the default cancellation token, so cancelling the parent never cancelled them; they now share the parent's token like .NET
- protectedCont routed exceptions thrown by already-invoked continuations back into onError, firing two continuations for one computation (a succeeded try/with body re-entered its with handler); continuation exceptions now propagate instead
- protectedBind/TryWith only guard the binder/handler evaluation, not the invocation of the resulting protected computation
- Unawaited cancelled/failed children no longer surface as unhandled promise rejections

(split from #4738)