### PR TITLE
chore: avoid Fantomas comment loss on `else if` lines

### DIFF
--- a/src/fable-library-dart/Map.fs
+++ b/src/fable-library-dart/Map.fs
@@ -123,7 +123,8 @@ module MapTree =
                 else // rotate left
                     mk (mk t1 k v t2'.Left) t2'.Key t2'.Value t2'.Right
             | _ -> failwith "internal error: Map.rebalance"
-        else if t1h > t2h + tolerance then // left is heavier than right
+        // left is heavier than right
+        else if t1h > t2h + tolerance then
             match t1.Value with
             | :? MapTreeNode<'Key, 'Value> as t1' ->
                 // one of the nodes must have height > height t2 + 1

--- a/src/fable-library-dart/Set.fs
+++ b/src/fable-library-dart/Set.fs
@@ -130,7 +130,8 @@ module SetTree =
                 else // rotate left
                     mk (mk t1 v t2'.Left) t2'.Key t2'.Right
             | _ -> failwith "internal error: Set.rebalance"
-        else if t1h > t2h + tolerance then // left is heavier than right
+        // left is heavier than right
+        else if t1h > t2h + tolerance then
             match t1.Value with
             | :? SetTreeNode<'T> as t1' ->
                 // one of the nodes must have height > height t2 + 1

--- a/src/fable-library-py/fable_library/Map.fs
+++ b/src/fable-library-py/fable_library/Map.fs
@@ -124,7 +124,8 @@ module MapTree =
                 else // rotate left
                     mk (mk t1 k v t2'.Left) t2'.Key t2'.Value t2'.Right
             | _ -> failwith "internal error: Map.rebalance"
-        else if t1h > t2h + tolerance then // left is heavier than right
+        // left is heavier than right
+        else if t1h > t2h + tolerance then
             match t1.Value with
             | :? MapTreeNode<'Key, 'Value> as t1' ->
                 // one of the nodes must have height > height t2 + 1

--- a/src/fable-library-py/fable_library/Set.fs
+++ b/src/fable-library-py/fable_library/Set.fs
@@ -130,7 +130,8 @@ module SetTree =
                 else // rotate left
                     mk (mk t1 v t2'.Left) t2'.Key t2'.Right
             | _ -> failwith "internal error: Set.rebalance"
-        else if t1h > t2h + tolerance then // left is heavier than right
+        // left is heavier than right
+        else if t1h > t2h + tolerance then
             match t1.Value with
             | :? SetTreeNode<'T> as t1' ->
                 // one of the nodes must have height > height t2 + 1

--- a/src/fable-library-rust/src/Map.fs
+++ b/src/fable-library-rust/src/Map.fs
@@ -99,7 +99,8 @@ let rebalance t1 (k: 'K) (v: 'V) t2 : Map<'K, 'V> =
             mk (mk t1 k v t2l.Left) t2l.Key t2l.Value (mk t2l.Right t2'.Key t2'.Value t2'.Right)
         else // rotate left
             mk (mk t1 k v t2'.Left) t2'.Key t2'.Value t2'.Right
-    else if t1h > t2h + tolerance then // left is heavier than right
+    // left is heavier than right
+    else if t1h > t2h + tolerance then
         let t1' = (getRoot t1).Value
         // one of the nodes must have height > height t2 + 1
         if height t1'.Right > t2h + 1 then

--- a/src/fable-library-rust/src/Set.fs
+++ b/src/fable-library-rust/src/Set.fs
@@ -97,7 +97,8 @@ let rebalance (t1: Set<'T>) v (t2: Set<'T>) =
             mk (mk t1 v t2l.Left) t2l.Key (mk t2l.Right t2'.Key t2'.Right)
         else // rotate left
             mk (mk t1 v t2'.Left) t2'.Key t2'.Right
-    else if t1h > t2h + tolerance then // left is heavier than right
+    // left is heavier than right
+    else if t1h > t2h + tolerance then
         let t1' = (getRoot t1).Value
         // one of the nodes must have height > height t2 + 1
         if height t1'.Right > t2h + 1 then

--- a/src/fable-library-ts/Map.fs
+++ b/src/fable-library-ts/Map.fs
@@ -123,7 +123,8 @@ module MapTree =
                 else // rotate left
                     mk (mk t1 k v t2'.Left) t2'.Key t2'.Value t2'.Right
             | _ -> failwith "internal error: Map.rebalance"
-        else if t1h > t2h + tolerance then // left is heavier than right
+        // left is heavier than right
+        else if t1h > t2h + tolerance then
             match t1.Value with
             | :? MapTreeNode<'Key, 'Value> as t1' ->
                 // one of the nodes must have height > height t2 + 1

--- a/src/fable-library-ts/Set.fs
+++ b/src/fable-library-ts/Set.fs
@@ -130,7 +130,8 @@ module SetTree =
                 else // rotate left
                     mk (mk t1 v t2'.Left) t2'.Key t2'.Right
             | _ -> failwith "internal error: Set.rebalance"
-        else if t1h > t2h + tolerance then // left is heavier than right
+        // left is heavier than right
+        else if t1h > t2h + tolerance then
             match t1.Value with
             | :? SetTreeNode<'T> as t1' ->
                 // one of the nodes must have height > height t2 + 1


### PR DESCRIPTION
## Problem

The `verify-linting` CI job fails on roughly every other run, always with:

```
[INF] ./src/fable-library-dart/Map.fs needs formatting
```

Fantomas 7.0.5 nondeterministically drops the trailing comment on an `else if ... then // comment` line when formatting a directory:

```diff
-        else if t1h > t2h + tolerance then // left is heavier than right
+        else if t1h > t2h + tolerance then
```

Only that trivia position is affected — trailing comments on plain `if ... then` and on `else` survive. It reproduces only in a whole-directory run (`dotnet fantomas . --check`), never single-file, which points at a concurrency bug in Fantomas' trivia handling. A fix on the Fantomas side is realistically months out.

Despite CI always naming the Dart `Map.fs`, the file isn't special: the pattern is duplicated in the Map/Set implementations of the ts, py, dart and rust libraries, and any of those eight files can lose the race (my local repro mangled `fable-library-ts/Map.fs`). Adding the Dart file to `.fantomasignore` would therefore have fixed nothing and would have dropped format checking for the file.

## Change

Move the comment to its own line above the `else if`, in all eight files, so the trivia Fantomas mishandles no longer exists. The comments are preserved; nothing semantic changes.

## Verification

Repeated repo-wide `dotnet fantomas . --check`:

| | failures |
|---|---|
| before | 1 / 30 |
| after | 0 / 150 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)