### PR TITLE
feat(beam): implement Async.StartChild in fable_async runtime

### DIFF
--- a/src/fable-library-beam/fable_async.erl
+++ b/src/fable-library-beam/fable_async.erl
@@ -63,20 +63,33 @@ start_immediate(Computation, CancelToken) ->
 %% waits for (and yields) its result. Mirrors .NET Async.StartChild: the child
 %% starts immediately, and awaiting the returned inner async blocks until it
 %% finishes. The optional timeout raises a timeout error if the child does not
-%% finish in time. A unique ResultRef tags the reply so several children in the
-%% same process (or nested under parallel/1 workers) do not cross-talk.
+%% finish in time.
+%%
+%% The child runs the computation to completion in its own process, then becomes
+%% a small "result holder" that replies to on-demand requests. Because each
+%% awaiter sends its own pid and the holder replies to that pid, the inner async
+%% can be awaited from any process (not only the one that called start_child)
+%% and any number of times — both matching .NET semantics. A unique ResultRef
+%% tags every reply so several children never cross-talk. The holder lives until
+%% it is killed (e.g. on timeout) or the VM stops, so a child whose result is
+%% never awaited leaves an idle process behind.
+%%
+%% Cancellation tokens are intentionally not propagated to the child: tokens are
+%% held in the process dictionary (see fable_cancellation), so they are only
+%% meaningful within a single process and cannot be shared with the child's
+%% separate process. This matches parallel/1.
 start_child(Computation) -> start_child(Computation, undefined).
 start_child(Computation, Timeout) ->
     fun(Ctx) ->
-        Self = self(),
         ResultRef = make_ref(),
         Pid = spawn(fun() ->
-            try
-                Result = fable_async:run_synchronously(Computation),
-                Self ! {async_child, ResultRef, {ok, Result}}
-            catch
-                _:Err -> Self ! {async_child, ResultRef, {error, Err}}
-            end
+            Result =
+                try
+                    {ok, fable_async:run_synchronously(Computation)}
+                catch
+                    _:Err -> {error, Err}
+                end,
+            child_result_holder(ResultRef, Result)
         end),
         TimeoutMs =
             case Timeout of
@@ -86,15 +99,30 @@ start_child(Computation, Timeout) ->
         Inner = fun(InnerCtx) ->
             OnSuccess = maps:get(on_success, InnerCtx),
             OnError = maps:get(on_error, InnerCtx),
+            Pid ! {get_child_result, ResultRef, self()},
             receive
                 {async_child, ResultRef, {ok, Value}} -> OnSuccess(Value);
                 {async_child, ResultRef, {error, Err}} -> OnError(wrap_error(Err))
             after TimeoutMs ->
                 exit(Pid, kill),
+                %% Drop a reply that may have raced in just before the kill so
+                %% it does not linger in our mailbox.
+                receive
+                    {async_child, ResultRef, _} -> ok
+                after 0 -> ok
+                end,
                 OnError(#{message => <<"The operation has timed out."/utf8>>})
             end
         end,
         (maps:get(on_success, Ctx))(Inner)
+    end.
+
+%% Serve a computed child result to any awaiter, any number of times.
+child_result_holder(ResultRef, Result) ->
+    receive
+        {get_child_result, ResultRef, Requester} ->
+            Requester ! {async_child, ResultRef, Result},
+            child_result_holder(ResultRef, Result)
     end.
 
 %% RunSynchronously: run CPS chain in current process, capture result

--- a/src/fable-library-beam/fable_async.erl
+++ b/src/fable-library-beam/fable_async.erl
@@ -1,6 +1,7 @@
 -module(fable_async).
 -export([
     start_immediate/1, start_immediate/2,
+    start_child/1, start_child/2,
     run_synchronously/1, run_synchronously/2,
     start_with_continuations/4, start_with_continuations/5,
     sleep/1,
@@ -26,6 +27,8 @@
 
 -spec start_immediate(async(term())) -> term().
 -spec start_immediate(async(term()), reference() | undefined) -> term().
+-spec start_child(async(term())) -> async(async(term())).
+-spec start_child(async(term()), non_neg_integer() | undefined) -> async(async(term())).
 -spec run_synchronously(async(term())) -> term().
 -spec run_synchronously(async(term()), reference() | undefined) -> term().
 -spec start_with_continuations(async(term()), fun(), fun(), fun()) -> term().
@@ -55,6 +58,44 @@ default_ctx(CancelToken) ->
 start_immediate(Computation) -> start_immediate(Computation, undefined).
 start_immediate(Computation, CancelToken) ->
     Computation(default_ctx(CancelToken)).
+
+%% StartChild: run the computation concurrently and return an inner async that
+%% waits for (and yields) its result. Mirrors .NET Async.StartChild: the child
+%% starts immediately, and awaiting the returned inner async blocks until it
+%% finishes. The optional timeout raises a timeout error if the child does not
+%% finish in time. A unique ResultRef tags the reply so several children in the
+%% same process (or nested under parallel/1 workers) do not cross-talk.
+start_child(Computation) -> start_child(Computation, undefined).
+start_child(Computation, Timeout) ->
+    fun(Ctx) ->
+        Self = self(),
+        ResultRef = make_ref(),
+        Pid = spawn(fun() ->
+            try
+                Result = fable_async:run_synchronously(Computation),
+                Self ! {async_child, ResultRef, {ok, Result}}
+            catch
+                _:Err -> Self ! {async_child, ResultRef, {error, Err}}
+            end
+        end),
+        TimeoutMs =
+            case Timeout of
+                undefined -> infinity;
+                _ -> Timeout
+            end,
+        Inner = fun(InnerCtx) ->
+            OnSuccess = maps:get(on_success, InnerCtx),
+            OnError = maps:get(on_error, InnerCtx),
+            receive
+                {async_child, ResultRef, {ok, Value}} -> OnSuccess(Value);
+                {async_child, ResultRef, {error, Err}} -> OnError(wrap_error(Err))
+            after TimeoutMs ->
+                exit(Pid, kill),
+                OnError(#{message => <<"The operation has timed out."/utf8>>})
+            end
+        end,
+        (maps:get(on_success, Ctx))(Inner)
+    end.
 
 %% RunSynchronously: run CPS chain in current process, capture result
 run_synchronously(Computation) -> run_synchronously(Computation, undefined).

--- a/tests/Beam/AsyncTests.fs
+++ b/tests/Beam/AsyncTests.fs
@@ -90,6 +90,65 @@ let ``test async start immediate works`` () =
     Async.StartImmediate (async { x <- 42 })
     equal 42 x
 
+[<Fact>]
+let ``test Async.StartChild works`` () =
+    let comp = async {
+        let! c = Async.StartChild(async { return 42 })
+        let! r = c
+        return r
+    }
+    Async.RunSynchronously comp |> equal 42
+
+[<Fact>]
+let ``test Async.StartChild runs children concurrently`` () =
+    // Each child sleeps 300ms. Started before either is awaited, they run in
+    // parallel (separate BEAM processes), so total time is ~300ms, not ~600ms.
+    let sleeper n = async {
+        do! Async.Sleep 300
+        return n
+    }
+    let comp = async {
+        let sw = System.Diagnostics.Stopwatch.StartNew()
+        let! c1 = Async.StartChild(sleeper 1)
+        let! c2 = Async.StartChild(sleeper 2)
+        let! r1 = c1
+        let! r2 = c2
+        sw.Stop()
+        return r1 + r2, sw.ElapsedMilliseconds
+    }
+    let sum, elapsed = Async.RunSynchronously comp
+    equal 3 sum
+    (elapsed < 500L) |> equal true
+
+[<Fact>]
+let ``test Async.StartChild applies timeout`` () =
+    let slow = async {
+        do! Async.Sleep 1000
+        return 1
+    }
+    let comp = async {
+        let! c = Async.StartChild(slow, 50)
+        try
+            let! _ = c
+            return "no timeout"
+        with ex ->
+            return ex.Message
+    }
+    Async.RunSynchronously comp |> equal "The operation has timed out."
+
+[<Fact>]
+let ``test Async.StartChild with timeout completes when computation finishes before timeout`` () =
+    let fast = async {
+        do! Async.Sleep 10
+        return 99
+    }
+    let comp = async {
+        let! c = Async.StartChild(fast, 1000)
+        let! r = c
+        return r
+    }
+    Async.RunSynchronously comp |> equal 99
+
 let asyncMap f a = async {
     let! a = a
     return f a

--- a/tests/Beam/AsyncTests.fs
+++ b/tests/Beam/AsyncTests.fs
@@ -149,6 +149,35 @@ let ``test Async.StartChild with timeout completes when computation finishes bef
     }
     Async.RunSynchronously comp |> equal 99
 
+[<Fact>]
+let ``test Async.StartChild result can be awaited multiple times`` () =
+    let comp = async {
+        let! c = Async.StartChild(async { return 21 })
+        let! r1 = c
+        let! r2 = c
+        return r1 + r2
+    }
+    Async.RunSynchronously comp |> equal 42
+
+[<Fact>]
+let ``test Async.StartChild result can be awaited from another process`` () =
+    // On Beam, Async.Parallel runs each computation in its own process, so
+    // awaiting the child from inside a parallel worker exercises cross-process
+    // await: the awaiter is not the process that called StartChild.
+    let comp = async {
+        let! c = Async.StartChild(async {
+            do! Async.Sleep 50
+            return 7
+        })
+        let! results =
+            Async.Parallel [ async {
+                let! r = c
+                return r
+            } ]
+        return Array.sum results
+    }
+    Async.RunSynchronously comp |> equal 7
+
 let asyncMap f a = async {
     let! a = a
     return f a


### PR DESCRIPTION
## The gap

The Beam backend already **emits** `fable_async:start_child/1,2` for `Async.StartChild(computation[, millisecondsTimeout])` (via the catch-all in `Beam/Replacements.fs` + snake_case conversion), but the runtime function did **not exist** in `src/fable-library-beam/fable_async.erl`. Any F# using `Async.StartChild` therefore crashed at runtime with:

```
{undef,[{fable_async,start_child,2,[]}, ...]}
```

This surfaced downstream in the Scriptorium test runner (`Scriptorium.Quill`), whose per-test timeout helper compiles to `Async.StartChild(computation, ms)`.

**No compiler change is needed** — confirmed via quicktest that the correct arities are already emitted (`start_child/1` for no-timeout, `start_child/2` for timeout). This PR is runtime-library only.

## Implementation

Added `start_child/1,2` to `fable_async.erl` (export, specs, body). The child runs the computation to completion in its own process via `run_synchronously`, then becomes a small **result holder** that serves the result on demand: each awaiter sends its own pid tagged with a unique `ResultRef`, and the holder replies to that pid. The returned inner async sends such a request and blocks on `receive`, with an `after TimeoutMs` clause that kills the child, flushes a possibly-raced reply, and raises `#{message => <<"The operation has timed out."/utf8>>}`.

The request/reply design (rather than the child eagerly messaging a captured `self()`) means the inner async matches .NET semantics in two ways that a naive version misses:
- **Awaitable from any process**, not only the one that called `StartChild` — e.g. awaiting the child inside an `Async.Parallel` worker (a separate BEAM process) works instead of deadlocking.
- **Awaitable any number of times** — the holder loops and replies to each request, instead of a single reply being consumed by the first await.

Trade-off: a child whose result is never awaited leaves an idle holder process behind (documented in a code comment).

Two Beam-specific details verified rather than assumed:
- **Exception shape**: on Beam, all built-in .NET exceptions compile to bare `#{message => Msg}` maps with no `__type` tag, so `:? TimeoutException` cannot match — asserting on `.Message` is the correct idiom (and matches how Quill consumes it).
- **Concurrency proof**: Fable Beam refs/mutables are backed by the process dictionary (process-local), so `StartChild`'s separate processes cannot share a mutable. Concurrency is proved by timing instead.

**Cancellation tokens are intentionally not propagated to the child.** They are also held in the process dictionary (see `fable_cancellation.erl`), so a token is only meaningful within a single process and cannot be shared with the child's separate process — passing it across would crash on `get(Token)`. This matches `parallel/1`; making tokens cross-process is a larger follow-up affecting both.

## Tests

Six tests in `tests/Beam/AsyncTests.fs`: basic `let! c = StartChild(...) in let! r = c` → 42; concurrent execution (timing); timeout raises; completion before timeout; **result awaited multiple times**; and **result awaited from another process** (via `Async.Parallel`). The last two directly exercise the paths that a naive single-message implementation would hang on.

**Full Beam suite: 2487 passed, 0 failed**, including all six `start_child` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
