### PR TITLE
fix(js/ts): don't drop unsupported `jsOptions` statements when inlining as POJO

### DIFF
--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -879,9 +879,11 @@ let makePojoFromLambda com (arg: Expr) =
     | Lambda(_, lambdaBody, _) ->
         let flattened = flattenSequential lambdaBody
 
+        // Returns None on the first unsupported statement, so the caller falls back
+        // to the runtime call instead of silently dropping it.
         let rec groupByGetter (acc: MakePojoFromLambdaContext) (body: Expr list) =
             match body with
-            | [] -> acc
+            | [] -> Some acc
             | head :: tail ->
                 match head with
                 | Set(IdentExpr _, FieldSet(fieldName), _, value, _) ->
@@ -919,9 +921,8 @@ let makePojoFromLambda com (arg: Expr) =
 
                     groupByGetter acc tail
 
-                | _ -> groupByGetter acc tail
-
-        let root = groupByGetter (MakePojoFromLambdaContext("/")) flattened
+                // Anything else (dynamic sets, loops, conditionals, etc.) can't be inlined.
+                | _ -> None
 
         let rec mapToExpression (node: MakePojoFromLambdaItem) =
             match node with
@@ -932,10 +933,13 @@ let makePojoFromLambda com (arg: Expr) =
 
         // Note: If the user mix nested getter and jsOptions then the last one will bein effect
         // We could try to generate a warning/error in this case but it seems complicated for little gain
-        if root.Children.Count = 0 then
-            None
-        else
-            root.Children |> Seq.map mapToExpression |> Seq.toList |> Some
+        match groupByGetter (MakePojoFromLambdaContext("/")) flattened with
+        | None -> None
+        | Some root ->
+            if root.Children.Count = 0 then
+                None
+            else
+                root.Children |> Seq.map mapToExpression |> Seq.toList |> Some
     | _ -> None
     |> Option.map (fun members -> ObjectExpr(members, typ, None))
     |> Option.defaultWith (fun () ->

--- a/tests/Js/Main/JsInteropTests.fs
+++ b/tests/Js/Main/JsInteropTests.fs
@@ -998,6 +998,19 @@ let tests =
         options.level2.level3.valueA |> equal 17
         options.level2.level3.valueB |> equal 20
 
+    // See https://github.com/fable-compiler/Fable/issues/4753
+    testCase "jsOptions doesn't drop statements that can't be inlined as a POJO" <| fun () ->
+        let data = [| "bar", 10 |]
+
+        let opts = jsOptions<JsOptions>(fun o ->
+            o.foo <- "bar"
+            for key, value in data do
+                o?(key) <- value
+        )
+
+        opts.foo |> equal "bar"
+        opts.bar |> equal 10
+
     testCase "Stringifying a JS object works" <| fun () ->
         let fooOptional = importMember "./js/1foo.js"
         string fooOptional |> equal "much foo, much awesome"


### PR DESCRIPTION
Fix #4753