### PR TITLE
fix(beam): preserve function-value identity for PhysicalEquality

### DIFF
--- a/src/Fable.Transforms/Beam/FABLE-BEAM.md
+++ b/src/Fable.Transforms/Beam/FABLE-BEAM.md
@@ -1212,12 +1212,22 @@ alone eliminates the single hardest piece of the Fable.Python runtime.
   removed by identity). Fix: both adapter kinds are built through tagged helpers in `fable_utils` —
   `make_curry/2` (routed from the `Curry` node in `Fable2Beam.fs`) and `make_eta/2` (routed from
   the `EtaAdapterDelegate` pattern) — each capturing an underlying `F` inside a
-  `{fable_curry_adapter, F}` / `{fable_eta_adapter, F}` marker as the outermost fun's ONLY captured
-  variable. `fun_ref_eq/2` then peels those markers via `erlang:fun_info(F, env)` before `=:=`,
-  normalising every representation of a value to the same `F`. Both helpers apply `F` exactly as the
-  default lowering would (`make_eta` via `apply_curried`, `make_curry` via `erlang:apply` — all args
-  at once, matching the multi-arg `Apply`), so they are behaviour-identical bar the marker.
+  `{fable_curry_adapter, F, N}` / `{fable_eta_adapter, F, N}` marker as the outermost fun's ONLY
+  captured variable. `fun_ref_eq/2` then peels those markers via `erlang:fun_info(F, env)` before
+  `=:=`, normalising every representation of a value to the same `F`. Both helpers apply `F` exactly
+  as the default lowering would (`make_eta` via `apply_curried`, `make_curry` via `erlang:apply` —
+  all args at once, matching the multi-arg `Apply`), so they are behaviour-identical bar the marker.
   Key points:
+    - **Adapter cancellation** (mirrors the Python target's `curry.py` memoization, where
+      `curry(uncurry(g))` returns the cached original `g`): if `make_eta`/`make_curry` receives a
+      value that is already the *opposite*, same-arity adapter, it returns the original underlying
+      fun instead of stacking a second wrapper — `uncurry ∘ curry = curry ∘ uncurry = id`. A
+      round-tripped value is then literally the *same* fun (native `=:=` holds with no unwrap and no
+      wrapper cost), and adapters never accumulate. The marker travels inside the closure env, so
+      unlike Python's process-local `WeakKeyDictionary` this survives a fun being sent between
+      processes. The arity in the marker guards the cancellation (a mismatch wraps instead of
+      cancelling — no `badarity`). `unwrap_fun` still covers the non-round-trip case (a value stored
+      in one representation and compared against the other).
     - This is **precise reference identity, not structural equality**: only Fable's own
       compiler-generated adapters carry a marker, so a hand-written eta expansion (`fun x -> g x`)
       or a partial application (which captures the collected args, so its outermost fun has >1
@@ -1233,7 +1243,9 @@ alone eliminates the single hardest piece of the Fable.Python runtime.
       value typed as a bare generic `'T` (Fable does not monomorphise) falls back to plain `=:=`, so
       wrapping `PhysicalEquality` in a generic helper does not get the function-aware path.
     - **Correctness over performance**: `make_curry` sits on the pervasive currying path and adds a
-      marker allocation + `erlang:apply` per call versus the inline nested lambdas. This is an
+      marker allocation + `erlang:apply` per call versus the inline nested lambdas — but this is the
+      same shape of incremental-application cost the Python target already pays (`_curry_n` /
+      `_uncurry_n`), and adapter cancellation removes it entirely on round-trips. Any residue is an
       accepted alpha-stage trade-off — a passing unit test wins over the micro-cost.
 
 ## Future Improvements

--- a/src/Fable.Transforms/Beam/FABLE-BEAM.md
+++ b/src/Fable.Transforms/Beam/FABLE-BEAM.md
@@ -1203,6 +1203,38 @@ alone eliminates the single hardest piece of the Fable.Python runtime.
       its tests, mirroring .NET module initialisation (which runs before any module code).
       This is safe because Beam test modules contain no top-level side effects beyond these
       initialisers.
+- **Function reference identity** (`LanguagePrimitives.PhysicalEquality` / `ReferenceEquals`):
+  the *same* F# function value is represented by different Erlang funs at different sites —
+  uncurried (a single N-arity fun), re-curried (`fun(A0) -> fun(A1) -> F(A0, A1) end end`, from a
+  `Curry` node), or wrapped in an uncurrying (eta) adapter to fill an uncurried slot. Erlang
+  compares funs by closure identity, so these are never `=:=` even though they denote one value —
+  which made `PhysicalEquality` wrongly return `false` (e.g. a stored callback could never be
+  removed by identity). Fix: both adapter kinds are built through tagged helpers in `fable_utils` —
+  `make_curry/2` (routed from the `Curry` node in `Fable2Beam.fs`) and `make_eta/2` (routed from
+  the `EtaAdapterDelegate` pattern) — each capturing an underlying `F` inside a
+  `{fable_curry_adapter, F}` / `{fable_eta_adapter, F}` marker as the outermost fun's ONLY captured
+  variable. `fun_ref_eq/2` then peels those markers via `erlang:fun_info(F, env)` before `=:=`,
+  normalising every representation of a value to the same `F`. Both helpers apply `F` exactly as the
+  default lowering would (`make_eta` via `apply_curried`, `make_curry` via `erlang:apply` — all args
+  at once, matching the multi-arg `Apply`), so they are behaviour-identical bar the marker.
+  Key points:
+    - This is **precise reference identity, not structural equality**: only Fable's own
+      compiler-generated adapters carry a marker, so a hand-written eta expansion (`fun x -> g x`)
+      or a partial application (which captures the collected args, so its outermost fun has >1
+      captured variable) is left intact and stays distinct — matching .NET. An earlier version used
+      a *shape heuristic* (unwrap any 1-arity fun capturing a single function) which wrongly
+      collapsed `fun x -> g x` onto `g`; the marker approach replaces it. Regression-guarded by
+      `test PhysicalEquality distinguishes eta expansion from the original`.
+    - **Arity cap 2..7** (matching `make_eta`). Functions with 8+ curried args fall back to the
+      default lowering and are not identity-preserved; extend the `make_curry_marked`/
+      `make_eta_marked` clauses if needed.
+    - **Generic call sites**: routing to `fun_ref_eq` is gated on the operand being a
+      `LambdaType`/`DelegateType` at the call site (`isFunctionType` in `Beam/Replacements.fs`). A
+      value typed as a bare generic `'T` (Fable does not monomorphise) falls back to plain `=:=`, so
+      wrapping `PhysicalEquality` in a generic helper does not get the function-aware path.
+    - **Correctness over performance**: `make_curry` sits on the pervasive currying path and adds a
+      marker allocation + `erlang:apply` per call versus the inline nested lambdas. This is an
+      accepted alpha-stage trade-off — a passing unit test wins over the micro-cost.
 
 ## Future Improvements
 

--- a/src/Fable.Transforms/Beam/Fable2Beam.fs
+++ b/src/Fable.Transforms/Beam/Fable2Beam.fs
@@ -1314,6 +1314,36 @@ let rec transformExpr (com: IBeamCompiler) (ctx: Context) (expr: Expr) : Beam.Er
                 "error",
                 [ Beam.ErlExpr.Literal(Beam.ErlLiteral.AtomLit(Beam.Atom "rethrow")) ]
             )
+        | Curry(e, arity) when
+            arity >= 2
+            && arity <= 7
+            && (
+                match e with
+                | Value(Null _, _) -> false
+                | _ ->
+                    match e.Type with
+                    | LambdaType _
+                    | DelegateType _ -> true
+                    | _ -> false
+            )
+            ->
+            // Re-curry an uncurried function into `arity` nested 1-arg funs. The default lowering
+            // (curryExprAtRuntime) builds a fresh nested-lambda closure at each site, so two curry
+            // adapters over the *same* underlying function compare unequal, breaking reference
+            // identity (LanguagePrimitives.PhysicalEquality). Route through fable_utils:make_curry,
+            // which tags the adapter with a `{fable_curry_adapter, F}` marker so fun_ref_eq can
+            // recover F and treat all adapters over it as reference-equal. make_curry applies F with
+            // all args at once (erlang:apply), matching the default multi-arg Apply lowering exactly,
+            // so it is behaviour-identical bar the marker. See Beam/FABLE-BEAM.md.
+            let eExpr = transformExpr com ctx e
+            let hoisted, cleanE = extractBlock eExpr
+
+            Beam.ErlExpr.Call(
+                Some "fable_utils",
+                "make_curry",
+                [ cleanE; Beam.ErlExpr.Literal(Beam.ErlLiteral.Integer(int64 arity)) ]
+            )
+            |> wrapWithHoisted hoisted
         | Curry(e, arity) -> transformExpr com ctx (Replacements.Api.curryExprAtRuntime com arity e)
         | Debugger ->
             com.WarnOnlyOnce("System.Diagnostics.Debugger is not supported for Beam target, ignoring")

--- a/src/Fable.Transforms/Beam/Fable2Beam.fs
+++ b/src/Fable.Transforms/Beam/Fable2Beam.fs
@@ -209,6 +209,28 @@ let rec readsFreeMutable (bound: Set<string>) (expr: Expr) : bool =
         || readsFreeMutable (Set.add ident.Name bound) body
     | _ -> getSubExpressions expr |> List.exists (readsFreeMutable bound)
 
+/// Matches an eta/uncurry adapter delegate: `fun(B0..Bn) -> f B0 B1 .. Bn`, where the applied
+/// arguments are exactly the delegate's parameters (same names, in order) and `f` is a captured
+/// value that does not reference any of them. Returns `(arity, f)`. Used to recognise the adapters
+/// Fable inserts to normalise a curried function to an uncurried arity, so they can be built
+/// through fable_utils:make_eta (which preserves reference identity across sites).
+let (|EtaAdapterDelegate|_|) (expr: Expr) : (int * Expr) option =
+    match expr with
+    | Delegate(args, CurriedApply(f, appArgs, _, _), _, _) when
+        List.length appArgs = List.length args
+        && List.forall2
+            (fun (a: Ident) (e: Expr) ->
+                match e with
+                | IdentExpr id -> id.Name = a.Name
+                | _ -> false
+            )
+            args
+            appArgs
+        && not (args |> List.exists (fun a -> containsIdentRef a.Name f))
+        ->
+        Some(List.length args, f)
+    | _ -> None
+
 let rec transformExpr (com: IBeamCompiler) (ctx: Context) (expr: Expr) : Beam.ErlExpr =
     match expr with
     | Unresolved(_, _, r) ->
@@ -479,6 +501,23 @@ let rec transformExpr (com: IBeamCompiler) (ctx: Context) (expr: Expr) : Beam.Er
                     Body = bodyExprs
                 }
             ]
+
+    // Uncurrying (eta) adapter: fun(B0..Bn) -> f B0 .. Bn, where f is a captured function value
+    // not referencing any Bi. Fable inserts these at argument sites to normalise a curried function
+    // to the arity an uncurried slot expects. Each inline adapter is a fresh closure, so two
+    // adapters built over the same f compare unequal, breaking reference identity
+    // (LanguagePrimitives.PhysicalEquality). Route through fable_utils:make_eta, which tags the
+    // adapter so fun_ref_eq can recover f and treat them as reference-equal.
+    | EtaAdapterDelegate(arity, f) when arity >= 2 && arity <= 7 ->
+        let fExpr = transformExpr com ctx f
+        let hoisted, cleanF = extractBlock fExpr
+
+        Beam.ErlExpr.Call(
+            Some "fable_utils",
+            "make_eta",
+            [ cleanF; Beam.ErlExpr.Literal(Beam.ErlLiteral.Integer(int64 arity)) ]
+        )
+        |> wrapWithHoisted hoisted
 
     | Delegate(args, body, _name, _tags) ->
         // Deduplicate Erlang variable names in arg patterns.

--- a/src/Fable.Transforms/Beam/Replacements.fs
+++ b/src/Fable.Transforms/Beam/Replacements.fs
@@ -12,8 +12,22 @@ type Context = FSharp2Fable.Context
 type ICompiler = FSharp2Fable.IFableCompiler
 type CallInfo = ReplaceCallInfo
 
+let private isFunctionType (t: Type) =
+    match t with
+    | LambdaType _
+    | DelegateType _ -> true
+    | _ -> false
+
 let private physicalEquals r (left: Expr) (right: Expr) =
-    emitExpr r Boolean [ left; right ] "($0 =:= $1)"
+    // Reference identity. For function values, the same F# value can be represented as either an
+    // uncurried fun or a re-curried nested adapter at different sites, which Erlang's `=:=` sees as
+    // distinct closures. Route those through fable_utils:fun_ref_eq, which unwraps curry adapters
+    // to the underlying function before comparing (see fun_ref_eq in fable_utils.erl). Non-function
+    // values keep plain `=:=`.
+    if isFunctionType left.Type || isFunctionType right.Type then
+        emitExpr r Boolean [ left; right ] "fable_utils:fun_ref_eq($0, $1)"
+    else
+        emitExpr r Boolean [ left; right ] "($0 =:= $1)"
 
 // Use fable_comparison:equals/2 for structural equality.
 // This handles ref-wrapped arrays (process dict refs) by dereferencing
@@ -561,8 +575,7 @@ let private languagePrimitives
     | ("GenericGreaterOrEqual" | "GenericGreaterOrEqualIntrinsic"), [ left; right ] ->
         let cmp = compare com r left right
         makeBinOp r Boolean cmp (makeIntConst 0) BinaryGreaterOrEqual |> Some
-    | ("PhysicalEquality" | "PhysicalEqualityIntrinsic"), [ left; right ] ->
-        emitExpr r Boolean [ left; right ] "$0 =:= $1" |> Some
+    | ("PhysicalEquality" | "PhysicalEqualityIntrinsic"), [ left; right ] -> physicalEquals r left right |> Some
     | ("GenericHash" | "GenericHashIntrinsic"), [ arg ] ->
         Helper.LibCall(com, "fable_comparison", "hash", t, [ arg ], ?loc = r) |> Some
     | ("PhysicalHash" | "PhysicalHashIntrinsic"), [ arg ] ->

--- a/src/fable-library-beam/fable_utils.erl
+++ b/src/fable-library-beam/fable_utils.erl
@@ -5,6 +5,7 @@
     field_get/2,
     inst_state/1,
     apply_curried/2,
+    fun_ref_eq/2,
     new_ref/1,
     safe_dispose/1,
     get_enumerator/1,
@@ -37,6 +38,7 @@
 -spec field_get(atom(), map() | reference()) -> term().
 -spec inst_state(map() | reference()) -> map().
 -spec apply_curried(fun(), list()) -> term().
+-spec fun_ref_eq(term(), term()) -> boolean().
 -spec new_ref(term()) -> reference().
 -spec safe_dispose(term()) -> ok.
 -spec get_enumerator(list() | reference() | map() | term()) -> reference().
@@ -129,6 +131,31 @@ safe_dispose(_) ->
 %% Used by CurriedApply when the target is a qualified call returning a curried function.
 apply_curried(Fun, []) -> Fun;
 apply_curried(Fun, [Arg | Rest]) -> apply_curried(Fun(Arg), Rest).
+
+%% Reference identity for function values (LanguagePrimitives.PhysicalEquality / ReferenceEquals).
+%%
+%% Fable-BEAM represents the *same* F# function value with different Erlang funs at different
+%% sites: sometimes uncurried (a single N-arity fun) and sometimes re-curried into a nested
+%% 1-arity adapter (`fun(A0) -> fun(A1) -> F(A0, A1) end end`) to satisfy a curried-typed slot.
+%% Erlang compares funs by closure identity, so those two representations are never `=:=` even
+%% though they denote one value — which would make PhysicalEquality wrongly return `false`.
+%%
+%% A curry adapter is a 1-arity fun whose only captured variable is the underlying function it
+%% wraps. We normalise by unwrapping such adapters to that underlying fun before comparing, so
+%% curried and uncurried representations of the same value compare equal. Crucially this does NOT
+%% degrade into structural equality: two genuinely distinct closures (identical body but no shared
+%% captured fun, or more than one captured variable — e.g. partial applications) are left intact
+%% and still compare unequal. Non-function values pass through untouched, so this is a safe drop-in
+%% for `=:=` on any operand type.
+fun_ref_eq(A, B) -> unwrap_fun(A) =:= unwrap_fun(B).
+
+unwrap_fun(F) when is_function(F, 1) ->
+    case erlang:fun_info(F, env) of
+        %% Exactly one captured variable, and it is itself a function: a curry adapter — unwrap it.
+        {env, [Inner]} when is_function(Inner) -> unwrap_fun(Inner);
+        _ -> F
+    end;
+unwrap_fun(V) -> V.
 
 %% Enumerator support for for-in loops over lists.
 %% Enumerator is a process dict ref pointing to #{items => List, current => undefined}.

--- a/src/fable-library-beam/fable_utils.erl
+++ b/src/fable-library-beam/fable_utils.erl
@@ -142,10 +142,21 @@ apply_curried(Fun, [Arg | Rest]) -> apply_curried(Fun(Arg), Rest).
 %% curried function value to the arity an uncurried slot expects. Each such adapter is a fresh
 %% closure, so two adapters built over the *same* F at different sites are never `=:=` — which
 %% breaks LanguagePrimitives.PhysicalEquality (e.g. removing a stored callback by identity).
-%% We build the adapter here, capturing F inside a tagged marker so fun_ref_eq/2 can recover F
-%% and treat all adapters over the same F as reference-equal. The marker is the adapter's ONLY
-%% captured variable, which keeps the fun_info/env recovery below unambiguous.
-make_eta(F, N) -> make_eta_marked({fable_eta_adapter, F}, N).
+%% We build the adapter here, capturing F inside a tagged `{fable_eta_adapter, F, N}` marker so
+%% fun_ref_eq/2 can recover F and treat all adapters over the same F as reference-equal. The marker
+%% is the adapter's ONLY captured variable, which keeps the fun_info/env recovery below unambiguous.
+%%
+%% Adapter cancellation (mirrors the Python target's curry.py memoization): if F is itself a
+%% same-arity curry adapter (built by make_curry/2 over some G), then uncurry ∘ curry = identity, so
+%% we hand back the original G unchanged rather than stacking a second wrapper. This keeps
+%% round-tripped values as the *same* fun (native `=:=` holds, no wrapper cost) and stops adapters
+%% accumulating. The arity guard avoids a `badarity` if a value were ever round-tripped at a
+%% different arity (does not happen in practice — a value has one arity — but is cheap insurance).
+make_eta(F, N) ->
+    case adapter_marker(F) of
+        {fable_curry_adapter, G, N} -> G;
+        _ -> make_eta_marked({fable_eta_adapter, F, N}, N)
+    end.
 
 make_eta_marked(M, 2) -> fun(B0, B1) -> apply_curried(erlang:element(2, M), [B0, B1]) end;
 make_eta_marked(M, 3) -> fun(B0, B1, B2) -> apply_curried(erlang:element(2, M), [B0, B1, B2]) end;
@@ -165,10 +176,18 @@ make_eta_marked(M, 7) ->
 %% LanguagePrimitives.PhysicalEquality. We build the adapter here, capturing F inside a tagged marker
 %% so fun_ref_eq/2 can recover F and treat all adapters over it as reference-equal. F is applied with
 %% all args at once (erlang:apply), matching the default multi-arg lowering exactly, so this is
-%% behaviour-identical bar the marker. The marker is the OUTERMOST fun's only captured variable
-%% (referenced only in the innermost body), keeping the fun_info/env recovery unambiguous; a
-%% partially-applied intermediate captures the collected args too, so it is correctly left distinct.
-make_curry(F, N) -> make_curry_marked({fable_curry_adapter, F}, N).
+%% behaviour-identical bar the marker. The `{fable_curry_adapter, F, N}` marker is the OUTERMOST
+%% fun's only captured variable (referenced only in the innermost body), keeping the fun_info/env
+%% recovery unambiguous; a partially-applied intermediate captures the collected args too, so it is
+%% correctly left distinct.
+%%
+%% Adapter cancellation (see make_eta/2): if F is itself a same-arity eta adapter over some G, then
+%% curry ∘ uncurry = identity, so we return the original G unchanged instead of wrapping again.
+make_curry(F, N) ->
+    case adapter_marker(F) of
+        {fable_eta_adapter, G, N} -> G;
+        _ -> make_curry_marked({fable_curry_adapter, F, N}, N)
+    end.
 
 make_curry_marked(M, 2) ->
     fun(A0) -> fun(A1) -> erlang:apply(erlang:element(2, M), [A0, A1]) end end;
@@ -219,23 +238,34 @@ make_curry_marked(M, 7) ->
 %% — which would make PhysicalEquality wrongly return `false`.
 %%
 %% We normalise to the underlying function before comparing: both the eta adapter (make_eta/2) and
-%% the curry adapter (make_curry/2) capture exactly their `{fable_eta_adapter, F}` /
-%% `{fable_curry_adapter, F}` marker as their outermost fun's only captured variable — unwrap to F.
-%% This is precise: ONLY Fable's own compiler-generated adapters carry a marker, so an unrelated
+%% the curry adapter (make_curry/2) capture exactly their `{fable_eta_adapter, F, N}` /
+%% `{fable_curry_adapter, F, N}` marker as their outermost fun's only captured variable — unwrap to
+%% F. This is precise: ONLY Fable's own compiler-generated adapters carry a marker, so an unrelated
 %% closure (including a hand-written eta expansion like `fun x -> g x`) is left intact and still
 %% compares unequal — this is reference identity, not structural equality. Non-function values pass
-%% through untouched, so this is a safe drop-in for `=:=`.
+%% through untouched, so this is a safe drop-in for `=:=`. (Adapter cancellation in make_eta/2 and
+%% make_curry/2 already collapses round-trips to the same fun; this handles the remaining case where
+%% a value is stored in one representation and compared against the other without a round-trip.)
 fun_ref_eq(A, B) -> unwrap_fun(A) =:= unwrap_fun(B).
 
 unwrap_fun(F) when is_function(F) ->
-    case erlang:fun_info(F, env) of
-        %% An eta adapter built by make_eta/2: recover the underlying function from the marker.
-        {env, [{fable_eta_adapter, Inner}]} -> unwrap_fun(Inner);
-        %% A curry adapter built by make_curry/2: recover the underlying function from the marker.
-        {env, [{fable_curry_adapter, Inner}]} -> unwrap_fun(Inner);
-        _ -> F
+    case adapter_marker(F) of
+        {_Tag, Inner, _N} -> unwrap_fun(Inner);
+        none -> F
     end;
 unwrap_fun(V) -> V.
+
+%% Return the `{fable_eta_adapter, F, N}` / `{fable_curry_adapter, F, N}` marker of a
+%% Fable-generated curry/eta adapter, or `none` for anything else. An adapter captures its marker as
+%% its outermost fun's single environment entry, so a one-element env holding a tagged 3-tuple is an
+%% unambiguous signature — no other closure Fable emits carries it.
+adapter_marker(F) when is_function(F) ->
+    case erlang:fun_info(F, env) of
+        {env, [{fable_eta_adapter, _, _} = M]} -> M;
+        {env, [{fable_curry_adapter, _, _} = M]} -> M;
+        _ -> none
+    end;
+adapter_marker(_) -> none.
 
 %% Enumerator support for for-in loops over lists.
 %% Enumerator is a process dict ref pointing to #{items => List, current => undefined}.

--- a/src/fable-library-beam/fable_utils.erl
+++ b/src/fable-library-beam/fable_utils.erl
@@ -5,6 +5,7 @@
     field_get/2,
     inst_state/1,
     apply_curried/2,
+    make_eta/2,
     fun_ref_eq/2,
     new_ref/1,
     safe_dispose/1,
@@ -38,6 +39,7 @@
 -spec field_get(atom(), map() | reference()) -> term().
 -spec inst_state(map() | reference()) -> map().
 -spec apply_curried(fun(), list()) -> term().
+-spec make_eta(fun(), 2..7) -> fun().
 -spec fun_ref_eq(term(), term()) -> boolean().
 -spec new_ref(term()) -> reference().
 -spec safe_dispose(term()) -> ok.
@@ -132,27 +134,52 @@ safe_dispose(_) ->
 apply_curried(Fun, []) -> Fun;
 apply_curried(Fun, [Arg | Rest]) -> apply_curried(Fun(Arg), Rest).
 
+%% Build an N-arity uncurrying (eta) adapter around curried function F.
+%%
+%% Fable inserts `fun(B0, ..., Bn) -> ((F(B0))...)(Bn) end` at argument sites to normalise a
+%% curried function value to the arity an uncurried slot expects. Each such adapter is a fresh
+%% closure, so two adapters built over the *same* F at different sites are never `=:=` — which
+%% breaks LanguagePrimitives.PhysicalEquality (e.g. removing a stored callback by identity).
+%% We build the adapter here, capturing F inside a tagged marker so fun_ref_eq/2 can recover F
+%% and treat all adapters over the same F as reference-equal. The marker is the adapter's ONLY
+%% captured variable, which keeps the fun_info/env recovery below unambiguous.
+make_eta(F, N) -> make_eta_marked({fable_eta_adapter, F}, N).
+
+make_eta_marked(M, 2) -> fun(B0, B1) -> apply_curried(erlang:element(2, M), [B0, B1]) end;
+make_eta_marked(M, 3) -> fun(B0, B1, B2) -> apply_curried(erlang:element(2, M), [B0, B1, B2]) end;
+make_eta_marked(M, 4) -> fun(B0, B1, B2, B3) -> apply_curried(erlang:element(2, M), [B0, B1, B2, B3]) end;
+make_eta_marked(M, 5) ->
+    fun(B0, B1, B2, B3, B4) -> apply_curried(erlang:element(2, M), [B0, B1, B2, B3, B4]) end;
+make_eta_marked(M, 6) ->
+    fun(B0, B1, B2, B3, B4, B5) -> apply_curried(erlang:element(2, M), [B0, B1, B2, B3, B4, B5]) end;
+make_eta_marked(M, 7) ->
+    fun(B0, B1, B2, B3, B4, B5, B6) -> apply_curried(erlang:element(2, M), [B0, B1, B2, B3, B4, B5, B6]) end.
+
 %% Reference identity for function values (LanguagePrimitives.PhysicalEquality / ReferenceEquals).
 %%
 %% Fable-BEAM represents the *same* F# function value with different Erlang funs at different
-%% sites: sometimes uncurried (a single N-arity fun) and sometimes re-curried into a nested
-%% 1-arity adapter (`fun(A0) -> fun(A1) -> F(A0, A1) end end`) to satisfy a curried-typed slot.
-%% Erlang compares funs by closure identity, so those two representations are never `=:=` even
-%% though they denote one value — which would make PhysicalEquality wrongly return `false`.
+%% sites: sometimes uncurried (a single N-arity fun), sometimes re-curried into a nested 1-arity
+%% adapter (`fun(A0) -> fun(A1) -> F(A0, A1) end end`), and sometimes wrapped in an N-arity
+%% uncurrying (eta) adapter built by make_eta/2 to satisfy an uncurried slot. Erlang compares funs
+%% by closure identity, so these representations are never `=:=` even though they denote one value
+%% — which would make PhysicalEquality wrongly return `false`.
 %%
-%% A curry adapter is a 1-arity fun whose only captured variable is the underlying function it
-%% wraps. We normalise by unwrapping such adapters to that underlying fun before comparing, so
-%% curried and uncurried representations of the same value compare equal. Crucially this does NOT
-%% degrade into structural equality: two genuinely distinct closures (identical body but no shared
-%% captured fun, or more than one captured variable — e.g. partial applications) are left intact
-%% and still compare unequal. Non-function values pass through untouched, so this is a safe drop-in
-%% for `=:=` on any operand type.
+%% We normalise to the underlying function before comparing:
+%%   * an eta adapter (built by make_eta/2) captures exactly the `{fable_eta_adapter, F}` marker —
+%%     unwrap it to F. This is precise: only make_eta's own adapters carry the marker;
+%%   * a curry adapter is a 1-arity fun whose only captured variable is itself a function —
+%%     unwrap it to that function.
+%% This does NOT degrade into structural equality: genuinely distinct closures (no shared captured
+%% fun, or more than one captured variable — e.g. partial applications) are left intact and still
+%% compare unequal. Non-function values pass through untouched, so this is a safe drop-in for `=:=`.
 fun_ref_eq(A, B) -> unwrap_fun(A) =:= unwrap_fun(B).
 
-unwrap_fun(F) when is_function(F, 1) ->
+unwrap_fun(F) when is_function(F) ->
     case erlang:fun_info(F, env) of
-        %% Exactly one captured variable, and it is itself a function: a curry adapter — unwrap it.
-        {env, [Inner]} when is_function(Inner) -> unwrap_fun(Inner);
+        %% An eta adapter built by make_eta/2: recover the underlying function from the marker.
+        {env, [{fable_eta_adapter, Inner}]} -> unwrap_fun(Inner);
+        %% A 1-arity curry adapter whose only captured variable is itself a function.
+        {env, [Inner]} when is_function(Inner), is_function(F, 1) -> unwrap_fun(Inner);
         _ -> F
     end;
 unwrap_fun(V) -> V.

--- a/src/fable-library-beam/fable_utils.erl
+++ b/src/fable-library-beam/fable_utils.erl
@@ -6,6 +6,7 @@
     inst_state/1,
     apply_curried/2,
     make_eta/2,
+    make_curry/2,
     fun_ref_eq/2,
     new_ref/1,
     safe_dispose/1,
@@ -40,6 +41,7 @@
 -spec inst_state(map() | reference()) -> map().
 -spec apply_curried(fun(), list()) -> term().
 -spec make_eta(fun(), 2..7) -> fun().
+-spec make_curry(fun(), 2..7) -> fun().
 -spec fun_ref_eq(term(), term()) -> boolean().
 -spec new_ref(term()) -> reference().
 -spec safe_dispose(term()) -> ok.
@@ -155,6 +157,58 @@ make_eta_marked(M, 6) ->
 make_eta_marked(M, 7) ->
     fun(B0, B1, B2, B3, B4, B5, B6) -> apply_curried(erlang:element(2, M), [B0, B1, B2, B3, B4, B5, B6]) end.
 
+%% Re-curry an uncurried N-arity function F into a chain of 1-arity funs.
+%%
+%% Fable inserts a `Curry` node to normalise an uncurried function (applied with all args at once)
+%% back to curried form. The default lowering builds `fun(A0) -> fun(A1) -> F(A0, A1) end end` fresh
+%% at each site, so two curry adapters over the *same* F are never `=:=` — which breaks
+%% LanguagePrimitives.PhysicalEquality. We build the adapter here, capturing F inside a tagged marker
+%% so fun_ref_eq/2 can recover F and treat all adapters over it as reference-equal. F is applied with
+%% all args at once (erlang:apply), matching the default multi-arg lowering exactly, so this is
+%% behaviour-identical bar the marker. The marker is the OUTERMOST fun's only captured variable
+%% (referenced only in the innermost body), keeping the fun_info/env recovery unambiguous; a
+%% partially-applied intermediate captures the collected args too, so it is correctly left distinct.
+make_curry(F, N) -> make_curry_marked({fable_curry_adapter, F}, N).
+
+make_curry_marked(M, 2) ->
+    fun(A0) -> fun(A1) -> erlang:apply(erlang:element(2, M), [A0, A1]) end end;
+make_curry_marked(M, 3) ->
+    fun(A0) -> fun(A1) -> fun(A2) -> erlang:apply(erlang:element(2, M), [A0, A1, A2]) end end end;
+make_curry_marked(M, 4) ->
+    fun(A0) ->
+        fun(A1) -> fun(A2) -> fun(A3) -> erlang:apply(erlang:element(2, M), [A0, A1, A2, A3]) end end end
+    end;
+make_curry_marked(M, 5) ->
+    fun(A0) ->
+        fun(A1) ->
+            fun(A2) -> fun(A3) -> fun(A4) -> erlang:apply(erlang:element(2, M), [A0, A1, A2, A3, A4]) end end end
+        end
+    end;
+make_curry_marked(M, 6) ->
+    fun(A0) ->
+        fun(A1) ->
+            fun(A2) ->
+                fun(A3) ->
+                    fun(A4) -> fun(A5) -> erlang:apply(erlang:element(2, M), [A0, A1, A2, A3, A4, A5]) end end
+                end
+            end
+        end
+    end;
+make_curry_marked(M, 7) ->
+    fun(A0) ->
+        fun(A1) ->
+            fun(A2) ->
+                fun(A3) ->
+                    fun(A4) ->
+                        fun(A5) ->
+                            fun(A6) -> erlang:apply(erlang:element(2, M), [A0, A1, A2, A3, A4, A5, A6]) end
+                        end
+                    end
+                end
+            end
+        end
+    end.
+
 %% Reference identity for function values (LanguagePrimitives.PhysicalEquality / ReferenceEquals).
 %%
 %% Fable-BEAM represents the *same* F# function value with different Erlang funs at different
@@ -164,22 +218,21 @@ make_eta_marked(M, 7) ->
 %% by closure identity, so these representations are never `=:=` even though they denote one value
 %% — which would make PhysicalEquality wrongly return `false`.
 %%
-%% We normalise to the underlying function before comparing:
-%%   * an eta adapter (built by make_eta/2) captures exactly the `{fable_eta_adapter, F}` marker —
-%%     unwrap it to F. This is precise: only make_eta's own adapters carry the marker;
-%%   * a curry adapter is a 1-arity fun whose only captured variable is itself a function —
-%%     unwrap it to that function.
-%% This does NOT degrade into structural equality: genuinely distinct closures (no shared captured
-%% fun, or more than one captured variable — e.g. partial applications) are left intact and still
-%% compare unequal. Non-function values pass through untouched, so this is a safe drop-in for `=:=`.
+%% We normalise to the underlying function before comparing: both the eta adapter (make_eta/2) and
+%% the curry adapter (make_curry/2) capture exactly their `{fable_eta_adapter, F}` /
+%% `{fable_curry_adapter, F}` marker as their outermost fun's only captured variable — unwrap to F.
+%% This is precise: ONLY Fable's own compiler-generated adapters carry a marker, so an unrelated
+%% closure (including a hand-written eta expansion like `fun x -> g x`) is left intact and still
+%% compares unequal — this is reference identity, not structural equality. Non-function values pass
+%% through untouched, so this is a safe drop-in for `=:=`.
 fun_ref_eq(A, B) -> unwrap_fun(A) =:= unwrap_fun(B).
 
 unwrap_fun(F) when is_function(F) ->
     case erlang:fun_info(F, env) of
         %% An eta adapter built by make_eta/2: recover the underlying function from the marker.
         {env, [{fable_eta_adapter, Inner}]} -> unwrap_fun(Inner);
-        %% A 1-arity curry adapter whose only captured variable is itself a function.
-        {env, [Inner]} when is_function(Inner), is_function(F, 1) -> unwrap_fun(Inner);
+        %% A curry adapter built by make_curry/2: recover the underlying function from the marker.
+        {env, [{fable_curry_adapter, Inner}]} -> unwrap_fun(Inner);
         _ -> F
     end;
 unwrap_fun(V) -> V.

--- a/tests/Beam/ComparisonTests.fs
+++ b/tests/Beam/ComparisonTests.fs
@@ -771,6 +771,21 @@ let ``test PhysicalEquality removal works for a tuple-sourced function via a cla
     registry2.Remove(other)
     registry2.Count |> equal 2
 
+[<Fact>]
+let ``test PhysicalEquality distinguishes eta expansion from the original`` () =
+    // A user-written eta expansion `fun x -> g x` is a distinct closure from `g`, so reference
+    // identity must return false — same as .NET. Fable's reference-identity recovery (fun_ref_eq
+    // in fable_utils.erl) only unwraps its own compiler-generated curry/eta adapters, which carry
+    // a marker; a hand-written eta expansion carries none and stays distinct. Regression guard
+    // for the earlier 1-arity shape heuristic, which wrongly unwrapped `fun x -> g x` to `g`.
+    let g: int -> int = fun x -> x + 1
+    let etaG: int -> int = fun x -> g x
+    LanguagePrimitives.PhysicalEquality etaG g |> equal false
+    // 2-arg eta expansion is likewise distinct from the original.
+    let h: int -> int -> int = fun a b -> a + b
+    let etaH: int -> int -> int = fun a b -> h a b
+    LanguagePrimitives.PhysicalEquality etaH h |> equal false
+
 // --- Raw Erlang reference comparison tests ---
 // These test that fable_comparison correctly handles Erlang references
 // that are NOT stored in the process dictionary (i.e., not mutable vars or class instances).

--- a/tests/Beam/ComparisonTests.fs
+++ b/tests/Beam/ComparisonTests.fs
@@ -39,6 +39,22 @@ let physEqStore (a: Sink) (b: Sink) : Sink list = [ a; b ]
 let physEqRemove (sinks: Sink list) (sink: Sink) : Sink list =
     sinks |> List.filter (fun s -> not (LanguagePrimitives.PhysicalEquality s sink))
 
+// Closer to the real Parchment shape: the sink originates from a tuple deconstruction
+// (captureSink) and is stored/removed via a class. This forces the curried function value to
+// be normalised to an uncurried arity at *both* the store site and the compare site, each via
+// a separately-built adapter — which must still preserve reference identity.
+let captureSink () : Sink * (unit -> string list) =
+    let received = System.Collections.Generic.List<string>()
+    let sink: Sink = fun _sev msg -> received.Add(msg)
+    let reader () = List.ofSeq received
+    sink, reader
+
+type SinkRegistry(a: Sink, b: Sink) =
+    let mutable sinks: Sink list = [ a; b ]
+    member _.Remove(sink: Sink) =
+        sinks <- sinks |> List.filter (fun s -> not (LanguagePrimitives.PhysicalEquality s sink))
+    member _.Count = List.length sinks
+
 [<Fact>]
 let ``test Typed array equality works`` () =
     let xs1 = [| 1; 2; 3 |]
@@ -734,6 +750,26 @@ let ``test PhysicalEquality is identity not structural on functions`` () =
     // But the same value compares equal to itself, even when stored in a list.
     LanguagePrimitives.PhysicalEquality f1 f1 |> equal true
     [ f1 ] |> List.exists (fun g -> LanguagePrimitives.PhysicalEquality g f1) |> equal true
+
+[<Fact>]
+let ``test PhysicalEquality removal works for a tuple-sourced function via a class`` () =
+    // Mirrors Scriptorium.Parchment: sink comes from a tuple deconstruction and is stored/removed
+    // through a class. The same curried value is uncurried by separately-built adapters at the
+    // store and compare sites, but must still be removed by reference identity.
+    let sink1, _ = captureSink ()
+    let sink2, _ = captureSink ()
+    let registry = SinkRegistry(sink1, sink2)
+    registry.Count |> equal 2
+    registry.Remove(sink2)
+    registry.Count |> equal 1
+    // Removing the remaining one empties the registry.
+    registry.Remove(sink1)
+    registry.Count |> equal 0
+    // Removing a non-stored sink is a no-op.
+    let registry2 = SinkRegistry(sink1, sink2)
+    let other, _ = captureSink ()
+    registry2.Remove(other)
+    registry2.Count |> equal 2
 
 // --- Raw Erlang reference comparison tests ---
 // These test that fable_comparison correctly handles Erlang references

--- a/tests/Beam/ComparisonTests.fs
+++ b/tests/Beam/ComparisonTests.fs
@@ -28,6 +28,17 @@ type RTest = { a: int; b: int }
 
 exception Ex of int
 
+// Helpers for testing reference identity (PhysicalEquality) of curried 2-argument function
+// values. A value is stored one way (curried) and passed/compared another way (uncurried)
+// across argument sites, but must still compare as the *same* value. Mirrors the
+// Scriptorium.Parchment sink registration/removal pattern.
+type Sink = int -> string -> unit
+
+let physEqStore (a: Sink) (b: Sink) : Sink list = [ a; b ]
+
+let physEqRemove (sinks: Sink list) (sink: Sink) : Sink list =
+    sinks |> List.filter (fun s -> not (LanguagePrimitives.PhysicalEquality s sink))
+
 [<Fact>]
 let ``test Typed array equality works`` () =
     let xs1 = [| 1; 2; 3 |]
@@ -685,6 +696,44 @@ let ``test PhysicalEquality works`` () =
     LanguagePrimitives.PhysicalEquality r1 r2 |> equal false
     LanguagePrimitives.PhysicalEquality r2 r2 |> equal true
     LanguagePrimitives.PhysicalEquality r3 r1 |> equal true
+
+[<Fact>]
+let ``test PhysicalEquality on a function value stored in a list works`` () =
+    // A curried 2-arg function value, captured once and stored in a list, must be found by
+    // reference identity — even though it is stored one way (curried) and passed another way
+    // (uncurried) across argument sites. Mirrors Scriptorium.Parchment sink registration.
+    let s1: Sink = fun _sev _msg -> ()
+    let s2: Sink = fun _sev _msg -> ()
+    let stored = physEqStore s1 s2
+    stored |> List.exists (fun g -> LanguagePrimitives.PhysicalEquality g s2) |> equal true
+    stored |> List.exists (fun g -> LanguagePrimitives.PhysicalEquality g s1) |> equal true
+    // A distinct function (identical body but a different value) must NOT be found.
+    let other: Sink = fun _sev _msg -> ()
+    stored |> List.exists (fun g -> LanguagePrimitives.PhysicalEquality g other) |> equal false
+
+[<Fact>]
+let ``test PhysicalEquality-based removal removes the right function`` () =
+    let s1: Sink = fun _sev _msg -> ()
+    let s2: Sink = fun _sev _msg -> ()
+    let stored = physEqStore s1 s2
+    // Remove an element that is stored: it is actually removed.
+    let afterRemove = physEqRemove stored s2
+    List.length afterRemove |> equal 1
+    afterRemove |> List.exists (fun g -> LanguagePrimitives.PhysicalEquality g s1) |> equal true
+    afterRemove |> List.exists (fun g -> LanguagePrimitives.PhysicalEquality g s2) |> equal false
+    // Removing a non-stored element is a no-op.
+    let other: Sink = fun _sev _msg -> ()
+    physEqRemove stored other |> List.length |> equal 2
+
+[<Fact>]
+let ``test PhysicalEquality is identity not structural on functions`` () =
+    // Two distinct closures with identical bodies must not be reference-equal.
+    let f1: int -> int -> int = fun a b -> a + b
+    let f2: int -> int -> int = fun a b -> a + b
+    LanguagePrimitives.PhysicalEquality f1 f2 |> equal false
+    // But the same value compares equal to itself, even when stored in a list.
+    LanguagePrimitives.PhysicalEquality f1 f1 |> equal true
+    [ f1 ] |> List.exists (fun g -> LanguagePrimitives.PhysicalEquality g f1) |> equal true
 
 // --- Raw Erlang reference comparison tests ---
 // These test that fable_comparison correctly handles Erlang references


### PR DESCRIPTION
## Problem

`LanguagePrimitives.PhysicalEquality` (and `ReferenceEquals`, and the `<>`/reference-identity patterns built on them) returned `false` for the **same** F# function value on the Beam target.

Fable-BEAM represents one logical function value with different Erlang funs depending on the argument site:

- **Re-curried form** (e.g. a function stored in a list/record): a nested 1-arity adapter `fun(A0) -> fun(A1) -> F(A0, A1) end end`, from a `Curry` node.
- **Uncurried form** (compared/passed to an uncurried slot): a single N-arity fun `fun(A, B) -> F(A, B) end`.

Erlang compares funs by closure identity, so these representations are never `=:=` even though they denote one value. Real-world symptom: removing a stored callback by reference identity (e.g. `sinks |> List.filter (fun s -> not (PhysicalEquality s sink))`) never matched, so nothing was removed.

## Fix

Make the two adapter kinds **identity-recoverable** by tagging them, rather than changing the underlying function representation (which would ripple through the hand-written curried runtime libs).

- **`fable_utils:make_curry/2`** — routed from the `Curry` node in `Fable2Beam.fs`. Builds the re-curried adapter but captures the underlying `F` inside a `{fable_curry_adapter, F, N}` marker as the outermost fun's only captured variable. Applies `F` with `erlang:apply` (all args at once), matching the default multi-arg lowering exactly, so it is behaviour-identical bar the marker.
- **`fable_utils:make_eta/2`** — routed from the `EtaAdapterDelegate` pattern in `Fable2Beam.fs`. Same idea for the uncurried adapter, tagged `{fable_eta_adapter, F, N}`.
- **`fable_utils:fun_ref_eq/2`** — peels either marker via `erlang:fun_info(F, env)` before `=:=`, normalising every representation of a value to the same `F`.
- **`Beam/Replacements.fs`** — route `PhysicalEquality`/`ReferenceEquals` through `fun_ref_eq` when either operand is a function type; keep plain `=:=` otherwise.

**Precise reference identity, not structural equality.** Only Fable's own compiler-generated adapters carry a marker, so a hand-written eta expansion (`fun x -> g x`) or a partial application is left intact and stays distinct — matching .NET. (An earlier iteration used a *shape heuristic* — unwrap any 1-arity fun capturing a single function — which wrongly collapsed `fun x -> g x` onto `g`; the marker approach fixes that false positive.)

**Adapter cancellation** (mirrors the Python target's `curry.py` memoization). If `make_eta`/`make_curry` receives a value that is already the opposite, same-arity adapter, it returns the original underlying fun instead of stacking a second wrapper (`uncurry ∘ curry = curry ∘ uncurry = id`). A round-tripped value is then the *same* fun object — native `=:=` holds with no unwrap and no per-call wrapper cost — and adapters never accumulate. The marker lives in the closure env, so unlike Python's process-local `WeakKeyDictionary` this survives a fun crossing process boundaries. The arity in the marker guards the cancellation (a mismatch wraps instead, avoiding `badarity`).

### Known limitations (documented in `Beam/FABLE-BEAM.md`)

- **Arity cap 2..7** (matching `make_eta`). Functions with 8+ curried args fall back to the default lowering and are not identity-preserved.
- **Generic call sites**: routing to `fun_ref_eq` is gated on the operand being a `LambdaType`/`DelegateType` at the call site. A value typed as a bare generic `'T` (Fable does not monomorphise) falls back to plain `=:=`, so wrapping `PhysicalEquality` in a generic helper does not get the function-aware path.

## Tests

New tests in `tests/Beam/ComparisonTests.fs` (pass on .NET first, then Beam):

- A curried 2-arg function stored in a list is found by reference identity; a distinct-but-identical function is **not** found.
- `PhysicalEquality`-based removal actually removes the stored element and is a no-op for a non-stored one (the sink-removal pattern), including a tuple-sourced sink stored/removed via a class.
- Identity, not structural equality: two distinct closures with identical bodies stay unequal, and a hand-written eta expansion (`fun x -> g x`) stays distinct from the original (regression guard for the former shape heuristic).

Full Beam suite: **2500 passed, 0 failed** (.NET 2494, 0 failed).

Note: changelog files are auto-generated from commit history per `AGENTS.md`, so none is edited here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)