### PR TITLE
fix(python): don't emit too many leading dots for relative imports of nested files

### DIFF
--- a/src/Fable.Cli/Pipeline.fs
+++ b/src/Fable.Cli/Pipeline.fs
@@ -244,7 +244,15 @@ module Python =
                     |> Array.mapi (fun i part ->
                         match part with
                         | "." when isLibrary -> Some ""
-                        | ".." when isLibrary -> Some "."
+                        // Joining with "." below already adds one dot per parent level,
+                        // so only the first ".." keeps its own dot. See #4797
+                        | ".." when isLibrary ->
+                            Some(
+                                if i = 0 then
+                                    "."
+                                else
+                                    ""
+                            )
                         | "."
                         | ".." -> None
                         | _ when i = parts.Length - 1 -> Some(normalizeFileName part)


### PR DESCRIPTION
Fixes #4797

When a file nested inside a package imports from a sibling package two or more levels up, the generated relative import had one leading dot too many, e.g.

`from ....relative_import_sibling.api import value  # ImportError: attempted relative import beyond top-level package`
instead of the correct
`from ...relative_import_sibling.api import value`

The parts of the resolved path are joined with `.`, so every `..` segment already contributes one dot through the separator. Since each segment was also mapped to a dot of its own, the result was only correct for single-level imports (the case in #4088/#4100). Now only the first `..` keeps its own dot. Single-level and same-package imports are unchanged.

Verified with the minimal reproduction from the issue. The existing test suite only exercises single-level fable_modules imports (Thoth.Json). Covering the multi-level case would need a dependency with nested source folders, so I've left test placement to your judgement.