### PR TITLE
fix(python): make the assert_not_equal failure message describe the failure

### DIFF
--- a/src/fable-library-py/fable_library/util.py
+++ b/src/fable-library-py/fable_library/util.py
@@ -338,7 +338,9 @@ def assert_equal(actual: Any, expected: Any, msg: str | None = None) -> None:
 
 def assert_not_equal[T](actual: T, expected: T, msg: str | None = None) -> None:
     if equals(actual, expected):
-        raise Exception(msg or f"Expected: {expected} - Actual: {actual}")
+        # "Expected: x - Actual: x" would describe a *passing* assertion, so say what was
+        # actually expected: a value other than this one. Mirrors xUnit's "Expected: Not x".
+        raise Exception(msg or f"Expected not equal to: {expected} - Actual: {actual}")
 
 
 MAX_LOCKS = 1024

--- a/src/fable-library-py/tests/test_assert.py
+++ b/src/fable-library-py/tests/test_assert.py
@@ -1,0 +1,33 @@
+import pytest
+from fable_library.util import assert_equal, assert_not_equal
+
+
+def test_assert_equal_passes_on_equal_values():
+    assert_equal(1, 1)
+    assert_equal([1, 2], [1, 2])
+
+
+def test_assert_equal_raises_on_mismatch():
+    with pytest.raises(Exception, match=r"^Expected: 1 - Actual: 2$"):
+        assert_equal(2, 1)
+
+
+def test_assert_equal_uses_the_custom_message():
+    with pytest.raises(Exception, match=r"^values differ$"):
+        assert_equal(2, 1, "values differ")
+
+
+def test_assert_not_equal_passes_on_different_values():
+    assert_not_equal(1, 2)
+
+
+def test_assert_not_equal_raises_when_equal():
+    # The failure has to describe what was expected -- some value *other* than 1. Rendering it as
+    # "Expected: 1 - Actual: 1" reads as a passing assertion, which is what it used to say.
+    with pytest.raises(Exception, match=r"^Expected not equal to: 1 - Actual: 1$"):
+        assert_not_equal(1, 1)
+
+
+def test_assert_not_equal_uses_the_custom_message():
+    with pytest.raises(Exception, match=r"^values are equal$"):
+        assert_not_equal(1, 1, "values are equal")


### PR DESCRIPTION
Follow-up to #4776, where the same wart surfaced on the Beam target.

On a **failing** `Assert.NotEqual`, `assert_not_equal` renders:

```
Expected: 1 - Actual: 1
```

The two values being equal is precisely *why* the assertion failed, so the message describes a **passing** assertion. Staring at a red test, it tells you nothing — and it briefly reads as though the test framework is broken. It happens because `assert_equal` and `assert_not_equal` share one format string:

```python
def assert_not_equal[T](actual: T, expected: T, msg: str | None = None) -> None:
    if equals(actual, expected):
        raise Exception(msg or f"Expected: {expected} - Actual: {actual}")   # same string as assert_equal
```

Now it says what was actually expected — some value *other* than this one:

```
Expected not equal to: 1 - Actual: 1
```

## Prior art

xUnit, which these same tests run against on .NET before being transpiled, goes out of its way to distinguish the two cases:

```
Assert.Equal() Failure: Values differ          Assert.NotEqual() Failure: Values are equal
Expected: 1                                    Expected: Not 1
Actual:   2                                    Actual:       1
```

The Beam target already words it this way (#4775). This brings Python into line, keeping the Fable house format (`Expected... - Actual...`) rather than adopting xUnit's layout.

## Scope: JS is deliberately left alone

`fable-library-ts`'s `Util.ts:assertNotEqual` has the identical wart. I have not touched it — that's a call for the JS/TS maintainers, and I'd rather use this PR to ask than to unilaterally change a message on the most-used target.

**@fable-compiler maintainers**: do you want the same one-line change on JS/TS (and Dart/Rust, which don't currently implement `Assert` at all), so all targets agree? Happy to fold it in here or leave it for a separate PR — or to drop this one if you'd rather all targets keep matching each other, warts and all.

## Compatibility

`fable-library-py` is on PyPI and must stay backward-compatible within a minor version. This changes no signature, no raising behaviour, and no return value — only the human-readable text of a message that, by construction, is produced *only* on an already-failing assertion. Nothing in the repo depends on the old wording. Flagging it explicitly since AGENTS.md asks for care with the semantics of existing `fable-library-py` functions.

## Tests

New `src/fable-library-py/tests/test_assert.py` covers both functions: pass, fail, and custom-message paths. The not-equal message test fails on `main` and passes here; the rest pass either way.

Full `fable-library-py` suite: **444 passed**. Pyright clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
