### PR TITLE
fix(all): skip translating unreachable branch of constant-condition if/then/else

### DIFF
--- a/src/Fable.Transforms/FSharp2Fable.fs
+++ b/src/Fable.Transforms/FSharp2Fable.fs
@@ -1145,23 +1145,38 @@ let private transformExpr (com: IFableCompiler) (ctx: Context) appliedGenArgs fs
 
         | FSharpExprPatterns.IfThenElse(guardExpr, thenExpr, elseExpr) ->
             let! guardExpr = transformExpr com ctx [] guardExpr
-            let! thenExpr = transformExpr com ctx [] thenExpr
-            let! fableElseExpr = transformExpr com ctx [] elseExpr
 
-            let altElseExpr =
-                match elseExpr with
-                | RaisingMatchFailureExpr _infoWhereErrorOccurs ->
-                    let errorMessage = "Match failure"
-                    let rangeOfElseExpr = makeRangeFrom elseExpr
+            match guardExpr with
+            // Skip translating the unreachable branch (e.g. Compiler.isXxx), so target-specific
+            // calls there can't fail. Not for quotations: they must keep the literal structure.
+            | Fable.Value(Fable.BoolConstant value, _) when not ctx.CapturingQuotation ->
+                return!
+                    transformExpr
+                        com
+                        ctx
+                        []
+                        (if value then
+                             thenExpr
+                         else
+                             elseExpr)
+            | _ ->
+                let! thenExpr = transformExpr com ctx [] thenExpr
+                let! fableElseExpr = transformExpr com ctx [] elseExpr
 
-                    let errorExpr =
-                        Fable.Value(Fable.StringConstant errorMessage, None)
-                        |> Replacements.Api.error com
+                let altElseExpr =
+                    match elseExpr with
+                    | RaisingMatchFailureExpr _infoWhereErrorOccurs ->
+                        let errorMessage = "Match failure"
+                        let rangeOfElseExpr = makeRangeFrom elseExpr
 
-                    makeThrow rangeOfElseExpr Fable.Any errorExpr
-                | _ -> fableElseExpr
+                        let errorExpr =
+                            Fable.Value(Fable.StringConstant errorMessage, None)
+                            |> Replacements.Api.error com
 
-            return Fable.IfThenElse(guardExpr, thenExpr, altElseExpr, makeRangeFrom fsExpr)
+                        makeThrow rangeOfElseExpr Fable.Any errorExpr
+                    | _ -> fableElseExpr
+
+                return Fable.IfThenElse(guardExpr, thenExpr, altElseExpr, makeRangeFrom fsExpr)
 
         | FSharpExprPatterns.TryFinally(body, finalBody, _, _) ->
             let r = makeRangeFrom fsExpr


### PR DESCRIPTION
This PR is a complement to `Compiler.isXXX` introduction.

Before this PR, the following code would emit a Fable error when compiling for JavaScript

> ./QuickTest.fs(108,8): (108,35) error FABLE: Fable.Core.PyInterop.emitPyExpr is not supported, try updating fable tool

```fs
let test : int =
    if Compiler.isJavaScript then
        emitJsExpr (1, 2) "$0 + $1"
    else
        emitPyExpr (1, 2) "$0 + $1" // should NOT error even though it's unreachable for JS
```

Before, the if/then/else optimization was done against Fable.AST meaning it needed to pass Fable transform.

Now, it is done during FSharp2Fable phase, so we will only transform branched that are reachable. Allowing, Fable probably to contain unsupported code if they are in an unreachable branch.
