### PR TITLE
fix(python): make class declarations and references agree on type names

### DIFF
--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -676,7 +676,11 @@ module Helpers =
 
         let sanitizedName =
             match com.Options.Language with
-            | Python -> Fable.Py.Naming.sanitizeIdent Fable.Py.Naming.pyBuiltins.Contains name part
+            | Python ->
+                // Python classes are declared with PascalCase names (PEP 8), so entity
+                // references must use the same casing as the declaration
+                let name = Fable.Py.Naming.toPascalCase name
+                Fable.Py.Naming.sanitizeIdent Fable.Py.Naming.pyBuiltins.Contains name part
             | Rust -> (entityName |> cleanNameAsRustIdentifier)
             | Dart -> Naming.sanitizeDartIdent (fun _ -> false) name part
             | _ -> Naming.sanitizeJsIdent (fun _ -> false) name part
@@ -768,7 +772,12 @@ module Helpers =
                     | Some _ -> name
                     | _ -> Fable.Py.Naming.toPythonNaming name
 
+                // Reference sites re-case the full composed name, so apply the naming
+                // convention to the composed name here as well. Otherwise a lowercase
+                // member name with an overload suffix is declared with the suffix
+                // preserved but referenced with it snake_cased
                 Fable.Py.Naming.sanitizeIdent Fable.Py.Naming.pyBuiltins.Contains name part
+                |> Fable.Py.Naming.toPythonNaming
             | Rust -> Naming.buildNameWithoutSanitation name part
             | Dart -> Naming.sanitizeDartIdent (fun _ -> false) name part
             | _ -> Naming.sanitizeJsIdent (fun _ -> false) name part

--- a/src/Fable.Transforms/Python/Fable2Python.Annotation.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.Annotation.fs
@@ -727,13 +727,20 @@ let makeEntityTypeAnnotation com ctx (entRef: Fable.EntityRef) genArgs repeatedG
                             // Inside base class or not a union - use as-is
                             id
 
-                    // Import the type if it's from another file
-                    if ent.IsFSharpUnion then
-                        match ent.Ref.SourcePath with
-                        | Some path when path <> com.CurrentFile ->
-                            let importPath = Path.getRelativeFileOrDirPath false com.CurrentFile false path
-                            com.GetImportExpr(ctx, importPath, annotationName) |> ignore
-                        | _ -> ()
+                    // Import the type if it's from another file. The import may be aliased when the
+                    // name clashes with a local declaration, so use the returned local identifier
+                    let annotationName =
+                        if ent.IsFSharpUnion then
+                            match ent.Ref.SourcePath with
+                            | Some path when path <> com.CurrentFile ->
+                                let importPath = Path.getRelativeFileOrDirPath false com.CurrentFile false path
+
+                                match com.GetImportExpr(ctx, importPath, annotationName) with
+                                | Expression.Name { Id = Identifier localId } -> localId
+                                | _ -> annotationName
+                            | _ -> annotationName
+                        else
+                            annotationName
 
                     makeGenericTypeAnnotation com ctx annotationName genArgs repeatedGenerics, stmts
                 // TODO: Resolve references to types in nested modules

--- a/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
@@ -3355,7 +3355,7 @@ let declareDataClassType
                     |> List.filter (fun genArg ->
                         match genArg with
                         | Fable.DeclaredType({ FullName = fullName }, _) ->
-                            Helpers.removeNamespace (fullName) <> entName
+                            Naming.toPascalCase (Helpers.removeNamespace fullName) <> entName
                         | _ -> true
                     )
 
@@ -3628,7 +3628,8 @@ let declareClassType
                 int.GenericArgs
                 |> List.filter (fun genArg ->
                     match genArg with
-                    | Fable.DeclaredType({ FullName = fullName }, _) -> Helpers.removeNamespace (fullName) <> entName
+                    | Fable.DeclaredType({ FullName = fullName }, _) ->
+                        Naming.toPascalCase (Helpers.removeNamespace fullName) <> entName
                     | _ -> true
                 )
 

--- a/tests/Python/Misc/Util2.fs
+++ b/tests/Python/Misc/Util2.fs
@@ -12,6 +12,11 @@ type Helper3(i: int) =
 
 type H = Helper3
 
+// Lowercase type name at the root of the file: the Python class declaration and
+// its references from other files must agree on the name
+type shape(size: int) =
+    member _.Size = size
+
 
 module Extensions =
     type String with

--- a/tests/Python/Misc/Util2.fs
+++ b/tests/Python/Misc/Util2.fs
@@ -17,6 +17,8 @@ type H = Helper3
 type shape(size: int) =
     member _.Size = size
 
+type Direction = | Up
+
 
 module Extensions =
     type String with

--- a/tests/Python/TestMisc.fs
+++ b/tests/Python/TestMisc.fs
@@ -963,6 +963,14 @@ let ``test Lowercase type name from another file works`` () =
     let s = Util2.shape (4)
     s.Size |> equal 4
 
+[<AttachMembers>]
+type Direction() =
+    static member Up = Util2.Direction.Up
+
+[<Fact>]
+let ``test Type with same name as type from another file works`` () =
+    Direction.Up |> equal Util2.Direction.Up
+
 [<Fact>]
 let ``test Can access nested recursive function with mangled name`` () =
     Util.Bar.nestedRecursive 3 |> equal 10

--- a/tests/Python/TestMisc.fs
+++ b/tests/Python/TestMisc.fs
@@ -959,6 +959,11 @@ let ``test Naming values with same name as module works`` () =
     equal 30 Same.Same.shouldEqual30
 
 [<Fact>]
+let ``test Lowercase type name from another file works`` () =
+    let s = Util2.shape (4)
+    s.Size |> equal 4
+
+[<Fact>]
 let ``test Can access nested recursive function with mangled name`` () =
     Util.Bar.nestedRecursive 3 |> equal 10
 


### PR DESCRIPTION
Fixes #4806

Class declarations are PascalCased on the Python target, but references to them are not, so a type with a lowercase name gets declared as class Shape while other modules import shape:
```
from lib import (shape__ctor, shape, shape__get_size)
ImportError: cannot import name 'shape' from 'lib'. Did you mean: 'Shape'?
```
First commit: all entity names funnel through `getEntityDeclarationName`, so the PascalCasing is applied there (Python branch only) and declarations and references agree by construction. The same commit fixes the equivalent mismatch for member names: reference sites re-case the full composed name, so a lowercase member with an overload suffix was declared as `shape__ctor_Z524259A4` but imported as `shape__ctor_z524259a4`. The composed declaration name now gets the same casing convention.

Second commit: when an imported union's name collides with a local declaration, the import is correctly aliased (`Direction as Direction_1`) but `makeEntityTypeAnnotation` discarded the returned local identifier and emitted the original name, which fails with a `NameError` inside `StaticProperty[...]` annotations. Annotations now use the actual (possibly aliased) import identifier.

Only types whose names aren't already PascalCase produce different output than before, and references to those were broken one way or another.
Note that `toPascalCase` only upper-cases the first character, which is why types nested in modules (mangled to `Module_name`) never hit this.