### PR TITLE
fix(beam): give sized integers .NET fixed-width semantics

### DIFF
--- a/src/Fable.Transforms/Beam/FABLE-BEAM.md
+++ b/src/Fable.Transforms/Beam/FABLE-BEAM.md
@@ -809,11 +809,15 @@ type Module =
 
 ## Sized & Signed Integer Semantics
 
-> **Status: not yet implemented.** Erlang's native arbitrary-precision integers make
-> `int`, `int64`, and `bigint` work out of the box, so the test suite passes today without
-> fixed-width wrapping. True sized-integer overflow semantics (`int8`/`int16`/`int32` and
-> unsigned wrapping) are **not** implemented yet — the rest of this section is the design
-> plan for when they are. Strategy A (bit-syntax wrapping) remains the recommendation.
+> **Status: implemented** using Strategy A (bit-syntax wrapping), described below.
+> The wrapping helpers live in `src/fable-library-beam/fable_int.erl` (`wrap_i8`..`wrap_i64`,
+> `wrap_u8`..`wrap_u64`). Codegen routes the operations that can leave a type's width —
+> `+`, `-`, `*`, `bsl`, negation, `bnot` and narrowing conversions — through them, and masks
+> shift counts to the width the way .NET does. `band`/`bor`/`bxor`/`bsr`/`rem` cannot grow an
+> in-range value, so they stay bare. `bigint` and the fixed-scale `decimal` are never wrapped.
+>
+> Unsigned types are represented as their unsigned value (0..2^n-1), not as a signed bit
+> pattern, so `UInt64.MaxValue` is `18446744073709551615` and `bsr` is a logical shift.
 
 ### The Problem
 

--- a/src/Fable.Transforms/Beam/Fable2Beam.Util.fs
+++ b/src/Fable.Transforms/Beam/Fable2Beam.Util.fs
@@ -31,11 +31,68 @@ let maskShiftCount (bits: int) (count: Beam.ErlExpr) =
     | Beam.ErlExpr.Literal(Beam.ErlLiteral.Integer n) -> Beam.ErlExpr.Literal(Beam.ErlLiteral.Integer(n &&& mask))
     | _ -> Beam.ErlExpr.BinOp("band", count, Beam.ErlExpr.Literal(Beam.ErlLiteral.Integer mask))
 
-/// Wrap an expression to the fixed width of `typ`. A no-op for unsized types.
+// Constant folding of the wrapped operations. Every one of them is exact modulo 2^64, so
+// the fold can be done in (unchecked, wrapping) int64 arithmetic and the literal carries
+// the bit pattern; truncating that to a narrower width afterwards gives the same answer as
+// truncating the true mathematical result would.
+
+/// Bit pattern of an integer literal. Unsigned values above `Int64.MaxValue` are emitted as
+/// `BigInt` literals, so both shapes have to be recognised. A genuine (unbounded) bigint
+/// literal does not parse as a `uint64` and is left alone — those are never wrapped.
+let private literalBits (expr: Beam.ErlExpr) =
+    match expr with
+    | Beam.ErlExpr.Literal(Beam.ErlLiteral.Integer n) -> Some n
+    | Beam.ErlExpr.Literal(Beam.ErlLiteral.BigInt s) ->
+        match System.UInt64.TryParse(s) with
+        | true, n -> Some(int64 n)
+        | _ -> None
+    | _ -> None
+
+/// The value `fable_int:wrap_*` would produce, as a literal.
+let private wrappedLiteral (bits: int, signed: bool) (value: int64) =
+    let truncated =
+        if bits = 64 then
+            value
+        else
+            let shift = 64 - bits
+
+            if signed then
+                (value <<< shift) >>> shift // sign-extend the low bits
+            else
+                int64 ((uint64 value <<< shift) >>> shift) // zero-extend them
+
+    if not signed && truncated < 0L then
+        // 64-bit unsigned above Int64.MaxValue: does not fit an Erlang int64 literal
+        Beam.ErlExpr.Literal(Beam.ErlLiteral.BigInt(string<uint64> (uint64 truncated)))
+    else
+        Beam.ErlExpr.Literal(Beam.ErlLiteral.Integer truncated)
+
+/// Fold a wrapped operation over integer literals, so constant expressions do not pay for a
+/// runtime wrapping call. `None` when the operands are not all statically known.
+let private foldConstant (expr: Beam.ErlExpr) =
+    let binary op left right =
+        match literalBits left, literalBits right with
+        | Some a, Some b -> Some(op a b)
+        | _ -> None
+
+    match expr with
+    | Beam.ErlExpr.BinOp("+", left, right) -> binary (+) left right
+    | Beam.ErlExpr.BinOp("-", left, right) -> binary (-) left right
+    | Beam.ErlExpr.BinOp("*", left, right) -> binary (*) left right
+    | Beam.ErlExpr.BinOp("bsl", left, right) -> binary (fun a b -> a <<< int b) left right
+    | Beam.ErlExpr.UnaryOp("-", operand) -> literalBits operand |> Option.map (~-)
+    | Beam.ErlExpr.UnaryOp("bnot", operand) -> literalBits operand |> Option.map (~~~)
+    | _ -> literalBits expr
+
+/// Wrap an expression to the fixed width of `typ`. A no-op for unsized types, and folded at
+/// compile time when the operands are literals.
 let wrapToIntType (typ: Fable.AST.Fable.Type) (expr: Beam.ErlExpr) =
     match Integers.sizedIntInfo typ with
-    | Some info -> Beam.ErlExpr.Call(Some "fable_int", Integers.wrapFunctionName info, [ expr ])
     | None -> expr
+    | Some info ->
+        match foldConstant expr with
+        | Some value -> wrappedLiteral info value
+        | None -> Beam.ErlExpr.Call(Some "fable_int", Integers.wrapFunctionName info, [ expr ])
 
 /// Check if a Fable expression contains a reference to the given identifier name
 let rec containsIdentRef (name: string) (expr: Expr) : bool =

--- a/src/Fable.Transforms/Beam/Fable2Beam.Util.fs
+++ b/src/Fable.Transforms/Beam/Fable2Beam.Util.fs
@@ -19,6 +19,24 @@ let isIntegerType (typ: Fable.AST.Fable.Type) =
         | _ -> true // Decimal is now a fixed-scale integer
     | _ -> true // default to integer division
 
+/// Bit width and signedness of a .NET sized integer type, if it has one.
+let sizedIntInfo = Integers.sizedIntInfo
+
+/// .NET only uses the low bits of a shift count: `x <<< 32` is `x` for an int32,
+/// where Erlang's `bsl` would shift the value out entirely.
+let maskShiftCount (bits: int) (count: Beam.ErlExpr) =
+    let mask = int64 bits - 1L
+
+    match count with
+    | Beam.ErlExpr.Literal(Beam.ErlLiteral.Integer n) -> Beam.ErlExpr.Literal(Beam.ErlLiteral.Integer(n &&& mask))
+    | _ -> Beam.ErlExpr.BinOp("band", count, Beam.ErlExpr.Literal(Beam.ErlLiteral.Integer mask))
+
+/// Wrap an expression to the fixed width of `typ`. A no-op for unsized types.
+let wrapToIntType (typ: Fable.AST.Fable.Type) (expr: Beam.ErlExpr) =
+    match Integers.sizedIntInfo typ with
+    | Some info -> Beam.ErlExpr.Call(Some "fable_int", Integers.wrapFunctionName info, [ expr ])
+    | None -> expr
+
 /// Check if a Fable expression contains a reference to the given identifier name
 let rec containsIdentRef (name: string) (expr: Expr) : bool =
     match expr with

--- a/src/Fable.Transforms/Beam/Fable2Beam.fs
+++ b/src/Fable.Transforms/Beam/Fable2Beam.fs
@@ -1540,7 +1540,10 @@ and transformValue (com: IBeamCompiler) (ctx: Context) (value: ValueKind) : Beam
     | NumberConstant(NumberValue.Int16 i, _) -> Beam.ErlExpr.Literal(Beam.ErlLiteral.Integer(int64 i))
     | NumberConstant(NumberValue.UInt16 i, _) -> Beam.ErlExpr.Literal(Beam.ErlLiteral.Integer(int64 i))
     | NumberConstant(NumberValue.UInt32 i, _) -> Beam.ErlExpr.Literal(Beam.ErlLiteral.Integer(int64 i))
-    | NumberConstant(NumberValue.UInt64 i, _) -> Beam.ErlExpr.Literal(Beam.ErlLiteral.Integer(int64 i))
+    // Unsigned 64-bit values are represented as the unsigned integer they are, so the
+    // upper half of the range does not fit in an int64 literal (`UInt64.MaxValue` would
+    // otherwise print as -1). Erlang integers are unbounded, so print the digits directly.
+    | NumberConstant(NumberValue.UInt64 i, _) -> Beam.ErlExpr.Literal(Beam.ErlLiteral.BigInt(string<uint64> i))
     | NumberConstant(NumberValue.Float32 f, _) ->
         let d = float f
 
@@ -1553,7 +1556,7 @@ and transformValue (com: IBeamCompiler) (ctx: Context) (value: ValueKind) : Beam
         else
             Beam.ErlExpr.Literal(Beam.ErlLiteral.Float d)
     | NumberConstant(NumberValue.NativeInt i, _) -> Beam.ErlExpr.Literal(Beam.ErlLiteral.Integer(int64 i))
-    | NumberConstant(NumberValue.UNativeInt i, _) -> Beam.ErlExpr.Literal(Beam.ErlLiteral.Integer(int64 i))
+    | NumberConstant(NumberValue.UNativeInt i, _) -> Beam.ErlExpr.Literal(Beam.ErlLiteral.BigInt(string<unativeint> i))
     | NumberConstant(NumberValue.BigInt i, _) -> Beam.ErlExpr.Literal(Beam.ErlLiteral.BigInt(string<bigint> i))
     | NumberConstant(NumberValue.Decimal d, _) ->
         // Decimal as fixed-scale integer: value × 10^28
@@ -1823,7 +1826,28 @@ and transformOperation
                 | BinaryAndBitwise -> "band"
                 | BinaryExponent -> "+" // unreachable, handled above
 
-            Beam.ErlExpr.BinOp(erlOp, cleanLeft, cleanRight) |> wrapWithHoisted allHoisted
+            // .NET only uses the low bits of a shift count (`x <<< 32` is `x` for an
+            // int32); Erlang would shift by the full amount.
+            let cleanRight =
+                match op, sizedIntInfo typ with
+                | (BinaryShiftLeft | BinaryShiftRightSignPropagating | BinaryShiftRightZeroFill), Some(bits, _) ->
+                    maskShiftCount bits cleanRight
+                | _ -> cleanRight
+
+            let result = Beam.ErlExpr.BinOp(erlOp, cleanLeft, cleanRight)
+
+            // Erlang integers are unbounded, so anything that can leave the width of a
+            // sized .NET integer has to be truncated back into it. `band`/`bor`/`bxor`/
+            // `bsr`/`rem` cannot grow an in-range value, so they stay bare.
+            let result =
+                match op with
+                | BinaryPlus
+                | BinaryMinus
+                | BinaryMultiply
+                | BinaryShiftLeft -> wrapToIntType typ result
+                | _ -> result
+
+            result |> wrapWithHoisted allHoisted
 
     | Unary(op, operand) ->
         let erlOperand = transformExpr com ctx operand
@@ -1831,10 +1855,13 @@ and transformOperation
 
         let result =
             match op with
-            | UnaryMinus -> Beam.ErlExpr.UnaryOp("-", cleanOperand)
+            // Negation leaves the width for the minimum signed value (`-Int32.MinValue`
+            // is `Int32.MinValue`) and for every non-zero unsigned value.
+            | UnaryMinus -> Beam.ErlExpr.UnaryOp("-", cleanOperand) |> wrapToIntType typ
             | UnaryPlus -> cleanOperand
             | UnaryNot -> Beam.ErlExpr.UnaryOp("not", cleanOperand)
-            | UnaryNotBitwise -> Beam.ErlExpr.UnaryOp("bnot", cleanOperand)
+            // `bnot` of an unsigned value is negative in Erlang, so it needs wrapping back.
+            | UnaryNotBitwise -> Beam.ErlExpr.UnaryOp("bnot", cleanOperand) |> wrapToIntType typ
             | UnaryAddressOf ->
                 // For mutable variables, pass the atom key (process dict key)
                 // instead of the dereferenced value. This enables out-parameter support

--- a/src/Fable.Transforms/Beam/Fable2Beam.fs
+++ b/src/Fable.Transforms/Beam/Fable2Beam.fs
@@ -1834,6 +1834,25 @@ and transformOperation
                     maskShiftCount bits cleanRight
                 | _ -> cleanRight
 
+            // Erlang's `bsr` propagates the sign, so a zero-filling shift of a *signed*
+            // value has to shift its unsigned reinterpretation instead.
+            let unsignedTyp =
+                match op, typ with
+                | BinaryShiftRightZeroFill, Fable.AST.Fable.Type.Number(kind, info) ->
+                    match kind with
+                    | Int8 -> Some(Fable.AST.Fable.Type.Number(UInt8, info))
+                    | Int16 -> Some(Fable.AST.Fable.Type.Number(UInt16, info))
+                    | Int32 -> Some(Fable.AST.Fable.Type.Number(UInt32, info))
+                    | Int64 -> Some(Fable.AST.Fable.Type.Number(UInt64, info))
+                    | NativeInt -> Some(Fable.AST.Fable.Type.Number(UNativeInt, info))
+                    | _ -> None
+                | _ -> None
+
+            let cleanLeft =
+                match unsignedTyp with
+                | Some unsignedTyp -> wrapToIntType unsignedTyp cleanLeft
+                | None -> cleanLeft
+
             let result = Beam.ErlExpr.BinOp(erlOp, cleanLeft, cleanRight)
 
             // Erlang integers are unbounded, so anything that can leave the width of a
@@ -1845,6 +1864,9 @@ and transformOperation
                 | BinaryMinus
                 | BinaryMultiply
                 | BinaryShiftLeft -> wrapToIntType typ result
+                // A zero-filled shift of a signed value was done on the unsigned
+                // reinterpretation, so it has to come back to the signed one.
+                | BinaryShiftRightZeroFill when unsignedTyp.IsSome -> wrapToIntType typ result
                 | _ -> result
 
             result |> wrapWithHoisted allHoisted

--- a/src/Fable.Transforms/Beam/Prelude.fs
+++ b/src/Fable.Transforms/Beam/Prelude.fs
@@ -128,3 +128,56 @@ module Naming =
         // Remove/replace characters invalid in Erlang variable names
         name.Replace("$", "_").Replace("@", "_")
         |> fun s -> Regex.Replace(s, "[^a-zA-Z0-9_]", "_")
+
+/// Fixed-width integer semantics. Erlang integers are arbitrary precision and never
+/// overflow, so operations that can leave the width of a .NET sized integer are routed
+/// through the `fable_int` runtime module to truncate them back (two's complement).
+module Integers =
+    open Fable.AST // NumberKind
+    open Fable.AST.Fable
+
+    /// Bit width and signedness of a .NET sized integer type. `None` for types whose
+    /// Erlang representation is legitimately unbounded (bigint, the fixed-scale decimal)
+    /// or not an integer at all — those must never be wrapped.
+    let sizedIntInfo (typ: Type) : (int * bool) option =
+        match typ with
+        // Chars are integers on Erlang, and .NET truncates conversions into them like a uint16
+        | Type.Char -> Some(16, false)
+        | Type.Number(kind, _) ->
+            match kind with
+            | Int8 -> Some(8, true)
+            | UInt8 -> Some(8, false)
+            | Int16 -> Some(16, true)
+            | UInt16 -> Some(16, false)
+            | Int32 -> Some(32, true)
+            | UInt32 -> Some(32, false)
+            | Int64 -> Some(64, true)
+            | UInt64 -> Some(64, false)
+            | NativeInt -> Some(64, true)
+            | UNativeInt -> Some(64, false)
+            | _ -> None
+        | _ -> None
+
+    /// Name of the `fable_int` function that wraps a value to the given width/signedness.
+    let wrapFunctionName (bits: int, signed: bool) =
+        let prefix =
+            if signed then
+                "i"
+            else
+                "u"
+
+        $"wrap_%s{prefix}%d{bits}"
+
+    /// Whether converting a value of type `source` to type `target` can leave `target`'s
+    /// range, i.e. whether the conversion needs truncating.
+    let conversionNeedsWrap (source: Type) (target: Type) =
+        match sizedIntInfo target, sizedIntInfo source with
+        | None, _ -> false
+        | Some _, None -> true // unbounded or non-integer source (float, bigint, decimal)
+        | Some(targetBits, targetSigned), Some(sourceBits, sourceSigned) ->
+            if sourceSigned = targetSigned then
+                sourceBits > targetBits
+            elif targetSigned then
+                sourceBits >= targetBits // unsigned source only fits in a strictly wider signed target
+            else
+                true // a signed source can be negative, which never fits an unsigned target

--- a/src/Fable.Transforms/Beam/Replacements.fs
+++ b/src/Fable.Transforms/Beam/Replacements.fs
@@ -5,12 +5,23 @@ open Fable
 open Fable.AST
 open Fable.AST.Fable
 open Fable.Transforms
+open Fable.Beam
 open Fable.Beam.Naming
 open Replacements.Util
 
 type Context = FSharp2Fable.Context
 type ICompiler = FSharp2Fable.IFableCompiler
 type CallInfo = ReplaceCallInfo
+
+/// Truncate a value of type `sourceType` into the fixed width of the target integer type
+/// `t`, the way .NET's unchecked narrowing conversions do (`byte 300 = 44uy`). Erlang
+/// integers are unbounded, so without this the value would simply keep its old magnitude.
+/// Left alone when the source range already fits in the target.
+let private wrapToIntType (com: ICompiler) r (t: Type) (sourceType: Type) (expr: Expr) =
+    match Integers.sizedIntInfo t with
+    | Some info when Integers.conversionNeedsWrap sourceType t ->
+        Helper.LibCall(com, "fable_int", Integers.wrapFunctionName info, t, [ expr ], ?loc = r)
+    | _ -> expr
 
 let private isFunctionType (t: Type) =
     match t with
@@ -331,15 +342,19 @@ let private operators
     | ("ToSByte" | "ToByte" | "ToInt8" | "ToUInt8" | "ToInt16" | "ToUInt16" | "ToInt" | "ToUInt" | "ToInt32" | "ToUInt32" | "ToInt64" | "ToUInt64" | "ToIntPtr" | "ToUIntPtr"),
       [ arg ] ->
         match arg.Type with
+        // Parsing raises on out-of-range input, so there is nothing to truncate
         | Type.String -> Helper.LibCall(com, "fable_convert", "to_int", _t, [ arg ], ?loc = r) |> Some
         | Type.Number(kind, _) ->
             match kind with
-            | Decimal -> Helper.LibCall(com, "fable_decimal", "to_int", _t, [ arg ], ?loc = r) |> Some
+            | Decimal ->
+                Helper.LibCall(com, "fable_decimal", "to_int", _t, [ arg ], ?loc = r)
+                |> wrapToIntType com r _t arg.Type
+                |> Some
             | Float16
             | Float32
-            | Float64 -> emitExpr r _t [ arg ] "trunc($0)" |> Some
-            | _ -> Some arg
-        | Type.Char -> Some arg
+            | Float64 -> emitExpr r _t [ arg ] "trunc($0)" |> wrapToIntType com r _t arg.Type |> Some
+            | _ -> arg |> wrapToIntType com r _t arg.Type |> Some
+        | Type.Char -> arg |> wrapToIntType com r _t arg.Type |> Some
         | _ -> Some arg
     | ("ToSingle" | "ToDouble"), [ arg ] ->
         match arg.Type with
@@ -416,15 +431,17 @@ let private operators
         |> Some
     // Erlang has native arbitrary-precision integers, so Int64/UInt64/BigInt
     // use direct binary ops instead of library calls (like Python's int)
-    // Bitwise operators — Erlang has native bitwise support for all integer sizes
+    // Bitwise operators — Erlang has native bitwise support for all integer sizes.
+    // These go through the regular Fable operations (rather than being emitted directly)
+    // so that codegen can apply fixed-width wrapping and shift-count masking to them.
     | Operators.booleanOr, [ left; right ] -> emitExpr r _t [ left; right ] "($0 orelse $1)" |> Some
     | Operators.booleanAnd, [ left; right ] -> emitExpr r _t [ left; right ] "($0 andalso $1)" |> Some
-    | Operators.bitwiseAnd, [ left; right ] -> emitExpr r _t [ left; right ] "($0 band $1)" |> Some
-    | Operators.bitwiseOr, [ left; right ] -> emitExpr r _t [ left; right ] "($0 bor $1)" |> Some
-    | Operators.exclusiveOr, [ left; right ] -> emitExpr r _t [ left; right ] "($0 bxor $1)" |> Some
-    | Operators.leftShift, [ left; right ] -> emitExpr r _t [ left; right ] "($0 bsl $1)" |> Some
-    | Operators.rightShift, [ left; right ] -> emitExpr r _t [ left; right ] "($0 bsr $1)" |> Some
-    | Operators.logicalNot, [ operand ] -> emitExpr r _t [ operand ] "(bnot $0)" |> Some
+    | Operators.bitwiseAnd, [ left; right ] -> makeBinOp r _t left right BinaryAndBitwise |> Some
+    | Operators.bitwiseOr, [ left; right ] -> makeBinOp r _t left right BinaryOrBitwise |> Some
+    | Operators.exclusiveOr, [ left; right ] -> makeBinOp r _t left right BinaryXorBitwise |> Some
+    | Operators.leftShift, [ left; right ] -> makeBinOp r _t left right BinaryShiftLeft |> Some
+    | Operators.rightShift, [ left; right ] -> makeBinOp r _t left right BinaryShiftRightSignPropagating |> Some
+    | Operators.logicalNot, [ operand ] -> Operation(Unary(UnaryNotBitwise, operand), Tags.empty, _t, r) |> Some
     // Erlang has native arbitrary-precision integers, so Int64/UInt64/BigInt
     // use direct binary ops instead of library calls
     // Ref cells: ref, !, :=, incr, decr
@@ -636,11 +653,14 @@ let private languagePrimitives
                 | ("DivideByInt" | Operators.divideByInt), [ left; right ] ->
                     makeBinOp r t left right BinaryDivide |> Some
                 | "op_UnaryNegation", [ operand ] -> Operation(Unary(UnaryMinus, operand), Tags.empty, t, r) |> Some
-                | "op_BitwiseAnd", [ left; right ] -> emitExpr r t [ left; right ] "($0 band $1)" |> Some
-                | "op_BitwiseOr", [ left; right ] -> emitExpr r t [ left; right ] "($0 bor $1)" |> Some
-                | "op_ExclusiveOr", [ left; right ] -> emitExpr r t [ left; right ] "($0 bxor $1)" |> Some
-                | "op_LeftShift", [ left; right ] -> emitExpr r t [ left; right ] "($0 bsl $1)" |> Some
-                | "op_RightShift", [ left; right ] -> emitExpr r t [ left; right ] "($0 bsr $1)" |> Some
+                | "op_LogicalNot", [ operand ] -> Operation(Unary(UnaryNotBitwise, operand), Tags.empty, t, r) |> Some
+                // Routed through the regular binary operations rather than emitted directly,
+                // so that they pick up fixed-width wrapping for sized integer types
+                | "op_BitwiseAnd", [ left; right ] -> makeBinOp r t left right BinaryAndBitwise |> Some
+                | "op_BitwiseOr", [ left; right ] -> makeBinOp r t left right BinaryOrBitwise |> Some
+                | "op_ExclusiveOr", [ left; right ] -> makeBinOp r t left right BinaryXorBitwise |> Some
+                | "op_LeftShift", [ left; right ] -> makeBinOp r t left right BinaryShiftLeft |> Some
+                | "op_RightShift", [ left; right ] -> makeBinOp r t left right BinaryShiftRightSignPropagating |> Some
                 | "op_Explicit", [ arg ] -> Some arg
                 | _ -> None
     | "DivideByInt", [ left; right ] -> makeBinOp r t left right BinaryDivide |> Some
@@ -1338,9 +1358,10 @@ let private conversions
             | Float16
             | Float32
             | Float64
-            | Decimal -> emitExpr r t [ arg ] "trunc($0)" |> Some
-            | _ -> Some arg // int-to-int: no conversion needed in Erlang
-        | Type.Char -> Some arg // char is already an integer in Erlang
+            | Decimal -> emitExpr r t [ arg ] "trunc($0)" |> wrapToIntType com r t arg.Type |> Some
+            // int-to-int: no conversion needed in Erlang, but narrowing still truncates
+            | _ -> arg |> wrapToIntType com r t arg.Type |> Some
+        | Type.Char -> arg |> wrapToIntType com r t arg.Type |> Some // char is already an integer in Erlang
         | _ -> Some arg
     // float(x), double(x) → convert to float
     | ("ToSingle" | "ToDouble"), [ arg ] ->

--- a/src/Fable.Transforms/Beam/Replacements.fs
+++ b/src/Fable.Transforms/Beam/Replacements.fs
@@ -342,7 +342,8 @@ let private operators
     | ("ToSByte" | "ToByte" | "ToInt8" | "ToUInt8" | "ToInt16" | "ToUInt16" | "ToInt" | "ToUInt" | "ToInt32" | "ToUInt32" | "ToInt64" | "ToUInt64" | "ToIntPtr" | "ToUIntPtr"),
       [ arg ] ->
         match arg.Type with
-        // Parsing raises on out-of-range input, so there is nothing to truncate
+        // TODO: `fable_convert:to_int` does not range-check against the target type, so
+        // out-of-range input yields the parsed value instead of raising the way .NET does.
         | Type.String -> Helper.LibCall(com, "fable_convert", "to_int", _t, [ arg ], ?loc = r) |> Some
         | Type.Number(kind, _) ->
             match kind with
@@ -399,8 +400,12 @@ let private operators
         match arg.Type with
         | Type.String -> emitExpr r _t [ arg ] "binary:first($0)" |> Some
         // Decimals are fixed-scale integers, so they need unscaling first
-        | Type.Number(Decimal, _) -> Helper.LibCall(com, "fable_decimal", "to_int", _t, [ arg ], ?loc = r) |> Some
-        | _ -> Some arg // other numbers are already chars in Erlang
+        | Type.Number(Decimal, _) ->
+            Helper.LibCall(com, "fable_decimal", "to_int", _t, [ arg ], ?loc = r)
+            |> wrapToIntType com r _t arg.Type
+            |> Some
+        // Other numbers are already chars in Erlang, but `char` truncates like a uint16
+        | _ -> arg |> wrapToIntType com r _t arg.Type |> Some
     // CreateSet: the `set [1;2;3]` syntax
     | "CreateSet", [ arg ] -> emitExpr r _t [ arg ] "ordsets:from_list($0)" |> Some
     // CreateDictionary: the `dict [...]` syntax
@@ -636,7 +641,9 @@ let private languagePrimitives
                 "op_" + operation
 
         if operation = "op_Explicit" then
-            Some arg
+            // Narrowing still truncates when the conversion is reached through an inline
+            // generic, the same as when it is written directly
+            arg |> wrapToIntType com r t arg.Type |> Some
         else
             let argTypes = args |> List.map (fun a -> a.Type)
             // Check for custom operator on DeclaredType before falling back to native ops
@@ -661,7 +668,6 @@ let private languagePrimitives
                 | "op_ExclusiveOr", [ left; right ] -> makeBinOp r t left right BinaryXorBitwise |> Some
                 | "op_LeftShift", [ left; right ] -> makeBinOp r t left right BinaryShiftLeft |> Some
                 | "op_RightShift", [ left; right ] -> makeBinOp r t left right BinaryShiftRightSignPropagating |> Some
-                | "op_Explicit", [ arg ] -> Some arg
                 | _ -> None
     | "DivideByInt", [ left; right ] -> makeBinOp r t left right BinaryDivide |> Some
     // IntrinsicFunctions within LanguagePrimitives
@@ -1402,8 +1408,12 @@ let private conversions
         match arg.Type with
         | Type.String -> emitExpr r t [ arg ] "binary:first($0)" |> Some
         // Decimals are fixed-scale integers, so they need unscaling first
-        | Type.Number(Decimal, _) -> Helper.LibCall(com, "fable_decimal", "to_int", t, [ arg ], ?loc = r) |> Some
-        | _ -> Some arg // other numbers are already chars in Erlang
+        | Type.Number(Decimal, _) ->
+            Helper.LibCall(com, "fable_decimal", "to_int", t, [ arg ], ?loc = r)
+            |> wrapToIntType com r t arg.Type
+            |> Some
+        // Other numbers are already chars in Erlang, but `char` truncates like a uint16
+        | _ -> arg |> wrapToIntType com r t arg.Type |> Some
     | _ -> None
 
 /// Beam-specific numeric type method replacements (Parse, ToString, Equals, CompareTo, GetHashCode).
@@ -1510,7 +1520,10 @@ let private numericTypes
         | Number((Float16 | Float32 | Float64), _), _ ->
             Helper.LibCall(com, "fable_decimal", "to_number", t, [ arg ], ?loc = r) |> Some
         // Chars are integers on Beam, so `char d` truncates like the integer conversions
-        | (Number(_, _) | Char), _ -> Helper.LibCall(com, "fable_decimal", "to_int", t, [ arg ], ?loc = r) |> Some
+        | (Number(_, _) | Char), _ ->
+            Helper.LibCall(com, "fable_decimal", "to_int", t, [ arg ], ?loc = r)
+            |> wrapToIntType com r t arg.Type
+            |> Some
         | _ -> None
     | _ -> None
 
@@ -5625,8 +5638,10 @@ let tryCall
         | "Abs", None, [ arg ] -> emitExpr r t [ arg ] "erlang:abs($0)" |> Some
         | ("get_IsZero" | "IsZero"), Some thisObj, _ -> emitExpr r t [ thisObj ] "($0 =:= 0)" |> Some
         | ("get_IsOne" | "IsOne"), Some thisObj, _ -> emitExpr r t [ thisObj ] "($0 =:= 1)" |> Some
+        // A bigint is unbounded, so converting out of it narrows and has to truncate.
+        // `ToInt64Unchecked` is the one that keeps .NET's non-throwing wrap either way.
         | ("ToInt64" | "ToInt64Unchecked" | "ToInt32" | "ToInt16" | "ToByte" | "ToSByte" | "op_Explicit"), None, [ arg ] ->
-            Some arg // identity in Erlang
+            arg |> wrapToIntType com r t arg.Type |> Some
         | "Parse", None, [ str ] -> emitExpr r t [ str ] "binary_to_integer($0)" |> Some
         | "Pow", None, [ base_; exp_ ] -> emitExpr r t [ base_; exp_ ] "math:pow($0, $1)" |> Some
         | "Log", None, [ arg ] -> emitExpr r t [ arg ] "math:log(float($0))" |> Some

--- a/src/fable-library-beam/fable_int.erl
+++ b/src/fable-library-beam/fable_int.erl
@@ -1,0 +1,73 @@
+-module(fable_int).
+-export([
+    wrap_i8/1,
+    wrap_i16/1,
+    wrap_i32/1,
+    wrap_i64/1,
+    wrap_u8/1,
+    wrap_u16/1,
+    wrap_u32/1,
+    wrap_u64/1
+]).
+
+-spec wrap_i8(integer()) -> integer().
+-spec wrap_i16(integer()) -> integer().
+-spec wrap_i32(integer()) -> integer().
+-spec wrap_i64(integer()) -> integer().
+-spec wrap_u8(integer()) -> non_neg_integer().
+-spec wrap_u16(integer()) -> non_neg_integer().
+-spec wrap_u32(integer()) -> non_neg_integer().
+-spec wrap_u64(integer()) -> non_neg_integer().
+
+%% Fixed-width (two's complement) integer semantics for .NET sized integers.
+%%
+%% Erlang integers are arbitrary precision and never overflow, while .NET's
+%% int8..int64/uint8..uint64 wrap. Every operation that can leave the width
+%% (+, -, *, bsl, negation, narrowing conversions) is routed through these by
+%% the compiler, so hash/PRNG/checksum code that relies on wraparound produces
+%% bit-identical results here.
+%%
+%% Constructing `<<N:Bits>>` keeps the low Bits bits of N (two's complement for
+%% negative N); matching it back with the signedness of the target type gives
+%% the wrapped value. The in-range guard is the overwhelmingly common case and
+%% short-circuits before any binary is built.
+
+wrap_i8(N) when N >= -16#80, N =< 16#7F -> N;
+wrap_i8(N) ->
+    <<V:8/signed>> = <<N:8>>,
+    V.
+
+wrap_i16(N) when N >= -16#8000, N =< 16#7FFF -> N;
+wrap_i16(N) ->
+    <<V:16/signed>> = <<N:16>>,
+    V.
+
+wrap_i32(N) when N >= -16#80000000, N =< 16#7FFFFFFF -> N;
+wrap_i32(N) ->
+    <<V:32/signed>> = <<N:32>>,
+    V.
+
+wrap_i64(N) when N >= -16#8000000000000000, N =< 16#7FFFFFFFFFFFFFFF -> N;
+wrap_i64(N) ->
+    <<V:64/signed>> = <<N:64>>,
+    V.
+
+wrap_u8(N) when N >= 0, N =< 16#FF -> N;
+wrap_u8(N) ->
+    <<V:8/unsigned>> = <<N:8>>,
+    V.
+
+wrap_u16(N) when N >= 0, N =< 16#FFFF -> N;
+wrap_u16(N) ->
+    <<V:16/unsigned>> = <<N:16>>,
+    V.
+
+wrap_u32(N) when N >= 0, N =< 16#FFFFFFFF -> N;
+wrap_u32(N) ->
+    <<V:32/unsigned>> = <<N:32>>,
+    V.
+
+wrap_u64(N) when N >= 0, N =< 16#FFFFFFFFFFFFFFFF -> N;
+wrap_u64(N) ->
+    <<V:64/unsigned>> = <<N:64>>,
+    V.

--- a/tests/Beam/ArithmeticTests.fs
+++ b/tests/Beam/ArithmeticTests.fs
@@ -658,14 +658,12 @@ let ``test Int32 literal addition is optimized`` () =
 let ``test Unary negation with negative literal values works`` () =
     -negLiteral |> equal 345
 
-// TODO: Erlang has arbitrary precision integers, so -(-128y) = 128, not SByte.MinValue (-128).
-// .NET fixed-width types overflow but Erlang integers don't, making this test invalid for Beam.
-// [<Fact>]
-// let ``test Unary negation with integer MinValue works`` () =
-//     -(-128y) |> equal SByte.MinValue
-//     -(-32768s) |> equal Int16.MinValue
-//     -(-2147483648) |> equal Int32.MinValue
-//     -(-9223372036854775808L) |> equal Int64.MinValue
+[<Fact>]
+let ``test Unary negation with integer MinValue works`` () =
+    -(-128y) |> equal SByte.MinValue
+    -(-32768s) |> equal Int16.MinValue
+    -(-2147483648) |> equal Int32.MinValue
+    -(-9223372036854775808L) |> equal Int64.MinValue
 
 [<Fact>]
 let ``test pown works`` () =
@@ -728,16 +726,14 @@ let ``Arithmetic right shift preserves sign for signed integer types`` () =
     -2 >>> 1 |> equal -1     // int32: 0xFFFFFFFF = -1
     -2L >>> 1 |> equal -1L   // int64: 0xFFFFFFFFFFFFFFFF = -1
 
-// TODO: ~~~ on unsigned integers uses LogicalNotDynamic which is not supported by Fable
-// [<Fact>]
-// let ``test Bitwise NOT on large unsigned integer works`` () =
-//     (~~~0x80000000u >>> 0) |> equal ~~~0x80000000u
-//     (~~~0x80000000UL>>> 0) |> equal ~~~0x80000000UL
+[<Fact>]
+let ``test Bitwise NOT on large unsigned integer works`` () =
+    (~~~0x80000000u >>> 0) |> equal ~~~0x80000000u
+    (~~~0x80000000UL>>> 0) |> equal ~~~0x80000000UL
 
-// TODO: UInt64 shift right requires unsigned masking (Erlang >>> is arithmetic shift)
-// [<Fact>]
-// let ``test UInt64 Bitwise shift right can be generated`` () =
-//     15210016002388773605UL >>> 33 |> equal 1770678907UL
+[<Fact>]
+let ``test UInt64 Bitwise shift right can be generated`` () =
+    15210016002388773605UL >>> 33 |> equal 1770678907UL
 
 // TODO: infinity/NaN not available in Erlang (1.0/0.0 raises badarith)
 // [<Fact>]
@@ -1009,3 +1005,124 @@ let ``test Decimal pown works`` () =
 // [<Fact>]
 // let ``test Big integer from byte array works`` () =
 //     Numerics.BigInteger([|255uy; 127uy|]) |> equal 32767I
+
+// --- Fixed-width integer semantics ---
+// .NET integers wrap on overflow; Erlang integers are arbitrary precision and never do.
+// The operands go through functions so the results are computed at run time rather than
+// folded into constants by the F# compiler.
+
+let private addInt32 (a: int) (b: int) = a + b
+let private subInt32 (a: int) (b: int) = a - b
+let private negInt32 (a: int) = -a
+let private addInt64 (a: int64) (b: int64) = a + b
+let private mulInt64 (a: int64) (b: int64) = a * b
+let private addByte (a: byte) (b: byte) = a + b
+let private subByte (a: byte) (b: byte) = a - b
+let private addSByte (a: sbyte) (b: sbyte) = a + b
+let private addInt16 (a: int16) (b: int16) = a + b
+let private addUInt16 (a: uint16) (b: uint16) = a + b
+let private addUInt32 (a: uint32) (b: uint32) = a + b
+let private addUInt64 (a: uint64) (b: uint64) = a + b
+let private notUInt32 (a: uint32) = ~~~a
+let private shiftLeftInt32 (a: int) (n: int) = a <<< n
+let private shiftLeftInt64 (a: int64) (n: int) = a <<< n
+let private shiftLeftUInt64 (a: uint64) (n: int) = a <<< n
+let private toByte (n: int) = byte n
+let private toSByte (n: int) = sbyte n
+let private toInt16 (n: int) = int16 n
+let private toInt32 (n: int64) = int n
+let private toUInt32 (n: int) = uint32 n
+let private toUInt64 (n: int64) = uint64 n
+
+[<Fact>]
+let ``test Int32 addition wraps on overflow`` () =
+    addInt32 Int32.MaxValue 1 |> equal Int32.MinValue
+
+[<Fact>]
+let ``test Int32 subtraction wraps on underflow`` () =
+    subInt32 Int32.MinValue 1 |> equal Int32.MaxValue
+
+[<Fact>]
+let ``test Int32 negation wraps for MinValue`` () =
+    negInt32 Int32.MinValue |> equal Int32.MinValue
+
+[<Fact>]
+let ``test Int64 addition wraps on overflow`` () =
+    addInt64 Int64.MaxValue 1L |> equal Int64.MinValue
+
+[<Fact>]
+let ``test Int16 and SByte addition wrap on overflow`` () =
+    addInt16 Int16.MaxValue 1s |> equal Int16.MinValue
+    addSByte SByte.MaxValue 1y |> equal SByte.MinValue
+
+[<Fact>]
+let ``test Unsigned addition wraps on overflow`` () =
+    addByte Byte.MaxValue 1uy |> equal 0uy
+    addUInt16 UInt16.MaxValue 1us |> equal 0us
+    addUInt32 UInt32.MaxValue 1u |> equal 0u
+    addUInt64 UInt64.MaxValue 1UL |> equal 0UL
+
+[<Fact>]
+let ``test Unsigned subtraction wraps on underflow`` () =
+    subByte 0uy 1uy |> equal 255uy
+
+[<Fact>]
+let ``test UInt64 MaxValue keeps its unsigned value`` () =
+    UInt64.MaxValue |> equal 18446744073709551615UL
+    string UInt64.MaxValue |> equal "18446744073709551615"
+
+[<Fact>]
+let ``test Bitwise complement of unsigned stays unsigned`` () =
+    notUInt32 0u |> equal UInt32.MaxValue
+
+[<Fact>]
+let ``test Shift left wraps out of the width`` () =
+    shiftLeftInt64 1L 63 |> equal Int64.MinValue
+    shiftLeftUInt64 1UL 63 |> equal 9223372036854775808UL
+    shiftLeftInt32 1 31 |> equal Int32.MinValue
+
+[<Fact>]
+let ``test Shift count is masked to the width`` () =
+    // .NET only uses the low 5 bits of an int32 shift count, and the low 6 of an int64 one
+    shiftLeftInt32 1 32 |> equal 1
+    shiftLeftInt64 1L 64 |> equal 1L
+
+[<Fact>]
+let ``test Narrowing conversions truncate`` () =
+    toByte 300 |> equal 44uy
+    toSByte 200 |> equal -56y
+    toInt16 70000 |> equal 4464s
+    toInt32 4294967297L |> equal 1
+
+[<Fact>]
+let ``test Signed to unsigned conversions reinterpret the bits`` () =
+    toUInt32 -1 |> equal UInt32.MaxValue
+    toUInt64 -1L |> equal UInt64.MaxValue
+    toInt32 (int64 (toUInt32 -1)) |> equal -1
+
+// splitmix64, as used by Hedgehog's random seed. It only produces the right numbers if
+// the int64 multiplications wrap.
+let private mix64 (x: int64) =
+    let y = (x ^^^ (x >>> 33)) * -49064778989728563L
+    let z = (y ^^^ (y >>> 33)) * -4265267296055464877L
+    z ^^^ (z >>> 33)
+
+[<Fact>]
+let ``test splitmix64 hashing matches .NET`` () =
+    mix64 42L |> equal 7599677983577462802L
+    mix64 (mix64 42L) |> equal 528134590981056164L
+    mulInt64 6364136223846793005L 1442695040888963407L |> equal 433315962919513059L
+
+// FNV-1a, the same for uint32
+let private fnv1a (s: string) =
+    let mutable hash = 2166136261u
+
+    for c in s do
+        hash <- (hash ^^^ uint32 (byte c)) * 16777619u
+
+    hash
+
+[<Fact>]
+let ``test FNV-1a hashing matches .NET`` () =
+    fnv1a "Fable" |> equal 959428905u
+    fnv1a "hello world" |> equal 3582672807u

--- a/tests/Beam/ArithmeticTests.fs
+++ b/tests/Beam/ArithmeticTests.fs
@@ -1023,16 +1023,21 @@ let private addInt16 (a: int16) (b: int16) = a + b
 let private addUInt16 (a: uint16) (b: uint16) = a + b
 let private addUInt32 (a: uint32) (b: uint32) = a + b
 let private addUInt64 (a: uint64) (b: uint64) = a + b
+let private mulUInt32 (a: uint32) (b: uint32) = a * b
+let private mulUInt64 (a: uint64) (b: uint64) = a * b
 let private notUInt32 (a: uint32) = ~~~a
 let private shiftLeftInt32 (a: int) (n: int) = a <<< n
 let private shiftLeftInt64 (a: int64) (n: int) = a <<< n
 let private shiftLeftUInt64 (a: uint64) (n: int) = a <<< n
+let private shiftLeftByte (a: byte) (n: int) = a <<< n
+let private shiftLeftInt16 (a: int16) (n: int) = a <<< n
 let private toByte (n: int) = byte n
 let private toSByte (n: int) = sbyte n
 let private toInt16 (n: int) = int16 n
 let private toInt32 (n: int64) = int n
 let private toUInt32 (n: int) = uint32 n
 let private toUInt64 (n: int64) = uint64 n
+let private toChar (n: int) = char n
 
 [<Fact>]
 let ``test Int32 addition wraps on overflow`` () =
@@ -1082,10 +1087,22 @@ let ``test Shift left wraps out of the width`` () =
     shiftLeftInt32 1 31 |> equal Int32.MinValue
 
 [<Fact>]
+let ``test Unsigned multiplication wraps on overflow`` () =
+    mulUInt32 UInt32.MaxValue 3u |> equal 4294967293u
+    mulUInt64 UInt64.MaxValue 2UL |> equal 18446744073709551614UL
+
+[<Fact>]
 let ``test Shift count is masked to the width`` () =
     // .NET only uses the low 5 bits of an int32 shift count, and the low 6 of an int64 one
     shiftLeftInt32 1 32 |> equal 1
     shiftLeftInt64 1L 64 |> equal 1L
+
+[<Fact>]
+let ``test Shift count is masked per width for narrow integers`` () =
+    // F# masks the count to the width of the type, not to 31 the way C# and JavaScript do:
+    // the low 3 bits for an 8-bit shift and the low 4 for a 16-bit one
+    shiftLeftByte 1uy 9 |> equal 2uy
+    shiftLeftInt16 1s 17 |> equal 2s
 
 [<Fact>]
 let ``test Narrowing conversions truncate`` () =
@@ -1093,6 +1110,11 @@ let ``test Narrowing conversions truncate`` () =
     toSByte 200 |> equal -56y
     toInt16 70000 |> equal 4464s
     toInt32 4294967297L |> equal 1
+
+[<Fact>]
+let ``test Narrowing conversion to char truncates`` () =
+    toChar 70000 |> equal (char 4464)
+    toChar 65 |> equal 'A'
 
 [<Fact>]
 let ``test Signed to unsigned conversions reinterpret the bits`` () =


### PR DESCRIPTION
## Problem

Erlang integers are arbitrary precision and never overflow, while .NET's `int8`..`int64` / `uint8`..`uint64` wrap. The Beam backend emitted bare Erlang arithmetic for them, so **any F# code relying on integer wraparound computed the wrong answer** on Beam.

Worse, it could hang. Hash/PRNG/checksum code depends on multiplication silently overflowing; Hedgehog's splitmix64 seed grew roughly twice as wide per iteration, and because `Seed.nextUInt64` draws with *rejection sampling* (redraw while the value exceeds a limit), an unbounded value never falls under the limit and the loop spins forever.

A second-order bug: `UInt64.MaxValue` was lowered via its signed bit pattern and emitted as `-1`, which on Beam is just minus one — so the sampling limit itself was nonsense.

## Fix

Strategy A from `FABLE-BEAM.md` (which specified this but was never implemented): bit-syntax wrapping, in a new `fable_int` runtime module. Pure Erlang, no NIF, exact, JIT-friendly. Each wrap has an in-range guard clause first, so the common case returns without building a binary.

Codegen routes through it only where a value can actually leave its width:

- **Arithmetic**: `+`, `-`, `*`, `bsl`, negation and `bnot` are wrapped. `band`/`bor`/`bxor`/`bsr`/`rem` cannot grow an in-range value, so they stay bare. `bigint` and the fixed-scale `decimal` are never wrapped.
- **Shift counts** are masked to the width, since .NET uses only the low bits (`1 <<< 32` is `1`, not `0`).
- **Conversions** now truncate on narrowing (`byte 300` = `44`), skipped when the source range already fits the target.
- **Unsigned representation**: stored as the unsigned value (`0..2^n-1`) rather than a signed bit pattern, so `UInt64.MaxValue` emits `18446744073709551615` and `bsr` is a logical shift.

Also implements `~~~` on unsigned integers (`LogicalNotDynamic`), previously an unsupported-construct error — it is one of the operations that needs wrapping.

## Verification

- Full Beam suite green: **2553 Erlang tests, 0 failures** (2546 on .NET, 0 failures).
- New fixed-width section in `tests/Beam/ArithmeticTests.fs`: wrapping on overflow/underflow for every width, shift-left wrapping, shift-count masking, narrowing conversions, signed↔unsigned reinterpretation, `UInt64.MaxValue`, and splitmix64 / FNV-1a round-trips asserted against .NET values.
- **Re-enables three tests** that were disabled for lack of fixed-width semantics: negation of `MinValue`, bitwise NOT on large unsigned, and `UInt64` shift right.
- The original symptom: a splitmix64 rejection sampler now terminates and produces draws bit-identical to .NET (`mix64 42L` = `7599677983577462802`).

Unblocks adding Beam to property-based testing with Hedgehog, which is impossible until the RNG works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)