### PR TITLE
fix(python): propagate [<EntryPoint>] return value as process exit code

### DIFF
--- a/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
@@ -3216,7 +3216,14 @@ let declareEntryPoint (com: IPythonCompiler) (ctx: Context) (funcExpr: Expressio
             [ Expression.stringConstant "__main__" ]
         )
 
-    let main = Expression.call (funcExpr, [ args ]) |> Statement.expr |> List.singleton
+    let mainCall = Expression.call (funcExpr, [ args ])
+
+    // Propagate the entry point's return value as the process exit code.
+    // int(...) coercion is required because fable-library-python's Int32 is not an int subclass.
+    let main =
+        emitExpression None "sys.exit(int($0))" [ mainCall ]
+        |> Statement.expr
+        |> List.singleton
 
     Statement.if' (test, main)
 


### PR DESCRIPTION
## Problem

In F#, an `[<EntryPoint>]` function has signature `string[] -> int`, and its `int` return value is the **process exit code** (the .NET runtime honours this). Fable's Python backend was **discarding** that return value, so every Fable-Python program exited `0` regardless of what `main` returned. A test runner that returns `1` on failure therefore reported failures on screen but **exited 0** — CI could never detect a failing suite.

### Before

```python
if __name__ == "__main__":
    main(Array[Any](sys.argv[1:]))      # return value dropped; process always exits 0
```

### After

```python
if __name__ == "__main__":
    sys.exit(int(main(Array[Any](sys.argv[1:]))))
```

## The fix

In `declareEntryPoint` (`src/Fable.Transforms/Python/Fable2Python.Transforms.fs`), the `main(...)` call is now wrapped in `sys.exit(int(...))`:

- `sys` is already imported in this function, so no new import is needed.
- The change stays inside the existing `if __name__ == "__main__":` guard, so importing the module as a library never triggers `sys.exit` (`OutputType = Library` is unaffected).
- `int(...)` coercion is required because fable-library-python's `Int32` is **not** a subclass of Python `int` (`isinstance(int32(0), int) == False`). Without it, `sys.exit` treats the object as a message, prints it to stderr, and exits `1` even on success. This mirrors what the `fable-library-py` `sys` binding already does (`[<Emit("$0.exit(int($1))")>]`).
- Python-target-specific only — the Babel/JS `declareEntryPoint` is untouched (a browser has no process to exit).

## Verification

Compiled a standalone repro with the locally-built compiler:

| `main` returns | process exit | before this fix |
|---|---|---|
| `1` (failure) | `1` ✅ | `0` (bug) |
| `0` (success) | `0` ✅ | `0` |

Library output is unaffected — the emitted call only runs under the `__main__` guard.

Full Python suite (`./build.sh test python`): **2391 passed**, no regressions.

## Test coverage (deliberate gap)

This PR ships **without an automated regression test**, by design. The behaviour under test — an `int` return propagating to the *process exit code* — is a process-level property that the existing test infrastructure can't observe:

- The Python test suite doesn't compile an entry point at all (`tests/Python/Main.fs` is `module Program; ()` under `FABLE_COMPILER`; pytest drives the tests directly), so `declareEntryPoint` never runs for it.
- The compiler-output tests (`tests/Integration/Compiler`) only surface log entries (errors/warnings) and target the JS backend — they don't expose generated Python source to assert on.
- There is no "compile a project to Python and run it as a process" integration harness.

A faithful test would require new bespoke process-level integration wiring, which felt disproportionate for a two-line printer change confined to the `__main__` guard. Verified manually in both directions (exit `1` and `0`) plus the full suite above. Happy to add a process-level test if reviewers would prefer the coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)