### PR TITLE
feat(rust): add tests to task computation expressions

### DIFF
--- a/src/Fable.Transforms/Rust/Replacements.fs
+++ b/src/Fable.Transforms/Rust/Replacements.fs
@@ -3181,7 +3181,10 @@ let taskBuilderB (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Exp
         Helper.LibCall(com, "Task", "delay", t, args, i.SignatureArgTypes, ?loc = r)
         |> Some
     | "Zero", _, _ ->
-        Helper.LibCall(com, "Task", "zero", t, args, i.SignatureArgTypes, ?loc = r)
+        // A body that does not end in `return` is just `return ()`. Its declared
+        // type is TaskCode<_,_>, whose generics are FSharp.Core resumable-code
+        // internals, so use unit here to keep them out of the emitted call.
+        Helper.LibCall(com, "Task", "zero", Fable.Unit, args, i.SignatureArgTypes, ?loc = r)
         |> Some
     | _ -> None
 
@@ -3191,7 +3194,8 @@ let taskBuilderHP (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Ex
         Helper.LibCall(com, "Task", "bind", t, args, i.SignatureArgTypes, ?loc = r)
         |> Some
     | "TaskBuilderBase.Zero", _, _ ->
-        Helper.LibCall(com, "Task", "zero", t, args, i.SignatureArgTypes, ?loc = r)
+        // see the Zero comment in taskBuilderB above
+        Helper.LibCall(com, "Task", "zero", Fable.Unit, args, i.SignatureArgTypes, ?loc = r)
         |> Some
     | meth, Some callee, _ -> makeInstanceCall r t i callee meth args |> Some
     | meth, None, _ ->

--- a/src/fable-library-rust/src/Async.rs
+++ b/src/fable-library-rust/src/Async.rs
@@ -377,7 +377,10 @@ pub mod Task_ {
         Arc::from(t)
     }
 
-    pub fn zero<T: Clone + Send + Sync + 'static>() -> Arc<Task<()>> {
+    // A task body that does not end in `return` is just `return ()`, so this
+    // needs no generic parameter. Keeping one would force the caller to name a
+    // type argument that has nothing to do with the result.
+    pub fn zero() -> Arc<Task<()>> {
         r_return(())
     }
 

--- a/tests/Rust/Fable.Tests.Rust.fsproj
+++ b/tests/Rust/Fable.Tests.Rust.fsproj
@@ -72,7 +72,7 @@
     <Compile Include="tests/src/StackTests.fs" />
     <Compile Include="tests/src/StringTests.fs" />
     <Compile Include="tests/src/SudokuTest.fs" />
-    <!-- <Compile Include="tests/src/TaskTests.fs" /> -->
+    <Compile Include="tests/src/TaskTests.fs" />
     <Compile Include="tests/src/TailCallTests.fs" />
     <Compile Include="tests/src/TimeOnlyTests.fs" />
     <Compile Include="tests/src/TimeSpanTests.fs" />

--- a/tests/Rust/tests/src/TaskTests.fs
+++ b/tests/Rust/tests/src/TaskTests.fs
@@ -4,7 +4,8 @@
 module Fable.Tests.TaskTests
 
 // Supported so far: return, let!, do!, Task.FromResult and .Result at concrete
-// types, plus Async.AwaitTask and Async.StartAsTask.
+// types, plus Async.AwaitTask and Async.StartAsTask. A body need not end in
+// `return`; without one it is just `return ()`.
 // The tests kept commented out below track what is still missing. They cannot be
 // marked with OuterAttr("ignore") instead: Fable rejects these builder members
 // outright, so they fail the build rather than compiling into a skipped test.
@@ -14,11 +15,6 @@ module Fable.Tests.TaskTests
 //     Replacements, and Task_ has no matching runtime combinators. Note the
 //     builder body of a loop would also have to be re-runnable, whereas a Task
 //     here is hot-started and caches its result.
-//
-//   - a computation that does not end in `return` compiles to
-//     TaskBuilderBase.Zero, whose TaskCode<_,_> return type leaks FSharp.Core
-//     resumable-code generics into the emitted turbofish, as in
-//     zero::<&MutCell<ResumableStateMachine_1<_>>, bool>().
 //
 //   - generic helpers over Task<'T> (such as `let run (t: Task<'T>) = t.Result`)
 //     need Send + Sync bounds that are not emitted, so use concrete types.
@@ -157,6 +153,29 @@ let ``task awaiting a delay inside the body waits for it`` () =
         }
     tsk.Result |> equal 42
     finished |> equal true
+
+[<Fact>]
+let ``task without a trailing return works`` () =
+    let mutable r = 0
+    let tsk =
+        task {
+            let! x = task { return 42 }
+            r <- x
+        }
+    tsk.Result
+    r |> equal 42
+
+[<Fact>]
+let ``task with two let! and no trailing return works`` () =
+    let mutable r = 0
+    let tsk =
+        task {
+            let! x = task { return 20 }
+            let! y = task { return 22 }
+            r <- x + y
+        }
+    tsk.Result
+    r |> equal 42
 
 // type DisposableAction(f) =
 //     interface System.IDisposable with

--- a/tests/Rust/tests/src/TaskTests.fs
+++ b/tests/Rust/tests/src/TaskTests.fs
@@ -1,25 +1,51 @@
+// Task support requires the `threaded` feature, as the Task runtime
+// (thread pool + futures) in the library is gated behind it.
+[<Fable.Core.Rust.OuterAttr("cfg", [|"feature = \"threaded\""|])>]
 module Fable.Tests.TaskTests
+
+// Supported so far: return, let!, do!, Task.FromResult and .Result at concrete
+// types, plus Async.AwaitTask and Async.StartAsTask.
+// The tests kept commented out below track what is still missing. They cannot be
+// marked with OuterAttr("ignore") instead: Fable rejects these builder members
+// outright, so they fail the build rather than compiling into a skipped test.
+//
+//   - while / for / try-with / try-finally / use!: TaskBuilderBase.While, For,
+//     TryWith, TryFinally, Using and Combine are not mapped in the Rust
+//     Replacements, and Task_ has no matching runtime combinators. Note the
+//     builder body of a loop would also have to be re-runnable, whereas a Task
+//     here is hot-started and caches its result.
+//
+//   - a computation that does not end in `return` compiles to
+//     TaskBuilderBase.Zero, whose TaskCode<_,_> return type leaks FSharp.Core
+//     resumable-code generics into the emitted turbofish, as in
+//     zero::<&MutCell<ResumableStateMachine_1<_>>, bool>().
+//
+//   - generic helpers over Task<'T> (such as `let run (t: Task<'T>) = t.Result`)
+//     need Send + Sync bounds that are not emitted, so use concrete types.
+//
+//   - Task.Delay is not implemented, and `do! Task.Delay ...` also needs
+//     binding of the non-generic Task, which goes through
+//     TaskBuilderExtensions.LowPriority.Bind and Task.GetAwaiter. Awaiting a
+//     delay works via `let! _ = Async.Sleep ms |> Async.StartAsTask`.
+//
+//   - GetAwaiter().GetResult() is not supported, so .Result is used to wait.
+//
+//   - TaskCompletionSource is not implemented.
+//
+//   - GetAwaiter().GetResult() is not supported, so .Result is used to wait.
 
 open Util.Testing
 open System.Threading.Tasks
 
-type DisposableAction(f) =
-    interface System.IDisposable with
-        member _.Dispose() = f ()
-
-let runSynchronously<'T> (tsk: Task<'T>) : 'T =
-    //tsk.GetAwaiter().GetResult()
-    tsk.Result
-
 [<Fact>]
 let ``Simple task translates without exception`` () =
     let tsk = task { return () }
-    tsk |> runSynchronously
+    tsk.Result
 
 [<Fact>]
 let ``Simple task result translates without exception`` () =
-    let tsk = task { return () }
-    tsk.Result
+    let tsk = task { return 42 }
+    tsk.Result |> equal 42
 
 [<Fact>]
 let ``Simple Task.FromResult translates without exception`` () =
@@ -28,114 +54,175 @@ let ``Simple Task.FromResult translates without exception`` () =
     result |> equal 42
 
 [<Fact>]
-let ``task while binding works correctly`` () =
-    let mutable result = 0
+let ``task let! binding works`` () =
+    let inner = task { return 21 }
     let tsk =
         task {
-            while result < 10 do
-                result <- result + 1
+            let! x = inner
+            return x * 2
         }
-    tsk |> runSynchronously
-    result |> equal 10
+    tsk.Result |> equal 42
 
 [<Fact>]
-let ``Task for binding works correctly`` () =
-    let inputs = [| 1; 2; 3 |]
-    let mutable result = 0
+let ``task do! binding works`` () =
+    let inner = task { return () }
     let tsk =
         task {
-            for inp in inputs do
-                result <- result + inp
+            do! inner
+            return 7
         }
-    tsk |> runSynchronously
-    result |> equal 6
+    tsk.Result |> equal 7
 
 [<Fact>]
-let ``Task exceptions are handled correctly`` () =
-    let mutable result = 0
-    let f shouldThrow =
-        let tsk =
-            task {
-                try
-                    if shouldThrow then
-                        failwith "boom!"
-                    else
-                        result <- 12
-                with
-                | _ -> result <- 10
-            }
-        tsk |> runSynchronously
-        result
-    f true + f false |> equal 22
-
-[<Fact>]
-let ``Simple task is executed correctly`` () =
-    let mutable result = false
-    let x = task { return 99 }
-    task {
-        let! x = x
-        let y = 99
-        result <- x = y
-    }
-    |> runSynchronously
-    result |> equal true
-
-[<Fact>]
-let ``task use statements should dispose of resources when they go out of scope`` () =
-    let mutable isDisposed = false
-    let mutable step1ok = false
-    let mutable step2ok = false
-
-    let resource =
-        task { return new DisposableAction(fun () -> isDisposed <- true) }
-
-    task {
-        use! r = resource
-        step1ok <- not isDisposed
-    }
-    |> runSynchronously
-
-    step2ok <- isDisposed
-    (step1ok && step2ok) |> equal true
-
-[<Fact>]
-let ``Try ... with ... expressions inside async expressions work the same`` () =
-    let mutable result = ""
-    let throw () : unit = raise (exn "Boo!")
-    let append (x) = result <- result + x
-
-    let innerAsync () =
+let ``task with two let! bindings works`` () =
+    let a = task { return 20 }
+    let b = task { return 22 }
+    let tsk =
         task {
-            append "b"
-            try
-                append "c"
-                throw ()
-                append "1"
-            with
-            | _ -> append "d"
-            append "e"
+            let! x = a
+            let! y = b
+            return x + y
         }
-
-    task {
-        append "a"
-        try
-            do! innerAsync ()
-        with
-        | _ -> append "2"
-        append "f"
-    }
-    |> runSynchronously
-
-    result |> equal "abcdef"
+    tsk.Result |> equal 42
 
 [<Fact>]
-let ``TaskCompletionSource is executed correctly`` () =
-    let x =
+let ``task with sequential let! bindings works`` () =
+    let tsk =
         task {
-            let tcs = TaskCompletionSource<int>()
-            tcs.SetResult 42
-            return! tcs.Task
+            let! x = task { return 1 }
+            let! y = task { return 2 }
+            let! z = task { return 3 }
+            return x + y + z
         }
-    let result =
-        x |> runSynchronously
-    result |> equal 42
+    tsk.Result |> equal 6
+
+[<Fact>]
+let ``Async.AwaitTask works`` () =
+    let tsk = task { return 42 }
+    let a =
+        async {
+            let! x = Async.AwaitTask tsk
+            return x
+        }
+    a |> Async.RunSynchronously |> equal 42
+
+[<Fact>]
+let ``Async.StartAsTask works`` () =
+    let a = async { return 42 }
+    let tsk = Async.StartAsTask a
+    tsk.Result |> equal 42
+
+[<Fact>]
+let ``task awaiting slow work waits for the result`` () =
+    let mutable finished = false
+    let slow =
+        async {
+            do! Async.Sleep 300
+            finished <- true
+            return 42
+        }
+        |> Async.StartAsTask
+    let tsk =
+        task {
+            let! x = slow
+            return (x, finished)
+        }
+    let (x, wasFinished) = tsk.Result
+    x |> equal 42
+    wasFinished |> equal true
+
+[<Fact>]
+let ``Task.Result blocks until the work completes`` () =
+    let mutable counter = 0
+    let slow =
+        async {
+            do! Async.Sleep 300
+            counter <- counter + 1
+            return counter
+        }
+        |> Async.StartAsTask
+    // the work is queued, not run inline
+    counter |> equal 0
+    slow.Result |> equal 1
+    counter |> equal 1
+
+[<Fact>]
+let ``task awaiting a delay inside the body waits for it`` () =
+    let mutable finished = false
+    let tsk =
+        task {
+            let! c = Async.Sleep 300 |> Async.StartAsTask
+            finished <- true
+            return 42
+        }
+    tsk.Result |> equal 42
+    finished |> equal true
+
+// type DisposableAction(f) =
+//     interface System.IDisposable with
+//         member _.Dispose() = f ()
+
+// [<Fact>]
+// let ``task while binding works correctly`` () =
+//     let mutable result = 0
+//     let tsk =
+//         task {
+//             while result < 10 do
+//                 result <- result + 1
+//         }
+//     tsk.Result
+//     result |> equal 10
+
+// [<Fact>]
+// let ``Task for binding works correctly`` () =
+//     let inputs = [| 1; 2; 3 |]
+//     let mutable result = 0
+//     let tsk =
+//         task {
+//             for inp in inputs do
+//                 result <- result + inp
+//         }
+//     tsk.Result
+//     result |> equal 6
+
+// [<Fact>]
+// let ``Task exceptions are handled correctly`` () =
+//     let mutable result = 0
+//     let f shouldThrow =
+//         let tsk =
+//             task {
+//                 try
+//                     if shouldThrow then
+//                         failwith "boom!"
+//                     else
+//                         result <- 12
+//                 with
+//                 | _ -> result <- 10
+//             }
+//         tsk.Result
+//         result
+//     f true + f false |> equal 22
+
+// [<Fact>]
+// let ``task use statements should dispose of resources when they go out of scope`` () =
+//     let mutable isDisposed = false
+//     let mutable step1ok = false
+//     let mutable step2ok = false
+//     let resource = task { return new DisposableAction(fun () -> isDisposed <- true) }
+//     task {
+//         use! r = resource
+//         step1ok <- not isDisposed
+//     }
+//     |> fun t -> t.Result
+//     step2ok <- isDisposed
+//     (step1ok && step2ok) |> equal true
+
+// [<Fact>]
+// let ``TaskCompletionSource is executed correctly`` () =
+//     let x =
+//         task {
+//             let tcs = TaskCompletionSource<int>()
+//             tcs.SetResult 42
+//             return! tcs.Task
+//         }
+//     x.Result |> equal 42


### PR DESCRIPTION
Turns on the `task { }` computation expression tests for the Rust target, and lets a computation omit a trailing `return`.

The `Task_` / `TaskBuilder_` runtime already existed in `Async.rs`, but `TaskTests.fs` was commented out of the test project, so none of it was exercised. Most of the core turned out to work already, so the first commit is tests only; the second is a small fix described below.

Like `AsyncTests.fs`, the module is gated with `OuterAttr("cfg", "feature = \"threaded\"")`, since the Task runtime (thread pool + futures) is behind the `threaded` feature.

### Supported (14 tests)

`return`, `let!` (including several bindings in one computation), `do!`, `Task.FromResult`, `.Result`, `Async.AwaitTask` and `Async.StartAsTask`, at concrete types.

Three of the tests cover work that does not complete immediately, rather than only tasks that are already finished:

- a task awaiting a 300ms computation observes its side effect, proving it really waits
- `.Result` blocks until the work completes, and the work is queued rather than run inline
- a delay awaited from inside a computation, via `let! _ = Async.Sleep ms |> Async.StartAsTask`

### No trailing `return` (second commit)

A body that does not end in `return` is just `return ()`, but it compiles to `TaskBuilderBase.Zero`, whose declared type is FSharp.Core's `TaskCode<'TOverall, unit>`. The Rust backend emits generic arguments for a library import called without args (`Fable2Rust`, "library imports without args need explicit genArgs") taking them from the return type, so the resumable-code internals leaked into the call:

```rust
zero::<&MutCell<ResumableStateMachine_1<_>>, bool>()
```

Giving the `Zero` mapping a `unit` return type keeps those generics out of the emitted call, which is then simply `zero()`, and `Task_::zero` loses a generic parameter it never used. No `ResumableStateMachine` reference remains in the generated code. This makes the common `task { let! x = f (); useIt x }` shape work.

### Not yet supported

The remaining tests are kept in the file, commented, each with the reason. They cannot be marked with `OuterAttr("ignore")` instead: Fable rejects these builder members outright, so they fail the build rather than compiling into a skipped test.

- **`while` / `for` / `try-with` / `try-finally` / `use!`** — `TaskBuilderBase.While`, `For`, `TryWith`, `TryFinally`, `Using` and `Combine` are not mapped in the Rust `Replacements`, and `Task_` has no matching runtime combinators. (`AsyncBuilder_` lacks these too; the async tests just avoid those constructs.) A loop body would also need to be re-runnable, whereas a `Task` here is hot-started and caches its result.
- **`Task.Delay`** — not implemented; `do! Task.Delay ...` also needs binding of the non-generic `Task`, which goes through `TaskBuilderExtensions.LowPriority.Bind` and `Task.GetAwaiter`.
- **`GetAwaiter().GetResult()`** — not supported, so `.Result` is used to wait.
- **Generic helpers over `Task<'T>`** — e.g. `let run (t: Task<'T>) = t.Result` emits `<T: Clone + 'static>` while `Task<T>` requires `T: Send`, so bounds are missing. Concrete types are unaffected.
- **`TaskCompletionSource`** — not implemented.

### Testing

- `./build.sh test rust --threaded` → 2516 passed, 14 task tests running
- `./build.sh test rust` → 2487 passed, module gated out as expected
- `./build.sh test rust --no_std` → module gated out as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)