### PR TITLE
fix(beam): make F# reflection work on the Beam target

### DIFF
--- a/src/Fable.Transforms/Beam/Fable2Beam.Reflection.fs
+++ b/src/Fable.Transforms/Beam/Fable2Beam.Reflection.fs
@@ -114,6 +114,32 @@ let rec private transformTypeInfoRec
     | Fable.Boolean -> makeTypeInfoMap Types.bool []
     | Fable.Char -> makeTypeInfoMap Types.char []
     | Fable.String -> makeTypeInfoMap Types.string []
+    | Fable.Number(kind, Fable.NumberInfo.IsEnum entRef) ->
+        // An enum keeps its underlying numeric kind in the Fable AST, so its type info carries
+        // the declared cases alongside the underlying type (as the single generic).
+        let ent = com.GetEntity(entRef)
+
+        let enumCases =
+            ent.FSharpFields
+            |> List.choose (fun fi ->
+                match fi.Name with
+                | "value__" -> None
+                | name ->
+                    let value =
+                        match fi.LiteralValue with
+                        | Some v -> System.Convert.ToInt64 v
+                        | None -> 0L
+
+                    Beam.ErlExpr.Tuple [ strLit name; Beam.ErlExpr.Literal(Beam.ErlLiteral.Integer value) ]
+                    |> Some
+            )
+
+        Beam.ErlExpr.Map
+            [
+                atomLit "fullname", strLit entRef.FullName
+                atomLit "generics", Beam.ErlExpr.List [ makeTypeInfoMap (getNumberFullName kind) [] ]
+                atomLit "enum_cases", Beam.ErlExpr.List enumCases
+            ]
     | Fable.Number(kind, _) -> makeTypeInfoMap (getNumberFullName kind) []
     | Fable.GenericParam(name = name) ->
         match Map.tryFind name genMap with

--- a/src/Fable.Transforms/Beam/Fable2Beam.Reflection.fs
+++ b/src/Fable.Transforms/Beam/Fable2Beam.Reflection.fs
@@ -49,10 +49,20 @@ let reflectionFuncName (declarationName: string) =
 /// reflection function (`gen0`, `gen1`, ...).
 let reflectionGenArgVar (index: int) = $"Gen%d{index}"
 
-/// Build a PropertyInfo map: #{name => <<"field_name">>, property_type => TypeInfo}
+/// Build a PropertyInfo map: #{name => <<"FieldName">>, erl_name => field_name, property_type => TypeInfo}
+///
+/// `name` is the F# field name, which is what `PropertyInfo.Name` must report; `erl_name` is the
+/// sanitized name the field is actually keyed by in the record map. Same split as the `name` /
+/// `erl_tag` pair on union case infos.
 let private makePropertyInfo (fieldName: string) (typeInfo: Beam.ErlExpr) =
     let erlName = Fable.Beam.Naming.sanitizeErlangName fieldName
-    Beam.ErlExpr.Map [ atomLit "name", strLit erlName; atomLit "property_type", typeInfo ]
+
+    Beam.ErlExpr.Map
+        [
+            atomLit "name", strLit fieldName
+            atomLit "erl_name", atomLit erlName
+            atomLit "property_type", typeInfo
+        ]
 
 /// Build a CaseInfo map: #{tag => N, name => <<"CaseName">>, erl_tag => case_name, fields => [...]}
 let private makeCaseInfo (tag: int) (caseName: string) (fields: Beam.ErlExpr list) =
@@ -125,12 +135,20 @@ let rec private transformTypeInfoRec
                 match fi.Name with
                 | "value__" -> None
                 | name ->
+                    // Emitted as a bignum literal, not an int64: a UInt64-backed enum can hold
+                    // values above Int64.MaxValue, and Convert.ToInt64 would overflow on them.
+                    // Erlang integers are arbitrary-precision, so the value always fits.
                     let value =
                         match fi.LiteralValue with
-                        | Some v -> System.Convert.ToInt64 v
-                        | None -> 0L
+                        | Some(:? uint64 as v) -> System.Numerics.BigInteger(v)
+                        | Some v -> System.Numerics.BigInteger(System.Convert.ToInt64 v)
+                        | None -> System.Numerics.BigInteger.Zero
 
-                    Beam.ErlExpr.Tuple [ strLit name; Beam.ErlExpr.Literal(Beam.ErlLiteral.Integer value) ]
+                    Beam.ErlExpr.Tuple
+                        [
+                            strLit name
+                            Beam.ErlExpr.Literal(Beam.ErlLiteral.BigInt(string<System.Numerics.BigInteger> value))
+                        ]
                     |> Some
             )
 
@@ -204,44 +222,48 @@ let rec private transformTypeInfoRec
             // emit the bare type info to stop the recursion.
             makeTypeInfoMap entRef.FullName resolved
         | Some ent when ent.IsFSharpRecord ->
-            let expanding = expanding.Add entRef.FullName
+            Beam.ErlExpr.Map
+                [
+                    atomLit "fullname", strLit entRef.FullName
+                    atomLit "generics", Beam.ErlExpr.List resolved
+                    makeFieldsEntry com r genMap (expanding.Add entRef.FullName) ent
+                ]
+        | Some ent when ent.IsFSharpUnion ->
+            Beam.ErlExpr.Map
+                [
+                    atomLit "fullname", strLit entRef.FullName
+                    atomLit "generics", Beam.ErlExpr.List resolved
+                    makeCasesEntry com r genMap (expanding.Add entRef.FullName) ent
+                ]
+        | _ -> makeTypeInfoMap entRef.FullName resolved
 
-            let fields =
-                ent.FSharpFields
+/// The `fields => fun() -> [...] end` entry of a record's type info.
+and private makeFieldsEntry com r genMap expanding (ent: Entity) =
+    let fields =
+        ent.FSharpFields
+        |> List.map (fun fi ->
+            let typeInfo = transformTypeInfoRec com r genMap expanding fi.FieldType
+            makePropertyInfo fi.Name typeInfo
+        )
+
+    atomLit "fields", makeThunk fields
+
+/// The `cases => fun() -> [...] end` entry of a union's type info.
+and private makeCasesEntry com r genMap expanding (ent: Entity) =
+    let cases =
+        ent.UnionCases
+        |> List.mapi (fun i uci ->
+            let caseFields =
+                uci.UnionCaseFields
                 |> List.map (fun fi ->
                     let typeInfo = transformTypeInfoRec com r genMap expanding fi.FieldType
                     makePropertyInfo fi.Name typeInfo
                 )
 
-            Beam.ErlExpr.Map
-                [
-                    atomLit "fullname", strLit entRef.FullName
-                    atomLit "generics", Beam.ErlExpr.List resolved
-                    atomLit "fields", makeThunk fields
-                ]
-        | Some ent when ent.IsFSharpUnion ->
-            let expanding = expanding.Add entRef.FullName
+            makeCaseInfo i uci.Name caseFields
+        )
 
-            let cases =
-                ent.UnionCases
-                |> List.mapi (fun i uci ->
-                    let caseFields =
-                        uci.UnionCaseFields
-                        |> List.map (fun fi ->
-                            let typeInfo = transformTypeInfoRec com r genMap expanding fi.FieldType
-                            makePropertyInfo fi.Name typeInfo
-                        )
-
-                    makeCaseInfo i uci.Name caseFields
-                )
-
-            Beam.ErlExpr.Map
-                [
-                    atomLit "fullname", strLit entRef.FullName
-                    atomLit "generics", Beam.ErlExpr.List resolved
-                    atomLit "cases", makeThunk cases
-                ]
-        | _ -> makeTypeInfoMap entRef.FullName resolved
+    atomLit "cases", makeThunk cases
 
 /// Transform a Fable Type into an Erlang type info map expression
 let transformTypeInfo
@@ -268,37 +290,15 @@ let transformEntityReflectionBody (com: Compiler) (ent: Entity) : Beam.ErlExpr =
 
     let expanding = Set.singleton ent.FullName
 
-    if ent.IsFSharpUnion then
-        let cases =
-            ent.UnionCases
-            |> List.mapi (fun i uci ->
-                let caseFields =
-                    uci.UnionCaseFields
-                    |> List.map (fun fi ->
-                        let typeInfo = transformTypeInfoRec com None genMap expanding fi.FieldType
-                        makePropertyInfo fi.Name typeInfo
-                    )
+    let membersEntry =
+        if ent.IsFSharpUnion then
+            makeCasesEntry com None genMap expanding ent
+        else
+            makeFieldsEntry com None genMap expanding ent
 
-                makeCaseInfo i uci.Name caseFields
-            )
-
-        Beam.ErlExpr.Map
-            [
-                atomLit "fullname", strLit ent.FullName
-                atomLit "generics", Beam.ErlExpr.List generics
-                atomLit "cases", makeThunk cases
-            ]
-    else
-        let fields =
-            ent.FSharpFields
-            |> List.map (fun fi ->
-                let typeInfo = transformTypeInfoRec com None genMap expanding fi.FieldType
-                makePropertyInfo fi.Name typeInfo
-            )
-
-        Beam.ErlExpr.Map
-            [
-                atomLit "fullname", strLit ent.FullName
-                atomLit "generics", Beam.ErlExpr.List generics
-                atomLit "fields", makeThunk fields
-            ]
+    Beam.ErlExpr.Map
+        [
+            atomLit "fullname", strLit ent.FullName
+            atomLit "generics", Beam.ErlExpr.List generics
+            membersEntry
+        ]

--- a/src/Fable.Transforms/Beam/Fable2Beam.Reflection.fs
+++ b/src/Fable.Transforms/Beam/Fable2Beam.Reflection.fs
@@ -25,6 +25,30 @@ let private makeTypeInfoMap (fullname: string) (generics: Beam.ErlExpr list) =
             atomLit "generics", Beam.ErlExpr.List generics
         ]
 
+/// Wrap a list of field/case infos in a zero-arity fun: `fun() -> [...] end`.
+///
+/// Record fields and union cases are emitted lazily so a recursive type (whose fields
+/// mention the type itself) does not build an infinite map. `fable_reflection` forces
+/// the thunk when the fields/cases are actually needed.
+let private makeThunk (elements: Beam.ErlExpr list) =
+    Beam.ErlExpr.Fun
+        [
+            {
+                Patterns = []
+                Guard = []
+                Body = [ Beam.ErlExpr.List elements ]
+            }
+        ]
+
+/// Name of the per-entity reflection function generated for a record/union
+/// (e.g. entity `Tree` -> `tree_reflection/0`).
+let reflectionFuncName (declarationName: string) =
+    Fable.Beam.Naming.sanitizeErlangName declarationName + "_reflection"
+
+/// Erlang variable names bound to an entity's resolved generic arguments inside its
+/// reflection function (`gen0`, `gen1`, ...).
+let reflectionGenArgVar (index: int) = $"Gen%d{index}"
+
 /// Build a PropertyInfo map: #{name => <<"field_name">>, property_type => TypeInfo}
 let private makePropertyInfo (fieldName: string) (typeInfo: Beam.ErlExpr) =
     let erlName = Fable.Beam.Naming.sanitizeErlangName fieldName
@@ -63,14 +87,23 @@ let private getNumberFullName (kind: NumberKind) =
     | Decimal -> Types.decimal
     | BigInt -> Types.bigint
 
-/// Transform a Fable Type into an Erlang type info map expression
-let rec transformTypeInfo
+/// Transform a Fable Type into an Erlang type info map expression.
+///
+/// `expanding` holds the entities whose fields/cases are currently being inlined. It only
+/// guards the fallback path taken by entities with no source file (BCL/`.dll` types, which
+/// have no generated Erlang module to call into); entities we compile get a by-name call to
+/// their reflection function instead, which is what breaks recursive types.
+let rec private transformTypeInfoRec
     (com: Compiler)
     (r: SourceLocation option)
     (genMap: Map<string, Beam.ErlExpr>)
+    (expanding: Set<string>)
     (t: Type)
     : Beam.ErlExpr
     =
+    let transformTypeInfo com r genMap t =
+        transformTypeInfoRec com r genMap expanding t
+
     let resolveGenerics (genArgs: Type list) =
         genArgs |> List.map (transformTypeInfo com r genMap)
 
@@ -124,11 +157,33 @@ let rec transformTypeInfo
         let resolved = resolveGenerics generics
 
         match com.TryGetEntity(entRef) with
+        | Some ent when (ent.IsFSharpRecord || ent.IsFSharpUnion) && entRef.SourcePath.IsSome ->
+            // Call the entity's generated reflection function instead of inlining its
+            // fields/cases. The by-name indirection is what lets a recursive type refer to
+            // itself: `tree_reflection()` mentions `tree_reflection()` inside a thunk.
+            let sourcePath = entRef.SourcePath.Value
+
+            let moduleName =
+                if sourcePath = com.CurrentFile then
+                    None // local call
+                else
+                    Some(Fable.Beam.Naming.moduleNameFromFile sourcePath)
+
+            let funcName =
+                FSharp2Fable.Helpers.getEntityDeclarationName com entRef |> reflectionFuncName
+
+            Beam.ErlExpr.Call(moduleName, funcName, resolved)
+        | Some ent when (ent.IsFSharpRecord || ent.IsFSharpUnion) && expanding.Contains entRef.FullName ->
+            // Re-entering an entity we are already inlining (no source file to call into):
+            // emit the bare type info to stop the recursion.
+            makeTypeInfoMap entRef.FullName resolved
         | Some ent when ent.IsFSharpRecord ->
+            let expanding = expanding.Add entRef.FullName
+
             let fields =
                 ent.FSharpFields
                 |> List.map (fun fi ->
-                    let typeInfo = transformTypeInfo com r genMap fi.FieldType
+                    let typeInfo = transformTypeInfoRec com r genMap expanding fi.FieldType
                     makePropertyInfo fi.Name typeInfo
                 )
 
@@ -136,16 +191,18 @@ let rec transformTypeInfo
                 [
                     atomLit "fullname", strLit entRef.FullName
                     atomLit "generics", Beam.ErlExpr.List resolved
-                    atomLit "fields", Beam.ErlExpr.List fields
+                    atomLit "fields", makeThunk fields
                 ]
         | Some ent when ent.IsFSharpUnion ->
+            let expanding = expanding.Add entRef.FullName
+
             let cases =
                 ent.UnionCases
                 |> List.mapi (fun i uci ->
                     let caseFields =
                         uci.UnionCaseFields
                         |> List.map (fun fi ->
-                            let typeInfo = transformTypeInfo com r genMap fi.FieldType
+                            let typeInfo = transformTypeInfoRec com r genMap expanding fi.FieldType
                             makePropertyInfo fi.Name typeInfo
                         )
 
@@ -156,6 +213,66 @@ let rec transformTypeInfo
                 [
                     atomLit "fullname", strLit entRef.FullName
                     atomLit "generics", Beam.ErlExpr.List resolved
-                    atomLit "cases", Beam.ErlExpr.List cases
+                    atomLit "cases", makeThunk cases
                 ]
         | _ -> makeTypeInfoMap entRef.FullName resolved
+
+/// Transform a Fable Type into an Erlang type info map expression
+let transformTypeInfo
+    (com: Compiler)
+    (r: SourceLocation option)
+    (genMap: Map<string, Beam.ErlExpr>)
+    (t: Type)
+    : Beam.ErlExpr
+    =
+    transformTypeInfoRec com r genMap Set.empty t
+
+/// Build the body of an entity's reflection function: the type info map for a record/union,
+/// with `fields`/`cases` emitted lazily and the entity's generic parameters bound to the
+/// function's arguments (`Gen0`, `Gen1`, ...).
+let transformEntityReflectionBody (com: Compiler) (ent: Entity) : Beam.ErlExpr =
+    let genMap =
+        ent.GenericParameters
+        |> List.mapi (fun i gp -> gp.Name, Beam.ErlExpr.Variable(reflectionGenArgVar i))
+        |> Map.ofList
+
+    let generics =
+        ent.GenericParameters
+        |> List.mapi (fun i _ -> Beam.ErlExpr.Variable(reflectionGenArgVar i))
+
+    let expanding = Set.singleton ent.FullName
+
+    if ent.IsFSharpUnion then
+        let cases =
+            ent.UnionCases
+            |> List.mapi (fun i uci ->
+                let caseFields =
+                    uci.UnionCaseFields
+                    |> List.map (fun fi ->
+                        let typeInfo = transformTypeInfoRec com None genMap expanding fi.FieldType
+                        makePropertyInfo fi.Name typeInfo
+                    )
+
+                makeCaseInfo i uci.Name caseFields
+            )
+
+        Beam.ErlExpr.Map
+            [
+                atomLit "fullname", strLit ent.FullName
+                atomLit "generics", Beam.ErlExpr.List generics
+                atomLit "cases", makeThunk cases
+            ]
+    else
+        let fields =
+            ent.FSharpFields
+            |> List.map (fun fi ->
+                let typeInfo = transformTypeInfoRec com None genMap expanding fi.FieldType
+                makePropertyInfo fi.Name typeInfo
+            )
+
+        Beam.ErlExpr.Map
+            [
+                atomLit "fullname", strLit ent.FullName
+                atomLit "generics", Beam.ErlExpr.List generics
+                atomLit "fields", makeThunk fields
+            ]

--- a/src/Fable.Transforms/Beam/Fable2Beam.fs
+++ b/src/Fable.Transforms/Beam/Fable2Beam.fs
@@ -3361,11 +3361,38 @@ and transformClassDeclaration
                     [ Beam.ErlForm.Function funcDef ]
         )
 
+    // Reflection function for records and unions: `<entity>_reflection(Gen0, ..., GenN)`.
+    // Emitting it here (rather than inlining the type info at each `typeof`) gives the
+    // by-name indirection that lets recursive types describe themselves.
+    let reflectionForms =
+        if ent.IsFSharpRecord || ent.IsFSharpUnion then
+            let genArgPatterns =
+                ent.GenericParameters
+                |> List.mapi (fun i _ -> Beam.PVar(Reflection.reflectionGenArgVar i))
+
+            let funcDef: Beam.ErlFunctionDef =
+                {
+                    Name = Beam.Atom(Reflection.reflectionFuncName decl.Name)
+                    Arity = genArgPatterns.Length
+                    Clauses =
+                        [
+                            {
+                                Patterns = genArgPatterns
+                                Guard = []
+                                Body = [ Reflection.transformEntityReflectionBody com ent ]
+                            }
+                        ]
+                }
+
+            [ Beam.ErlForm.Function funcDef ]
+        else
+            []
+
     // Deduplicate functions by name+arity. This can happen when a property setter
     // (e.g., `set StatusCode`) and a method (e.g., `SetStatusCode`) both mangle to
     // the same Erlang function name. Unlike JS/Python which have native getter/setter
     // syntax, Erlang uses plain functions so name collisions produce duplicate definitions.
-    let allForms = constructorForms @ memberForms
+    let allForms = constructorForms @ memberForms @ reflectionForms
 
     let dedup =
         allForms

--- a/src/Fable.Transforms/Beam/Fable2Beam.fs
+++ b/src/Fable.Transforms/Beam/Fable2Beam.fs
@@ -3388,6 +3388,34 @@ and transformClassDeclaration
         else
             []
 
+    // The reflection function shares the Erlang function namespace with the entity's members,
+    // and `sanitizeErlangName` is lossy enough that a member can mangle onto its name (a member
+    // `TreeReflection` on a type `Tree` both give `tree_reflection`). The dedup below keeps the
+    // first form, so the collision would silently drop the reflection function and leave every
+    // `typeof` for this entity calling the member instead. Report it rather than miscompile.
+    for form in reflectionForms do
+        match form with
+        | Beam.ErlForm.Function reflectionDef ->
+            let clashes =
+                memberForms
+                |> List.exists (fun memberForm ->
+                    match memberForm with
+                    | Beam.ErlForm.Function memberDef ->
+                        memberDef.Name = reflectionDef.Name && memberDef.Arity = reflectionDef.Arity
+                    | _ -> false
+                )
+
+            if clashes then
+                let (Beam.Atom name) = reflectionDef.Name
+
+                com.AddLog(
+                    $"Member of '%s{decl.Name}' collides with its generated reflection function '%s{name}/%d{reflectionDef.Arity}'. Rename the member.",
+                    Severity.Error,
+                    fileName = com.CurrentFile,
+                    tag = "FABLE"
+                )
+        | _ -> ()
+
     // Deduplicate functions by name+arity. This can happen when a property setter
     // (e.g., `set StatusCode`) and a method (e.g., `SetStatusCode`) both mangle to
     // the same Erlang function name. Unlike JS/Python which have native getter/setter

--- a/src/Fable.Transforms/Beam/Replacements.fs
+++ b/src/Fable.Transforms/Beam/Replacements.fs
@@ -361,12 +361,12 @@ let private operators
             | Float16
             | Float32
             | Float64 ->
-                // float → fixed-scale: trunc(x * 10^28)
-                emitExpr r _t [ arg ] "trunc($0 * 10000000000000000000000000000)" |> Some
-            | _ ->
-                // int → fixed-scale: x * 10^28
-                emitExpr r _t [ arg ] "($0 * 10000000000000000000000000000)" |> Some
-        | _ -> emitExpr r _t [ arg ] "($0 * 10000000000000000000000000000)" |> Some
+                // float → fixed-scale. Scaling by 10^28 in float arithmetic would be lossy
+                // (10^28 is not a representable double), so go via the float's decimal string.
+                Helper.LibCall(com, "fable_decimal", "from_float", _t, [ arg ], ?loc = r)
+                |> Some
+            | _ -> Helper.LibCall(com, "fable_decimal", "from_int", _t, [ arg ], ?loc = r) |> Some
+        | _ -> Helper.LibCall(com, "fable_decimal", "from_int", _t, [ arg ], ?loc = r) |> Some
     | "ToString", [ arg ] ->
         match arg.Type with
         | Type.String -> Some arg
@@ -1477,13 +1477,15 @@ let private numericTypes
     | "get_MaxValue", None, _ -> Helper.LibCall(com, "fable_decimal", "max_value", t, [], ?loc = r) |> Some
     | "get_MinValue", None, _ -> Helper.LibCall(com, "fable_decimal", "min_value", t, [], ?loc = r) |> Some
     // Explicit conversions to and from decimal (`decimal x`, `int d`, `float d`).
-    // Decimals are fixed-scale integers (value × 10^28), so converting is scaling.
+    // Decimals are fixed-scale integers (value × 10^28), so converting is scaling. The scale
+    // lives in fable_decimal, so go through it rather than inlining the factor here — scaling
+    // a float by 10^28 in float arithmetic is lossy, since 10^28 is not a representable double.
     | "op_Explicit", None, [ arg ] ->
         match t, arg.Type with
         | Number(Decimal, _), Number(Decimal, _) -> Some arg
         | Number(Decimal, _), Number((Float16 | Float32 | Float64), _) ->
-            emitExpr r t [ arg ] "trunc($0 * 10000000000000000000000000000)" |> Some
-        | Number(Decimal, _), _ -> emitExpr r t [ arg ] "($0 * 10000000000000000000000000000)" |> Some
+            Helper.LibCall(com, "fable_decimal", "from_float", t, [ arg ], ?loc = r) |> Some
+        | Number(Decimal, _), _ -> Helper.LibCall(com, "fable_decimal", "from_int", t, [ arg ], ?loc = r) |> Some
         | Number((Float16 | Float32 | Float64), _), _ ->
             Helper.LibCall(com, "fable_decimal", "to_number", t, [ arg ], ?loc = r) |> Some
         // Chars are integers on Beam, so `char d` truncates like the integer conversions
@@ -2183,8 +2185,14 @@ let private arrays
     | "IndexOf", None, [ arr; value ] ->
         let arr = derefArr r arr
         Helper.LibCall(com, "fable_list", "index_of_value", t, [ value; arr ]) |> Some
-    // Iterating an array as a non-generic IEnumerable (e.g. `for v in Enum.GetValues t do`)
-    | "GetEnumerator", Some c, _ -> emitExpr r t [ c ] "fable_utils:get_enumerator(erlang:get($0))" |> Some
+    // Iterating an array as a non-generic IEnumerable (e.g. `for v in Enum.GetValues t do`).
+    // Deref via derefArr so byte arrays (atomics, not process-dict refs) are handled too;
+    // the non-generic System.Array of Enum.GetValues stays a ref, which get_enumerator accepts.
+    | "GetEnumerator", Some c, _ ->
+        let arr = derefArr r c
+
+        Helper.LibCall(com, "fable_utils", "get_enumerator", t, [ arr ], ?loc = r)
+        |> Some
     | _ -> None
 
 /// Beam-specific Array module replacements.

--- a/src/Fable.Transforms/Beam/Replacements.fs
+++ b/src/Fable.Transforms/Beam/Replacements.fs
@@ -110,6 +110,13 @@ let private wrapArr (com: ICompiler) r (t: Type) (expr: Expr) =
     | Array _ -> Helper.LibCall(com, "fable_utils", "new_ref", t, [ expr ], ?loc = r)
     | _ -> expr
 
+/// Wrap a plain list result as an array ref even when the declared type is not a Fable `Array`
+/// (e.g. the non-generic `System.Array` returned by `Enum.GetValues`), which `wrapArr` skips.
+let private asArrayRef (com: ICompiler) r (t: Type) (expr: Expr) =
+    match t with
+    | Array _ -> wrapArr com r t expr
+    | _ -> Helper.LibCall(com, "fable_utils", "new_ref", t, [ expr ], ?loc = r)
+
 let private getOne (com: ICompiler) (ctx: Context) (t: Type) =
     match t with
     | Boolean -> makeBoolConst true
@@ -1463,8 +1470,20 @@ let private numericTypes
     | "get_Zero", None, _ -> makeIntConst 0 |> Some
     | "get_One", None, _ -> Helper.LibCall(com, "fable_decimal", "get_one", t, [], ?loc = r) |> Some
     | "get_MinusOne", None, _ -> Helper.LibCall(com, "fable_decimal", "get_minus_one", t, [], ?loc = r) |> Some
-    // MaxValue / MinValue
-    | ("get_MaxValue" | "get_MinValue"), None, _ -> None // Not yet supported
+    | "get_MaxValue", None, _ -> Helper.LibCall(com, "fable_decimal", "max_value", t, [], ?loc = r) |> Some
+    | "get_MinValue", None, _ -> Helper.LibCall(com, "fable_decimal", "min_value", t, [], ?loc = r) |> Some
+    // Explicit conversions to and from decimal (`decimal x`, `int d`, `float d`).
+    // Decimals are fixed-scale integers (value × 10^28), so converting is scaling.
+    | "op_Explicit", None, [ arg ] ->
+        match t, arg.Type with
+        | Number(Decimal, _), Number(Decimal, _) -> Some arg
+        | Number(Decimal, _), Number((Float16 | Float32 | Float64), _) ->
+            emitExpr r t [ arg ] "trunc($0 * 10000000000000000000000000000)" |> Some
+        | Number(Decimal, _), _ -> emitExpr r t [ arg ] "($0 * 10000000000000000000000000000)" |> Some
+        | Number((Float16 | Float32 | Float64), _), _ ->
+            Helper.LibCall(com, "fable_decimal", "to_number", t, [ arg ], ?loc = r) |> Some
+        | Number(_, _), _ -> Helper.LibCall(com, "fable_decimal", "to_int", t, [ arg ], ?loc = r) |> Some
+        | _ -> None
     | _ -> None
 
 /// Beam-specific System.Convert replacements.
@@ -2159,6 +2178,8 @@ let private arrays
     | "IndexOf", None, [ arr; value ] ->
         let arr = derefArr r arr
         Helper.LibCall(com, "fable_list", "index_of_value", t, [ value; arr ]) |> Some
+    // Iterating an array as a non-generic IEnumerable (e.g. `for v in Enum.GetValues t do`)
+    | "GetEnumerator", Some c, _ -> emitExpr r t [ c ] "fable_utils:get_enumerator(erlang:get($0))" |> Some
     | _ -> None
 
 /// Beam-specific Array module replacements.
@@ -3950,6 +3971,12 @@ let tryField (com: ICompiler) returnTyp ownerTyp fieldName : Expr option =
     | Number(Decimal, _), "MinusOne" ->
         Helper.LibCall(com, "fable_decimal", "get_minus_one", returnTyp, [], ?loc = None)
         |> Some
+    | Number(Decimal, _), "MinValue" ->
+        Helper.LibCall(com, "fable_decimal", "min_value", returnTyp, [], ?loc = None)
+        |> Some
+    | Number(Decimal, _), "MaxValue" ->
+        Helper.LibCall(com, "fable_decimal", "max_value", returnTyp, [], ?loc = None)
+        |> Some
     | Number(Decimal, _), _ -> None
     | String, "Empty" -> makeStrConst "" |> Some
     | DeclaredType(ent, _), fieldName ->
@@ -5340,6 +5367,88 @@ let tryResolveTypeInfo
         | _ -> None
     | _ -> None
 
+/// FSharp.Reflection.FSharpType.
+///
+/// The `FSharpReflectionExtensions` overloads pass an extra `allowAccessToPrivateRepresentation`
+/// (or `BindingFlags`) argument. Erlang has no private representations to hide, so — as on JS —
+/// the flag is ignored and only the leading arguments are forwarded.
+let private fsharpType (com: ICompiler) r (t: Type) (methName: string) (args: Expr list) =
+    match methName, args with
+    | "MakeTupleType", typesArr :: _ ->
+        let derefed = derefArr r typesArr
+
+        Helper.LibCall(com, "fable_reflection", "make_tuple_type", t, [ derefed ], ?loc = r)
+        |> Some
+    | "GetRecordFields", typ :: _ ->
+        Helper.LibCall(com, "fable_reflection", "get_record_elements", t, [ typ ], ?loc = r)
+        |> wrapArr com r t
+        |> Some
+    | "GetUnionCases", typ :: _ ->
+        Helper.LibCall(com, "fable_reflection", "get_union_cases", t, [ typ ], ?loc = r)
+        |> wrapArr com r t
+        |> Some
+    | "GetTupleElements", typ :: _ ->
+        Helper.LibCall(com, "fable_reflection", "get_tuple_elements", t, [ typ ], ?loc = r)
+        |> wrapArr com r t
+        |> Some
+    | "GetFunctionElements", typ :: _ ->
+        Helper.LibCall(com, "fable_reflection", "get_function_elements", t, [ typ ], ?loc = r)
+        |> Some
+    | "IsRecord", typ :: _ ->
+        Helper.LibCall(com, "fable_reflection", "is_record", t, [ typ ], ?loc = r)
+        |> Some
+    | "IsUnion", typ :: _ ->
+        Helper.LibCall(com, "fable_reflection", "is_union", t, [ typ ], ?loc = r)
+        |> Some
+    | "IsTuple", typ :: _ ->
+        Helper.LibCall(com, "fable_reflection", "is_tuple_type", t, [ typ ], ?loc = r)
+        |> Some
+    | "IsFunction", typ :: _ ->
+        Helper.LibCall(com, "fable_reflection", "is_function_type", t, [ typ ], ?loc = r)
+        |> Some
+    | _ -> None
+
+/// FSharp.Reflection.FSharpValue. See `fsharpType` for the extension overloads.
+let private fsharpValue (com: ICompiler) r (t: Type) (methName: string) (args: Expr list) =
+    match methName, args with
+    | "MakeTuple", values :: _ ->
+        // MakeTuple(values, tupleType) — values is an array ref, convert to Erlang tuple
+        emitExpr r t [ values ] "list_to_tuple(erlang:get($0))" |> Some
+    | "GetTupleFields", tuple :: _ ->
+        Helper.LibCall(com, "fable_reflection", "get_tuple_fields_value", t, [ tuple ], ?loc = r)
+        |> wrapArr com r t
+        |> Some
+    | "GetTupleField", tuple :: index :: _ ->
+        Helper.LibCall(com, "fable_reflection", "get_tuple_field_value", t, [ tuple; index ], ?loc = r)
+        |> Some
+    | "GetRecordFields", record :: _ ->
+        // Inject type info at compile time since Erlang maps don't preserve order
+        // Look through TypeCast to get the concrete type (since GetRecordFields takes obj)
+        let rec getConcreteType (expr: Expr) =
+            match expr with
+            | TypeCast(inner, _) -> getConcreteType inner
+            | _ -> expr.Type
+
+        let concreteType = getConcreteType record
+        let typeInfo = Value(TypeInfo(concreteType, []), None)
+
+        Helper.LibCall(com, "fable_reflection", "get_record_fields_value", t, [ record; typeInfo ], ?loc = r)
+        |> wrapArr com r t
+        |> Some
+    | "GetRecordField", record :: propInfo :: _ ->
+        Helper.LibCall(com, "fable_reflection", "get_record_field_value", t, [ record; propInfo ], ?loc = r)
+        |> Some
+    | "MakeRecord", typ :: values :: _ ->
+        Helper.LibCall(com, "fable_reflection", "make_record_from_values", t, [ typ; values ], ?loc = r)
+        |> Some
+    | "GetUnionFields", union :: typ :: _ ->
+        Helper.LibCall(com, "fable_reflection", "get_union_fields_value", t, [ union; typ ], ?loc = r)
+        |> Some
+    | "MakeUnion", caseInfo :: values :: _ ->
+        Helper.LibCall(com, "fable_reflection", "make_union_value", t, [ caseInfo; values ], ?loc = r)
+        |> Some
+    | _ -> None
+
 let tryCall
     (com: ICompiler)
     (ctx: Context)
@@ -5754,11 +5863,77 @@ let tryCall
                 Helper.LibCall(com, "fable_reflection", "get_generics", t, [ c ], ?loc = r)
                 |> wrapArr com r t
                 |> Some
+            | "MakeGenericType", Some c ->
+                Helper.LibCall(com, "fable_reflection", "make_generic_type", t, c :: args, ?loc = r)
+                |> Some
+            | "get_IsEnum", Some c -> Helper.LibCall(com, "fable_reflection", "is_enum", t, [ c ], ?loc = r) |> Some
+            | "GetEnumUnderlyingType", Some c ->
+                Helper.LibCall(com, "fable_reflection", "get_enum_underlying_type", t, [ c ], ?loc = r)
+                |> Some
+            | "GetEnumValues", Some c ->
+                // Returns the non-generic System.Array, which is not a Fable `Array` type, so
+                // wrapArr would leave it unwrapped. Arrays are refs on Beam, so wrap it here.
+                Helper.LibCall(com, "fable_reflection", "get_enum_values", t, [ c ], ?loc = r)
+                |> asArrayRef com r t
+                |> Some
+            | "GetEnumNames", Some c ->
+                Helper.LibCall(com, "fable_reflection", "get_enum_names", t, [ c ], ?loc = r)
+                |> wrapArr com r t
+                |> Some
             | _ -> None
+    // System.Activator
+    | "System.Activator" ->
+        match info.CompiledName, args with
+        | "CreateInstance", [] ->
+            // Generic overload: `Activator.CreateInstance<'T>()`
+            let typeInfo = genArg com ctx r 0 info.GenericArgs |> makeTypeInfo r
+
+            Helper.LibCall(com, "fable_reflection", "create_instance", t, [ typeInfo; makeArray Any [] ], ?loc = r)
+            |> Some
+        | "CreateInstance", [ typ ] ->
+            Helper.LibCall(com, "fable_reflection", "create_instance", t, [ typ; makeArray Any [] ], ?loc = r)
+            |> Some
+        | "CreateInstance", [ typ; consArgs ] ->
+            Helper.LibCall(com, "fable_reflection", "create_instance", t, [ typ; consArgs ], ?loc = r)
+            |> Some
+        | _ -> None
     // System.Enum
     | "System.Enum" ->
         match info.CompiledName, thisArg, args with
         | "HasFlag", Some value, [ flag ] -> emitExpr r t [ value; flag ] "(($0 band $1) =:= $1)" |> Some
+        // Static methods taking the enum's Type as first argument
+        | "GetUnderlyingType", None, [ typ ] ->
+            Helper.LibCall(com, "fable_reflection", "get_enum_underlying_type", t, [ typ ], ?loc = r)
+            |> Some
+        | "GetValues", None, [ typ ] ->
+            Helper.LibCall(com, "fable_reflection", "get_enum_values", t, [ typ ], ?loc = r)
+            |> asArrayRef com r t
+            |> Some
+        | "GetNames", None, [ typ ] ->
+            Helper.LibCall(com, "fable_reflection", "get_enum_names", t, [ typ ], ?loc = r)
+            |> wrapArr com r t
+            |> Some
+        | "GetName", None, [ typ; value ] ->
+            Helper.LibCall(com, "fable_reflection", "get_enum_name", t, [ typ; value ], ?loc = r)
+            |> Some
+        | "IsDefined", None, [ typ; value ] ->
+            Helper.LibCall(com, "fable_reflection", "is_enum_defined", t, [ typ; value ], ?loc = r)
+            |> Some
+        | "Parse", None, [ typ; value ] ->
+            Helper.LibCall(com, "fable_reflection", "parse_enum", t, [ typ; value ], ?loc = r)
+            |> Some
+        // The generic overloads (`Enum.Parse<Suit> s`) take the enum type from the
+        // return type / generic argument rather than from an argument.
+        | "Parse", None, [ value ] ->
+            let typeInfo = makeTypeInfo r t
+
+            Helper.LibCall(com, "fable_reflection", "parse_enum", t, [ typeInfo; value ], ?loc = r)
+            |> Some
+        | "TryParse", None, [ value; outRef ] ->
+            let typeInfo = genArg com ctx r 0 info.GenericArgs |> makeTypeInfo r
+
+            Helper.LibCall(com, "fable_reflection", "try_parse_enum", t, [ typeInfo; value; outRef ], ?loc = r)
+            |> Some
         | _ -> None
     // Lazy — lazy values use process dict for memoization
     | "System.Lazy`1"
@@ -5804,76 +5979,20 @@ let tryCall
                 emitExpr r t (callee :: args) $"($0)(%s{placeholders})" |> Some
         | _ -> None
     // F# Reflection
-    | "Microsoft.FSharp.Reflection.FSharpType" ->
-        match info.CompiledName, args with
-        | "MakeTupleType", [ typesArr ] ->
-            let derefed = derefArr r typesArr
+    | "Microsoft.FSharp.Reflection.FSharpType" -> fsharpType com r t info.CompiledName args
+    | "Microsoft.FSharp.Reflection.FSharpValue" -> fsharpValue com r t info.CompiledName args
+    | "Microsoft.FSharp.Reflection.FSharpReflectionExtensions" ->
+        // In netcore the F# Reflection methods become static extensions
+        // with names like `FSharpType.IsUnion.Static`
+        let isFSharpType =
+            info.CompiledName.StartsWith("FSharpType", System.StringComparison.Ordinal)
 
-            Helper.LibCall(com, "fable_reflection", "make_tuple_type", t, [ derefed ], ?loc = r)
-            |> Some
-        | "GetRecordFields", _ ->
-            Helper.LibCall(com, "fable_reflection", "get_record_elements", t, args, ?loc = r)
-            |> wrapArr com r t
-            |> Some
-        | "GetUnionCases", _ ->
-            Helper.LibCall(com, "fable_reflection", "get_union_cases", t, args, ?loc = r)
-            |> wrapArr com r t
-            |> Some
-        | "GetTupleElements", _ ->
-            Helper.LibCall(com, "fable_reflection", "get_tuple_elements", t, args, ?loc = r)
-            |> wrapArr com r t
-            |> Some
-        | "GetFunctionElements", _ ->
-            Helper.LibCall(com, "fable_reflection", "get_function_elements", t, args, ?loc = r)
-            |> Some
-        | "IsRecord", _ -> Helper.LibCall(com, "fable_reflection", "is_record", t, args, ?loc = r) |> Some
-        | "IsUnion", _ -> Helper.LibCall(com, "fable_reflection", "is_union", t, args, ?loc = r) |> Some
-        | "IsTuple", _ ->
-            Helper.LibCall(com, "fable_reflection", "is_tuple_type", t, args, ?loc = r)
-            |> Some
-        | "IsFunction", _ ->
-            Helper.LibCall(com, "fable_reflection", "is_function_type", t, args, ?loc = r)
-            |> Some
-        | _ -> None
-    | "Microsoft.FSharp.Reflection.FSharpValue" ->
-        match info.CompiledName, args with
-        | "MakeTuple", [ values; _ ] ->
-            // MakeTuple(values, tupleType) — values is an array ref, convert to Erlang tuple
-            emitExpr r t [ values ] "list_to_tuple(erlang:get($0))" |> Some
-        | "GetTupleFields", [ tuple ] ->
-            Helper.LibCall(com, "fable_reflection", "get_tuple_fields_value", t, [ tuple ], ?loc = r)
-            |> wrapArr com r t
-            |> Some
-        | "GetTupleField", [ tuple; index ] ->
-            Helper.LibCall(com, "fable_reflection", "get_tuple_field_value", t, [ tuple; index ], ?loc = r)
-            |> Some
-        | "GetRecordFields", [ record ] ->
-            // Inject type info at compile time since Erlang maps don't preserve order
-            // Look through TypeCast to get the concrete type (since GetRecordFields takes obj)
-            let rec getConcreteType (expr: Expr) =
-                match expr with
-                | TypeCast(inner, _) -> getConcreteType inner
-                | _ -> expr.Type
+        let methName = info.CompiledName |> Naming.extensionMethodName
 
-            let concreteType = getConcreteType record
-            let typeInfo = Value(TypeInfo(concreteType, []), None)
-
-            Helper.LibCall(com, "fable_reflection", "get_record_fields_value", t, [ record; typeInfo ], ?loc = r)
-            |> wrapArr com r t
-            |> Some
-        | "GetRecordField", [ record; propInfo ] ->
-            Helper.LibCall(com, "fable_reflection", "get_record_field_value", t, [ record; propInfo ], ?loc = r)
-            |> Some
-        | "MakeRecord", [ typ; values ] ->
-            Helper.LibCall(com, "fable_reflection", "make_record_from_values", t, [ typ; values ], ?loc = r)
-            |> Some
-        | "GetUnionFields", [ union; typ ] ->
-            Helper.LibCall(com, "fable_reflection", "get_union_fields_value", t, [ union; typ ], ?loc = r)
-            |> Some
-        | "MakeUnion", [ caseInfo; values ] ->
-            Helper.LibCall(com, "fable_reflection", "make_union_value", t, [ caseInfo; values ], ?loc = r)
-            |> Some
-        | _ -> None
+        if isFSharpType then
+            fsharpType com r t methName args
+        else
+            fsharpValue com r t methName args
     // PropertyInfo and UnionCaseInfo
     | "Microsoft.FSharp.Reflection.UnionCaseInfo"
     | "System.Reflection.PropertyInfo"

--- a/src/Fable.Transforms/Beam/Replacements.fs
+++ b/src/Fable.Transforms/Beam/Replacements.fs
@@ -383,7 +383,9 @@ let private operators
     | "ToChar", [ arg ] ->
         match arg.Type with
         | Type.String -> emitExpr r _t [ arg ] "binary:first($0)" |> Some
-        | _ -> Some arg
+        // Decimals are fixed-scale integers, so they need unscaling first
+        | Type.Number(Decimal, _) -> Helper.LibCall(com, "fable_decimal", "to_int", _t, [ arg ], ?loc = r) |> Some
+        | _ -> Some arg // other numbers are already chars in Erlang
     // CreateSet: the `set [1;2;3]` syntax
     | "CreateSet", [ arg ] -> emitExpr r _t [ arg ] "ordsets:from_list($0)" |> Some
     // CreateDictionary: the `dict [...]` syntax
@@ -1378,7 +1380,9 @@ let private conversions
     | "ToChar", [ arg ] ->
         match arg.Type with
         | Type.String -> emitExpr r t [ arg ] "binary:first($0)" |> Some
-        | _ -> Some arg // numbers are already chars in Erlang
+        // Decimals are fixed-scale integers, so they need unscaling first
+        | Type.Number(Decimal, _) -> Helper.LibCall(com, "fable_decimal", "to_int", t, [ arg ], ?loc = r) |> Some
+        | _ -> Some arg // other numbers are already chars in Erlang
     | _ -> None
 
 /// Beam-specific numeric type method replacements (Parse, ToString, Equals, CompareTo, GetHashCode).
@@ -1482,7 +1486,8 @@ let private numericTypes
         | Number(Decimal, _), _ -> emitExpr r t [ arg ] "($0 * 10000000000000000000000000000)" |> Some
         | Number((Float16 | Float32 | Float64), _), _ ->
             Helper.LibCall(com, "fable_decimal", "to_number", t, [ arg ], ?loc = r) |> Some
-        | Number(_, _), _ -> Helper.LibCall(com, "fable_decimal", "to_int", t, [ arg ], ?loc = r) |> Some
+        // Chars are integers on Beam, so `char d` truncates like the integer conversions
+        | (Number(_, _) | Char), _ -> Helper.LibCall(com, "fable_decimal", "to_int", t, [ arg ], ?loc = r) |> Some
         | _ -> None
     | _ -> None
 

--- a/src/fable-library-beam/fable_decimal.erl
+++ b/src/fable-library-beam/fable_decimal.erl
@@ -7,6 +7,8 @@
     to_string/1,
     to_number/1,
     to_int/1,
+    from_int/1,
+    from_float/1,
     from_parts/5,
     parse/1,
     try_parse/2,
@@ -28,6 +30,8 @@
 -spec to_string(integer()) -> binary().
 -spec to_number(integer()) -> float().
 -spec to_int(integer()) -> integer().
+-spec from_int(integer()) -> integer().
+-spec from_float(float() | integer()) -> integer().
 -spec from_parts(integer(), integer(), integer(), boolean(), non_neg_integer()) -> integer().
 -spec parse(binary()) -> integer().
 -spec try_parse(binary(), reference()) -> boolean().
@@ -114,6 +118,35 @@ to_number(X) ->
 %% Convert fixed-scale decimal to integer (truncate)
 to_int(X) ->
     X div ?SCALE28.
+
+%% Convert an integer to a fixed-scale decimal.
+from_int(X) when is_integer(X) ->
+    X * ?SCALE28.
+
+%% Convert a float to a fixed-scale decimal, via the float's shortest round-tripping
+%% decimal string. Scaling with float arithmetic (`trunc(X * 10^28)`) would not do: 10^28
+%% is not representable as a double, so `decimal 1.0` would come out as
+%% 9999999999999999583119736832 rather than 10^28 and compare unequal to the literal `1.0M`.
+from_float(X) when is_float(X) ->
+    parse_float_string(float_to_binary(X, [short]));
+from_float(X) when is_integer(X) ->
+    from_int(X).
+
+%% `float_to_binary/2` falls back to scientific notation for large/small magnitudes
+%% (`<<"1.0e30">>`), which `parse/1` does not accept, so split the exponent off here.
+parse_float_string(Bin) ->
+    case binary:split(Bin, [<<"e">>, <<"E">>]) of
+        [Mantissa] ->
+            parse(Mantissa);
+        [Mantissa, Exp] ->
+            shift(parse(Mantissa), binary_to_integer(Exp))
+    end.
+
+%% Multiply a fixed-scale decimal by 10^Exp.
+shift(Value, Exp) when Exp >= 0 ->
+    Value * pow10(Exp);
+shift(Value, Exp) ->
+    Value div pow10(-Exp).
 
 %% MakeDecimal(low, mid, high, isNegative, scale)
 %% low/mid/high are signed int32 from .NET — mask to unsigned

--- a/src/fable-library-beam/fable_decimal.erl
+++ b/src/fable-library-beam/fable_decimal.erl
@@ -12,6 +12,8 @@
     try_parse/2,
     get_one/0,
     get_minus_one/0,
+    min_value/0,
+    max_value/0,
     round_decimal/1,
     round_decimal/2,
     ceil_decimal/1,
@@ -31,6 +33,8 @@
 -spec try_parse(binary(), reference()) -> boolean().
 -spec get_one() -> integer().
 -spec get_minus_one() -> integer().
+-spec min_value() -> integer().
+-spec max_value() -> integer().
 -spec round_decimal(integer()) -> integer().
 -spec round_decimal(integer(), non_neg_integer()) -> integer().
 -spec ceil_decimal(integer()) -> integer().
@@ -173,6 +177,16 @@ get_one() ->
 
 get_minus_one() ->
     -?SCALE28.
+
+%% System.Decimal.MinValue / MaxValue — the .NET decimal range (±(2^96 - 1)),
+%% expressed in the fixed-scale representation.
+-define(DECIMAL_LIMIT, 79228162514264337593543950335).
+
+min_value() ->
+    -?DECIMAL_LIMIT * ?SCALE28.
+
+max_value() ->
+    ?DECIMAL_LIMIT * ?SCALE28.
 
 %% Round decimal to nearest integer (banker's rounding / round half to even).
 %% Returns a fixed-scale decimal (integer part × SCALE28).

--- a/src/fable-library-beam/fable_reflection.erl
+++ b/src/fable-library-beam/fable_reflection.erl
@@ -25,7 +25,17 @@
     get_union_case_fields/1,
     get_union_fields_value/2,
     make_union_value/2,
-    get_value/2
+    get_value/2,
+    is_enum/1,
+    get_enum_underlying_type/1,
+    get_enum_values/1,
+    get_enum_names/1,
+    get_enum_name/2,
+    is_enum_defined/2,
+    parse_enum/2,
+    try_parse_enum/3,
+    make_generic_type/2,
+    create_instance/2
 ]).
 
 -spec full_name(map()) -> binary().
@@ -54,6 +64,16 @@
 -spec get_union_fields_value(term(), map()) -> {map(), list()}.
 -spec make_union_value(map(), list() | reference()) -> term().
 -spec get_value(map(), map()) -> term().
+-spec is_enum(term()) -> boolean().
+-spec get_enum_underlying_type(map()) -> map().
+-spec get_enum_values(map()) -> list().
+-spec get_enum_names(map()) -> list().
+-spec get_enum_name(map(), integer()) -> binary().
+-spec is_enum_defined(map(), integer() | binary()) -> boolean().
+-spec parse_enum(map(), binary()) -> integer().
+-spec try_parse_enum(map(), binary(), reference()) -> boolean().
+-spec make_generic_type(map(), list() | reference()) -> map().
+-spec create_instance(map(), list() | reference()) -> term().
 
 full_name(TypeInfo) ->
     maps:get(fullname, TypeInfo).
@@ -199,6 +219,8 @@ get_union_case_fields(CaseInfo) ->
     force(maps:get(fields, CaseInfo, [])).
 
 %% FSharpValue.GetUnionFields(value, typeInfo) — returns {CaseInfo, FieldValues}.
+%% FieldValues is typed `obj[]` by the compiler, so it must be an array ref. The result is a
+%% tuple, so the compiler cannot wrap it at the call site the way it does for GetRecordFields.
 get_union_fields_value(Value, TypeInfo) ->
     Cases = force(maps:get(cases, TypeInfo)),
     %% Determine the atom tag from the value
@@ -224,7 +246,7 @@ get_union_fields_value(Value, TypeInfo) ->
             true ->
                 []
         end,
-    {CaseInfo, Fields}.
+    {CaseInfo, fable_utils:new_ref(Fields)}.
 
 %% FSharpValue.MakeUnion(caseInfo, values) — create union value from case info.
 make_union_value(CaseInfo, Values) ->
@@ -246,7 +268,115 @@ get_value(PropInfo, Obj) ->
     Name = maps:get(name, PropInfo),
     maps:get(binary_to_atom(Name), Obj).
 
+%% --- Enums ---
+%% An enum type info carries `enum_cases => [{Name, Value}]` and its underlying
+%% numeric type as the single entry in `generics`.
+
+%% Type.IsEnum
+is_enum(TypeInfo) when is_map(TypeInfo) ->
+    maps:get(enum_cases, TypeInfo, []) =/= [];
+is_enum(_) ->
+    false.
+
+%% Type.GetEnumUnderlyingType / Enum.GetUnderlyingType
+get_enum_underlying_type(TypeInfo) ->
+    case maps:get(generics, TypeInfo, []) of
+        [Underlying | _] -> Underlying;
+        [] -> erlang:error({not_enum_type, maps:get(fullname, TypeInfo, <<"unknown">>)})
+    end.
+
+%% Enum.GetValues
+get_enum_values(TypeInfo) ->
+    [Value || {_Name, Value} <- enum_cases(TypeInfo)].
+
+%% Enum.GetNames
+get_enum_names(TypeInfo) ->
+    [Name || {Name, _Value} <- enum_cases(TypeInfo)].
+
+%% Enum.GetName — .NET returns undefined when no case matches.
+get_enum_name(TypeInfo, Value) ->
+    case lists:keyfind(Value, 2, enum_cases(TypeInfo)) of
+        {Name, _} -> Name;
+        false -> undefined
+    end.
+
+%% Enum.IsDefined — accepts either a case name or a value.
+is_enum_defined(TypeInfo, NameOrValue) ->
+    Cases = enum_cases(TypeInfo),
+
+    case is_binary(NameOrValue) of
+        true -> lists:keyfind(NameOrValue, 1, Cases) =/= false;
+        false -> lists:keyfind(NameOrValue, 2, Cases) =/= false
+    end.
+
+%% Enum.Parse
+parse_enum(TypeInfo, Name) ->
+    case lists:keyfind(Name, 1, enum_cases(TypeInfo)) of
+        {_, Value} ->
+            Value;
+        false ->
+            erlang:error(
+                {enum_case_not_found, maps:get(fullname, TypeInfo, <<"unknown">>), Name}
+            )
+    end.
+
+%% Enum.TryParse — F# out-parameter pattern: sets the out-ref and returns a boolean.
+try_parse_enum(TypeInfo, Name, OutRef) ->
+    case lists:keyfind(Name, 1, enum_cases(TypeInfo)) of
+        {_, Value} ->
+            erlang:put(OutRef, Value),
+            true;
+        false ->
+            erlang:put(OutRef, 0),
+            false
+    end.
+
+%% --- Type construction ---
+
+%% Type.MakeGenericType — substitute the generic arguments, keeping the rest of the type
+%% info (including the lazy fields/cases) intact. Mirrors makeGenericType in fable-library-ts.
+make_generic_type(TypeInfo, Generics) ->
+    maps:put(generics, deref(Generics), TypeInfo).
+
+%% Activator.CreateInstance. Beam has no runtime constructors attached to type infos, so this
+%% covers records (built from their field values) and the primitives that have a zero value.
+create_instance(TypeInfo, Args) ->
+    case is_record(TypeInfo) of
+        true ->
+            make_record_from_values(TypeInfo, deref(Args));
+        false ->
+            case maps:get(fullname, TypeInfo, <<>>) of
+                <<"System.String">> -> <<>>;
+                <<"System.Boolean">> -> false;
+                <<"System.Char">> -> 0;
+                <<"System.Double">> -> 0.0;
+                <<"System.Single">> -> 0.0;
+                <<"System.SByte">> -> 0;
+                <<"System.Byte">> -> 0;
+                <<"System.Int16">> -> 0;
+                <<"System.UInt16">> -> 0;
+                <<"System.Int32">> -> 0;
+                <<"System.UInt32">> -> 0;
+                <<"System.Int64">> -> 0;
+                <<"System.UInt64">> -> 0;
+                <<"System.Decimal">> -> 0;
+                FullName -> erlang:error({cannot_create_instance, FullName})
+            end
+    end.
+
 %% --- Internal helpers ---
+
+%% Fable passes arrays as refs into the process dictionary.
+deref(Values) when is_reference(Values) ->
+    erlang:get(Values);
+deref(Values) when is_list(Values) ->
+    Values.
+
+enum_cases(TypeInfo) ->
+    case maps:get(enum_cases, TypeInfo, []) of
+        [] -> erlang:error({not_enum_type, maps:get(fullname, TypeInfo, <<"unknown">>)});
+        Cases -> Cases
+    end.
 
 %% Record fields and union cases are emitted as zero-arity funs so that a recursive type
 %% (whose fields mention the type itself) terminates: forcing a thunk yields a type info

--- a/src/fable-library-beam/fable_reflection.erl
+++ b/src/fable-library-beam/fable_reflection.erl
@@ -68,7 +68,7 @@
 -spec get_enum_underlying_type(map()) -> map().
 -spec get_enum_values(map()) -> list().
 -spec get_enum_names(map()) -> list().
--spec get_enum_name(map(), integer()) -> binary().
+-spec get_enum_name(map(), integer()) -> binary() | undefined.
 -spec is_enum_defined(map(), integer() | binary()) -> boolean().
 -spec parse_enum(map(), binary()) -> integer().
 -spec try_parse_enum(map(), binary(), reference()) -> boolean().
@@ -186,19 +186,20 @@ get_function_elements(TypeInfo) ->
 
 %% FSharpValue.GetRecordFields(record) — extract values in field order.
 %% TypeInfo is injected by the compiler since Erlang maps don't preserve order.
+%% Fields are keyed in the record map by `erl_name`, the sanitized name; `name` holds the
+%% F# name that PropertyInfo.Name reports and is not a valid key.
 get_record_fields_value(Record, TypeInfo) ->
     Fields = force(maps:get(fields, TypeInfo)),
-    [maps:get(binary_to_atom(maps:get(name, F)), Record) || F <- Fields].
+    [maps:get(maps:get(erl_name, F), Record) || F <- Fields].
 
 %% FSharpValue.GetRecordField(record, propertyInfo) — get single field value.
 get_record_field_value(Record, PropInfo) ->
-    Name = maps:get(name, PropInfo),
-    maps:get(binary_to_atom(Name), Record).
+    maps:get(maps:get(erl_name, PropInfo), Record).
 
 %% FSharpValue.MakeRecord(typeInfo, values) — create record from type info and values.
 make_record_from_values(TypeInfo, Values) ->
     Fields = force(maps:get(fields, TypeInfo)),
-    FieldNames = [binary_to_atom(maps:get(name, F)) || F <- Fields],
+    FieldNames = [maps:get(erl_name, F) || F <- Fields],
     ValList =
         case is_reference(Values) of
             true -> erlang:get(Values);
@@ -265,16 +266,16 @@ make_union_value(CaseInfo, Values) ->
 
 %% PropertyInfo.GetValue(propInfo, obj)
 get_value(PropInfo, Obj) ->
-    Name = maps:get(name, PropInfo),
-    maps:get(binary_to_atom(Name), Obj).
+    maps:get(maps:get(erl_name, PropInfo), Obj).
 
 %% --- Enums ---
 %% An enum type info carries `enum_cases => [{Name, Value}]` and its underlying
 %% numeric type as the single entry in `generics`.
 
-%% Type.IsEnum
+%% Type.IsEnum — keyed on the presence of `enum_cases`, not on it being non-empty,
+%% since an enum with no cases is still an enum.
 is_enum(TypeInfo) when is_map(TypeInfo) ->
-    maps:get(enum_cases, TypeInfo, []) =/= [];
+    maps:is_key(enum_cases, TypeInfo);
 is_enum(_) ->
     false.
 
@@ -373,9 +374,9 @@ deref(Values) when is_list(Values) ->
     Values.
 
 enum_cases(TypeInfo) ->
-    case maps:get(enum_cases, TypeInfo, []) of
-        [] -> erlang:error({not_enum_type, maps:get(fullname, TypeInfo, <<"unknown">>)});
-        Cases -> Cases
+    case maps:find(enum_cases, TypeInfo) of
+        {ok, Cases} -> Cases;
+        error -> erlang:error({not_enum_type, maps:get(fullname, TypeInfo, <<"unknown">>)})
     end.
 
 %% Record fields and union cases are emitted as zero-arity funs so that a recursive type

--- a/src/fable-library-beam/fable_reflection.erl
+++ b/src/fable-library-beam/fable_reflection.erl
@@ -112,7 +112,7 @@ make_tuple_type(TypeInfos) when is_list(TypeInfos) ->
 
 %% FSharpType.GetRecordFields — returns list of PropertyInfo maps.
 get_record_elements(#{fields := Fields}) ->
-    Fields;
+    force(Fields);
 get_record_elements(TypeInfo) ->
     erlang:error({not_record_type, maps:get(fullname, TypeInfo, <<"unknown">>)}).
 
@@ -130,7 +130,7 @@ is_union(_) ->
 
 %% FSharpType.GetUnionCases — returns list of CaseInfo maps.
 get_union_cases(#{cases := Cases}) ->
-    Cases;
+    force(Cases);
 get_union_cases(TypeInfo) ->
     erlang:error({not_union_type, maps:get(fullname, TypeInfo, <<"unknown">>)}).
 
@@ -167,7 +167,7 @@ get_function_elements(TypeInfo) ->
 %% FSharpValue.GetRecordFields(record) — extract values in field order.
 %% TypeInfo is injected by the compiler since Erlang maps don't preserve order.
 get_record_fields_value(Record, TypeInfo) ->
-    Fields = maps:get(fields, TypeInfo),
+    Fields = force(maps:get(fields, TypeInfo)),
     [maps:get(binary_to_atom(maps:get(name, F)), Record) || F <- Fields].
 
 %% FSharpValue.GetRecordField(record, propertyInfo) — get single field value.
@@ -177,7 +177,7 @@ get_record_field_value(Record, PropInfo) ->
 
 %% FSharpValue.MakeRecord(typeInfo, values) — create record from type info and values.
 make_record_from_values(TypeInfo, Values) ->
-    Fields = maps:get(fields, TypeInfo),
+    Fields = force(maps:get(fields, TypeInfo)),
     FieldNames = [binary_to_atom(maps:get(name, F)) || F <- Fields],
     ValList =
         case is_reference(Values) of
@@ -196,11 +196,11 @@ get_tuple_field_value(Tuple, Index) ->
 
 %% UnionCaseInfo.GetFields(caseInfo) — returns the case's field list.
 get_union_case_fields(CaseInfo) ->
-    maps:get(fields, CaseInfo, []).
+    force(maps:get(fields, CaseInfo, [])).
 
 %% FSharpValue.GetUnionFields(value, typeInfo) — returns {CaseInfo, FieldValues}.
 get_union_fields_value(Value, TypeInfo) ->
-    Cases = maps:get(cases, TypeInfo),
+    Cases = force(maps:get(cases, TypeInfo)),
     %% Determine the atom tag from the value
     Tag =
         if
@@ -247,6 +247,15 @@ get_value(PropInfo, Obj) ->
     maps:get(binary_to_atom(Name), Obj).
 
 %% --- Internal helpers ---
+
+%% Record fields and union cases are emitted as zero-arity funs so that a recursive type
+%% (whose fields mention the type itself) terminates: forcing a thunk yields a type info
+%% map whose own fields/cases are still unforced. Plain lists are accepted too, for the
+%% type infos that are still inlined (types with no generated Erlang module).
+force(Thunk) when is_function(Thunk, 0) ->
+    Thunk();
+force(List) when is_list(List) ->
+    List.
 
 starts_with(Bin, Prefix) ->
     PLen = byte_size(Prefix),

--- a/tests/Beam/ArithmeticTests.fs
+++ b/tests/Beam/ArithmeticTests.fs
@@ -530,6 +530,8 @@ let ``test Decimal literals can be generated`` () =
     0M |> equal Decimal.Zero
     1M |> equal Decimal.One
     -1M |> equal Decimal.MinusOne
+    79228162514264337593543950335M |> equal Decimal.MaxValue
+    -79228162514264337593543950335M |> equal Decimal.MinValue
 
 [<Fact>]
 let ``test Decimal.ToString works`` () =

--- a/tests/Beam/ConversionTests.fs
+++ b/tests/Beam/ConversionTests.fs
@@ -763,6 +763,19 @@ let ``test System.Convert.ToString Decimal works`` () =
 
 // --- Decimal conversions ---
 
+// Float-to-decimal must be exact, not a float multiply by the 10^28 scale: 10^28 is not a
+// representable double, so scaling in float arithmetic makes `decimal 1.0` land just short of
+// `1.0M`. The ToSingle/ToDouble tests below cannot catch that, since converting back divides
+// the error away again — these compare against the literal and the string instead.
+[<Fact>]
+let ``test Decimal from float is exact`` () =
+    decimal 1.0 |> equal 1.0M
+    decimal 0.1 |> equal 0.1M
+    decimal -2.5 |> equal -2.5M
+    decimal 1.0f |> equal 1.0M
+    string (decimal 1.0) |> equal "1"
+    string (decimal 0.1) |> equal "0.1"
+
 [<Fact>]
 let ``test Decimal.ToChar works`` () =
     let value = 'A'

--- a/tests/Beam/ConversionTests.fs
+++ b/tests/Beam/ConversionTests.fs
@@ -763,14 +763,60 @@ let ``test System.Convert.ToString Decimal works`` () =
 
 // --- Decimal conversions ---
 
-// TODO: System.Decimal.op_Explicit not supported by Fable Beam
-// #if FABLE_COMPILER
-// [<Fact>]
-// let ``test Decimal.ToSByte works`` () =
-//     let value = 0x02y
-//     sbyte (decimal (int32 value)) |> equal value
-// ... (all Decimal.To* tests need Decimal.op_Explicit)
-// #endif
+[<Fact>]
+let ``test Decimal.ToChar works`` () =
+    let value = 'A'
+    char (decimal (int32 value)) |> equal value
+
+[<Fact>]
+let ``test Decimal.ToSByte works`` () =
+    let value = 0x02y
+    sbyte (decimal (int32 value)) |> equal value
+
+[<Fact>]
+let ``test Decimal.ToInt16 works`` () =
+    let value = 0x0102s
+    int16 (decimal (int32 value)) |> equal value
+
+[<Fact>]
+let ``test Decimal.ToInt32 works`` () =
+    let value = 0x01020304
+    int32 (decimal value) |> equal value
+
+[<Fact>]
+let ``test Decimal.ToInt64 works`` () =
+    let value = 0x0102030405060708L
+    int64 (decimal value) |> equal value
+
+[<Fact>]
+let ``test Decimal.ToByte works`` () =
+    let value = 0x02uy
+    byte (decimal (uint32 value)) |> equal value
+
+[<Fact>]
+let ``test Decimal.ToUInt16 works`` () =
+    let value = 0xFF02us
+    uint16 (decimal (uint32 value)) |> equal value
+
+[<Fact>]
+let ``test Decimal.ToUInt32 works`` () =
+    let value = 0xFF020304u
+    uint32 (decimal value) |> equal value
+
+[<Fact>]
+let ``test Decimal.ToUInt64 works`` () =
+    let value = 0xFF02030405060708UL
+    uint64 (decimal value) |> equal value
+
+[<Fact>]
+let ``test Decimal.ToSingle works`` () =
+    let value = 1.0f
+    single (decimal value) |> equal value
+
+[<Fact>]
+let ``test Decimal.ToDouble works`` () =
+    let value = -1.0
+    double (decimal value) |> equal value
 
 // --- BigInt conversions ---
 

--- a/tests/Beam/Misc/Util2.fs
+++ b/tests/Beam/Misc/Util2.fs
@@ -12,6 +12,17 @@ type Helper3(i: int) =
 
 type H = Helper3
 
+// Reflection fixtures declared away from ReflectionTests.fs, so that reflecting over them
+// exercises the cross-module path: the type info is a remote call to the reflection function
+// generated in this file's module, rather than a local call.
+type CrossFileRecord = { Name: string; Count: int }
+
+type CrossFileTree =
+    | CrossFileLeaf of int
+    | CrossFileBranch of CrossFileTree * CrossFileTree
+
+type CrossFileGeneric<'T> = { Item: 'T; Rest: CrossFileGeneric<'T> option }
+
 
 module Extensions =
     type String with

--- a/tests/Beam/ReflectionTests.fs
+++ b/tests/Beam/ReflectionTests.fs
@@ -363,3 +363,106 @@ let ``test GetInterface works when types are known at compile time`` () =
     typeof<MyClass3<int>>.GetInterface("myInterface`1") |> isNull |> equal true
     typeof<MyClass3<int>>.GetInterface("myInterface`1", true) |> isNull |> equal false
     typeof<MyClass2>.GetInterface("MyInterface`1") |> isNull |> equal true
+
+// === Recursive types ===
+// Reflecting over a type whose fields mention the type itself must terminate, both when
+// emitting the type info and when forcing it at runtime.
+
+type Tree =
+    | Leaf of int
+    | Branch of Tree * Tree
+
+type LinkedNode = { Value: int; Next: LinkedNode option }
+
+type RecGeneric<'T> = { Head: 'T; Tail: RecGeneric<'T> option }
+
+type OddExpr =
+    | OddLit of int
+    | OddPair of EvenExpr
+
+and EvenExpr = { Left: OddExpr; Right: OddExpr }
+
+type MyList<'T> =
+    | Nil
+    | Cons of 'T * MyList<'T>
+
+// Same test as the JS and Python suites (tests/Js/Main/ReflectionTests.fs)
+[<Fact>]
+let ``test Recursive types work`` () =
+    let cons =
+        FSharpType.GetUnionCases(typeof<MyList<int>>)
+        |> Array.find (fun x -> x.Name = "Cons")
+
+    let fieldTypes = cons.GetFields()
+    fieldTypes.[0].PropertyType.FullName |> equal typeof<int>.FullName
+
+    fieldTypes.[1].PropertyType.GetGenericTypeDefinition().FullName
+    |> equal typedefof<MyList<obj>>.FullName
+
+[<Fact>]
+let ``test reflection of self-recursive union works`` () =
+    let cases = FSharpType.GetUnionCases typeof<Tree>
+    cases.Length |> equal 2
+    cases.[0].Name |> equal "Leaf"
+    cases.[1].Name |> equal "Branch"
+
+[<Fact>]
+let ``test reflection of self-recursive union case fields works`` () =
+    let cases = FSharpType.GetUnionCases typeof<Tree>
+    let branchFields = cases.[1].GetFields()
+    branchFields.Length |> equal 2
+    branchFields.[0].PropertyType |> equal typeof<Tree>
+    branchFields.[1].PropertyType |> equal typeof<Tree>
+
+[<Fact>]
+let ``test reflection of self-recursive record works`` () =
+    let fields = FSharpType.GetRecordFields typeof<LinkedNode>
+    fields.Length |> equal 2
+    fields.[0].PropertyType |> equal typeof<int>
+    fields.[1].PropertyType |> equal typeof<LinkedNode option>
+
+[<Fact>]
+let ``test reflection of recursive generic record works`` () =
+    let fields = FSharpType.GetRecordFields typeof<RecGeneric<string>>
+    fields.Length |> equal 2
+    fields.[0].PropertyType |> equal typeof<string>
+    fields.[1].PropertyType |> equal typeof<RecGeneric<string> option>
+
+[<Fact>]
+let ``test reflection of mutually recursive types works`` () =
+    let cases = FSharpType.GetUnionCases typeof<OddExpr>
+    cases.Length |> equal 2
+    let fields = FSharpType.GetRecordFields typeof<EvenExpr>
+    fields.Length |> equal 2
+    fields.[0].PropertyType |> equal typeof<OddExpr>
+
+[<Fact>]
+let ``test IsUnion and IsRecord work for recursive types`` () =
+    FSharpType.IsUnion typeof<Tree> |> equal true
+    FSharpType.IsRecord typeof<LinkedNode> |> equal true
+    FSharpType.IsRecord typeof<Tree> |> equal false
+    FSharpType.IsUnion typeof<LinkedNode> |> equal false
+
+[<Fact>]
+let ``test MakeUnion round-trips a recursive union`` () =
+    let cases = FSharpType.GetUnionCases typeof<Tree>
+    let leaf = FSharpValue.MakeUnion(cases.[0], [| box 42 |])
+    leaf |> equal (box (Leaf 42))
+
+    let branch =
+        FSharpValue.MakeUnion(cases.[1], [| box (Leaf 1); box (Leaf 2) |])
+
+    branch |> equal (box (Branch(Leaf 1, Leaf 2)))
+
+[<Fact>]
+let ``test MakeRecord round-trips a recursive record`` () =
+    let node =
+        FSharpValue.MakeRecord(typeof<LinkedNode>, [| box 1; box (Some { Value = 2; Next = None }) |])
+
+    node
+    |> equal (box { Value = 1; Next = Some { Value = 2; Next = None } })
+
+[<Fact>]
+let ``test recursive type FullName works`` () =
+    typeof<Tree>.FullName.EndsWith("Tree") |> equal true
+    typeof<LinkedNode>.FullName.EndsWith("LinkedNode") |> equal true

--- a/tests/Beam/ReflectionTests.fs
+++ b/tests/Beam/ReflectionTests.fs
@@ -573,21 +573,3 @@ let ``test Activator.CreateInstance guarded by Compiler.isDotnet compiles`` () =
 let ``test Type.MakeGenericType substitutes the generic arguments`` () =
     let t = typedefof<RecGeneric<obj>>.MakeGenericType [| typeof<string> |]
     t.GetGenericArguments().[0] |> equal typeof<string>
-
-// === Decimal ===
-
-[<Fact>]
-let ``test Decimal MinValue and MaxValue work`` () =
-    string System.Decimal.MinValue
-    |> equal "-79228162514264337593543950335"
-
-    string System.Decimal.MaxValue |> equal "79228162514264337593543950335"
-    System.Decimal.MinValue < 0M |> equal true
-    System.Decimal.MaxValue > 0M |> equal true
-
-[<Fact>]
-let ``test Decimal explicit conversions work`` () =
-    int 3.75M |> equal 3
-    float 3.75M |> equal 3.75
-    int64 3.75M |> equal 3L
-    decimal 3 |> equal 3M

--- a/tests/Beam/ReflectionTests.fs
+++ b/tests/Beam/ReflectionTests.fs
@@ -466,3 +466,128 @@ let ``test MakeRecord round-trips a recursive record`` () =
 let ``test recursive type FullName works`` () =
     typeof<Tree>.FullName.EndsWith("Tree") |> equal true
     typeof<LinkedNode>.FullName.EndsWith("LinkedNode") |> equal true
+
+// === FSharpReflectionExtensions (the allowAccessToPrivateRepresentation overloads) ===
+
+// Same test as the JS suite (tests/Js/Main/ReflectionTests.fs)
+[<Fact>]
+let ``test Reflection functions accept allowAccessToPrivateRepresentation`` () =
+    let recordType = typeof<MyRecord>
+    let record = { String = "a"; Int = 1 }
+
+    FSharpType
+        .GetRecordFields(recordType, allowAccessToPrivateRepresentation = true)
+        .Length
+    |> equal 2
+
+    let values =
+        FSharpValue.GetRecordFields(record, allowAccessToPrivateRepresentation = true)
+
+    let rebuilt =
+        FSharpValue.MakeRecord(recordType, values, allowAccessToPrivateRepresentation = true) :?> MyRecord
+
+    rebuilt |> equal record
+
+    let unionType = typeof<MyUnion>
+    let intCase = FSharpType.GetUnionCases(unionType).[1]
+
+    let u =
+        FSharpValue.MakeUnion(intCase, [| box 5 |], allowAccessToPrivateRepresentation = true) :?> MyUnion
+
+    let info, fields =
+        FSharpValue.GetUnionFields(u, unionType, allowAccessToPrivateRepresentation = true)
+
+    info.Name |> equal "IntCase"
+    fields.[0] |> equal (box 5)
+
+[<Fact>]
+let ``test IsRecord and IsUnion accept allowAccessToPrivateRepresentation`` () =
+    FSharpType.IsRecord(typeof<MyRecord>, allowAccessToPrivateRepresentation = true)
+    |> equal true
+
+    FSharpType.IsUnion(typeof<MyUnion>, allowAccessToPrivateRepresentation = true)
+    |> equal true
+
+    FSharpType.IsRecord(typeof<MyUnion>, allowAccessToPrivateRepresentation = true)
+    |> equal false
+
+// === Enums ===
+
+type MyEnum =
+    | Foo = 1y
+    | Bar = 5y
+    | Baz = 8y
+
+// Same test as the JS suite (tests/Js/Main/ReflectionTests.fs)
+[<Fact>]
+let ``test Reflection works with enums`` () =
+    typeof<MyEnum>.IsEnum |> equal true
+    typeof<int>.IsEnum |> equal false
+    let t = typeof<MyEnum>
+    t.IsEnum |> equal true
+    t.GetEnumUnderlyingType() |> equal typeof<sbyte>
+    System.Enum.GetUnderlyingType(t) |> equal typeof<sbyte>
+
+[<Fact>]
+let ``test Enum.GetValues works`` () =
+    let values = System.Enum.GetValues(typeof<MyEnum>)
+    values.Length |> equal 3
+
+    // Iterating the non-generic System.Array is what needs Array.GetEnumerator
+    let mutable count = 0
+
+    for v in values do
+        System.Enum.IsDefined(typeof<MyEnum>, v) |> equal true
+        count <- count + 1
+
+    count |> equal 3
+
+[<Fact>]
+let ``test Enum.GetNames works`` () =
+    let names = System.Enum.GetNames(typeof<MyEnum>)
+    names.Length |> equal 3
+    names.[0] |> equal "Foo"
+    names.[2] |> equal "Baz"
+
+[<Fact>]
+let ``test Enum.GetName and IsDefined work`` () =
+    System.Enum.GetName(typeof<MyEnum>, MyEnum.Bar) |> equal "Bar"
+    System.Enum.IsDefined(typeof<MyEnum>, MyEnum.Baz) |> equal true
+
+// === Type.MakeGenericType / Activator.CreateInstance ===
+
+// Portable Fable code guards .NET-only reflection behind `Compiler.isDotnet`. On Fable the
+// branch is dead, but it still has to survive the replacement stage, which runs before DCE.
+// Both branches must agree, since .NET takes the first one and Beam the second.
+let defaultOf (t: System.Type) : obj =
+    if Fable.Core.Compiler.isDotnet then
+        System.Activator.CreateInstance(t)
+    else
+        box 0
+
+[<Fact>]
+let ``test Activator.CreateInstance guarded by Compiler.isDotnet compiles`` () =
+    defaultOf typeof<int> |> equal (box 0)
+
+[<Fact>]
+let ``test Type.MakeGenericType substitutes the generic arguments`` () =
+    let t = typedefof<RecGeneric<obj>>.MakeGenericType [| typeof<string> |]
+    t.GetGenericArguments().[0] |> equal typeof<string>
+
+// === Decimal ===
+
+[<Fact>]
+let ``test Decimal MinValue and MaxValue work`` () =
+    string System.Decimal.MinValue
+    |> equal "-79228162514264337593543950335"
+
+    string System.Decimal.MaxValue |> equal "79228162514264337593543950335"
+    System.Decimal.MinValue < 0M |> equal true
+    System.Decimal.MaxValue > 0M |> equal true
+
+[<Fact>]
+let ``test Decimal explicit conversions work`` () =
+    int 3.75M |> equal 3
+    float 3.75M |> equal 3.75
+    int64 3.75M |> equal 3L
+    decimal 3 |> equal 3M

--- a/tests/Beam/ReflectionTests.fs
+++ b/tests/Beam/ReflectionTests.fs
@@ -243,13 +243,8 @@ let ``test FSharp.Reflection: GetRecordFields returns field names`` () =
     let typ = typeof<MyRecord>
     let fields = FSharpType.GetRecordFields typ
     fields.Length |> equal 2
-    #if FABLE_COMPILER
-    fields.[0].Name |> equal "string"
-    fields.[1].Name |> equal "int"
-    #else
     fields.[0].Name |> equal "String"
     fields.[1].Name |> equal "Int"
-    #endif
 
 [<Fact>]
 let ``test FSharp.Reflection Record`` () =
@@ -258,19 +253,11 @@ let ``test FSharp.Reflection Record`` () =
     let recordTypeFields = FSharpType.GetRecordFields typ
     let recordValueFields = FSharpValue.GetRecordFields record
 
-    #if FABLE_COMPILER
-    let expectedRecordFields =
-        [|
-            "string", box "a"
-            "int", box 1
-        |]
-    #else
     let expectedRecordFields =
         [|
             "String", box "a"
             "Int", box 1
         |]
-    #endif
 
     let recordFields =
         recordTypeFields
@@ -573,3 +560,48 @@ let ``test Activator.CreateInstance guarded by Compiler.isDotnet compiles`` () =
 let ``test Type.MakeGenericType substitutes the generic arguments`` () =
     let t = typedefof<RecGeneric<obj>>.MakeGenericType [| typeof<string> |]
     t.GetGenericArguments().[0] |> equal typeof<string>
+
+// === Cross-file reflection ===
+// The types below live in Misc/Util2.fs, so their type info is a remote call into that file's
+// module (`util2:cross_file_tree_reflection()`) rather than a local one. This is the path the
+// per-entity reflection function exists for, so it needs its own coverage.
+
+[<Fact>]
+let ``test reflection over a record from another file works`` () =
+    let fields = FSharpType.GetRecordFields typeof<Fable.Tests.Util2.CrossFileRecord>
+    fields.Length |> equal 2
+    fields.[0].Name |> equal "Name"
+    fields.[0].PropertyType |> equal typeof<string>
+    fields.[1].PropertyType |> equal typeof<int>
+
+[<Fact>]
+let ``test reflection over a recursive union from another file works`` () =
+    let cases = FSharpType.GetUnionCases typeof<Fable.Tests.Util2.CrossFileTree>
+    cases.Length |> equal 2
+    cases.[1].Name |> equal "CrossFileBranch"
+
+    let branchFields = cases.[1].GetFields()
+    branchFields.Length |> equal 2
+
+    branchFields.[0].PropertyType
+    |> equal typeof<Fable.Tests.Util2.CrossFileTree>
+
+[<Fact>]
+let ``test reflection over a generic record from another file works`` () =
+    // The remote call has to pass the resolved generic argument, so its arity must line up
+    // with the reflection function generated in the other file.
+    let fields =
+        FSharpType.GetRecordFields typeof<Fable.Tests.Util2.CrossFileGeneric<string>>
+
+    fields.Length |> equal 2
+    fields.[0].PropertyType |> equal typeof<string>
+
+[<Fact>]
+let ``test round-tripping a value of a type from another file works`` () =
+    let recordType = typeof<Fable.Tests.Util2.CrossFileRecord>
+    let record: Fable.Tests.Util2.CrossFileRecord = { Name = "a"; Count = 1 }
+
+    let values = FSharpValue.GetRecordFields record
+
+    FSharpValue.MakeRecord(recordType, values) :?> Fable.Tests.Util2.CrossFileRecord
+    |> equal record


### PR DESCRIPTION
Brings the Beam target's reflection support up to parity with JS/Python, so that reflection-based code (`typeof<'T>`, `FSharp.Reflection`) compiles and runs.

Found while adding a Beam target to a `FSharp.Reflection`-based generic-value generator, which already works on .NET, JS, TS and Python. There were five distinct gaps.

## 1. Compiler stack-overflowed on recursive types (the blocker)

`transformTypeInfo` inlined a declared type's fields/cases structurally, with no by-name indirection and no cycle guard, so reflecting over a recursive type recursed forever and the compiler died:

```fsharp
type Tree =
    | Leaf of int
    | Branch of Tree * Tree   // self-referential

let t = typeof<Tree>          // Stack overflow, exit 134
```

Beam now emits a per-entity reflection function for each record/union (`tree_reflection/0`, `pair_1_reflection/1`, …) and `transformTypeInfo` emits a **call** to it rather than inlining — a remote call (`module:fn(...)`) when the entity lives in another file. That by-name indirection is what lets a recursive type refer to itself, and it matches what `Fable2Babel` and `Fable2Python` already do.

The indirection alone only moves the infinite recursion from compile time to run time, so — mirroring the lazy `fields`/`cases` thunks in `fable-library-ts` — the fields and cases are emitted as zero-arity funs, and `fable_reflection` forces them at the points that consume them:

```erlang
tree_reflection() ->
    #{fullname => <<"Tree">>, generics => [], cases => fun() ->
        [..., #{tag => 1, name => <<"Branch">>, erl_tag => branch,
                fields => [#{name => <<"Item1">>, erl_name => item1,
                             property_type => tree_reflection()}, ...]}]
end}.
```

Types with no source file (BCL/`.dll`) have no generated module to call into, so they keep the inline path, now with a recursion guard.

## 2–5. Missing entries in `Beam/Replacements.fs`

Each of these is already supported on JS/Python:

- **`FSharpReflectionExtensions`** — the `allowAccessToPrivateRepresentation` overloads resolve to static extensions (`FSharpType.IsUnion.Static`). They now route onto the same `fable_reflection` primitives, ignoring the flag as JS does. `fsharpType`/`fsharpValue` are extracted so both entities share them. (The old handlers forwarded `args` verbatim, so these overloads' extra argument would have produced an arity error.)
- **Enums** — enums are `Number(kind, IsEnum ent)` in the Fable AST, not `DeclaredType`, so they were being erased to a bare numeric type info. The type info now carries `enum_cases` and the underlying type, plus `Type.IsEnum`, `Enum.GetValues`/`GetNames`/`GetName`/`Parse`/`TryParse`/`IsDefined`/`GetUnderlyingType`. Also adds `Array.GetEnumerator`, needed to iterate the non-generic array `Enum.GetValues` returns.
- **`Type.MakeGenericType` / `Activator.CreateInstance`** — portable code guards .NET-only reflection behind `Compiler.isDotnet`, and while the branch is dead on Fable it still has to survive the replacement stage, which runs *before* DCE.
- **Decimal** — `MinValue`/`MaxValue` (both the property and the `ILFieldGet` path) and `op_Explicit` conversions to and from decimal.

## Also fixed along the way

- **`FSharpValue.GetUnionFields`** returned its field values as a plain Erlang list, but the compiler types them `obj[]`, so indexing (`fields.[0]`) compiled to `lists:nth(1, erlang:get(Fields))` and crashed with a `function_clause`. It now returns an array ref. `GetRecordFields` never had the problem because it is wrapped at the call site, which a tuple-returning function cannot be.
- **`char d`** passed decimals through unscaled, so `Decimal.ToChar` returned `65 × 10^28` instead of `65`. Both `ToChar` handlers now unscale first.

## Fixed in review

- **Float→decimal was inexact.** Scaling by 10^28 in float arithmetic is lossy — 10^28 is not a representable double — so `decimal 1.0` came out as `9999999999999999583119736832` rather than `10^28`: it compared unequal to the literal `1.0M`, and `string (decimal 0.1)` printed `0.1000000000000000013287555072`. This bug already existed in `Operators.ToDecimal`; the new `Decimal.op_Explicit` handler was a second copy of it. Both now go through `fable_decimal:from_int/1` and `from_float/1`, the latter converting via the float's shortest round-tripping decimal string. The `Decimal.ToSingle`/`ToDouble` tests below cannot catch this — converting back divides the error away again — so `Decimal from float is exact` compares against the literal and the string instead.
- **`PropertyInfo.Name` reported the Erlang field name** (`"string"`) rather than the F# name (`"String"`). The property info now carries `name` (the F# name, which is what `PropertyInfo.Name` must report) alongside `erl_name` (the sanitized key the field is stored under), the same split union case infos already use with `name`/`erl_tag`. Two Beam tests had `#if FABLE_COMPILER` branches asserting the lowercase names — they were written around the bug, and now assert the same thing as .NET.
- **A member colliding with its entity's generated reflection function is now an error.** `sanitizeErlangName` is lossy enough that a member `TreeReflection` on a type `Tree` mangles onto `tree_reflection/0`. The form dedup kept the member and silently dropped the reflection function, leaving every `typeof<Tree>` calling the member instead. It cannot be renamed away (call sites compute the name independently), so it is reported rather than miscompiled.
- **`Array.GetEnumerator`** dereferenced with a raw `erlang:get/1`, which is wrong for `byte[]` — byte arrays are atomics, not process-dict refs. It now goes through `derefArr`.
- **Enum case values are emitted as bignums.** `Convert.ToInt64` overflowed and took down the compiler on a `UInt64`-backed enum with a value above `Int64.MaxValue`. Erlang integers are arbitrary-precision, so the value always fits.
- **`Type.IsEnum`** keys on the presence of `enum_cases` rather than on it being non-empty, so an enum with no cases is still an enum; and `get_enum_name`'s spec admits the `undefined` it returns when no case matches.
- The duplicated record/union construction shared by the inline path and the reflection-function body is factored into `makeFieldsEntry`/`makeCasesEntry`.

## Known limitations

- `Activator.CreateInstance` covers records and primitives. Beam attaches no constructors to type infos (JS uses `TypeInfo.construct`), so arbitrary classes are not constructible at runtime; the JS `Can create generic classes at runtime` test is therefore not ported.
- Decimal→integer conversions are not range-checked, since Erlang has arbitrary-precision integers. JS's `Decimal to integer conversions are min/max-checked` tests are not ported.
- A reflection function is emitted for every record and union whether or not anything reflects on it. This matches JS/Python, which rely on bundler tree-shaking; Erlang has no equivalent, so output grows with record count. Accepted.

## Testing

Beam suite: **2535 passing, 0 failed** (up from 2501). New tests run on .NET first and then on the BEAM. Where JS already had an equivalent test it was ported rather than reinvented — `Recursive types work`, `Reflection functions accept allowAccessToPrivateRepresentation`, `Reflection works with enums`, and the `Decimal.To*` conversions (which replace a commented-out `TODO: System.Decimal.op_Explicit not supported by Fable Beam` placeholder in `ConversionTests.fs`). `Decimal.MinValue`/`MaxValue` were restored to `Decimal literals can be generated` in `ArithmeticTests.fs`, where Beam had dropped the two lines JS has.

Cross-file reflection gets its own coverage: the per-entity reflection function exists precisely so that a type info can be a *remote* call, so the fixtures for those tests live in `Misc/Util2.fs` and are reflected over from `ReflectionTests.fs` — including a recursive union and a generic record, whose remote call has to get the arity right.

End-to-end, the downstream project that motivated this — previously aborting with `Stack overflow (exit 134)` — now completes `dotnet fable --lang beam` and `rebar3 compile` cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
