### PR TITLE
fix(python): emit forward reference for self-referencing static union members

### DIFF
--- a/src/Fable.Transforms/Python/Fable2Python.Annotation.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.Annotation.fs
@@ -404,6 +404,33 @@ let resolveGenerics com ctx generics repeatedGenerics : Expression list * Statem
     |> List.map (typeAnnotation com ctx repeatedGenerics)
     |> Helpers.unzipArgs
 
+/// Serialize an annotation expression to its Python source form for use as a string forward
+/// reference (e.g. `Array[Example] | None` -> "Array[Example] | None"). Only the shapes
+/// `typeAnnotation` can produce need handling.
+let rec annotationToString (expr: Expression) =
+    match expr with
+    | Expression.Name { Id = Identifier id } -> id
+    | Expression.Attribute {
+                               Value = value
+                               Attr = Identifier attr
+                           } -> $"{annotationToString value}.{attr}"
+    | Expression.Subscript {
+                               Value = value
+                               Slice = slice
+                           } -> $"{annotationToString value}[{annotationToString slice}]"
+    | Expression.Tuple { Elements = elements } -> elements |> List.map annotationToString |> String.concat ", "
+    | Expression.List(elements, _) ->
+        let inner = elements |> List.map annotationToString |> String.concat ", "
+        $"[{inner}]"
+    | Expression.BinOp {
+                           Left = left
+                           Right = right
+                           Operator = BitOr
+                       } -> $"{annotationToString left} | {annotationToString right}"
+    | Expression.Constant(StringLiteral s, _) -> s
+    | Expression.Constant(NoneLiteral, _) -> "None"
+    | _ -> "Any"
+
 let rec typeAnnotation
     (com: IPythonCompiler)
     ctx

--- a/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
@@ -4762,28 +4762,28 @@ let transformStaticProperty
         let staticPropertyClass = libValue com ctx "util" className
 
         // The `StaticProperty[T]` subscript is a value expression evaluated in the class body, so
-        // any name it references must already be bound. A self-referencing type breaks this: for
-        // unions the descriptor lives on the base class (`_Example`) and the type alias (`Example`)
-        // is only defined afterwards, so a bare name raises `NameError` at class-body evaluation.
-        // Detect a reference to the enclosing entity anywhere in the type (including nested inside
-        // `Array<Example>`, `Example option`, tuples, etc.) and emit the whole annotation as a
-        // string forward reference, which the type checker still resolves at module scope.
+        // the whole annotation must evaluate without error. A type referencing the enclosing entity
+        // breaks this: for unions the descriptor lives on the base class (`_Example`) and the type
+        // alias (`Example`) is only defined afterwards, so a bare name raises `NameError`. Quoting
+        // just that name is not enough either — an operator like the `|` in `Example | None` still
+        // runs eagerly and fails on a string operand. So when the type references the enclosing
+        // entity anywhere, emit the whole annotation as a single string forward reference, which
+        // never evaluates at runtime yet the type checker still resolves at module scope.
         let referencesEnclosingEntity (propType: Fable.Type) =
+            // Walk the type structurally via `Type.Generics`, which enumerates the generic args of
+            // every case (Array, Option, List, Tuple, Lambda/Delegate, Nullable, anonymous records,
+            // nested declared types), so no shape is missed as new cases are added.
             let rec check (t: Fable.Type) =
-                match t with
-                | Fable.DeclaredType(entRef, genArgs) ->
-                    let e = com.GetEntity(entRef)
-                    e.DisplayName = name || e.FullName = ent.FullName || List.exists check genArgs
-                | Fable.Option(gen, _)
-                | Fable.Array(gen, _)
-                | Fable.List gen -> check gen
-                | Fable.Tuple(gens, _) -> List.exists check gens
-                | _ -> false
+                (match t with
+                 | Fable.DeclaredType(entRef, _) -> (com.GetEntity entRef).FullName = ent.FullName
+                 | _ -> false)
+                || List.exists check t.Generics
 
             check propType
 
-        // Serialize an annotation expression to its Python source form so it can be emitted as a
-        // string forward reference (e.g. `Array[Example]` -> "Array[Example]").
+        // Serialize an annotation expression to its Python source form for use as a forward
+        // reference (e.g. `Array[Example] | None` -> "Array[Example] | None"). Only the shapes
+        // `Annotation.typeAnnotation` can produce need handling.
         let rec annotationToString (expr: Expression) =
             match expr with
             | Expression.Name { Id = Identifier id } -> id
@@ -4810,13 +4810,17 @@ let transformStaticProperty
 
         let typeAnnotation =
             if referencesEnclosingEntity propType then
-                // Render with the type alias (not the `_Example` base name) so the forward
-                // reference resolves to the public type at module scope.
-                let ctx = { ctx with EnclosingUnionBaseClass = None }
+                // Render the enclosing union with its base-class name (`_Example`, not the alias
+                // `Example`): both resolve at module scope inside the forward-reference string, but
+                // the generated *value* is typed against the base class (e.g. a `unit -> Example`
+                // factory produces `() -> _Example`), so the base name keeps the annotation and the
+                // value consistent for the type checker. `typeAnnotation` still registers the
+                // imports the string references (e.g. `Array`) as a side effect.
+                let ctx = { ctx with EnclosingUnionBaseClass = Some ent.DisplayName }
+
                 let ta, _ = Annotation.typeAnnotation com ctx None propType
                 Expression.stringConstant (annotationToString ta)
             else
-                // Use normal type annotation
                 let ta, _ = Annotation.typeAnnotation com ctx None propType
                 ta
 

--- a/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
@@ -4761,14 +4761,11 @@ let transformStaticProperty
 
         let staticPropertyClass = libValue com ctx "util" className
 
-        // The `StaticProperty[T]` subscript is a value expression evaluated in the class body, so
-        // the whole annotation must evaluate without error. A type referencing the enclosing entity
-        // breaks this: for unions the descriptor lives on the base class (`_Example`) and the type
-        // alias (`Example`) is only defined afterwards, so a bare name raises `NameError`. Quoting
-        // just that name is not enough either — an operator like the `|` in `Example | None` still
-        // runs eagerly and fails on a string operand. So when the type references the enclosing
-        // entity anywhere, emit the whole annotation as a single string forward reference, which
-        // never evaluates at runtime yet the type checker still resolves at module scope.
+        // `StaticProperty[T]` is a value expression evaluated in the class body, so a type
+        // referencing the enclosing entity (not yet bound there) raises `NameError`. Quoting just
+        // the name is not enough — an operator like the `|` in `Example | None` still runs eagerly
+        // and fails on a string operand. So emit the whole annotation as one string forward
+        // reference: it never evaluates at runtime, yet the type checker resolves it at module scope.
         let referencesEnclosingEntity (propType: Fable.Type) =
             // Walk the type structurally via `Type.Generics`, which enumerates the generic args of
             // every case (Array, Option, List, Tuple, Lambda/Delegate, Nullable, anonymous records,

--- a/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
@@ -4761,22 +4761,60 @@ let transformStaticProperty
 
         let staticPropertyClass = libValue com ctx "util" className
 
-        // Check if the property type references the current class (forward reference needed)
-        let typeAnnotation =
-            // The property type is self-referencing when it is the enclosing entity. Compare by
-            // FullName as well as DisplayName: for unions the descriptor lives on the base class
-            // and the type alias (`name`) is only defined afterwards, so a bare name would raise
-            // NameError at class-body evaluation.
-            let isSelfReference =
-                match propType with
-                | Fable.DeclaredType(entRef, _) ->
+        // The `StaticProperty[T]` subscript is a value expression evaluated in the class body, so
+        // any name it references must already be bound. A self-referencing type breaks this: for
+        // unions the descriptor lives on the base class (`_Example`) and the type alias (`Example`)
+        // is only defined afterwards, so a bare name raises `NameError` at class-body evaluation.
+        // Detect a reference to the enclosing entity anywhere in the type (including nested inside
+        // `Array<Example>`, `Example option`, tuples, etc.) and emit the whole annotation as a
+        // string forward reference, which the type checker still resolves at module scope.
+        let referencesEnclosingEntity (propType: Fable.Type) =
+            let rec check (t: Fable.Type) =
+                match t with
+                | Fable.DeclaredType(entRef, genArgs) ->
                     let e = com.GetEntity(entRef)
-                    e.DisplayName = name || e.FullName = ent.FullName
+                    e.DisplayName = name || e.FullName = ent.FullName || List.exists check genArgs
+                | Fable.Option(gen, _)
+                | Fable.Array(gen, _)
+                | Fable.List gen -> check gen
+                | Fable.Tuple(gens, _) -> List.exists check gens
                 | _ -> false
 
-            if isSelfReference then
-                // Use string forward reference for self-referencing types
-                Expression.stringConstant name
+            check propType
+
+        // Serialize an annotation expression to its Python source form so it can be emitted as a
+        // string forward reference (e.g. `Array[Example]` -> "Array[Example]").
+        let rec annotationToString (expr: Expression) =
+            match expr with
+            | Expression.Name { Id = Identifier id } -> id
+            | Expression.Attribute {
+                                       Value = value
+                                       Attr = Identifier attr
+                                   } -> $"{annotationToString value}.{attr}"
+            | Expression.Subscript {
+                                       Value = value
+                                       Slice = slice
+                                   } -> $"{annotationToString value}[{annotationToString slice}]"
+            | Expression.Tuple { Elements = elements } -> elements |> List.map annotationToString |> String.concat ", "
+            | Expression.List(elements, _) ->
+                let inner = elements |> List.map annotationToString |> String.concat ", "
+                $"[{inner}]"
+            | Expression.BinOp {
+                                   Left = left
+                                   Right = right
+                                   Operator = BitOr
+                               } -> $"{annotationToString left} | {annotationToString right}"
+            | Expression.Constant(StringLiteral s, _) -> s
+            | Expression.Constant(NoneLiteral, _) -> "None"
+            | _ -> "Any"
+
+        let typeAnnotation =
+            if referencesEnclosingEntity propType then
+                // Render with the type alias (not the `_Example` base name) so the forward
+                // reference resolves to the public type at module scope.
+                let ctx = { ctx with EnclosingUnionBaseClass = None }
+                let ta, _ = Annotation.typeAnnotation com ctx None propType
+                Expression.stringConstant (annotationToString ta)
             else
                 // Use normal type annotation
                 let ta, _ = Annotation.typeAnnotation com ctx None propType

--- a/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
@@ -4778,33 +4778,6 @@ let transformStaticProperty
 
             check propType
 
-        // Serialize an annotation expression to its Python source form for use as a forward
-        // reference (e.g. `Array[Example] | None` -> "Array[Example] | None"). Only the shapes
-        // `Annotation.typeAnnotation` can produce need handling.
-        let rec annotationToString (expr: Expression) =
-            match expr with
-            | Expression.Name { Id = Identifier id } -> id
-            | Expression.Attribute {
-                                       Value = value
-                                       Attr = Identifier attr
-                                   } -> $"{annotationToString value}.{attr}"
-            | Expression.Subscript {
-                                       Value = value
-                                       Slice = slice
-                                   } -> $"{annotationToString value}[{annotationToString slice}]"
-            | Expression.Tuple { Elements = elements } -> elements |> List.map annotationToString |> String.concat ", "
-            | Expression.List(elements, _) ->
-                let inner = elements |> List.map annotationToString |> String.concat ", "
-                $"[{inner}]"
-            | Expression.BinOp {
-                                   Left = left
-                                   Right = right
-                                   Operator = BitOr
-                               } -> $"{annotationToString left} | {annotationToString right}"
-            | Expression.Constant(StringLiteral s, _) -> s
-            | Expression.Constant(NoneLiteral, _) -> "None"
-            | _ -> "Any"
-
         let typeAnnotation =
             if referencesEnclosingEntity propType then
                 // Render the enclosing union with its base-class name (`_Example`, not the alias
@@ -4816,7 +4789,7 @@ let transformStaticProperty
                 let ctx = { ctx with EnclosingUnionBaseClass = Some ent.DisplayName }
 
                 let ta, _ = Annotation.typeAnnotation com ctx None propType
-                Expression.stringConstant (annotationToString ta)
+                Expression.stringConstant (Annotation.annotationToString ta)
             else
                 let ta, _ = Annotation.typeAnnotation com ctx None propType
                 ta

--- a/tests/Python/TestUnionType.fs
+++ b/tests/Python/TestUnionType.fs
@@ -237,9 +237,11 @@ let ``test Union cases with no fields are physically equal`` () =
     obj.ReferenceEquals(T1, T1) |> equal true
 
 // See https://github.com/fable-compiler/Fable/issues/4736
-// A static member whose type references the enclosing union (here `Example[]`) used to emit a
-// class-body `StaticLazyProperty[Array[_Example]]` subscript that evaluated `_Example` before the
-// class name was bound, raising `NameError` at import time.
+// A static member whose type references the enclosing union used to emit a class-body
+// `StaticLazyProperty[...]` subscript that evaluated the union type before its name was bound,
+// raising `NameError` at import time. The reference can be nested in any type shape, so each
+// member below exercises a different one: array, option (rendered with `|`), nested list/array,
+// tuple, and a function type (`unit -> Example`).
 [<Fable.Core.AttachMembers>]
 [<RequireQualifiedAccess>]
 type Example =
@@ -248,9 +250,25 @@ type Example =
     | Other of string
 
     static member All = [| Example.First; Example.Second |]
+    static member Head = Some Example.First
+    static member Nested = [ [| Example.First |] ]
+    static member Pair = (Example.First, Example.Second)
+    static member Factory: unit -> Example = fun () -> Example.First
 
 [<Fact>]
 let ``test Static union member returning the union type works`` () =
     Example.All |> Array.length |> equal 2
     Example.All.[0] |> equal Example.First
     Example.All.[1] |> equal Example.Second
+
+[<Fact>]
+let ``test Static union member with nested self-reference works`` () =
+    // Option (`_Example | None`): a bare quoted leaf would leave the `|` to run eagerly and fail.
+    Example.Head |> equal (Some Example.First)
+    // Nested list of array (`FSharpList[Array[_Example]]`).
+    Example.Nested |> List.head |> Array.head |> equal Example.First
+    // Tuple (`tuple[_Example, _Example]`).
+    Example.Pair |> fst |> equal Example.First
+    Example.Pair |> snd |> equal Example.Second
+    // Function type (`Callable[[], _Example]`) — missed by the original narrower detection.
+    Example.Factory() |> equal Example.First

--- a/tests/Python/TestUnionType.fs
+++ b/tests/Python/TestUnionType.fs
@@ -235,3 +235,22 @@ let ``test Union cases with no fields are physically equal`` () =
     obj.ReferenceEquals(MyUnion.Case0, MyUnion.Case0) |> equal true
     obj.ReferenceEquals(MyUnion.Case1 "a", MyUnion.Case1 "a") |> equal false
     obj.ReferenceEquals(T1, T1) |> equal true
+
+// See https://github.com/fable-compiler/Fable/issues/4736
+// A static member whose type references the enclosing union (here `Example[]`) used to emit a
+// class-body `StaticLazyProperty[Array[_Example]]` subscript that evaluated `_Example` before the
+// class name was bound, raising `NameError` at import time.
+[<Fable.Core.AttachMembers>]
+[<RequireQualifiedAccess>]
+type Example =
+    | First
+    | Second
+    | Other of string
+
+    static member All = [| Example.First; Example.Second |]
+
+[<Fact>]
+let ``test Static union member returning the union type works`` () =
+    Example.All |> Array.length |> equal 2
+    Example.All.[0] |> equal Example.First
+    Example.All.[1] |> equal Example.Second


### PR DESCRIPTION
## Problem

Fixes #4736.

Fable's Python codegen emitted a class-body self-reference for a static union member whose type references the enclosing union. For:

```fsharp
[<AttachMembers>]
[<RequireQualifiedAccess>]
type Example =
    | First
    | Second
    | Other of string
    static member All = [| Example.First; Example.Second |]
```

it generated:

```python
class _Example(Union):
    All = StaticLazyProperty[Array[_Example]](lambda: ...)  # NameError: name '_Example' is not defined
```

`StaticLazyProperty[...]` is a **value** expression (a real subscript executed while the class body runs), so `from __future__ import annotations` does not defer it. The enclosing union name (`_Example` inside the base class, `Example` as the alias) isn't bound yet at that point, so the module fails at import with `NameError`.

The self-reference can be nested inside *any* type shape — `Array<Example>`, `Example option`, tuples, nested generics, and function types like `unit -> Example`.

## Fix

In `Fable2Python.Transforms.fs` (`transformStaticProperty`):

1. **Detect a reference to the enclosing entity structurally**, walking the type via `Type.Generics`. This covers every generic-bearing case — `Array`, `Option`, `List`, `Tuple`, `Lambda`/`Delegate`, `Nullable`, anonymous records, and nested declared types — and stays correct as new `Type` cases are added.

2. **Emit the whole annotation as a single string forward reference.** Quoting only the self-referencing leaf is not enough: an operator like the `|` in `Example | None` still runs eagerly in the class body and fails on a string operand (`TypeError`). Serializing the entire annotation to one string sidesteps this:

```python
All = StaticLazyProperty["Array[_Example]"](lambda: ...)
Head = StaticLazyProperty["_Example | None"](lambda: ...)
Factory = StaticLazyProperty["Callable[[], _Example]"](lambda: ...)
```

3. **Render with the base-class name (`_Example`), not the alias (`Example`).** Both resolve at module scope inside the forward-reference string, but the generated *value* is typed against the base class (e.g. a `unit -> Example` factory produces `() -> _Example`), so the base name keeps the annotation and the value consistent for Pyright.

At runtime the string is passed to `__class_getitem__` (no name lookup → no `NameError`), and Pyright still resolves the forward-ref string at module scope, so type information is preserved.

## Verification

- Reproduced the `NameError` (and the `TypeError` for the `option` shape) via quicktest, then confirmed the module imports and runs across array, option, nested list/array, tuple, and function-type self-references.
- Extended regression test in `tests/Python/TestUnionType.fs` to cover those five shapes.
- .NET suite: **2289 passed**. Full Python suite: **2375 passed**. Pyright on `test_union_type.py`: **0 errors, 0 warnings** (no type-checking regressions in the suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)