### PR TITLE
fix(beam): correct char-to-string conversion and console Unicode encoding

### DIFF
--- a/src/Fable.Build/Test/Beam.fs
+++ b/src/Fable.Build/Test/Beam.fs
@@ -94,6 +94,7 @@ let private testEntryPointPrograms () =
     // whichever device encoding you picked, one of them mangled non-ASCII text.
     expect "Console.WriteLine encodes non-ASCII" true (output.Contains "writeline=✓ ✗ · é")
     expect "printfn encodes non-ASCII" true (output.Contains "printfn=✓ ✗ · é")
+    expect "Console.WriteLine of a char" true (output.Contains "char=✓")
 
     // ...and its return value must become the exit code, or a failing suite looks like a passing one.
     let _, failExitCode = runErl buildDir paArgs "main:main([\\\"fail\\\"])"

--- a/src/Fable.Build/Test/Beam.fs
+++ b/src/Fable.Build/Test/Beam.fs
@@ -89,6 +89,12 @@ let private testEntryPointPrograms () =
     expect "argv contents" true (output.Contains "argv=alpha,beta")
     expect "exit code of a successful run" 0 exitCode
 
+    // Both console paths must agree on encoding, under the plain `erl -noshell` above with no
+    // extra flags: `Console.WriteLine` wrote raw UTF-8 bytes while `printfn` wrote unicode, so
+    // whichever device encoding you picked, one of them mangled non-ASCII text.
+    expect "Console.WriteLine encodes non-ASCII" true (output.Contains "writeline=✓ ✗ · é")
+    expect "printfn encodes non-ASCII" true (output.Contains "printfn=✓ ✗ · é")
+
     // ...and its return value must become the exit code, or a failing suite looks like a passing one.
     let _, failExitCode = runErl buildDir paArgs "main:main([\\\"fail\\\"])"
     expect "exit code of a failing run" 3 failExitCode

--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -1160,6 +1160,7 @@ let private generateBeamScaffold (cliArgs: CliArgs) (entryModule: string) =
 main() -> main([]).
 
 main(Args) ->
+    ok = setup_io(),
     _ = code:ensure_loaded({entryModule}),
     case erlang:function_exported({entryModule}, main, 1) of
         true ->
@@ -1168,6 +1169,16 @@ main(Args) ->
         false ->
             {entryModule}:main()
     end.
+
+%% An F# string is a UTF-8 binary, and every path that prints one — `Console.WriteLine`, `printfn` —
+%% writes it with the `~ts` (unicode) modifier. That only reaches the terminal intact on a device
+%% whose encoding is unicode; on the latin1 default of `erl -noshell` a non-latin1 codepoint comes
+%% out as a `\\x{{2713}}` escape. The `+pc unicode` VM flag does not do this — it only affects
+%% printable-list detection in `~p`.
+setup_io() ->
+    _ = io:setopts(standard_io, [{{encoding, unicode}}]),
+    _ = io:setopts(standard_error, [{{encoding, unicode}}]),
+    ok.
 
 exit_with(Code) when is_integer(Code) -> erlang:halt(Code);
 exit_with(_) -> ok.

--- a/src/Fable.Transforms/Beam/FABLE-BEAM.md
+++ b/src/Fable.Transforms/Beam/FABLE-BEAM.md
@@ -413,6 +413,30 @@ breaking change to a core type, costs arithmetic and comparison performance, and
 convention that strings are lists of integer codepoints. Not worth it for a case with a one-keyword
 workaround.
 
+### Console output requires a unicode io device
+
+An F# `string` is a UTF-8 `binary()`, and every path that prints one — `Console.Write`,
+`Console.WriteLine`, `printf`/`printfn`, `eprintfn` — writes it with io's `t` (unicode) modifier
+(`~ts`). That reaches the terminal intact only on a device whose encoding is `unicode`; on the
+latin1 default of `erl -noshell` a codepoint above latin1 comes out as a `\x{2713}` escape instead.
+
+Programs started through Fable's generated `main.erl` need to do nothing: the shim's `setup_io/0`
+sets both `standard_io` and `standard_error` to unicode before calling into F#. Anything else —
+a Fable-compiled module called from a hand-written OTP release, an `escript`, a `gen_server`
+started by someone else's supervisor — has to set the device itself:
+
+```erlang
+ok = io:setopts(standard_io, [{encoding, unicode}]),
+ok = io:setopts(standard_error, [{encoding, unicode}]).
+```
+
+The `+pc unicode` VM flag is *not* a substitute: it only affects printable-list detection in `~p`,
+not the device encoding.
+
+There is no device-independent alternative to fall back on. `io:put_chars` follows the device
+encoding for both binaries and codepoint lists, so writing a string's raw bytes with `~s` would
+merely move the corruption to unicode devices instead of latin1 ones.
+
 ### Class instance representation: map vs process-dict ref
 
 A class instance has two possible representations, chosen per class at construction:

--- a/src/Fable.Transforms/Beam/FABLE-BEAM.md
+++ b/src/Fable.Transforms/Beam/FABLE-BEAM.md
@@ -334,6 +334,7 @@ its module-level actions compile to that module's `main/0`.
 | ---------------- | ---------------------- | ------------------------------------------ | ---------------------------- |
 | `int`, `float`   | `integer()`, `float()` | Direct                                     |                              |
 | `string`         | `binary()`             | `<<"hello">>`                              |                              |
+| `char`           | `integer()`            | Unicode codepoint; see caveat below        |                              |
 | `bool`           | `true \                | false`                                     | Atoms                        |
 | `unit`           | `ok`                   | Atom                                       |                              |
 | `tuple`          | `tuple`                | Direct: `{A, B, C}`                        |                              |
@@ -358,6 +359,59 @@ its module-level actions compile to that module's `main/0`.
 | **Currying**                      | Lambda wrapping (same as Python target)           | —                                    |
 | **Nested modules**                | Flat module names: `My_Module_Sub`                | One file per module                  |
 | **Computation expressions**       | Transformed at Fable AST level; async/task → CPS  | —                                    |
+
+### Known limitation: `char` at a generic type stringifies to its codepoint
+
+A `char` is a plain `integer()` at runtime — the same representation as an `int`, and the same
+choice the Dart target makes. Nothing at runtime can tell the two apart, so converting a `char` to
+a string is correct only where the compiler can still see the type statically. It can in every
+ordinary case:
+
+```fsharp
+string c            // "2"
+c.ToString()        // "2"
+"x" + string c      // "x2"
+System.Char.ToString c   // "2"
+$"{c}"              // "2"
+```
+
+But when `string x` is applied where `x`'s type is a *generic parameter*, the backend can only emit
+`fable_convert:to_string/1`, which sees an integer and prints the number:
+
+```fsharp
+// F# generalizes this to Op<'a> -> Op<string>, so `string c` is applied at a generic type.
+let toStr =
+    function
+    | Keep c -> Keep(string c)
+    | Drop c -> Drop(string c)
+
+[ Keep '2'; Drop '1' ] |> List.map toStr   // "5049", not "21"
+```
+
+The trigger is F# generalizing a let-bound lambda, which is easy to hit by accident — the DU is
+incidental. `%A` and structural printing of a boxed char have the same limitation.
+
+Fable erases generics by design, so there is no type witness to dispatch on. The fix is the same
+one the compiler already recommends when `typeof<'T>` fails for this reason (see
+`genericTypeInfoError` in `Replacements.Util.fs`): make the function `inline`, so the type is
+resolved at the call site.
+
+```fsharp
+let inline toStr op =
+    match op with
+    | Keep c -> Keep(string c)
+    | Drop c -> Drop(string c)
+
+[ Keep '2'; Drop '1' ] |> List.map toStr   // "21"
+```
+
+Annotating the parameter concretely (`Op<char>`) works too, for the same reason — it defeats
+generalization.
+
+Giving `char` a tagged runtime form such as `{char, 50}` would fix this everywhere, but it is a
+breaking change to a core type, costs arithmetic and comparison performance, and fights Erlang's own
+convention that strings are lists of integer codepoints. Not worth it for a case with a one-keyword
+workaround.
 
 ### Class instance representation: map vs process-dict ref
 

--- a/src/Fable.Transforms/Beam/Fable2Beam.fs
+++ b/src/Fable.Transforms/Beam/Fable2Beam.fs
@@ -1639,14 +1639,6 @@ and transformValue (com: IBeamCompiler) (ctx: Context) (value: ValueKind) : Beam
         Beam.ErlExpr.Map entries
 
     | StringTemplate(_tag, parts, values) ->
-        // F# boxes every interpolation hole, so `$"{c}"` on a char arrives here as a cast to `Any`
-        // with the char type visible only underneath. Peel the box for chars specifically: `Any`
-        // otherwise falls through to `fable_string:to_string`, which is right for everything else.
-        let holeType (e: Fable.Expr) =
-            match e with
-            | TypeCast(inner, Any) when inner.Type = Char -> Char
-            | _ -> e.Type
-
         let toStringExpr erlValue (typ: Fable.AST.Fable.Type) =
             match typ with
             | Fable.AST.Fable.Type.String -> erlValue
@@ -1687,7 +1679,9 @@ and transformValue (com: IBeamCompiler) (ctx: Context) (value: ValueKind) : Beam
                 ([ Beam.ErlExpr.Literal(Beam.ErlLiteral.StringLit firstPart) ], List.zip values restParts)
                 ||> List.fold (fun acc (value, part) ->
                     let erlValue = transformExpr com ctx value
-                    let stringified = toStringExpr erlValue (holeType value)
+                    // F# boxes every interpolation hole, so `$"{c}"` on a char arrives here as a
+                    // cast to `Any` with the char type visible only underneath.
+                    let stringified = toStringExpr erlValue (Fable.Beam.Chars.unboxedType value)
                     acc @ [ stringified; Beam.ErlExpr.Literal(Beam.ErlLiteral.StringLit part) ]
                 )
 

--- a/src/Fable.Transforms/Beam/Fable2Beam.fs
+++ b/src/Fable.Transforms/Beam/Fable2Beam.fs
@@ -1639,9 +1639,22 @@ and transformValue (com: IBeamCompiler) (ctx: Context) (value: ValueKind) : Beam
         Beam.ErlExpr.Map entries
 
     | StringTemplate(_tag, parts, values) ->
+        // F# boxes every interpolation hole, so `$"{c}"` on a char arrives here as a cast to `Any`
+        // with the char type visible only underneath. Peel the box for chars specifically: `Any`
+        // otherwise falls through to `fable_string:to_string`, which is right for everything else.
+        let holeType (e: Fable.Expr) =
+            match e with
+            | TypeCast(inner, Any) when inner.Type = Char -> Char
+            | _ -> e.Type
+
         let toStringExpr erlValue (typ: Fable.AST.Fable.Type) =
             match typ with
             | Fable.AST.Fable.Type.String -> erlValue
+            // A `char` is a plain integer at runtime, so the generic `fable_string:to_string` would
+            // take its `is_integer` clause and print the codepoint. The type is known here, so
+            // encode it as UTF-8 directly — the same thing `Convert.ToString` and `obj.ToString()`
+            // do for `Type.Char` in Beam's Replacements.
+            | Fable.AST.Fable.Type.Char -> Beam.ErlExpr.Call(Some "fable_char", "to_string", [ erlValue ])
             | Fable.AST.Fable.Type.Number(kind, _) ->
                 match kind with
                 | Float16
@@ -1674,7 +1687,7 @@ and transformValue (com: IBeamCompiler) (ctx: Context) (value: ValueKind) : Beam
                 ([ Beam.ErlExpr.Literal(Beam.ErlLiteral.StringLit firstPart) ], List.zip values restParts)
                 ||> List.fold (fun acc (value, part) ->
                     let erlValue = transformExpr com ctx value
-                    let stringified = toStringExpr erlValue value.Type
+                    let stringified = toStringExpr erlValue (holeType value)
                     acc @ [ stringified; Beam.ErlExpr.Literal(Beam.ErlLiteral.StringLit part) ]
                 )
 

--- a/src/Fable.Transforms/Beam/Prelude.fs
+++ b/src/Fable.Transforms/Beam/Prelude.fs
@@ -496,6 +496,30 @@ module Naming =
         name.Replace("$", "_").Replace("@", "_")
         |> fun s -> Regex.Replace(s, "[^a-zA-Z0-9_]", "_")
 
+/// A `char` is a plain `integer()` on Erlang — the same representation an `int` gets — so nothing
+/// at runtime can tell the two apart, and every conversion of a char to text has to be dispatched
+/// on the static type instead. F# hands some of those sites a *boxed* char (interpolation holes,
+/// `Console.WriteLine`'s `obj` overload), which erases the type to `Any`; peel the box so the char
+/// is still visible there.
+module Chars =
+    open Fable.AST.Fable
+
+    /// The char-typed expression underneath a boxing cast to `obj`, or the expression itself when
+    /// it is already a char. `None` for everything else, which keeps the generic runtime path.
+    let tryAsChar (e: Expr) =
+        match e with
+        | TypeCast(inner, Any) when inner.Type = Char -> Some inner
+        | e when e.Type = Char -> Some e
+        | _ -> None
+
+    /// The type of an expression with a boxing cast to `obj` peeled off, but only when what it
+    /// boxes is a char. Anything else keeps its own type — an `Any` there falls through to the
+    /// generic `fable_string:to_string`, which is right for every other value.
+    let unboxedType (e: Expr) =
+        match tryAsChar e with
+        | Some _ -> Char
+        | None -> e.Type
+
 /// Fixed-width integer semantics. Erlang integers are arbitrary precision and never
 /// overflow, so operations that can leave the width of a .NET sized integer are routed
 /// through the `fable_int` runtime module to truncate them back (two's complement).

--- a/src/Fable.Transforms/Beam/Replacements.fs
+++ b/src/Fable.Transforms/Beam/Replacements.fs
@@ -2038,7 +2038,10 @@ let rec private getZero (com: ICompiler) (ctx: Context) (t: Type) =
     match t with
     | Boolean -> makeBoolConst false
     | Number(kind, uom) -> NumberConstant(NumberValue.GetZero kind, uom) |> makeValue None
-    | Char
+    // A `char` is an integer at runtime, not a binary, and F# does allow summing chars
+    // (`Seq.sum [ 'a'; 'b' ]` is 195). Sharing `String`'s empty-binary zero seeded the fold with
+    // `<<"">>` and made the first addition fail with `badarith`.
+    | Char -> CharConstant '\u0000' |> makeValue None
     | String -> makeStrConst ""
     | ListSingleton(CustomOp com ctx None t "get_Zero" [] e) -> e
     | _ -> Value(Null Any, None)

--- a/src/Fable.Transforms/Beam/Replacements.fs
+++ b/src/Fable.Transforms/Beam/Replacements.fs
@@ -5559,13 +5559,21 @@ let tryCall
         | None -> conversions com ctx r t info thisArg args
     | "System.Convert" -> convert com ctx r t info thisArg args
     | "System.Console" ->
+        // `console_write`/`console_writeline` dispatch on the runtime value, where a char is an
+        // integer and so would print as its codepoint (`Console.WriteLine '2'` → "50"). The static
+        // type is still known here, so encode chars to text up front and hand over a binary.
+        let consoleArg (arg: Expr) =
+            match Chars.tryAsChar arg with
+            | Some c -> Helper.LibCall(com, "fable_char", "to_string", String, [ c ], ?loc = r)
+            | None -> arg
+
         match info.CompiledName, thisArg, args with
         | "WriteLine", None, [] -> emitExpr r t [] "io:format(<<\"~n\">>)" |> Some
         | "WriteLine", None, [ arg ] ->
-            Helper.LibCall(com, "fable_string", "console_writeline", t, [ arg ], ?loc = r)
+            Helper.LibCall(com, "fable_string", "console_writeline", t, [ consoleArg arg ], ?loc = r)
             |> Some
         | "Write", None, [ arg ] ->
-            Helper.LibCall(com, "fable_string", "console_write", t, [ arg ], ?loc = r)
+            Helper.LibCall(com, "fable_string", "console_write", t, [ consoleArg arg ], ?loc = r)
             |> Some
         | _ -> None
     | "System.Boolean" ->

--- a/src/fable-library-beam/fable_string.erl
+++ b/src/fable-library-beam/fable_string.erl
@@ -1082,24 +1082,31 @@ get_slice(Lower, Upper, Str) ->
     binary:part(Str, Start, End - Start + 1).
 
 %% Console.WriteLine / Console.Write
+%%
+%% An F# string is a UTF-8 binary, so it must go out through the `t` (unicode) modifier: plain `~s`
+%% writes the binary's raw bytes, which only looks right on a latin1 device that happens to
+%% reassemble the UTF-8 itself, and turns into mojibake the moment the device is set to unicode.
+%% `~ts` is the other half of the contract — it needs the device set to unicode, which the generated
+%% `main.erl` entry shim does at startup. `printfn` already takes a `~ts` path, so before this the
+%% two disagreed and no device setting satisfied both.
 console_writeline(Value) when is_binary(Value) ->
-    io:format(<<"~s~n">>, [Value]);
+    io:format(<<"~ts~n">>, [Value]);
 console_writeline(Value) when is_integer(Value) ->
     io:format(<<"~B~n">>, [Value]);
 console_writeline(Value) when is_float(Value) ->
     io:format(<<"~p~n">>, [Value]);
 console_writeline(Value) when is_boolean(Value) ->
-    io:format(<<"~s~n">>, [atom_to_binary(Value)]);
+    io:format(<<"~ts~n">>, [atom_to_binary(Value)]);
 console_writeline(Value) ->
-    io:format(<<"~p~n">>, [Value]).
+    io:format(<<"~tp~n">>, [Value]).
 
 console_write(Value) when is_binary(Value) ->
-    io:format(<<"~s">>, [Value]);
+    io:format(<<"~ts">>, [Value]);
 console_write(Value) when is_integer(Value) ->
     io:format(<<"~B">>, [Value]);
 console_write(Value) when is_float(Value) ->
     io:format(<<"~p">>, [Value]);
 console_write(Value) when is_boolean(Value) ->
-    io:format(<<"~s">>, [atom_to_binary(Value)]);
+    io:format(<<"~ts">>, [atom_to_binary(Value)]);
 console_write(Value) ->
-    io:format(<<"~p">>, [Value]).
+    io:format(<<"~tp">>, [Value]).

--- a/tests/Beam/CharTests.fs
+++ b/tests/Beam/CharTests.fs
@@ -28,6 +28,26 @@ let ``test Char.ToString works`` () =
 let ``test Char.ToString type is casted correctly`` () =
     ('t'.ToString()) + "est" |> equal "test"
 
+// A `char` is a plain integer at runtime on Beam, so every conversion path has to be told the type
+// is a char — miss one and it prints the codepoint instead of the character.
+[<Fact>]
+let ``test char conversions to string agree`` () =
+    let c = '2'
+    string c |> equal "2"
+    c.ToString() |> equal "2"
+    "x" + string c |> equal "x2"
+    Char.ToString c |> equal "2"
+    $"{c}" |> equal "2"
+
+[<Fact>]
+let ``test char conversions to string work above the latin1 range`` () =
+    let c = '✗' // U+2717 — needs real UTF-8 encoding, not a byte
+    string c |> equal "✗"
+    c.ToString() |> equal "✗"
+    Char.ToString c |> equal "✗"
+    $"{c}" |> equal "✗"
+    $"a{c}b" |> equal "a✗b"
+
 [<Fact>]
 let ``test Char.IsLetter works`` () =
     Char.IsLetter('a') |> equal true

--- a/tests/Beam/Program/Program.fs
+++ b/tests/Beam/Program/Program.fs
@@ -13,6 +13,13 @@ let main argv =
     printfn "argc=%d" argv.Length
     printfn "argv=%s" (String.concat "," argv)
 
+    // `Console.WriteLine` and `printfn` used to have contradictory encoding contracts — one wrote
+    // the UTF-8 binary's raw bytes, the other wrote it as unicode — so no device setting made both
+    // print a non-ASCII string correctly. Both go out through the shim's unicode device now, and
+    // this is the only test that observes what actually reaches a terminal.
+    System.Console.WriteLine("writeline=✓ ✗ · é")
+    printfn "printfn=✓ ✗ · é"
+
     // ...and the return value has to become the process exit code, or a failing suite is
     // indistinguishable from a passing one.
     match argv with

--- a/tests/Beam/Program/Program.fs
+++ b/tests/Beam/Program/Program.fs
@@ -20,6 +20,11 @@ let main argv =
     System.Console.WriteLine("writeline=✓ ✗ · é")
     printfn "printfn=✓ ✗ · é"
 
+    // A char is an integer at runtime, so the console functions can't tell one from an `int` and
+    // used to print its codepoint. Only the compiler still knows the type, hence a test here.
+    System.Console.Write("char=")
+    System.Console.WriteLine('✓')
+
     // ...and the return value has to become the process exit code, or a failing suite is
     // indistinguishable from a passing one.
     match argv with

--- a/tests/Beam/SeqTests.fs
+++ b/tests/Beam/SeqTests.fs
@@ -972,6 +972,17 @@ let ``test Seq.sumBy works with float`` () =
     xs |> Seq.sumBy ((*) 2.)
     |> equal 6.
 
+// F# does allow summing chars, and the injected generic adder has to seed the fold with a char
+// zero. Sharing `string`'s empty-binary zero made the first addition fail with `badarith`, since a
+// char is an integer at runtime on Beam.
+[<Fact>]
+let ``test Seq.sum works with char`` () =
+    [ 'a'; 'b' ] |> Seq.sum |> int |> equal 195
+
+[<Fact>]
+let ``test Seq.sumBy works with char`` () =
+    [ 'a'; 'b' ] |> Seq.sumBy id |> int |> equal 195
+
 // TODO: Seq.sum with custom types causes badarith in Beam (Zero + operator not inlined properly)
 // [<Fact>]
 // let ``test Seq.sum with non numeric types works`` () =


### PR DESCRIPTION
Three silent text-mangling defects on the Beam target, plus a crash found while investigating them. No compile errors, no diagnostics — just wrong characters in the output.

## 1. `Console.WriteLine` and `printfn` had contradictory encoding contracts

`console_writeline`/`console_write` wrote an F# string's raw UTF-8 bytes with `~s`, while `printfn` wrote it as unicode with `~ts`. Verified matrix:

| | `~s` | `~ts` |
|---|---|---|
| latin1 device (`erl -noshell` default) | `✓ ✗ · é` — right *by accident*, the terminal reassembles the UTF-8 | `\x{2713} \x{2717} � �` |
| unicode device | `â ✗ Â· Ã©` | `✓ ✗ · é` |

No device configuration satisfied both. I also checked `io:put_chars` with binaries and with codepoint lists — both follow the device encoding too, so there is no device-independent output path and both halves of the fix are required:

- `~ts`/`~tp` for user-supplied text in `fable_string.erl` (`~B` for integers is unaffected).
- `io:setopts` to unicode for **both** `standard_io` and `standard_error` in the generated `main.erl` shim. The `+pc unicode` VM flag does *not* do this — it only affects printable-list detection in `~p`.

## 2. `$"{c}"` on a char printed its codepoint

```fsharp
let c = '2'
string c              // "2"  ok
c.ToString()          // "2"  ok
System.Char.ToString c // "2"  ok
$"{c}"                // "50" BUG
```

`toStringExpr` in `Fable2Beam.fs` had no `Char` case, so it fell through to `fable_string:to_string`, whose `is_integer` clause prints the number.

Adding a `Type.Char` case alone does **not** fix it: F# boxes every interpolation hole, so the value arrives as `TypeCast(Value(CharConstant '2'), Any)` and `value.Type` is `Any`, not `Char`. The fix peels the box, scoped to chars specifically so boxed floats and ints keep their existing formatting.

## 3. `Seq.sum` on chars crashed with `badarith`

Found while investigating the above. `getZero` collapsed `Char` and `String` into one empty-binary zero, but a char is an `integer()` at runtime on Beam:

```fsharp
[ 'a'; 'b' ] |> Seq.sum   // .NET: 195   Beam: badarith in seq:fold/3
```

Summing chars is legal F# (`GenericZero<char>` = 0), so this is reachable from ordinary code. It only hit the seq path — `Array.sum`/`List.sum` lower to `lists:sum` and `Array.sumBy`/`List.sumBy` to `fable_list:sum_by`, none of which take the injected generic adder.

Every other backend already separates the two cases — JS and Python use a NUL char constant, Dart uses `TypeCast(makeIntConst 0, t)` — and Beam's own `defaultof` did too. Beam's `getZero` was the lone outlier.

## Known limitation, documented rather than fixed

`string x` where `x`'s type is a *generic parameter* still yields the codepoint:

```fsharp
// F# generalizes this, so `string c` is applied at a generic type
let toStr = function Keep c -> Keep(string c) | Drop c -> Drop(string c)
[ Keep '2'; Drop '1' ] |> List.map toStr   // "5049", not "21"
```

A char is an integer at runtime and Fable erases generics, so there is no witness to dispatch on. Marking the function `inline` resolves it at the call site and produces `21` — verified end to end, and the same remedy the compiler already recommends when `typeof<'T>` fails for this reason. Documented in `FABLE-BEAM.md` with a `char` row in the type-mapping table.

A tagged runtime form such as `{char, 50}` would fix it everywhere, but it is a breaking change to a core type, costs arithmetic/comparison performance, and fights Erlang's convention that strings are lists of integer codepoints. Not worth it for a case with a one-keyword workaround.

## Testing

`./build.sh test beam` green. Added:

- `CharTests.fs` — all five conversion forms, ASCII and above-latin1 (`'✗'`, U+2717), since `<<C/utf8>>` handles those but `~s`-based paths do not.
- `SeqTests.fs` — `Seq.sum`/`Seq.sumBy` on chars.
- `tests/Beam/Program/Program.fs` + assertions in `Build.Test.Beam` — non-ASCII through both `Console.WriteLine` and `printfn`, under plain `erl -noshell` with no extra flags.

That last one matters: the main suite calls test functions directly and never runs the shim, so `testEntryPointPrograms` is the only place that observes what actually reaches a terminal. A `~s`-only regression would go undetected in `CharTests`.

## Notes for reviewers

- **Consumers that don't use the generated shim** still need to set their own device encoding — the `setopts` only covers programs started through Fable's `main.erl`.
- **Dart has the identical generic-char bug** at `Dart/Replacements.fs:258`, for the same reason (char represented as `int`). Left out of scope here.
- **Pre-existing, untouched:** `tests/Beam/SeqTests.fs:975` has two disabled tests for `Seq.sum` on custom types with the same `badarith` symptom but a different cause — the `CustomOp ... "get_Zero"` branch not matching, so the fold is seeded with `undefined`. Separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
