### PR TITLE
chore(python): cover overloaded-ctor casing on lowercase types

### DIFF
--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -767,15 +767,24 @@ module Helpers =
             match com.Options.Language with
             | Python ->
                 let name =
-                    // Don't apply Python naming convention if member has compiled name attribute
+                    // Don't snake_case the prefix for [<CompiledName>] members. This is
+                    // largely subsumed by the re-casing of the whole composed name below,
+                    // but keeps the intent explicit at this step.
                     match memb.Attributes |> Helpers.tryFindAttrib Atts.compiledName with
                     | Some _ -> name
                     | _ -> Fable.Py.Naming.toPythonNaming name
 
-                // Reference sites re-case the full composed name, so apply the naming
-                // convention to the composed name here as well. Otherwise a lowercase
-                // member name with an overload suffix is declared with the suffix
-                // preserved but referenced with it snake_cased
+                // Import/reference sites re-case the full composed name unconditionally
+                // (see the imports printer in Fable2Python.Transforms), so re-case it here
+                // too to keep declarations and references in agreement. This is what makes
+                // a lowercase member with an overload suffix, e.g. `foo__ctor_Z<hash>`, be
+                // both declared and imported as `foo__ctor_z<hash>`.
+                //
+                // Caveat: being unconditional, this also overrides the [<CompiledName>] skip
+                // above when the composed name has no uppercase entity/module prefix, i.e. a
+                // root-level compiled name starting lowercase is snake_cased. Prefixed names
+                // (class / nested-module members) keep their uppercase prefix, so toPythonNaming
+                // is a no-op there and the compiled name survives.
                 Fable.Py.Naming.sanitizeIdent Fable.Py.Naming.pyBuiltins.Contains name part
                 |> Fable.Py.Naming.toPythonNaming
             | Rust -> Naming.buildNameWithoutSanitation name part

--- a/tests/Python/Misc/Util2.fs
+++ b/tests/Python/Misc/Util2.fs
@@ -15,6 +15,10 @@ type H = Helper3
 // Lowercase type name at the root of the file: the Python class declaration and
 // its references from other files must agree on the name
 type shape(size: int) =
+    // Overloaded constructors are emitted as module-level names with an overload
+    // suffix (e.g. `shape__ctor_Z<hash>`) and imported across files. The declaration
+    // and the import must agree on the suffix casing too, not just the base name.
+    new(label: string) = shape(label.Length)
     member _.Size = size
 
 type Direction = | Up

--- a/tests/Python/TestMisc.fs
+++ b/tests/Python/TestMisc.fs
@@ -963,6 +963,14 @@ let ``test Lowercase type name from another file works`` () =
     let s = Util2.shape (4)
     s.Size |> equal 4
 
+[<Fact>]
+let ``test Overloaded constructor on lowercase type from another file works`` () =
+    // Exercises the `shape__ctor_Z<hash>` overload-suffix casing across files
+    let s1 = Util2.shape (4)
+    let s2 = Util2.shape ("abc")
+    s1.Size |> equal 4
+    s2.Size |> equal 3
+
 [<AttachMembers>]
 type Direction() =
     static member Up = Util2.Direction.Up


### PR DESCRIPTION
Follow-up to #4807.

### 1. Regression test for the overload-suffix casing path

#4807 fixed Python class/member declarations and references disagreeing on casing for lowercase-named types, but its test (`type shape` with a single constructor) never exercised the **overload-suffix** path called out in the PR description (`shape__ctor_Z524259A4` declared but `shape__ctor_z524259a4` imported).

This gives `shape` a second, overloaded constructor and references both across files. Transpiled output confirms declaration and import agree on the lowercased suffix:
```python
# Misc/util2.py
def shape__ctor_z524259a4(size: int32) -> Shape: ...
def shape__ctor_z721c83c5(label: str) -> Shape: ...
# test_misc.py
from Misc.util2 import (..., shape__ctor_z524259a4, Shape as Shape_1, shape__ctor_z721c83c5, ...)
```
Before the #4807 fix, the declaration kept `...Z524259A4` while the import used `...z524259a4` → `ImportError`.

### 2. Accurate comments on the composed-name `toPythonNaming`

While reviewing the double `toPythonNaming` application in `getMemberDeclarationName`, I traced (via quicktest) exactly what the unconditional outer call does:

- It mirrors the re-casing applied at import/reference sites, which is what keeps declarations and references consistent (the whole point of #4807).
- As a **side effect**, being unconditional it also re-cases `[<CompiledName>]` members. This is a no-op for class/nested-module members (uppercase entity/module prefix), so their compiled name survives — but a **root-level** `[<CompiledName>]` function starting lowercase gets snake_cased (`[<CompiledName("rootLevelCompiled")>]` → `root_level_compiled`).

This is a pre-existing tension, not something this PR changes: cross-file references to such a function were already broken before #4807 (`ImportError`), so #4807 traded "compiled name honored but cross-file broken" for "always consistent but not honored verbatim". A fully correct fix would need the import printer to be `CompiledName`-aware (it only sees a bare string today) — out of scope here. This PR just documents the real behavior instead of the earlier misleading "idempotent, harmless" note.

No compiler behavior change — comments only.

### Testing

`./build.sh test python` — all 2405 tests pass (run against the initial version of this PR; item 2 is comments-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)