### PR TITLE
fix(beam): make Assert.AreEqual/NotEqual raise, and stop emitting reflection calls for erased types

### DIFF
--- a/src/Fable.Transforms/Beam/Fable2Beam.Reflection.fs
+++ b/src/Fable.Transforms/Beam/Fable2Beam.Reflection.fs
@@ -233,6 +233,18 @@ let rec private transformTypeInfoRec
         let resolved = resolveGenerics generics
 
         match com.TryGetEntity(entRef) with
+        | Some ent when
+            FSharp2Fable.Util.isErasedOrStringEnumEntity ent
+            || FSharp2Fable.Util.isGlobalOrImportedEntity ent
+            ->
+            // An erased ([<Erase>], [<StringEnum>], [<TypeScriptTaggedUnion>]) or global/imported
+            // entity is never declared in the generated Erlang, so it has no reflection function
+            // to call. Report the bare type info instead — emitting `<entity>_reflection()` here
+            // produces a dangling call that fails to compile (when local) or crashes at run time
+            // (when remote). Types replaced from a dll (Result, Choice, ...) are deliberately not
+            // covered here: they have no SourcePath, so they never took the call branch below, and
+            // they still need their cases inlined to reflect as real unions.
+            makeTypeInfoMap entRef.FullName resolved
         | Some ent when (ent.IsFSharpRecord || ent.IsFSharpUnion) && entRef.SourcePath.IsSome ->
             // Call the entity's generated reflection function instead of inlining its
             // fields/cases. The by-name indirection is what lets a recursive type refer to

--- a/src/Fable.Transforms/Beam/Replacements.fs
+++ b/src/Fable.Transforms/Beam/Replacements.fs
@@ -5836,11 +5836,15 @@ let tryCall
         | "receive", [] -> emitExpr r t [] "__fable_beam_receive_forever__" |> Some
         | "receive", [ timeoutArg ] -> emitExpr r t [ timeoutArg ] "__fable_beam_receive__($0)" |> Some
         | _ -> None
-    // Testing assertions (used by our test framework)
+    // Testing assertions (used by our test framework). These must *raise* on failure, like every
+    // other target does: lowering them to a bare `equals` yields a boolean that is then discarded,
+    // so no assertion could ever fail. Signature is Assert.AreEqual(actual, expected, ?msg).
     | "Fable.Core.Testing.Assert" ->
-        match info.CompiledName, args with
-        | "AreEqual", [ expected; actual ] -> equals com r true expected actual |> Some
-        | "NotEqual", [ expected; actual ] -> equals com r false expected actual |> Some
+        match info.CompiledName with
+        | "AreEqual" -> Helper.LibCall(com, "fable_utils", "assert_equal", t, args, ?loc = r) |> Some
+        | "NotEqual" ->
+            Helper.LibCall(com, "fable_utils", "assert_not_equal", t, args, ?loc = r)
+            |> Some
         | _ -> None
     // IDisposable
     | "System.IDisposable" ->

--- a/src/fable-library-beam/fable_utils.erl
+++ b/src/fable-library-beam/fable_utils.erl
@@ -32,7 +32,11 @@
     byte_array_get/2,
     byte_array_set/3,
     byte_array_length/1,
-    div_rem/3
+    div_rem/3,
+    assert_equal/2,
+    assert_equal/3,
+    assert_not_equal/2,
+    assert_not_equal/3
 ]).
 
 -spec iface_get(atom(), map() | reference() | {fable_import_all, atom()}) -> term().
@@ -68,6 +72,10 @@
 -spec byte_array_set(tuple() | reference(), non_neg_integer(), non_neg_integer()) -> ok.
 -spec byte_array_length(tuple() | reference()) -> non_neg_integer().
 -spec div_rem(integer(), integer(), reference()) -> integer().
+-spec assert_equal(term(), term()) -> ok.
+-spec assert_equal(term(), term(), binary() | undefined) -> ok.
+-spec assert_not_equal(term(), term()) -> ok.
+-spec assert_not_equal(term(), term(), binary() | undefined) -> ok.
 
 %% Interface dispatch: works for both object expressions (maps) and class instances (refs).
 %% Class interface property getters are stored as {getter, Fun} tagged thunks — call Fun().
@@ -534,3 +542,41 @@ byte_array_length(PdRef) when is_reference(PdRef) ->
 div_rem(X, Y, RemRef) ->
     put(RemRef, X rem Y),
     X div Y.
+
+%% Fable.Core.Testing.Assert. Mirrors fable-library-ts Util:assertEqual/assertNotEqual: on
+%% failure raise, rather than return a boolean, so a failing assertion actually fails the test.
+%% The raised term is a map carrying `message` plus the two operands, which is the shape
+%% Fable2Beam unwraps into an F# exception -- so `e.Message` reads cleanly in `try ... with`,
+%% and a test runner can still pattern-match `actual`/`expected` off the map.
+assert_equal(Actual, Expected) ->
+    assert_equal(Actual, Expected, undefined).
+
+assert_equal(Actual, Expected, Msg) ->
+    case fable_comparison:equals(Actual, Expected) of
+        true -> ok;
+        false -> assert_failed(Msg, <<"Expected">>, Actual, Expected)
+    end.
+
+assert_not_equal(Actual, Expected) ->
+    assert_not_equal(Actual, Expected, undefined).
+
+assert_not_equal(Actual, Expected, Msg) ->
+    case fable_comparison:equals(Actual, Expected) of
+        false -> ok;
+        true -> assert_failed(Msg, <<"Expected not equal to">>, Actual, Expected)
+    end.
+
+assert_failed(Msg, Label, Actual, Expected) ->
+    Message =
+        case Msg of
+            undefined ->
+                iolist_to_binary([
+                    Label, ": ", format_term(Expected), " - Actual: ", format_term(Actual)
+                ]);
+            _ ->
+                Msg
+        end,
+    erlang:error(#{message => Message, actual => Actual, expected => Expected}).
+
+format_term(V) when is_binary(V) -> V;
+format_term(V) -> iolist_to_binary(io_lib:format("~p", [V])).

--- a/tests/Beam/AssertTests.fs
+++ b/tests/Beam/AssertTests.fs
@@ -1,0 +1,73 @@
+module Fable.Tests.AssertTests
+
+// The suite's own `equal` (Util.fs) *is* `Assert.AreEqual`, so these tests deliberately avoid it on
+// the paths that matter: an assertion that never raises would otherwise make a test of "assertions
+// raise" vacuously green, which is precisely the bug being pinned here. Anything that must fail the
+// test fails it with `failwith`, which raises on its own.
+
+#if FABLE_COMPILER
+open Xunit
+open Fable.Core.Testing
+
+/// Returns the message of the exception raised by `f`, or None if it didn't raise.
+let private messageOf (f: unit -> unit) =
+    try
+        f ()
+        None
+    with e ->
+        Some e.Message
+
+[<Fact>]
+let ``test Assert.AreEqual raises on mismatch`` () =
+    match messageOf (fun () -> Assert.AreEqual(2, 1)) with
+    | None -> failwith "Assert.AreEqual did not raise on a mismatch"
+    | Some msg ->
+        if msg <> "Expected: 1 - Actual: 2" then
+            failwith ("Unexpected assertion message: " + msg)
+
+[<Fact>]
+let ``test Assert.AreEqual does not raise when equal`` () =
+    match messageOf (fun () -> Assert.AreEqual(1, 1)) with
+    | Some msg -> failwith ("Assert.AreEqual raised on equal values: " + msg)
+    | None -> ()
+
+[<Fact>]
+let ``test Assert.AreEqual raises on structural mismatch`` () =
+    match messageOf (fun () -> Assert.AreEqual([ 1; 2 ], [ 1; 3 ])) with
+    | None -> failwith "Assert.AreEqual did not raise on a structural mismatch"
+    | Some _ -> ()
+
+[<Fact>]
+let ``test Assert.AreEqual does not raise on structural equality`` () =
+    match messageOf (fun () -> Assert.AreEqual([ 1; 2 ], [ 1; 2 ])) with
+    | Some msg -> failwith ("Assert.AreEqual raised on structurally equal values: " + msg)
+    | None -> ()
+
+[<Fact>]
+let ``test Assert.AreEqual uses the custom message`` () =
+    match messageOf (fun () -> Assert.AreEqual(2, 1, "values differ")) with
+    | None -> failwith "Assert.AreEqual did not raise on a mismatch"
+    | Some msg ->
+        if msg <> "values differ" then
+            failwith ("Unexpected assertion message: " + msg)
+
+[<Fact>]
+let ``test Assert.NotEqual raises when equal`` () =
+    match messageOf (fun () -> Assert.NotEqual(1, 1)) with
+    | None -> failwith "Assert.NotEqual did not raise on equal values"
+    | Some _ -> ()
+
+[<Fact>]
+let ``test Assert.NotEqual does not raise on mismatch`` () =
+    match messageOf (fun () -> Assert.NotEqual(1, 2)) with
+    | Some msg -> failwith ("Assert.NotEqual raised on different values: " + msg)
+    | None -> ()
+
+[<Fact>]
+let ``test Assert.NotEqual uses the custom message`` () =
+    match messageOf (fun () -> Assert.NotEqual(1, 1, "values are equal")) with
+    | None -> failwith "Assert.NotEqual did not raise on equal values"
+    | Some msg ->
+        if msg <> "values are equal" then
+            failwith ("Unexpected assertion message: " + msg)
+#endif

--- a/tests/Beam/Fable.Tests.Beam.fsproj
+++ b/tests/Beam/Fable.Tests.Beam.fsproj
@@ -34,6 +34,7 @@
     <Compile Include="Naming/First/Types.fs" />
     <Compile Include="Naming/Second/Types.fs" />
     <Compile Include="Util.fs" />
+    <Compile Include="AssertTests.fs" />
     <Compile Include="ArithmeticTests.fs" />
     <Compile Include="RandomTests.fs" />
     <Compile Include="ListTests.fs" />

--- a/tests/Beam/Misc/Util2.fs
+++ b/tests/Beam/Misc/Util2.fs
@@ -23,6 +23,15 @@ type CrossFileTree =
 
 type CrossFileGeneric<'T> = { Item: 'T; Rest: CrossFileGeneric<'T> option }
 
+// An erased type is never declared in the generated Erlang, so it has no reflection function that
+// a referring type could call. Declared here so a record in another file can hold one: that is the
+// remote-call variant of the bug, which Erlang resolves only at run time (the local variant fails
+// to compile instead).
+[<Fable.Core.Erase>]
+type CrossFileErased = CrossFileErased of string
+
+type CrossFileRecordWithErasedField = { Erased: CrossFileErased; Label: string }
+
 
 module Extensions =
     type String with

--- a/tests/Beam/ReflectionTests.fs
+++ b/tests/Beam/ReflectionTests.fs
@@ -697,3 +697,58 @@ let ``test round-tripping a value of a type from another file works`` () =
 
     FSharpValue.MakeRecord(recordType, values) :?> Fable.Tests.Util2.CrossFileRecord
     |> equal record
+
+// === Reflection over erased types ===
+// An erased type emits no declaration, and therefore no reflection function for a referring type to
+// call. A record holding one used to emit that call anyway: a compile error when the erased type is
+// in the same file, and a run-time crash when it is in another one (Erlang resolves remote calls
+// lazily). Both variants are covered below; the local one is pinned by this file compiling at all.
+
+[<Fable.Core.Erase>]
+type ErasedId = ErasedId of string
+
+type RecordWithErasedField = { Id: ErasedId; Name: string }
+
+/// The erased field type lives in another file, so the dangling call would be a *remote* one.
+/// Erlang doesn't resolve those at compile time, so this variant compiles happily and only blows
+/// up when the reflection function is actually called — hence the test below reflects over it.
+type RecordWithCrossFileErasedField = {
+    Remote: Fable.Tests.Util2.CrossFileErased
+    Count: int
+}
+
+[<Fact>]
+let ``test reflection over a record with an erased field works`` () =
+    let fields = FSharpType.GetRecordFields typeof<RecordWithErasedField>
+    fields.Length |> equal 2
+    fields.[0].Name |> equal "Id"
+    fields.[0].PropertyType.FullName.EndsWith("ErasedId") |> equal true
+    fields.[1].PropertyType |> equal typeof<string>
+
+[<Fact>]
+let ``test reflection over an erased type works`` () =
+    typeof<ErasedId>.FullName.EndsWith("ErasedId") |> equal true
+
+[<Fact>]
+let ``test reflection over a record whose erased field type is in another file works`` () =
+    let fields = FSharpType.GetRecordFields typeof<RecordWithCrossFileErasedField>
+    fields.Length |> equal 2
+    fields.[0].Name |> equal "Remote"
+
+    fields.[0].PropertyType.FullName.EndsWith("CrossFileErased")
+    |> equal true
+
+    fields.[1].PropertyType |> equal typeof<int>
+
+[<Fact>]
+let ``test reflection over a record with an erased field from another file works`` () =
+    let fields =
+        FSharpType.GetRecordFields typeof<Fable.Tests.Util2.CrossFileRecordWithErasedField>
+
+    fields.Length |> equal 2
+    fields.[0].Name |> equal "Erased"
+
+    fields.[0].PropertyType.FullName.EndsWith("CrossFileErased")
+    |> equal true
+
+    fields.[1].PropertyType |> equal typeof<string>


### PR DESCRIPTION
Two independent Beam-target bugs, both found while upgrading [Fable.Beam](https://github.com/dbrattli/Fable.Beam) from 5.6.0 to 5.8.1.

## 1. `Assert.AreEqual` / `Assert.NotEqual` never raised when called directly

`Beam/Replacements.fs` lowered them to a bare *equality expression*. The resulting boolean sits in statement position, so it is computed and discarded — the assertion could never fail. The three-argument overload (custom message) was not supported at all: `Assert.AreEqual(a, b, "msg")` was a hard compile error (`Fable.Core.Testing.Assert.AreEqual is not supported, try updating fable tool`).

They now lower to throwing library calls, mirroring JS (`Replacements.fs`) and Python.

**Scope: this does not mean the Beam test suite was unasserted.** `Fable2Beam.fs:2261` intercepts call sites whose import selector is `Testing_equal`/`assertEqual` and inlines a raising assertion, with no runtime dependency:

```erlang
test_infix_add_can_be_generated() ->
    case fable_comparison:equals(999, 6) of
        true  -> ok;
        false -> erlang:error({assert_equal, 6, 999})
    end.
```

`tests/Beam/Util.fs`'s `equal` compiles to that selector, so the suite's assertions have always fired (verified by corrupting an expected value under the pre-fix compiler and watching it fail). The bug bites code that calls `Fable.Core.Testing.Assert` **directly**, which is what a downstream test framework does — that's how it was found.

The new `fable_utils:assert_equal/2,3` and `assert_not_equal/2,3` raise a map carrying `message` plus the two operands. `Fable2Beam` already binds a raised map directly as the exception and reads its `message` key, so `e.Message` reads cleanly in `try ... with`, while a runner can still pattern-match `actual`/`expected` off the map. This mirrors JS, which throws an `Exception` with the message and attaches `actual`/`expected` as properties.

Note this leaves Beam with two assertion shapes: the inlined `{assert_equal, Expected, Actual}` tuple at `Testing_equal` call sites, and the new `#{message, actual, expected}` map from the library. Consolidating them is worth a follow-up, but is out of scope here.

## 2. Erased types emitted dangling `<entity>_reflection()` calls (regression, blocks compilation)

Regression from b15b280d9 ("fix(beam): make F# reflection work on the Beam target", #4766), first shipped in **5.8.1**.

That change made a reference to a record/union emit a *call* to the entity's generated `<entity>_reflection/0`. But an erased (`[<Erase>]`, `[<StringEnum>]`, `[<TypeScriptTaggedUnion>]`) or global/imported entity never gets a declaration emitted, so there is no reflection function to call:

```fsharp
[<Erase>]
type Shutdown = Shutdown of obj        // erased: no Erlang declaration emitted

type ChildSpec = { Shutdown: Shutdown } // its reflection fn calls shutdown_reflection()
```

Two failure modes, the second nastier:
- **Local** (erased type in the same file) → compile error: `function shutdown_reflection/0 undefined`.
- **Remote** (erased type in another module) → Erlang does not resolve remote calls at compile time, so it compiles fine and crashes at run time with `undef`.

This blocks compilation of any project using `[<Erase>]` types in records — an idiomatic pattern for zero-cost opaque Erlang types.

Fixed by reporting the bare type info for entities that produce no declaration, which is what Python already does. The guard is deliberately kept to exactly the two "no declaration is emitted" predicates: including `isReplacementCandidate` (as Python's does) short-circuits `Result` and `Choice` into a type info with **no `cases` entry**, so reflection reports them as non-unions. They have no `SourcePath` and so never reached the call branch anyway.

## Tests

`tests/Beam/AssertTests.fs` (new) asserts that a mismatching `Assert.AreEqual`/`NotEqual` *throws* and that `e.Message` is the expected string. It calls `Assert` directly rather than through the suite's `equal`, which is the path that was broken; anything that must fail the test fails it with `failwith`.

`ReflectionTests.fs` / `Misc/Util2.fs` cover reflection over a record with an erased field in **both** the local and the cross-module position — only the local one is caught at compile time, so the remote variant needs its own run-time coverage. `ReflectionTests.fs` already covers `Result`/`Choice`, which pins the `isReplacementCandidate` trap above.

Each new test was verified to fail without its corresponding fix. Full suite: **2586 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)