### PR TITLE
fix(js/ts): int64 non-decimal parsing and BitConverter .NET mismatches

### DIFF
--- a/src/fable-library-ts/BitConverter.ts
+++ b/src/fable-library-ts/BitConverter.ts
@@ -95,7 +95,7 @@ export function doubleToInt64Bits(value: float64): int64 {
 export function toBoolean(bytes: ArrayLike<uint8>, offset: int32): boolean {
   const array = ArrayBuffer.isView(bytes) ? bytes : Uint8Array.from(bytes);
   const view = new DataView(array.buffer, array.byteOffset, array.byteLength);
-  return view.getUint8(offset) === 1 ? true : false;
+  return view.getUint8(offset) !== 0;
 }
 
 export function toChar(bytes: ArrayLike<uint8>, offset: int32): char {
@@ -161,5 +161,5 @@ export function toString(bytes: ArrayLike<uint8>, offset?: int32, count?: int32)
   } else if (offset != null) {
     buffer = buffer.subarray(offset);
   }
-  return Array.from(buffer).map((b) => ("0" + b.toString(16)).slice(-2)).join("-");
+  return Array.from(buffer).map((b) => ("0" + b.toString(16)).slice(-2).toUpperCase()).join("-");
 }

--- a/src/fable-library-ts/Long.ts
+++ b/src/fable-library-ts/Long.ts
@@ -3,38 +3,29 @@ import { fromString } from "./BigInt.ts";
 import { FSharpRef } from "./Types.ts";
 import { Exception } from "./Util.ts";
 
-function getMaxValue(unsigned: boolean, radix: number, isNegative: boolean) {
-  switch (radix) {
-    case 2: return unsigned ?
-      "1111111111111111111111111111111111111111111111111111111111111111" :
-      (isNegative ? "1000000000000000000000000000000000000000000000000000000000000000"
-        : "111111111111111111111111111111111111111111111111111111111111111");
-    case 8: return unsigned ?
-      "1777777777777777777777" :
-      (isNegative ? "1000000000000000000000" : "777777777777777777777");
-    case 10: return unsigned ?
-      "18446744073709551615" :
-      (isNegative ? "9223372036854775808" : "9223372036854775807");
-    case 16: return unsigned ?
-      "FFFFFFFFFFFFFFFF" :
-      (isNegative ? "8000000000000000" : "7FFFFFFFFFFFFFFF");
-    default: throw new Exception("Invalid radix.");
+function getRange(unsigned: boolean, bitsize: number): [bigint, bigint] {
+  switch (bitsize) {
+    case 64: return unsigned ?
+      [0n, 18446744073709551615n] :
+      [-9223372036854775808n, 9223372036854775807n];
+    default: throw new Exception("Invalid bit size.");
   }
 }
 
-export function parse(str: string, style: number, unsigned: boolean, _bitsize: number, radix?: number) {
+export function parse(str: string, style: number, unsigned: boolean, bitsize: number, radix?: number) {
   const res = isValid(str, style, radix);
   if (res != null) {
-    const lessOrEqual = (x: string, y: string) => {
-      const len = Math.max(x.length, y.length);
-      return x.padStart(len, "0") <= y.padStart(len, "0");
-    };
-    const isNegative = res.sign === "-";
-    const maxValue = getMaxValue(unsigned || res.radix !== 10, res.radix, isNegative);
-    if (lessOrEqual(res.digits.toUpperCase(), maxValue)) {
-      str = getPrefix(res.radix) + res.digits;
-      str = isNegative ? res.sign + str : str;
-      return fromString(str);
+    let v = fromString(getPrefix(res.radix) + res.digits);
+    if (res.sign === "-") {
+      v = -v;
+    }
+    const [umin, umax] = getRange(true, bitsize);
+    if (!unsigned && res.radix !== 10 && v >= umin && v <= umax) {
+      v = BigInt.asIntN(bitsize, v);
+    }
+    const [min, max] = getRange(unsigned, bitsize);
+    if (v >= min && v <= max) {
+      return v;
     }
   }
   throw new Exception(`The input string ${str} was not in a correct format.`);

--- a/tests/Js/Main/ConvertTests.fs
+++ b/tests/Js/Main/ConvertTests.fs
@@ -2021,8 +2021,6 @@ let tests =
     testCase "BitConverter.ToString uppercase works" <| fun () ->
         BitConverter.ToString([|0uy; 1uy; 0xABuy; 0xFFuy|]) |> equal "00-01-AB-FF"
 
-
-
     // System.Decimal
     //-------------------------------------
 

--- a/tests/Js/Main/ConvertTests.fs
+++ b/tests/Js/Main/ConvertTests.fs
@@ -1334,7 +1334,7 @@ let tests =
         uint64 "0x9fffffff_ffffffff" |> equal 11529215046068469759UL
         uint64 "0x9fff_ffff_ffff_ffff" |> equal 11529215046068469759UL
 
-    testCase "Special cases conversion to Int64 work" <| fun () -> // hex/two's-complement wrap
+    testCase "Special cases conversion to Int64 work" <| fun () ->
         int64 "0xFFFFFFFFFFFFFFFF" |> equal -1L
         int64 "0x8000000000000000" |> equal -9223372036854775808L
         int64 "0x7FFFFFFFFFFFFFFF" |> equal 9223372036854775807L

--- a/tests/Js/Main/ConvertTests.fs
+++ b/tests/Js/Main/ConvertTests.fs
@@ -1334,6 +1334,13 @@ let tests =
         uint64 "0x9fffffff_ffffffff" |> equal 11529215046068469759UL
         uint64 "0x9fff_ffff_ffff_ffff" |> equal 11529215046068469759UL
 
+    testCase "Special cases conversion to Int64 work" <| fun () -> // hex/two's-complement wrap
+        int64 "0xFFFFFFFFFFFFFFFF" |> equal -1L
+        int64 "0x8000000000000000" |> equal -9223372036854775808L
+        int64 "0x7FFFFFFFFFFFFFFF" |> equal 9223372036854775807L
+        int64 "-0xFF" |> equal -255L
+        Int64.Parse("FFFFFFFFFFFFFFFF", System.Globalization.NumberStyles.HexNumber) |> equal -1L
+
     testCase "System.Convert.ToInt64 works" <| fun () ->
         let x = 1L
         int64(1y) |> equal x
@@ -2005,6 +2012,17 @@ let tests =
         BitConverter.ToString(bytes, 1, 2) |> equal "03-02"
 
     //-------------------------------------
+    testCase "BitConverter.ToBoolean with any nonzero byte works" <| fun () ->
+        BitConverter.ToBoolean([|0uy|], 0) |> equal false
+        BitConverter.ToBoolean([|1uy|], 0) |> equal true
+        BitConverter.ToBoolean([|2uy|], 0) |> equal true
+        BitConverter.ToBoolean([|255uy|], 0) |> equal true
+
+    testCase "BitConverter.ToString uppercase works" <| fun () ->
+        BitConverter.ToString([|0uy; 1uy; 0xABuy; 0xFFuy|]) |> equal "00-01-AB-FF"
+
+
+
     // System.Decimal
     //-------------------------------------
 


### PR DESCRIPTION
- Long.parse never applied two's-complement wrap for hex/octal/binary, returning values outside the int64 range (0xFFFFFFFFFFFFFFFF parsed to 2^64-1 instead of -1); now mirrors Int32's sign-extension via BigInt.asIntN with proper range checks
- parse crashed with a raw JS error on negative prefixed input like -0xFF (valid .NET input, expect -255)
- BitConverter.toBoolean returned true only for byte 1; .NET treats any nonzero byte as true
- BitConverter.toString emitted lowercase hex; .NET is uppercase

(split from #4738)