### PR TITLE
fix(beam): qualify Erlang module names by their OTP app

### DIFF
--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -1018,39 +1018,56 @@ let private compileBeamFiles (workingDir: string) =
 /// Erlang's module namespace is flat and global, and an .erl file must be named after the module
 /// it declares. Two source files that map to the same module name therefore write the same output
 /// file, and whichever is compiled last silently overwrites the other — its functions simply
-/// disappear from the output, with the failure only surfacing as `undef` at runtime. Fail here
-/// instead, while we can still say which files are to blame.
+/// disappear from the output. A module named after one of OTP's own is just as fatal: the two
+/// names are the same atom, and whichever module loses the lookup is unreachable. Both failures
+/// surface only as `undef` at runtime, so fail here instead, while we can still say which files
+/// are to blame.
 let private checkBeamModuleNames (cliArgs: CliArgs) (sourceFiles: string seq) =
-    let collisions =
+    let modules =
         sourceFiles
-        |> Seq.filter (fun path -> path.EndsWith(".fs") || path.EndsWith(".fsx"))
+        |> Seq.filter Fable.Beam.Naming.isGeneratedModuleSource
         |> Seq.map (fun path -> Pipeline.Beam.moduleName cliArgs path, path)
-        |> Seq.groupBy fst
-        |> Seq.choose (fun (moduleName, files) ->
-            let paths = files |> Seq.map snd |> Seq.toArray
+        |> Seq.toArray
 
-            if paths.Length > 1 then
+    let fail (message: string) (details: string seq) =
+        let details = details |> String.concat Log.newLine
+        Fable.FableError($"{message}{Log.newLine}{details}") |> raise
+
+    let duplicates =
+        modules
+        |> Array.groupBy fst
+        |> Array.choose (fun (moduleName, files) ->
+            if files.Length > 1 then
                 let paths =
-                    paths
-                    |> Array.map (fun path -> "  " + File.relPathToCurDir path)
+                    files
+                    |> Array.map (fun (_, path) -> "  " + File.relPathToCurDir path)
                     |> String.concat Log.newLine
 
                 Some $"'{moduleName}' is generated from more than one file:{Log.newLine}{paths}"
             else
                 None
         )
-        |> Seq.toArray
 
-    if not (Array.isEmpty collisions) then
-        let details = collisions |> String.concat Log.newLine
+    if not (Array.isEmpty duplicates) then
+        fail
+            ("Erlang module names must be unique across the whole compilation: the module namespace "
+             + "is global and each module is written to a file named after it, so one of these would "
+             + "silently overwrite the other. Rename one of the files, or move it to a different "
+             + "assembly.")
+            duplicates
 
-        Fable.FableError(
-            "Erlang module names must be unique across the whole compilation: the module namespace "
-            + "is global and each module is written to a file named after it, so one of these would "
-            + $"silently overwrite the other.{Log.newLine}{details}{Log.newLine}"
-            + "Rename one of the files, or move it to a different assembly."
-        )
-        |> raise
+    let shadowed =
+        modules
+        |> Array.filter (fst >> Fable.Beam.Naming.otpModules.Contains)
+        |> Array.map (fun (moduleName, path) -> $"  '{moduleName}' from {File.relPathToCurDir path}")
+
+    if not (Array.isEmpty shadowed) then
+        fail
+            ("These files generate Erlang modules that shadow OTP's own: the module namespace is "
+             + "global, so the generated module and OTP's would be the same atom and one of them "
+             + "unreachable. Rename the file, or move it to a directory or assembly whose name does "
+             + "not produce a clashing module name.")
+            shadowed
 
 let private generateBeamScaffold (cliArgs: CliArgs) (entryModule: string) =
     let outDir =

--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -155,9 +155,13 @@ module private Util =
         | Beam ->
             let fileExt = cliArgs.CompilerOptions.FileExtension
 
+            // An Erlang module's file name must match the `-module` atom it declares, so the
+            // output file is named after the module, not after the F# source file.
+            let fileName = Pipeline.Beam.moduleName cliArgs file + fileExt
+
             if Naming.isInFableModules file then
-                // Library files in fable_modules: preserve subdirectory structure
-                // so they stay in fable_modules/fable-library-beam/src/
+                // Package and library sources in fable_modules: preserve the containing
+                // directory so each stays its own OTP app (fable_modules/<dep>/src/)
                 let projDir = IO.Path.GetDirectoryName cliArgs.ProjectFile
 
                 let outDir =
@@ -167,17 +171,14 @@ module private Util =
 
                 let absPath = Imports.getTargetAbsolutePath pathResolver file projDir outDir
                 let dir = IO.Path.GetDirectoryName(absPath)
-                let fileName = Pipeline.Beam.normalizeFileName absPath
-                IO.Path.Combine(dir, "src", fileName + fileExt)
+                IO.Path.Combine(dir, "src", fileName)
             else
                 // Project files: go into src/ so rebar3 picks them up
-                let fileName = Pipeline.Beam.normalizeFileName file
-
                 match cliArgs.OutDir with
-                | Some outDir -> IO.Path.Combine(IO.Path.GetFullPath outDir, "src", fileName + fileExt)
+                | Some outDir -> IO.Path.Combine(IO.Path.GetFullPath outDir, "src", fileName)
                 | None ->
                     let projDir = IO.Path.GetDirectoryName cliArgs.ProjectFile
-                    IO.Path.Combine(projDir, "src", fileName + fileExt)
+                    IO.Path.Combine(projDir, "src", fileName)
 
         | lang ->
             let changeExtension path fileExt =
@@ -1014,7 +1015,44 @@ let private compileBeamFiles (workingDir: string) =
              :: mainErlFiles)
         |> ignore
 
-let private generateBeamScaffold (cliArgs: CliArgs) =
+/// Erlang's module namespace is flat and global, and an .erl file must be named after the module
+/// it declares. Two source files that map to the same module name therefore write the same output
+/// file, and whichever is compiled last silently overwrites the other — its functions simply
+/// disappear from the output, with the failure only surfacing as `undef` at runtime. Fail here
+/// instead, while we can still say which files are to blame.
+let private checkBeamModuleNames (cliArgs: CliArgs) (sourceFiles: string seq) =
+    let collisions =
+        sourceFiles
+        |> Seq.filter (fun path -> path.EndsWith(".fs") || path.EndsWith(".fsx"))
+        |> Seq.map (fun path -> Pipeline.Beam.moduleName cliArgs path, path)
+        |> Seq.groupBy fst
+        |> Seq.choose (fun (moduleName, files) ->
+            let paths = files |> Seq.map snd |> Seq.toArray
+
+            if paths.Length > 1 then
+                let paths =
+                    paths
+                    |> Array.map (fun path -> "  " + File.relPathToCurDir path)
+                    |> String.concat Log.newLine
+
+                Some $"'{moduleName}' is generated from more than one file:{Log.newLine}{paths}"
+            else
+                None
+        )
+        |> Seq.toArray
+
+    if not (Array.isEmpty collisions) then
+        let details = collisions |> String.concat Log.newLine
+
+        Fable.FableError(
+            "Erlang module names must be unique across the whole compilation: the module namespace "
+            + "is global and each module is written to a file named after it, so one of these would "
+            + $"silently overwrite the other.{Log.newLine}{details}{Log.newLine}"
+            + "Rename one of the files, or move it to a different assembly."
+        )
+        |> raise
+
+let private generateBeamScaffold (cliArgs: CliArgs) (entryModule: string) =
     let outDir =
         cliArgs.OutDir
         |> Option.defaultWith (fun () -> IO.Path.GetDirectoryName cliArgs.ProjectFile)
@@ -1072,6 +1110,29 @@ let private generateBeamScaffold (cliArgs: CliArgs) =
     let srcDir = IO.Path.Combine(outDir, "src")
     IO.Directory.CreateDirectory(srcDir) |> ignore
     writeIfChanged (IO.Path.Combine(srcDir, projectName + ".app.src")) (appContent projectName "0.1.0")
+
+    // Module names are qualified by the app they belong to, so the entry point of a project
+    // compiled from Program.fs is `my_app_program:main/0`, not `main:main/0`. Emit a `main`
+    // shim forwarding to it so runners have a stable, well-known entry module to call.
+    //
+    // Not for fable-library: its compiled output is copied into every consuming app's
+    // fable_modules, so a `main` module of its own would collide with the app's.
+    if
+        entryModule <> "main"
+        && not (Fable.Beam.Naming.isFableLibraryPath cliArgs.ProjectFile)
+        && IO.File.Exists(IO.Path.Combine(srcDir, entryModule + ".erl"))
+    then
+        let mainShim =
+            $"""{generatedMarker}
+-module(main).
+-export([main/0, main/1]).
+
+main() -> {entryModule}:main().
+
+main(_Args) -> {entryModule}:main().
+"""
+
+        writeIfChanged (IO.Path.Combine(srcDir, "main.erl")) mainShim
 
     // Write root rebar.config
     let rootRebarConfig = IO.Path.Combine(outDir, "rebar.config")
@@ -1303,6 +1364,11 @@ let private compilationCycle (state: State) (changes: ISet<string>) =
                     cliArgs
                 | _ -> state, cliArgs
 
+            if cliArgs.CompilerOptions.Language = Beam then
+                projCracked.SourceFiles
+                |> Array.map (fun f -> f.NormalizedFullPath)
+                |> checkBeamModuleNames cliArgs
+
             let! fableCompiler =
                 match fableCompiler with
                 | None -> FableCompiler.Init(projCracked)
@@ -1462,7 +1528,14 @@ let private compilationCycle (state: State) (changes: ISet<string>) =
 
             // Generate rebar3 scaffold for BEAM target after successful compilation
             if cliArgs.CompilerOptions.Language = Beam && not hasError then
-                generateBeamScaffold cliArgs
+                // The last source file is the entry point of a Fable program: its module-level
+                // actions compile to that module's main/0.
+                let entryModule =
+                    projCracked.SourceFiles
+                    |> Array.last
+                    |> fun f -> Pipeline.Beam.moduleName cliArgs f.NormalizedFullPath
+
+                generateBeamScaffold cliArgs entryModule
 
             // Run process
             let exitCode, state =

--- a/src/Fable.Cli/Pipeline.fs
+++ b/src/Fable.Cli/Pipeline.fs
@@ -503,74 +503,27 @@ module Rust =
         }
 
 module Beam =
-    /// Erlang module names must be lowercase snake_case and match the filename
-    let normalizeFileName path =
-        Path.GetFileNameWithoutExtension(path).Replace(".", "_").Replace("-", "_")
-        |> Naming.applyCaseRule Core.CaseRules.SnakeCase
+    // Module naming lives in Fable.Transforms so the code generator and the CLI agree on the
+    // name of every generated module — an Erlang module's file name must match its `-module`
+    // atom, and an import must resolve to the same atom the imported file declared.
+    let normalizeAppName = Fable.Beam.Naming.normalizeAppName
+    let deriveDepAppName = Fable.Beam.Naming.deriveDepAppName
+    let extractDepVersion = Fable.Beam.Naming.extractDepVersion
 
-    /// True when a dot-segment looks like a version number (starts with a digit).
-    let private isVersionSegment (s: string) = s.Length > 0 && Char.IsDigit(s.[0])
+    /// The Erlang module name of an F# source file, qualified by the assembly it belongs to.
+    let moduleName (cliArgs: CliArgs) (sourcePath: string) =
+        Fable.Beam.Naming.erlangModuleName cliArgs.ProjectFile sourcePath
 
-    /// Normalize a name to a valid OTP application name (lowercase snake_case, no leading/trailing underscores).
-    ///   "Fable.Tests.Beam" → "fable_tests_beam"
-    ///   "fable-library-beam" → "fable_library_beam"
-    let normalizeAppName (name: string) =
-        name.Replace('.', '_').Replace('-', '_').ToLowerInvariant().Trim('_')
-
-    /// Derive an OTP application name from a fable_modules directory name.
-    ///   "Fable.Logging.0.10.0"         → "fable_logging"
-    ///   "fable-library-beam"           → "fable_library_beam"
-    ///   "Fable.Python.4.0.0-theta-003" → "fable_python"
-    let deriveDepAppName (dirName: string) =
-        let dotParts = dirName.Split('.')
-
-        let namePart =
-            match dotParts |> Array.tryFindIndex isVersionSegment with
-            | Some idx when idx > 0 -> dotParts.[.. idx - 1] |> String.concat "."
-            | _ -> dirName
-
-        normalizeAppName namePart
-
-    /// Extract the version string from a fable_modules directory name.
-    ///   "Fable.Logging.0.10.0"         → "0.10.0"
-    ///   "Fable.Python.4.0.0-theta-003" → "4.0.0-theta-003"
-    ///   "fable-library-beam"           → "0.1.0"
-    let extractDepVersion (dirName: string) =
-        let dotParts = dirName.Split('.')
-
-        match dotParts |> Array.tryFindIndex isVersionSegment with
-        | Some idx -> dotParts.[idx..] |> String.concat "."
-        | None -> "0.1.0"
-
-    let getTargetPath (cliArgs: CliArgs) (targetPath: string) =
-        let fileExt = cliArgs.CompilerOptions.FileExtension
-        let targetDir = Path.GetDirectoryName(targetPath)
-        let fileName = normalizeFileName targetPath
-        Path.Combine(targetDir, fileName + fileExt)
-
-    type BeamWriter(com: Compiler, cliArgs: CliArgs, pathResolver, targetPath: string) =
-        let sourcePath = com.CurrentFile
-        let fileExt = cliArgs.CompilerOptions.FileExtension
+    type BeamWriter(com: Compiler, targetPath: string) =
         let stream = new IO.StreamWriter(targetPath)
 
         interface Printer.Writer with
             member _.Write(str) =
                 stream.WriteAsync(str) |> Async.AwaitTask
 
-            member _.MakeImportPath(path) =
-                let projDir = IO.Path.GetDirectoryName(cliArgs.ProjectFile)
-
-                let path =
-                    Imports.getImportPath pathResolver sourcePath targetPath projDir cliArgs.OutDir path
-
-                if path.EndsWith(".fs", StringComparison.Ordinal) then
-                    let path = Path.ChangeExtension(path, fileExt)
-                    // Convert filename to snake_case to match Erlang module naming
-                    let dir = Path.GetDirectoryName(path)
-                    let fileName = normalizeFileName path + Path.GetExtension(path)
-                    Path.Combine(dir, fileName)
-                else
-                    path
+            // Erlang has no import paths: a module is referenced by its atom alone, and the
+            // Erlang printer never asks for one. Module names are resolved in Fable2Beam.
+            member _.MakeImportPath(path) = path
 
             member _.AddSourceMapping(_, _, _, _, _, _) = ()
 
@@ -579,7 +532,7 @@ module Beam =
 
             member _.Dispose() = stream.Dispose()
 
-    let compileFile (com: Compiler) (cliArgs: CliArgs) pathResolver isSilent (outPath: string) =
+    let compileFile (com: Compiler) isSilent (outPath: string) =
         async {
             let erlModule =
                 FSharp2Fable.Compiler.transformFile com
@@ -587,7 +540,7 @@ module Beam =
                 |> Fable.Transforms.Beam.Compiler.transformFile com
 
             if not (isSilent || ErlangPrinter.isEmpty erlModule) then
-                use writer = new BeamWriter(com, cliArgs, pathResolver, outPath)
+                use writer = new BeamWriter(com, outPath)
                 do! ErlangPrinter.run writer erlModule
         }
 
@@ -599,4 +552,4 @@ let compileFile (com: Compiler) (cliArgs: CliArgs) pathResolver isSilent (outPat
     | Php -> Php.compileFile com cliArgs pathResolver isSilent outPath
     | Dart -> Dart.compileFile com cliArgs pathResolver isSilent outPath
     | Rust -> Rust.compileFile com cliArgs pathResolver isSilent outPath
-    | Beam -> Beam.compileFile com cliArgs pathResolver isSilent outPath
+    | Beam -> Beam.compileFile com isSilent outPath

--- a/src/Fable.Transforms/Beam/FABLE-BEAM.md
+++ b/src/Fable.Transforms/Beam/FABLE-BEAM.md
@@ -262,6 +262,63 @@ Erlang modules implementing F# core types:
 | `quicktest.fs`        | `printfn "Hello from BEAM!"`        | Done   |
 | `quicktest.fsproj`    | Project file referencing Fable.Core | Done   |
 
+## Module Naming
+
+Erlang's module namespace is **flat and global**. The atom in `-module(...)` is a module's only
+identity: neither the directory the `.erl` file sits in nor the OTP application it belongs to
+scopes it, and the code server resolves the atom across the whole code path. An `.erl` file must
+also be named after the module it declares.
+
+So every generated module name is qualified by the application it belongs to — the same
+convention OTP itself follows (`cowboy_req`, `rebar_app_info`) and that Fable's own runtime
+already used (`fable_list`, `fable_map`):
+
+| F# source                            | Erlang module           |
+| ------------------------------------ | ----------------------- |
+| `<proj>/Program.fs` in `MyApp`       | `my_app_program`        |
+| `<proj>/Misc/Util2.fs` in `MyApp`    | `my_app_misc_util2`     |
+| `../Scriptorium.Quill/DSL.fs`        | `scriptorium_quill_dsl` |
+| `fable_modules/Hedgehog.0.11/Gen.fs` | `hedgehog_gen`          |
+
+Naming a module after the bare basename of its file, as the backend used to, breaks in three ways
+— all silent at compile time and fatal at runtime:
+
+1. **OTP is shadowed.** `Gen.fs`, `Random.fs`, `String.fs`, `Timer.fs`, `Queue.fs`, ... all name
+   real OTP stdlib modules. OTP's win, and calls into the generated code raise `undef`.
+2. **Assemblies overwrite each other.** Two `DSL.fs` files in two projects both emit `dsl.erl`
+   into the flat output `src/`; the one compiled last overwrites the other **on disk**, and the
+   loser's functions vanish from the output entirely.
+3. **Files within an assembly collide** the same way (`Foo/Types.fs` vs `Bar/Types.fs`).
+
+Two exemptions:
+
+- **fable-library** keeps its bare, hand-maintained names (`fable_list`, `seq`, `range`, ...).
+  It is the one project whose *compiled* output ships as a dependency, and `getLibPath` in
+  `Transforms.Util` refers to its modules by exactly those names.
+- **Native Erlang modules** reached through `BeamInterop` (`string`, `lists`, ...) are of course
+  referenced by their own names.
+
+Naming lives in one place, `Fable.Beam.Naming.erlangModuleName` (`Beam/Prelude.fs`), because the
+code generator (which must resolve an import to the atom the imported file declared) and the CLI
+(which must write the file under the name of the module inside it) have to agree exactly.
+
+If two source files ever do map to the same module name, Fable **fails with an error** naming both
+files rather than silently overwriting one — see `checkBeamModuleNames` in `Fable.Cli/Main.fs`.
+
+### Entry point
+
+Since module names are qualified, the entry point of a project compiled from `Program.fs` is
+`my_app_program:main/0`, not `main:main/0`. Fable therefore also emits a small `src/main.erl`
+shim exporting `main/0` and `main/1` that forwards to it, so runners have a stable, well-known
+entry module:
+
+```sh
+erl -noshell -pa src -eval "main:main([])" -s init stop
+```
+
+As elsewhere in Fable's Beam output, the entry point is the *last* source file of the project:
+its module-level actions compile to that module's `main/0`.
+
 ## Type Mappings
 
 ### Natural fits (F# → Erlang)
@@ -574,6 +631,8 @@ DecisionTree) were implemented in Phase 2. This phase adds records and structura
 - [x] Import resolution and path handling
 - [x] Export lists (`-export([...])`)
 - [x] Snake_case output filenames (matching Erlang module name convention)
+- [x] Module names qualified by their OTP app, so they can neither shadow an OTP module nor
+  collide across assemblies (see [Module Naming](#module-naming))
 - [x] Function name sanitization (`$XXXX` hex sequences from F# backtick names)
 - [x] Cross-module call resolution (derive module from `importInfo.Path`)
 - [x] Inline `assertEqual`/`assertNotEqual` assertions (no util dependency needed)

--- a/src/Fable.Transforms/Beam/FABLE-BEAM.md
+++ b/src/Fable.Transforms/Beam/FABLE-BEAM.md
@@ -302,8 +302,15 @@ Naming lives in one place, `Fable.Beam.Naming.erlangModuleName` (`Beam/Prelude.f
 code generator (which must resolve an import to the atom the imported file declared) and the CLI
 (which must write the file under the name of the module inside it) have to agree exactly.
 
-If two source files ever do map to the same module name, Fable **fails with an error** naming both
-files rather than silently overwriting one — see `checkBeamModuleNames` in `Fable.Cli/Main.fs`.
+Qualification is a convention, not a guarantee, so `checkBeamModuleNames` (`Fable.Cli/Main.fs`)
+**fails the build** on the two ways it can still go wrong, rather than letting either surface as an
+`undef` at runtime:
+
+- two source files mapping to the same module name — it names both files;
+- a module name that is one of OTP's own (`Naming.otpModules`). Qualification rules out the bare
+  names, but a two-segment name can still land on a real OTP module — an app named `Gen` with a
+  `Server.fs` produces `gen_server` — and fable-library's exempt modules are not qualified at all,
+  so a `Timer.fs` added to it would silently shadow OTP's `timer`.
 
 ### Entry point
 

--- a/src/Fable.Transforms/Beam/Fable2Beam.Reflection.fs
+++ b/src/Fable.Transforms/Beam/Fable2Beam.Reflection.fs
@@ -211,7 +211,7 @@ let rec private transformTypeInfoRec
                 if sourcePath = com.CurrentFile then
                     None // local call
                 else
-                    Some(Fable.Beam.Naming.moduleNameFromFile sourcePath)
+                    Some(Fable.Beam.Naming.erlangModuleName com.ProjectFile sourcePath)
 
             let funcName =
                 FSharp2Fable.Helpers.getEntityDeclarationName com entRef |> reflectionFuncName

--- a/src/Fable.Transforms/Beam/Fable2Beam.fs
+++ b/src/Fable.Transforms/Beam/Fable2Beam.fs
@@ -166,7 +166,7 @@ let resolveImportModuleName (com: IBeamCompiler) (importPath: string) =
     // Imports that don't point at an F# source file name a module Fable doesn't generate:
     // a native Erlang module (`string`, `lists`, ...) or a fable-library `.erl` file. Those
     // are referenced by their own name.
-    if not (importPath.EndsWith(".fs", System.StringComparison.Ordinal)) then
+    if not (isFSharpSource importPath) then
         Some(moduleNameFromFile importPath)
     else
         // Resolve the import path to an absolute path so we can reliably compare against the

--- a/src/Fable.Transforms/Beam/Fable2Beam.fs
+++ b/src/Fable.Transforms/Beam/Fable2Beam.fs
@@ -163,26 +163,28 @@ let private matchTargetIdentAndValues idents values =
 
 /// Resolve the Erlang module name for an import, returning None if it's the current module.
 let resolveImportModuleName (com: IBeamCompiler) (importPath: string) =
-    let name = moduleNameFromFile importPath
-
-    // Resolve the import path to an absolute path so we can reliably compare
-    // against the current file. Import paths may be relative (e.g., "../Foo/Types.fs")
-    // or absolute. Without resolving, two different files with the same base name
-    // (e.g., Agent/Types.fs vs Reactive/Types.fs) would both produce module name "types"
-    // and the import would be incorrectly treated as a local (self-recursive) call.
-    let resolvedImportPath =
-        if Path.IsPathRooted(importPath) then
-            Path.GetFullPath(importPath)
-        else
-            let currentDir = Path.GetDirectoryName(com.CurrentFile)
-            Path.GetFullPath(Path.Combine(currentDir, importPath))
-
-    let currentFileFull = Path.GetFullPath(com.CurrentFile)
-
-    if resolvedImportPath = currentFileFull then
-        None
+    // Imports that don't point at an F# source file name a module Fable doesn't generate:
+    // a native Erlang module (`string`, `lists`, ...) or a fable-library `.erl` file. Those
+    // are referenced by their own name.
+    if not (importPath.EndsWith(".fs", System.StringComparison.Ordinal)) then
+        Some(moduleNameFromFile importPath)
     else
-        Some name
+        // Resolve the import path to an absolute path so we can reliably compare against the
+        // current file, and so the module name is derived from the file's real location.
+        // Import paths may be relative (e.g., "../Foo/Types.fs") or absolute.
+        let resolvedImportPath =
+            if Path.IsPathRooted(importPath) then
+                Path.GetFullPath(importPath)
+            else
+                let currentDir = Path.GetDirectoryName(com.CurrentFile)
+                Path.GetFullPath(Path.Combine(currentDir, importPath))
+
+        let currentFileFull = Path.GetFullPath(com.CurrentFile)
+
+        if resolvedImportPath = currentFileFull then
+            None
+        else
+            Some(erlangModuleName com.ProjectFile resolvedImportPath)
 
 /// Detect whether an expression reads a *free* mutable ident — a module-level mutable
 /// not bound locally within the expression. Such reads must be snapshotted at module-init
@@ -3771,7 +3773,7 @@ and transformDeclaration (com: IBeamCompiler) (ctx: Context) (decl: Declaration)
         transformClassDeclaration com ctx className ent decl
 
 let transformFile (com: Fable.Compiler) (file: File) : Beam.ErlModule =
-    let moduleName = moduleNameFromFile com.CurrentFile
+    let moduleName = erlangModuleName com.ProjectFile com.CurrentFile
 
     let ctx =
         {

--- a/src/Fable.Transforms/Beam/Prelude.fs
+++ b/src/Fable.Transforms/Beam/Prelude.fs
@@ -143,9 +143,237 @@ module Naming =
         | Some idx -> dotParts.[idx..] |> String.concat "."
         | None -> "0.1.0"
 
-    let private isFSharpSource (path: string) =
+    /// True for a source file Fable compiles into a generated Erlang module. A signature file
+    /// declares no module of its own, so it is not one.
+    let isGeneratedModuleSource (path: string) =
         let ext = Fable.Path.GetExtension(path)
-        ext = ".fs" || ext = ".fsx" || ext = ".fsi"
+        ext = ".fs" || ext = ".fsx"
+
+    /// True for a path naming an F# source file. Anything else (a native Erlang module named in
+    /// a `BeamInterop` import, one of fable-library's hand-written `.erl` files) names a module
+    /// Fable does not generate, and keeps its own name.
+    let isFSharpSource (path: string) =
+        isGeneratedModuleSource path || Fable.Path.GetExtension(path) = ".fsi"
+
+    /// Modules of OTP's own `erts`, `kernel` and `stdlib` applications. The module namespace is
+    /// flat and global, so a generated module named after one of these shadows it (or is shadowed
+    /// by it) everywhere in the release, and calls to either raise `undef` at runtime.
+    ///
+    /// Qualifying generated names by their app rules out the bare ones (`gen`, `string`, ...),
+    /// but a two-segment name can still land on `gen_server` or `erl_eval` — an app named `Gen`
+    /// with a `Server.fs` does exactly that — and fable-library's exempt modules are not
+    /// qualified at all. `checkBeamModuleNames` fails the build on any name in this set.
+    let otpModules =
+        System.Collections.Generic.HashSet
+            [
+                // erts (preloaded)
+                "atomics"
+                "counters"
+                "erl_init"
+                "erl_prim_loader"
+                "erl_tracer"
+                "erlang"
+                "erts_code_purger"
+                "erts_dirty_process_signal_handler"
+                "erts_internal"
+                "erts_literal_area_collector"
+                "erts_trace_cleaner"
+                "init"
+                "persistent_term"
+                "prim_buffer"
+                "prim_eval"
+                "prim_file"
+                "prim_inet"
+                "prim_net"
+                "prim_socket"
+                "prim_zip"
+                "socket_registry"
+                "zlib"
+                // kernel + stdlib
+                "application"
+                "application_controller"
+                "application_master"
+                "application_starter"
+                "array"
+                "auth"
+                "base64"
+                "beam_lib"
+                "binary"
+                "c"
+                "calendar"
+                "code"
+                "code_server"
+                "dets"
+                "dets_server"
+                "dets_sup"
+                "dets_utils"
+                "dets_v9"
+                "dict"
+                "digraph"
+                "digraph_utils"
+                "disk_log"
+                "disk_log_1"
+                "disk_log_server"
+                "disk_log_sup"
+                "dist_ac"
+                "dist_util"
+                "edlin"
+                "edlin_expand"
+                "epp"
+                "erl_abstract_code"
+                "erl_anno"
+                "erl_bits"
+                "erl_boot_server"
+                "erl_compile"
+                "erl_compile_server"
+                "erl_ddll"
+                "erl_distribution"
+                "erl_epmd"
+                "erl_error"
+                "erl_erts_errors"
+                "erl_eval"
+                "erl_expand_records"
+                "erl_features"
+                "erl_internal"
+                "erl_kernel_errors"
+                "erl_lint"
+                "erl_parse"
+                "erl_posix_msg"
+                "erl_pp"
+                "erl_reply"
+                "erl_scan"
+                "erl_signal_handler"
+                "erl_stdlib_errors"
+                "erl_tar"
+                "erpc"
+                "error_handler"
+                "error_logger"
+                "error_logger_file_h"
+                "error_logger_tty_h"
+                "erts_debug"
+                "escript"
+                "ets"
+                "eval_bits"
+                "file"
+                "file_io_server"
+                "file_server"
+                "file_sorter"
+                "filelib"
+                "filename"
+                "gb_sets"
+                "gb_trees"
+                "gen"
+                "gen_event"
+                "gen_fsm"
+                "gen_sctp"
+                "gen_server"
+                "gen_statem"
+                "gen_tcp"
+                "gen_tcp_socket"
+                "gen_udp"
+                "gen_udp_socket"
+                "global"
+                "global_group"
+                "global_search"
+                "group"
+                "group_history"
+                "heart"
+                "inet"
+                "inet6_sctp"
+                "inet6_tcp"
+                "inet6_tcp_dist"
+                "inet6_udp"
+                "inet_config"
+                "inet_db"
+                "inet_dns"
+                "inet_gethost_native"
+                "inet_hosts"
+                "inet_parse"
+                "inet_res"
+                "inet_sctp"
+                "inet_tcp"
+                "inet_tcp_dist"
+                "inet_udp"
+                "io"
+                "io_lib"
+                "io_lib_format"
+                "io_lib_fread"
+                "io_lib_pretty"
+                "kernel"
+                "kernel_config"
+                "kernel_refc"
+                "lists"
+                "local_tcp"
+                "local_udp"
+                "log_mf_h"
+                "logger"
+                "logger_backend"
+                "logger_config"
+                "logger_disk_log_h"
+                "logger_filters"
+                "logger_formatter"
+                "logger_h_common"
+                "logger_handler_watcher"
+                "logger_olp"
+                "logger_proxy"
+                "logger_server"
+                "logger_simple_h"
+                "logger_std_h"
+                "logger_sup"
+                "maps"
+                "math"
+                "ms_transform"
+                "net"
+                "net_adm"
+                "net_kernel"
+                "orddict"
+                "ordsets"
+                "os"
+                "otp_internal"
+                "peer"
+                "pg"
+                "pg2"
+                "pool"
+                "proc_lib"
+                "proplists"
+                "qlc"
+                "qlc_pt"
+                "queue"
+                "ram_file"
+                "rand"
+                "random"
+                "raw_file_io"
+                "raw_file_io_compressed"
+                "raw_file_io_deflate"
+                "raw_file_io_delayed"
+                "raw_file_io_inflate"
+                "raw_file_io_list"
+                "re"
+                "rpc"
+                "seq_trace"
+                "sets"
+                "shell"
+                "shell_default"
+                "shell_docs"
+                "slave"
+                "socket"
+                "sofs"
+                "standard_error"
+                "string"
+                "supervisor"
+                "supervisor_bridge"
+                "sys"
+                "timer"
+                "unicode"
+                "unicode_util"
+                "uri_string"
+                "user"
+                "user_drv"
+                "user_sup"
+                "win32reg"
+                "wrap_log_reader"
+                "zip"
+            ]
 
     /// True for a path inside fable-library — its own sources, or its sources copied into a
     /// consumer's fable_modules.
@@ -212,15 +440,20 @@ module Naming =
                 let projSegs = splitPath (Fable.Path.GetDirectoryName(projectFile))
                 let shared = commonPrefixLength projSegs fileSegs
                 let belowProjDir = fileSegs.[shared..]
+                let appName = Fable.Path.GetFileNameWithoutExtension(projectFile)
 
                 // A file outside the project directory belongs to a referenced project, and its
                 // path below the shared ancestor starts with that project's own directory —
                 // conventionally its name — which is the qualifier we want. Unless there is no
                 // such directory (the file sits directly in the shared ancestor, as a linked
                 // `../Gen.fs` does), in which case the only assembly it can belong to is this one.
-                if shared = projSegs.Length || belowProjDir.Length < 2 then
-                    let appName = Fable.Path.GetFileNameWithoutExtension(projectFile)
-
+                if projSegs.Length > 0 && shared = 0 then
+                    // The two paths have no ancestor in common at all (different Windows drives,
+                    // say). "Below the shared ancestor" is then the whole absolute path, which
+                    // would bake the machine's directory layout into the module name — qualify by
+                    // the project and keep only the file name.
+                    joinModuleName [| appName; Array.last fileSegs |]
+                elif shared = projSegs.Length || belowProjDir.Length < 2 then
                     Array.append [| appName |] belowProjDir |> joinModuleName
                 else
                     belowProjDir |> joinModuleName

--- a/src/Fable.Transforms/Beam/Prelude.fs
+++ b/src/Fable.Transforms/Beam/Prelude.fs
@@ -91,6 +91,140 @@ module Naming =
         |> fun s -> s.Replace(".", "_").Replace("-", "_")
         |> Fable.Naming.applyCaseRule Fable.Core.CaseRules.SnakeCase
 
+    // ----------------------------------------------------------------------------------
+    // Qualified module names
+    //
+    // Erlang's module namespace is flat and global: the atom in `-module(...)` is a module's
+    // only identity, and neither the directory nor the OTP application an .erl file lives in
+    // scopes it. Naming a module after the bare basename of its F# file therefore collides
+    // with OTP's own modules (`gen`, `random`, `string`, ...) and with same-named files from
+    // other assemblies — silently, and fatally at runtime.
+    //
+    // So qualify the name with the application it belongs to, which is what OTP itself does
+    // (`cowboy_req`, `rebar_app_info`) and what Fable's own runtime already does (`fable_list`).
+    // ----------------------------------------------------------------------------------
+
+    let private splitPath (path: string) =
+        path.Replace('\\', '/').Split('/')
+        |> Array.filter (fun s -> s <> "" && s <> ".")
+
+    /// True when a dot-segment looks like a version number (starts with a digit).
+    let private isVersionSegment (s: string) =
+        s.Length > 0 && System.Char.IsDigit(s.[0])
+
+    /// Normalize a name to a valid OTP application name (lowercase snake_case, no leading/trailing underscores).
+    ///   "Fable.Tests.Beam" → "fable_tests_beam"
+    ///   "fable-library-beam" → "fable_library_beam"
+    let normalizeAppName (name: string) =
+        name.Replace('.', '_').Replace('-', '_').ToLowerInvariant().Trim('_')
+
+    /// Derive an OTP application name from a fable_modules directory name.
+    ///   "Fable.Logging.0.10.0"         → "fable_logging"
+    ///   "fable-library-beam"           → "fable_library_beam"
+    ///   "Fable.Python.4.0.0-theta-003" → "fable_python"
+    let deriveDepAppName (dirName: string) =
+        let dotParts = dirName.Split('.')
+
+        let namePart =
+            match dotParts |> Array.tryFindIndex isVersionSegment with
+            | Some idx when idx > 0 -> dotParts.[.. idx - 1] |> String.concat "."
+            | _ -> dirName
+
+        normalizeAppName namePart
+
+    /// Extract the version string from a fable_modules directory name.
+    ///   "Fable.Logging.0.10.0"         → "0.10.0"
+    ///   "Fable.Python.4.0.0-theta-003" → "4.0.0-theta-003"
+    ///   "fable-library-beam"           → "0.1.0"
+    let extractDepVersion (dirName: string) =
+        let dotParts = dirName.Split('.')
+
+        match dotParts |> Array.tryFindIndex isVersionSegment with
+        | Some idx -> dotParts.[idx..] |> String.concat "."
+        | None -> "0.1.0"
+
+    let private isFSharpSource (path: string) =
+        let ext = Fable.Path.GetExtension(path)
+        ext = ".fs" || ext = ".fsx" || ext = ".fsi"
+
+    /// True for a path inside fable-library — its own sources, or its sources copied into a
+    /// consumer's fable_modules.
+    ///
+    /// fable-library is the one Fable project whose *compiled* output ships as a dependency of
+    /// other projects, so it gets two exemptions: its modules keep their bare, hand-maintained
+    /// names (`fable_list`, `seq`, ...) — already namespaced by the `fable_` convention, and
+    /// `Transforms.Util.getLibPath` refers to them by exactly those names — and it is never
+    /// given an entry-point shim, which would collide with the consuming app's own.
+    let isFableLibraryPath (path: string) =
+        splitPath path
+        |> Array.exists (fun seg -> seg.StartsWith("fable-library", System.StringComparison.Ordinal))
+
+    /// Join path segments into a single snake_case Erlang atom.
+    /// `[ "Scriptorium.Quill"; "DSL" ]` → `scriptorium_quill_dsl`
+    let private joinModuleName (segments: string seq) =
+        segments
+        |> Seq.map (fun s -> s.Replace('.', '_').Replace('-', '_'))
+        |> String.concat "_"
+        |> Fable.Naming.applyCaseRule Fable.Core.CaseRules.SnakeCase
+        |> fun s -> Regex.Replace(s, "_+", "_")
+        |> fun s -> s.Trim('_')
+        |> checkErlKeywords
+
+    /// Number of leading segments `a` and `b` have in common.
+    let private commonPrefixLength (a: string[]) (b: string[]) =
+        let mutable i = 0
+
+        while i < a.Length
+              && i < b.Length
+              && System.String.Equals(a.[i], b.[i], System.StringComparison.OrdinalIgnoreCase) do
+            i <- i + 1
+
+        i
+
+    /// The Erlang module name for an F# source file, qualified by the assembly it belongs to
+    /// so that it is unique across the whole compilation and cannot shadow an OTP module:
+    ///
+    ///   fable_modules/Hedgehog.0.11.0/Gen.fs  → hedgehog_gen        (package source)
+    ///   <projDir>/Misc/Util2.fs               → my_app_misc_util2   (the project's own source)
+    ///   <projDir>/../Quill/DSL.fs             → quill_dsl           (referenced project)
+    ///
+    /// Non-source paths (native Erlang modules such as `string`, and fable-library's `.erl`
+    /// files) are passed through untouched — they name modules Fable does not generate.
+    let erlangModuleName (projectFile: string) (filePath: string) =
+        if not (isFSharpSource filePath) || isFableLibraryPath filePath then
+            moduleNameFromFile filePath
+        else
+            let fileSegs = splitPath filePath
+
+            // Drop the extension from the file name segment
+            let fileSegs =
+                Array.append
+                    fileSegs.[.. fileSegs.Length - 2]
+                    [| Fable.Path.GetFileNameWithoutExtension(fileSegs.[fileSegs.Length - 1]) |]
+
+            match fileSegs |> Array.tryFindIndex (fun s -> s = Fable.Naming.fableModules) with
+            | Some i when i + 2 <= fileSegs.Length - 1 ->
+                // A package's sources, copied into fable_modules: the containing directory names
+                // the app (`Hedgehog.0.11.0` → `hedgehog`), the rest is its path within the app.
+                Array.append [| deriveDepAppName fileSegs.[i + 1] |] fileSegs.[i + 2 ..]
+                |> joinModuleName
+            | _ ->
+                let projSegs = splitPath (Fable.Path.GetDirectoryName(projectFile))
+                let shared = commonPrefixLength projSegs fileSegs
+                let belowProjDir = fileSegs.[shared..]
+
+                // A file outside the project directory belongs to a referenced project, and its
+                // path below the shared ancestor starts with that project's own directory —
+                // conventionally its name — which is the qualifier we want. Unless there is no
+                // such directory (the file sits directly in the shared ancestor, as a linked
+                // `../Gen.fs` does), in which case the only assembly it can belong to is this one.
+                if shared = projSegs.Length || belowProjDir.Length < 2 then
+                    let appName = Fable.Path.GetFileNameWithoutExtension(projectFile)
+
+                    Array.append [| appName |] belowProjDir |> joinModuleName
+                else
+                    belowProjDir |> joinModuleName
+
     let capitalizeFirst (s: string) =
         if s.Length = 0 then
             s

--- a/tests/Beam/Fable.Tests.Beam.fsproj
+++ b/tests/Beam/Fable.Tests.Beam.fsproj
@@ -27,6 +27,12 @@
     <Compile Include="Misc/Imports.fs" />
     <Compile Include="Misc/Util2.fs" />
     <Compile Include="Misc/Util3.fs" />
+    <!-- File names that collide with OTP stdlib modules, and with each other -->
+    <Compile Include="Naming/Gen.fs" />
+    <Compile Include="Naming/Random.fs" />
+    <Compile Include="Naming/String.fs" />
+    <Compile Include="Naming/First/Types.fs" />
+    <Compile Include="Naming/Second/Types.fs" />
     <Compile Include="Util.fs" />
     <Compile Include="ArithmeticTests.fs" />
     <Compile Include="RandomTests.fs" />
@@ -91,6 +97,7 @@
     <Compile Include="QuotationTests.fs" />
     <Compile Include="ModuleMutableOneTests.fs" />
     <Compile Include="ModuleMutableTwoTests.fs" />
+    <Compile Include="ModuleNamingTests.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
 </Project>

--- a/tests/Beam/ModuleNamingTests.fs
+++ b/tests/Beam/ModuleNamingTests.fs
@@ -1,0 +1,33 @@
+module Fable.Tests.ModuleNaming
+
+open Fable.Tests.Util
+open Util.Testing
+
+// Erlang's module namespace is flat and global, so the Beam backend qualifies every generated
+// module with the app it belongs to. These tests call across file boundaries into modules whose
+// file names would otherwise produce a colliding module name — a wrong module atom shows up as
+// an `undef` at runtime, not as a compile error.
+
+// --- Names that collide with OTP stdlib modules ---
+
+[<Fact>]
+let ``test Module named Gen does not resolve to OTP gen`` () =
+    Naming.Gen.delay (fun () -> 41) |> equal 42
+    Naming.Gen.constant "x" () |> equal "x"
+
+[<Fact>]
+let ``test Module named Random does not resolve to OTP random`` () =
+    Naming.Random.next 1 |> equal 1103527590
+    Naming.Random.range 0 10 1 |> equal 0
+
+[<Fact>]
+let ``test Module named String does not resolve to OTP string`` () =
+    Naming.String.reverse "abc" |> equal "cba"
+    Naming.String.repeat 3 "ab" |> equal "ababab"
+
+// --- Same file name in two directories of the same assembly ---
+
+[<Fact>]
+let ``test Same-named files in different directories both survive`` () =
+    Naming.First.Types.area (Naming.First.Types.Circle 2.0) |> equal 12.0
+    Naming.Second.Types.name Naming.Second.Types.Red |> equal "red"

--- a/tests/Beam/Naming/First/Types.fs
+++ b/tests/Beam/Naming/First/Types.fs
@@ -1,0 +1,13 @@
+/// Same file name as Naming/Second/Types.fs. Both used to compile to `types.erl`: the one
+/// compiled last overwrote the other on disk, so half of these declarations vanished from the
+/// output entirely.
+module Fable.Tests.Naming.First.Types
+
+type Shape =
+    | Circle of float
+    | Square of float
+
+let area =
+    function
+    | Circle r -> 3.0 * r * r
+    | Square s -> s * s

--- a/tests/Beam/Naming/Gen.fs
+++ b/tests/Beam/Naming/Gen.fs
@@ -1,0 +1,8 @@
+/// The file name is what the Beam backend used to name the generated Erlang module after, so
+/// this file used to compile to `gen.erl` — and `gen` is an OTP stdlib module, which won every
+/// lookup. Calls into this module hit OTP's `gen` instead and failed at runtime with `undef`.
+module Fable.Tests.Naming.Gen
+
+let delay (f: unit -> int) = f () + 1
+
+let constant x = fun () -> x

--- a/tests/Beam/Naming/Random.fs
+++ b/tests/Beam/Naming/Random.fs
@@ -1,0 +1,7 @@
+/// Used to compile to `random.erl`, shadowing OTP's deprecated `random` stdlib module. rebar3
+/// reported the clash only as a deprecation warning on our own function.
+module Fable.Tests.Naming.Random
+
+let next (seed: int) = (seed * 1103515245 + 12345) % 2147483647
+
+let range (lo: int) (hi: int) (seed: int) = lo + (abs (next seed) % (hi - lo))

--- a/tests/Beam/Naming/Second/Types.fs
+++ b/tests/Beam/Naming/Second/Types.fs
@@ -1,0 +1,11 @@
+/// Same file name as Naming/First/Types.fs — see the comment there.
+module Fable.Tests.Naming.Second.Types
+
+type Colour =
+    | Red
+    | Green
+
+let name =
+    function
+    | Red -> "red"
+    | Green -> "green"

--- a/tests/Beam/Naming/String.fs
+++ b/tests/Beam/Naming/String.fs
@@ -1,0 +1,6 @@
+/// Used to compile to `string.erl`, shadowing OTP's `string` stdlib module.
+module Fable.Tests.Naming.String
+
+let reverse (s: string) = s |> Seq.rev |> Seq.toArray |> System.String
+
+let repeat (n: int) (s: string) = String.replicate n s

--- a/tests/Beam/erl_test_runner.erl
+++ b/tests/Beam/erl_test_runner.erl
@@ -2,50 +2,54 @@
 -export([main/1]).
 
 main([Dir]) ->
-    %% Load all .beam files in the directory
+    %% Load all .beam files in the directory. Generated module names are qualified by the app
+    %% they belong to (fable_tests_beam_list_tests), so a name pattern can no longer tell a test
+    %% module from any other one: a module is a test module iff it exports test_* functions.
     Beams = filelib:wildcard(filename:join(Dir, "*.beam")),
     Modules = [list_to_atom(filename:basename(F, ".beam")) || F <- Beams,
-               filename:basename(F, ".beam") =/= "erl_test_runner",
-               string:find(filename:basename(F, ".beam"), "_tests") =/= nomatch],
-    %% For each module, find exported functions with arity 1 (test functions)
+               filename:basename(F, ".beam") =/= "erl_test_runner"],
     Results = lists:foldl(fun(Mod, Acc) ->
         code:purge(Mod),
         code:load_file(Mod),
         Exports = Mod:module_info(exports),
-        %% Run the module initializer (main/0) before the module's tests, if present.
-        %% F# evaluates module-level bindings (including mutable values and `do` actions)
-        %% once before any module code runs; main/0 carries that initialization, so it must
-        %% execute before the test functions that read module-level state.
-        case lists:member({main, 0}, Exports) of
-            true ->
-                try Mod:main()
-                catch InitClass:InitReason ->
-                    %% Don't abort the run on a broken initializer, but log it so a
-                    %% failing main/0 is diagnosable instead of surfacing later as
-                    %% silent `undefined` reads of module-level state.
-                    io:format("  WARN init failed ~s:main/0 - ~p:~p~n", [Mod, InitClass, InitReason]),
-                    ok
-                end;
-            false -> ok
-        end,
         TestFuns = [{Mod, F} || {F, 0} <- Exports,
                      F =/= module_info,
                      F =/= main,
                      lists:prefix("test_", atom_to_list(F))],
-        lists:foldl(fun({M, F}, {Pass, Fail}) ->
-            try
-                M:F(),
-                io:format("  PASS ~s:~s~n", [M, F]),
-                {Pass + 1, Fail}
-            catch
-                error:Reason ->
-                    io:format("  FAIL ~s:~s - ~p~n", [M, F, Reason]),
-                    {Pass, Fail + 1};
-                Class:Reason ->
-                    io:format("  FAIL ~s:~s - ~p:~p~n", [M, F, Class, Reason]),
-                    {Pass, Fail + 1}
-            end
-        end, Acc, TestFuns)
+        case TestFuns of
+            [] -> Acc;
+            _ ->
+                %% Run the module initializer (main/0) before the module's tests, if present.
+                %% F# evaluates module-level bindings (including mutable values and `do` actions)
+                %% once before any module code runs; main/0 carries that initialization, so it must
+                %% execute before the test functions that read module-level state.
+                case lists:member({main, 0}, Exports) of
+                    true ->
+                        try Mod:main()
+                        catch InitClass:InitReason ->
+                            %% Don't abort the run on a broken initializer, but log it so a
+                            %% failing main/0 is diagnosable instead of surfacing later as
+                            %% silent `undefined` reads of module-level state.
+                            io:format("  WARN init failed ~s:main/0 - ~p:~p~n", [Mod, InitClass, InitReason]),
+                            ok
+                        end;
+                    false -> ok
+                end,
+                lists:foldl(fun({M, F}, {Pass, Fail}) ->
+                    try
+                        M:F(),
+                        io:format("  PASS ~s:~s~n", [M, F]),
+                        {Pass + 1, Fail}
+                    catch
+                        error:Reason ->
+                            io:format("  FAIL ~s:~s - ~p~n", [M, F, Reason]),
+                            {Pass, Fail + 1};
+                        Class:Reason ->
+                            io:format("  FAIL ~s:~s - ~p:~p~n", [M, F, Class, Reason]),
+                            {Pass, Fail + 1}
+                    end
+                end, Acc, TestFuns)
+        end
     end, {0, 0}, Modules),
     {Pass, Fail} = Results,
     io:format("~n~p passed, ~p failed~n", [Pass, Fail]),


### PR DESCRIPTION
## Problem

Erlang's module namespace is **flat and global**: the atom in `-module(...)` is a module's only identity, and neither the directory nor the OTP application an `.erl` file lives in scopes it. The Beam backend named each module after the bare basename of its F# file (`Gen.fs` → `gen.erl`), which collides three ways — all silent at compile time and fatal at runtime:

1. **OTP stdlib is shadowed.** `Gen.fs`, `Random.fs`, `String.fs` (and `Timer`, `Queue`, `Math`, `IO`, …) emit `gen.erl` / `random.erl` / `string.erl`. OTP's modules win, so calls into the generated code raise `undef`.
2. **Assemblies overwrite each other.** Two `DSL.fs` files in two projects both emit `src/dsl.erl`; the one compiled last overwrites the other **on disk** and the loser's functions vanish from the output entirely. No diagnostic at all.
3. **Files within one assembly** (`Foo/Types.fs` vs `Bar/Types.fs`) collide the same way.

Discovered compiling Scriptorium's `Scriptorium.Hedgehog` suite, which pulls in the `Hedgehog` package (`Gen.fs`, `Random.fs`) alongside Quill's and Hedgehog's `DSL.fs`.

## Fix

Qualify every generated module name with the application it belongs to — the convention OTP itself follows (`cowboy_req`, `rebar_app_info`) and that Fable's own runtime already used (`fable_list`):

| F# source                            | before           | after                   |
| ------------------------------------ | ---------------- | ----------------------- |
| `fable_modules/Hedgehog.0.11/Gen.fs` | `gen`            | `hedgehog_gen`          |
| `../Scriptorium.Quill/DSL.fs`        | `dsl`            | `scriptorium_quill_dsl` |
| `../Scriptorium.Hedgehog/DSL.fs`     | `dsl` (clobbers) | `scriptorium_hedgehog_dsl` |
| `<proj>/Misc/Util2.fs`               | `util2`          | `my_app_misc_util2`     |

Naming lives in one place, `Fable.Beam.Naming.erlangModuleName` (`Beam/Prelude.fs`), because the code generator (which resolves an import to the atom the imported file declared) and the CLI (which writes the file under the name of the module inside it) must agree exactly. It is a pure function of the path, since `resolveImportModuleName` only ever sees a path.

Two exemptions: **fable-library** keeps its bare, hand-maintained names (`fable_list`, `seq`, …) — it is the one project whose *compiled* output ships as a dependency, and `getLibPath` refers to its modules by exactly those names — and **native Erlang modules** reached via `BeamInterop` are untouched.

## Guards

Qualification is a convention, not a guarantee, so `checkBeamModuleNames` **fails the build** on the two ways a name can still go wrong — instead of letting either surface as an `undef` at runtime:

- **Duplicate module names**, naming both files, instead of silently overwriting one.
- **Names that shadow OTP's own** (`Naming.otpModules`, the module lists of `erts` + `kernel` + `stdlib`). Qualification rules out the bare names, but a *two-segment* name can still land on a real OTP module — an app named `Gen` with a `Server.fs` produces `gen_server` — and fable-library's exempt modules aren't qualified at all, so a `Timer.fs` added to it would silently shadow OTP's `timer`.

## Breaking

This renames every generated module, so the entry point of a project is no longer `main`. Fable now emits a `src/main.erl` shim exporting `main/0` and `main/1` that forwards to the real entry module, so runners calling `erl -eval "main:main([])"` keep working unchanged.

Existing output directories are **not** pruned: a rebuild in place leaves the old bare-named `.erl` files (`gen.erl`, …) next to the new qualified ones, and rebar3 compiles both — so the shadowing persists until the output directory is cleaned. Delete it once when upgrading.

## Verification

- Confirmed these are genuine regression tests by rebuilding the **old** compiler against them: it emitted `gen.erl` / `random.erl` / `string.erl` (all real OTP stdlib modules, verified with `code:which/1`) and a single `types.erl` exporting only `shape_reflection/0, area/1` — the second `Types.fs` silently absent from the output.
- **2539 Beam tests pass**, including four new ones in `ModuleNamingTests.fs` that call across file boundaries into `Naming/Gen.fs`, `Naming/Random.fs`, `Naming/String.fs` and two same-named `Types.fs` files. The same run also shows the OTP guard doesn't over-fire across the test project, its dependencies, or fable-library.
- Duplicate-name error verified by forcing a clash; it names both files.
- OTP-shadowing error verified by compiling a project named `Gen` containing `Server.fs`: `'gen_server' from Gen/Server.fs`.
- Forced `fable-library` rebuild still emits `seq` / `range` / `fable_list` unchanged.
- `quicktest beam` runs both via `--run` and via `main:main([])` / `main:main()`.

The test runner's `*_tests` name filter no longer discriminates (every module now carries the app prefix), so it selects test modules by whether they export `test_*` functions instead.

## Follow-up

The `[<Erlang.ModuleName("...")>]` escape hatch — needed for anything implementing an OTP behaviour, where the module name is part of the contract — is **not** in this PR. An importing file only ever sees the imported file's *path*, so a per-file attribute override has to be precomputed into a path→name map alongside `RootModule` in `Fable.Transforms/State.fs`, which is shared by every target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
