### PR TITLE
test: add test project for Fable plugins

### DIFF
--- a/src/Fable.Build/Fable.Build.fsproj
+++ b/src/Fable.Build/Fable.Build.fsproj
@@ -29,6 +29,7 @@
     <Compile Include="Test/Beam.fs" />
     <Compile Include="Test/Integration.fs" />
     <Compile Include="Test/CompilerJs.fs" />
+    <Compile Include="Test/Plugins.fs" />
     <Compile Include="Quicktest/Core.fs" />
     <Compile Include="Quicktest/TypeScript.fs" />
     <Compile Include="Quicktest/JavaScript.fs" />

--- a/src/Fable.Build/Main.fs
+++ b/src/Fable.Build/Main.fs
@@ -46,6 +46,7 @@ Available commands:
             integration             Run the integration test suite
             standalone              Tests the standalone version of Fable
                                     (Fable running on top of Node.js)
+            plugins                 Run the plugin test suite (tests MemberDeclarationPluginAttribute)
 
         Options for all except integration and standalone:
             --watch                 Watch for changes and re-run the tests
@@ -153,6 +154,7 @@ let main argv =
             // This test is using quicktest project for now,
             // because it can't compile (yet?) the Main JavaScript tests
             | "compiler-js" :: _ -> Test.CompilerJs.handle args
+            | "plugins" :: args -> Test.Plugins.handle args
             | _ -> printHelp ()
         | "quicktest" :: args ->
             match args with

--- a/src/Fable.Build/Test/Plugins.fs
+++ b/src/Fable.Build/Test/Plugins.fs
@@ -1,0 +1,32 @@
+module Build.Test.Plugins
+
+open Build.FableLibrary
+open System.IO
+open BlackFox.CommandLine
+open Build.Utils
+open SimpleExec
+open Fake.IO
+
+let private pluginsTestsDir =
+    Path.Resolve("tests", "Integration", "Plugins", "Tests")
+
+let handle (args: string list) =
+    BuildFableLibraryJavaScript().Run()
+
+    let destinationDir = Path.Resolve("temp", "tests", "Plugins")
+
+    Directory.clean destinationDir
+
+    CmdLine.empty
+    |> CmdLine.appendRaw pluginsTestsDir
+    |> CmdLine.appendPrefix "--outDir" destinationDir
+    |> CmdLine.appendPrefix "--lang" "javascript"
+    |> CmdLine.appendPrefix "--exclude" "Fable.Core"
+    // The plugin assembly must be loaded via reflection, not compiled from source.
+    |> CmdLine.appendPrefix "--exclude" "Fable.Tests.Plugin"
+    // Fable.AST must stay the same assembly the plugin was built against, not be re-cracked from source.
+    |> CmdLine.appendPrefix "--exclude" "Fable.AST"
+    |> CmdLine.appendRaw "--noCache"
+    |> Command.Fable
+
+    Command.Run("node", "--test-reporter spec --test-timeout 20000 --test Main.js", workingDirectory = destinationDir)

--- a/tests/Integration/Plugins/Plugin/Fable.Tests.Plugin.fsproj
+++ b/tests/Integration/Plugins/Plugin/Fable.Tests.Plugin.fsproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../../../src/Fable.AST/Fable.AST.fsproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Plugin.fs" />
+  </ItemGroup>
+</Project>

--- a/tests/Integration/Plugins/Plugin/Plugin.fs
+++ b/tests/Integration/Plugins/Plugin/Plugin.fs
@@ -1,0 +1,27 @@
+namespace Fable.Tests
+
+open Fable.AST
+open Fable.AST.Fable
+
+[<assembly: Fable.ScanForPlugins>]
+do ()
+
+/// Replaces the whole member body with a constant, proving `Transform` fires.
+type ReturnConstPlugin() =
+    inherit Fable.MemberDeclarationPluginAttribute()
+    override _.FableMinimumVersion = "5.0"
+
+    override _.Transform(_, _, decl) =
+        { decl with Body = Value(NumberConstant(NumberValue.Int32 42, NumberInfo.Empty), None) }
+
+    override _.TransformCall(_, _, expr) = expr
+
+/// Replaces the call site with the called member's name, proving `TransformCall` fires.
+type ReturnMemberNamePlugin() =
+    inherit Fable.MemberDeclarationPluginAttribute()
+    override _.FableMinimumVersion = "5.0"
+
+    override _.Transform(_, _, decl) = decl
+
+    override _.TransformCall(_, member_, expr) =
+        Value(StringConstant member_.DisplayName, expr.Range)

--- a/tests/Integration/Plugins/Tests/Fable.Tests.Plugins.fsproj
+++ b/tests/Integration/Plugins/Tests/Fable.Tests.Plugins.fsproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <RollForward>Major</RollForward>
+    <LangVersion>Preview</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../../../src/Fable.Core/Fable.Core.fsproj" />
+    <ProjectReference Include="../Plugin/Fable.Tests.Plugin.fsproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="../../../Js/Main/Util/Util.Testing.fs" />
+    <Compile Include="PluginsTests.fs" />
+    <Compile Include="Main.fs" />
+  </ItemGroup>
+</Project>

--- a/tests/Integration/Plugins/Tests/Main.fs
+++ b/tests/Integration/Plugins/Tests/Main.fs
@@ -1,11 +1,9 @@
 module Fable.Tests.Main
 
-let allTests = [| PluginsTests.tests |]
-
-#if FABLE_COMPILER
-
 open Fable.Core
 open Fable.Core.JsInterop
+
+let allTests = [| PluginsTests.tests |]
 
 let inline describe (name: string) (f: unit -> unit) : unit = import "describe" "node:test"
 let inline it (msg: string) (f: unit -> unit) : unit = import "it" "node:test"
@@ -22,12 +20,8 @@ let run () =
     for t in allTests do
         flattenTest t
 
-run ()
-
-#else
-
 // This project only ever runs through Fable; this branch just keeps it a valid .NET project.
 [<EntryPoint>]
-let main _ = 0
-
-#endif
+let main _ =
+    run ()
+    0

--- a/tests/Integration/Plugins/Tests/Main.fs
+++ b/tests/Integration/Plugins/Tests/Main.fs
@@ -1,0 +1,33 @@
+module Fable.Tests.Main
+
+let allTests = [| PluginsTests.tests |]
+
+#if FABLE_COMPILER
+
+open Fable.Core
+open Fable.Core.JsInterop
+
+let inline describe (name: string) (f: unit -> unit) : unit = import "describe" "node:test"
+let inline it (msg: string) (f: unit -> unit) : unit = import "it" "node:test"
+
+let rec flattenTest (test: Util.Testing.TestKind) : unit =
+    match test with
+    | Util.Testing.TestKind.TestList(name, tests) ->
+        describe name (fun () ->
+            for t in tests do
+                flattenTest t)
+    | Util.Testing.TestKind.TestCase(name, test) -> it name (unbox test)
+
+let run () =
+    for t in allTests do
+        flattenTest t
+
+run ()
+
+#else
+
+// This project only ever runs through Fable; this branch just keeps it a valid .NET project.
+[<EntryPoint>]
+let main _ = 0
+
+#endif

--- a/tests/Integration/Plugins/Tests/PluginsTests.fs
+++ b/tests/Integration/Plugins/Tests/PluginsTests.fs
@@ -1,0 +1,21 @@
+module Fable.Tests.PluginsTests
+
+open Fable.Tests
+open Util.Testing
+
+[<ReturnConstPlugin>]
+let constFn () = 0
+
+[<ReturnMemberNamePlugin>]
+let memberNameFn () = ""
+
+let tests =
+    testList
+        "Member Declaration Plugins"
+        [
+            testCase "Transform replaces the compiled member body"
+            <| fun () -> equal 42 (constFn ())
+
+            testCase "TransformCall rewrites the call site"
+            <| fun () -> equal "memberNameFn" (memberNameFn ())
+        ]


### PR DESCRIPTION
I am adding a specific test project dedicated to testing Fable plugins.

Currently, we were kind of using the React tests to check Fable plugins, but as I am planning to make improvement to the plugin system a dedicated project makes more sense.