### PR TITLE
fix(python): make union case classes hashable again

### DIFF
--- a/src/fable-library-py/fable_library/union.py
+++ b/src/fable-library-py/fable_library/union.py
@@ -126,11 +126,13 @@ def tagged_union(tag: int):
     Uses @dataclass_transform() so type checkers understand:
     - Field annotations become constructor parameters
     - __match_args__ is generated
-    - __eq__, __repr__, __hash__ are generated
+    - __eq__, __repr__ are generated
 
     Additionally sets:
     - cls.tag = tag (numeric case discriminator)
     - cls.fields property (list of field values for backwards compat)
+    - cls.__hash__ from HashableBase (dataclass sets it to None when
+      generating __eq__, which would make union values unhashable)
     """
 
     def decorator[T](cls: type[T]) -> type[T]:
@@ -148,6 +150,12 @@ def tagged_union(tag: int):
             return Array[Any]([getattr(self, name) for name in field_names])
 
         dc_cls.fields = fields
+
+        # dataclass() generates __eq__ and therefore sets __hash__ to None.
+        # Restore the hash protocol so union values stay hashable via
+        # GetHashCode, e.g. when a union is a field of another union.
+        dc_cls.__hash__ = HashableBase.__hash__
+
         return dc_cls
 
     return decorator

--- a/src/fable-library-py/tests/test_union.py
+++ b/src/fable-library-py/tests/test_union.py
@@ -1,0 +1,45 @@
+from fable_library.union import Union, tagged_union
+
+
+class _Shape(Union):
+    @staticmethod
+    def cases() -> list[str]:
+        return ["Circle", "Boxed"]
+
+
+@tagged_union(0)
+class Shape_Circle(_Shape):
+    radius: int
+
+
+@tagged_union(1)
+class Shape_Boxed(_Shape):
+    inner: _Shape
+
+
+def test_union_case_is_hashable() -> None:
+    # dataclass() generates __eq__, which sets __hash__ to None unless it is
+    # restored -- union values must keep supporting the hash protocol.
+    assert isinstance(hash(Shape_Circle(1)), int)
+
+
+def test_equal_unions_have_equal_hashes() -> None:
+    assert Shape_Circle(2) == Shape_Circle(2)
+    assert hash(Shape_Circle(2)) == hash(Shape_Circle(2))
+
+
+def test_nested_union_is_hashable() -> None:
+    # A union hashes over its fields, so a union nested as a field of another
+    # union must be hashable as well.
+    nested = Shape_Boxed(Shape_Circle(3))
+    assert nested.GetHashCode() == Shape_Boxed(Shape_Circle(3)).GetHashCode()
+    assert hash(nested) == hash(Shape_Boxed(Shape_Circle(3)))
+
+
+def test_union_works_in_sets() -> None:
+    # set([...]) instead of a set literal: type checkers model tagged_union case
+    # classes as non-frozen dataclasses (statically unhashable), while the
+    # decorator restores __hash__ at runtime.
+    distinct = set([Shape_Circle(1), Shape_Circle(1), Shape_Boxed(Shape_Circle(1))])
+    assert len(distinct) == 2
+    assert Shape_Circle(1) in distinct


### PR DESCRIPTION
Fixes #4804

Hashing a union value that contains another union as a field raises TypeError: unhashable type at runtime, e.g.
```
type Inner = | A
type Outer = | Wrap of Inner

(Wrap A).GetHashCode() // TypeError: unhashable type: 'Inner_A'
```
The same code works on .NET and JS, and breaks things like `List.distinct` or using unions as dictionary keys on Python.

The `tagged_union` decorator applies `dataclass()` to every case class. Since that generates `__eq__` without `frozen=True`, Python sets `__hash__ = None` on the class, shadowing the `__hash__` the Union base inherits from `HashableBase`. So case classes were explicitly unhashable, and `Union.GetHashCode (hash((self.tag, *self.fields)))` blows up as soon as a field is itself a union. The decorator's docstring already claims `__hash__` is generated. This restores it after the `dataclass()` call. It's consistent with the dataclass `__eq__`: equal values have equal `(tag, *fields)`, hence equal hashes.

Added tests for the hash protocol, hash/eq consistency, nested unions and set membership.

One note: type checkers still consider the case classes unhashable statically (`dataclass_transform` models them as non-frozen dataclasses), even though `__hash__` now exists at runtime.