### PR TITLE
test(js): stop asserting exact timer tick counts in flaky JS timer tests

### DIFF
--- a/tests/Js/Main/DateTimeTests.fs
+++ b/tests/Js/Main/DateTimeTests.fs
@@ -1199,7 +1199,7 @@ let tests =
             // timing-dependent — how many 50ms ticks fit in the sleep varies with runner load.
             afterStop > 5 |> equal true
             // Stop halts it: no further ticks after the snapshot.
-            !res |> equal afterStop
+            equal afterStop !res
         }
 
     testCaseAsync "Timer.Elapsed.Subscribe works" <| fun () ->
@@ -1218,7 +1218,7 @@ let tests =
             // many 50ms ticks fit in the sleep varies with runner load.
             afterDispose > 5 |> equal true
             // Dispose detaches it: no further ticks after the snapshot.
-            !res |> equal afterDispose
+            equal afterDispose !res
             t.Stop()
         }
 

--- a/tests/Js/Main/DateTimeTests.fs
+++ b/tests/Js/Main/DateTimeTests.fs
@@ -1189,10 +1189,17 @@ let tests =
             let t = new Timers.Timer(50.)
             t.Elapsed.Add(fun ev -> res := !res + 5)
             t.Start()
-            do! Async.Sleep 125
+            do! Async.Sleep 200
             t.Stop()
-            do! Async.Sleep 50
-            equal 10 !res
+            // Snapshot after Stop: a tick landing between the read and the stop is a legal
+            // interleaving, and would be indistinguishable from Stop failing to halt the timer.
+            let afterStop = !res
+            do! Async.Sleep 100
+            // AutoReset keeps the timer firing, so more than one tick lands. The exact number is
+            // timing-dependent — how many 50ms ticks fit in the sleep varies with runner load.
+            afterStop > 5 |> equal true
+            // Stop halts it: no further ticks after the snapshot.
+            !res |> equal afterStop
         }
 
     testCaseAsync "Timer.Elapsed.Subscribe works" <| fun () ->
@@ -1201,10 +1208,17 @@ let tests =
             let t = new Timers.Timer(50.)
             let disp = t.Elapsed.Subscribe(fun ev -> res := !res + 5)
             t.Start()
-            do! Async.Sleep 125
+            do! Async.Sleep 200
             disp.Dispose()
-            do! Async.Sleep 50
-            equal 10 !res
+            // Snapshot after Dispose: a tick landing between the read and the unsubscribe is a
+            // legal interleaving, and would be indistinguishable from Dispose failing to detach.
+            let afterDispose = !res
+            do! Async.Sleep 100
+            // The subscriber receives Elapsed events. The exact number is timing-dependent — how
+            // many 50ms ticks fit in the sleep varies with runner load.
+            afterDispose > 5 |> equal true
+            // Dispose detaches it: no further ticks after the snapshot.
+            !res |> equal afterDispose
             t.Stop()
         }
 


### PR DESCRIPTION
`Timer.Elapsed.Subscribe works` failed on the `windows-latest` JavaScript leg of an unrelated PR ([run](https://github.com/fable-compiler/Fable/actions/runs/29230559347/job/86753644624)) with `Expected: 10 - Actual: 5`. It is a wall-clock race, and so is its sibling `Timer with AutoReset = true works`.

## The race

```fsharp
let t = new Timers.Timer(50.)
let disp = t.Elapsed.Subscribe(fun ev -> res := !res + 5)
t.Start()
do! Async.Sleep 125
disp.Dispose()
do! Async.Sleep 50
equal 10 !res          // exactly two 50ms ticks
```

The test asserts the handler ran exactly twice inside a 125ms sleep. The second tick is due at 100ms, so there are 25ms of slack. On a loaded CI runner — where Windows timer resolution is ~15.6ms and scheduling is coarse — that tick slips past the window, one tick arrives, and `res` is 5. The same job also reported the Main.js file itself hitting its 20s timeout, which is the signature of a runner that was simply slow at that moment.

Nothing about the count of 2 is part of the contract being tested; it is an artifact of the sleep being 2.5× the interval.

## The fix

Assert the semantics each test is named for:

- the handler fires **repeatedly** (more than one tick — this is what `AutoReset = true` means, and what a live subscription means), and
- it **stops firing** once the timer is stopped / the subscription is disposed.

The counter is read *after* `Stop()`/`Dispose()`, so a tick cannot land between the read and the unsubscribe and make the second assertion flaky in turn.

This is the same tolerance the neighbouring `Assigning an event to a variable works` (#1863) already uses — 200ms sleep, at least two ticks (`acc > 2 |> equal true`) — which has been stable, so the new budget is a proven one in this file rather than a guess.

`Timer with AutoReset = false works` is deliberately left alone: it asserts exactly one tick, which *is* the invariant it exists to check (AutoReset off ⇒ fires once), not a timing artifact.

## Testing

Full JavaScript suite: **3049 passing, 0 failed**. The two rewritten tests take ~300ms each, up from ~175ms — negligible against the 20s per-file budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)