### PR TITLE
feat(beam): render %A in F# syntax instead of dumping Erlang terms

### DIFF
--- a/src/Fable.Build/Test/Beam.fs
+++ b/src/Fable.Build/Test/Beam.fs
@@ -28,29 +28,49 @@ let private ebinArgs (projectBuildDir: string) =
     else
         ""
 
-/// Run an Erlang expression, returning its stdout and exit code. `Command.Run` throws on a non-zero
-/// exit, and a non-zero exit is exactly what one of these programs is supposed to produce.
+/// Run an Erlang expression, returning its stdout and exit code.
+///
+/// Driven through `Process` rather than `Command.Run`/`Command.ReadAsync` for two reasons: those
+/// throw on a non-zero exit, and a non-zero exit is exactly what one of these programs is supposed
+/// to produce; and the assertions below compare non-ASCII text, which needs the child's stdout
+/// decoded as UTF-8. `Command.ReadAsync` decodes with the ambient console encoding, which is UTF-8
+/// on the Linux CI runner but the console codepage on Windows — mangling `✓` for a developer
+/// running the suite locally, in a failure that says nothing about what actually went wrong.
 let private runErl (workingDir: string) (paArgs: string) (expr: string) =
-    let mutable exitCode = 0
-
-    let struct (output, _) =
-        Command.ReadAsync(
-            "erl",
-            $"-noshell {paArgs} -eval \"{expr}\" -s init stop",
-            workingDirectory = workingDir,
-            handleExitCode =
-                fun code ->
-                    exitCode <- code
-                    true
+    let startInfo =
+        System.Diagnostics.ProcessStartInfo(
+            FileName = "erl",
+            Arguments = $"-noshell {paArgs} -eval \"{expr}\" -s init stop",
+            WorkingDirectory = workingDir,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            StandardOutputEncoding = System.Text.Encoding.UTF8,
+            StandardErrorEncoding = System.Text.Encoding.UTF8
         )
-        |> Async.AwaitTask
-        |> Async.RunSynchronously
 
-    output, exitCode
+    use proc = System.Diagnostics.Process.Start(startInfo)
+
+    // Read both streams before waiting: a child that fills one pipe's buffer blocks forever if
+    // we are waiting on exit instead of draining.
+    let stdout = proc.StandardOutput.ReadToEndAsync()
+    let stderr = proc.StandardError.ReadToEndAsync()
+    proc.WaitForExit()
+
+    // stderr is folded into the returned text so a crash report reaches the failure message.
+    stdout.Result + stderr.Result, proc.ExitCode
 
 let private expect (what: string) (expected: 'a) (actual: 'a) =
     if expected <> actual then
         failwith $"Entry point test: %s{what}\n  expected: %A{expected}\n  actual:   %A{actual}"
+
+/// Assert that a program's output contains `substring`, showing the output when it does not.
+/// `expect` on a bare `output.Contains ...` reports only `expected: true / actual: false`, which
+/// leaves a mismatch undiagnosable without re-running the program by hand.
+let private expectContains (what: string) (substring: string) (output: string) =
+    if not (output.Contains substring) then
+        failwith
+            $"Entry point test: %s{what}\n  expected output to contain: %s{substring}\n  actual output:\n%s{output}"
 
 /// Compile a whole program and run it on the BEAM through the generated `main.erl` shim.
 ///
@@ -85,16 +105,16 @@ let private testEntryPointPrograms () =
     let output, exitCode =
         runErl buildDir paArgs "main:main([\\\"alpha\\\", \\\"beta\\\"])"
 
-    expect "argv length" true (output.Contains "argc=2")
-    expect "argv contents" true (output.Contains "argv=alpha,beta")
+    expectContains "argv length" "argc=2" output
+    expectContains "argv contents" "argv=alpha,beta" output
     expect "exit code of a successful run" 0 exitCode
 
     // Both console paths must agree on encoding, under the plain `erl -noshell` above with no
     // extra flags: `Console.WriteLine` wrote raw UTF-8 bytes while `printfn` wrote unicode, so
     // whichever device encoding you picked, one of them mangled non-ASCII text.
-    expect "Console.WriteLine encodes non-ASCII" true (output.Contains "writeline=✓ ✗ · é")
-    expect "printfn encodes non-ASCII" true (output.Contains "printfn=✓ ✗ · é")
-    expect "Console.WriteLine of a char" true (output.Contains "char=✓")
+    expectContains "Console.WriteLine encodes non-ASCII" "writeline=✓ ✗ · é" output
+    expectContains "printfn encodes non-ASCII" "printfn=✓ ✗ · é" output
+    expectContains "Console.WriteLine of a char" "char=✓" output
 
     // ...and its return value must become the exit code, or a failing suite looks like a passing one.
     let _, failExitCode = runErl buildDir paArgs "main:main([\\\"fail\\\"])"
@@ -102,7 +122,7 @@ let private testEntryPointPrograms () =
 
     // main/0 forwards to main/1 with an empty argv.
     let output0, exitCode0 = runErl buildDir paArgs "main:main()"
-    expect "argv of main/0" true (output0.Contains "argc=0")
+    expectContains "argv of main/0" "argc=0" output0
     expect "exit code of main/0" 0 exitCode0
 
     // A program with no [<EntryPoint>] has only top-level effects, and the shim falls back to main/0.
@@ -111,7 +131,7 @@ let private testEntryPointPrograms () =
     let noEntryOutput, noEntryExitCode =
         runErl noEntryBuildDir noEntryPaArgs "main:main()"
 
-    expect "top-level effects ran" true (noEntryOutput.Contains "no-entry-point program ran")
+    expectContains "top-level effects ran" "no-entry-point program ran" noEntryOutput
     expect "exit code without an entry point" 0 noEntryExitCode
 
     printfn "Entry point program tests passed"

--- a/src/Fable.Transforms/Beam/FABLE-BEAM.md
+++ b/src/Fable.Transforms/Beam/FABLE-BEAM.md
@@ -456,6 +456,15 @@ Where several F# types share one Erlang shape, the ambiguity is unresolvable and
 | `set [1; 2]` | `set [1; 2]` | `[1; 2]` | an F# `Set` is an ordset, i.e. a plain list |
 | `(Empty, 1)` | `(Empty, 1)` | `Empty 1` | `{empty, 1}` is also the shape of a one-field union case |
 | `'x'` | `'x'` | `120` | a `char` is an `integer()`, per the limitation above |
+| `ref 5` | `{ contents = 5 }` | `5` | a ref cell is the same process-dictionary reference an array is, with no `contents` field to name |
+| `ref [1; 2]` | `{ contents = [1; 2] }` | `[\|1; 2\|]` | the same collision, landing on the array rendering because the stored value is a list |
+| `1.0M` | `1.0M` | `10000000000000000000000000000` | a `decimal` is a fixed-scale integer (value × 10²⁸) and is indistinguishable from one |
+| `DateTime(...)` | `1/2/2024 3:04:05 AM` | `(638396498450000000, 1)` | a `DateTime` is a `{Ticks, Kind}` tuple; likewise `TimeSpan`, which is a bare integer |
+
+The last four are worse than the ambiguities above them, in that the value is not merely rendered in
+the wrong style but is unreadable. They are still shape collisions rather than bugs — nothing about
+the runtime term says "this reference is a ref cell, not an array" or "this integer is scaled" — and
+all four print at least as well as the `~p` dump they replaced.
 
 Recovering the first three needs the argument's static type threaded from the `%A` call site, where
 it does still exist: `printfn`'s `PrintfFormat<'Printer, _, _, _>` carries the per-argument types as

--- a/src/Fable.Transforms/Beam/FABLE-BEAM.md
+++ b/src/Fable.Transforms/Beam/FABLE-BEAM.md
@@ -368,12 +368,32 @@ a string is correct only where the compiler can still see the type statically. I
 ordinary case:
 
 ```fsharp
-string c            // "2"
-c.ToString()        // "2"
-"x" + string c      // "x2"
-System.Char.ToString c   // "2"
-$"{c}"              // "2"
+string c                    // "2"
+c.ToString()                // "2"
+"x" + string c              // "x2"
+System.Char.ToString c      // "2"
+$"{c}"                      // "2"
+string (box c)              // "2"  — the boxing cast is still visible at the call site
+System.String.Format("{0}", c)       // "2"
+System.String.Format("{0}", box c)   // "2"
 ```
+
+Boxing only survives while the cast is part of the same expression. Once the boxed char is bound to
+an `obj` — by a `let`, or by flowing through a pipe — the static type is gone before the conversion
+is reached, and these degrade to the generic case below:
+
+```fsharp
+box c |> string             // "50"  — the pipe binds it as obj first
+let b: obj = box c in string b       // "50"
+sprintf "%O" c              // "50"  — printf applies its arguments through a curried runtime
+sprintf "%A" c              // "50"  — .NET gives "'2'"
+[ box '2' ] |> List.map string       // ["50"] — element type is obj
+```
+
+The `%O`/`%A` cases are not a boxing problem but a printf one: `printf` parses its format string and
+applies its arguments at runtime, so no argument's static type reaches the formatter at all. Fixing
+those means threading per-argument type info from the call site — see "Structured formatting (`%A`)"
+below.
 
 But when `string x` is applied where `x`'s type is a *generic parameter*, the backend can only emit
 `fable_convert:to_string/1`, which sees an integer and prints the number:
@@ -412,6 +432,41 @@ Giving `char` a tagged runtime form such as `{char, 50}` would fix this everywhe
 breaking change to a core type, costs arithmetic and comparison performance, and fights Erlang's own
 convention that strings are lists of integer codepoints. Not worth it for a case with a one-keyword
 workaround.
+
+### Structured formatting (`%A`) reads shapes, not types
+
+`%A` renders a value in F# syntax. The other targets get this for free because their generated types
+carry a real `ToString` — a JS record is a class instance, a Python record defines `__str__` — so the
+formatter just calls it. Beam has nothing to call: a record is a bare Erlang map and a union a bare
+tagged tuple, neither carrying any back-pointer to its type. Reflection does not help either, since
+every `fable_reflection` accessor takes a type-info map and a runtime value cannot produce one.
+
+So `fable_string:format_any/1` dispatches on the *shape* of the term. That gets the common cases
+right — strings are quoted, lists print as `[a; b]`, tuples as `(a, b)`, unions as `Case value`, and
+arrays are dereferenced from their ref cell to `[|a; b|]` instead of printing an opaque `#Ref<...>`.
+
+Where several F# types share one Erlang shape, the ambiguity is unresolvable and `%A` deviates from
+.NET:
+
+| Case | .NET | Beam | Why |
+| --- | --- | --- | --- |
+| record field order | declaration order | Erlang term order | a map does not remember key insertion order |
+| record/union names | original casing | reconstructed | names compile to lowercased atoms; `my_case` → `MyCase` is a convention, not a recovery |
+| `Some x` | `Some x` | `x` | `option` is erased (JS and Python collapse it too) |
+| `set [1; 2]` | `set [1; 2]` | `[1; 2]` | an F# `Set` is an ordset, i.e. a plain list |
+| `(Empty, 1)` | `(Empty, 1)` | `Empty 1` | `{empty, 1}` is also the shape of a one-field union case |
+| `'x'` | `'x'` | `120` | a `char` is an `integer()`, per the limitation above |
+
+Recovering the first three needs the argument's static type threaded from the `%A` call site, where
+it does still exist: `printfn`'s `PrintfFormat<'Printer, _, _, _>` carries the per-argument types as
+a `LambdaType` chain in `CallInfo.GenericArgs`, which `NestedLambdaType` decomposes. That would mean
+emitting a `makeTypeInfo` per argument in `fsFormat` and pairing each format specifier with it in
+`create_printer` — machinery no Fable target has today, and it would still need a fallback for
+generic parameters (which erase to a placeholder) and for `%a`/`%t`/`%*d` specifiers whose arity does
+not line up with the value list.
+
+Anything the formatter does not recognise — pids, ports, a cyclic term past the depth cap — falls
+back to `~tp`, which is what `%A` did for *everything* before, so it can never be worse than it was.
 
 ### Console output requires a unicode io device
 

--- a/src/Fable.Transforms/Beam/Replacements.fs
+++ b/src/Fable.Transforms/Beam/Replacements.fs
@@ -393,6 +393,12 @@ let private operators
             | _ -> Helper.LibCall(com, "fable_decimal", "from_int", _t, [ arg ], ?loc = r) |> Some
         | _ -> Helper.LibCall(com, "fable_decimal", "from_int", _t, [ arg ], ?loc = r) |> Some
     | "ToString", [ arg ] ->
+        // `box c |> string` arrives as a char under a boxing cast to `obj`, and would otherwise fall
+        // through to `fable_convert:to_string`, which sees only the integer and prints the codepoint.
+        // Peeling the cast puts it back on the `Type.Char` branch below; every other type is
+        // unaffected, since `tryAsChar` only ever looks through a box around a char.
+        let arg = Chars.tryAsChar arg |> Option.defaultValue arg
+
         match arg.Type with
         | Type.String -> Some arg
         | Type.Char -> emitExpr r _t [ arg ] "<<($0)/utf8>>" |> Some
@@ -1220,6 +1226,18 @@ let private strings
                 | realFmt :: rest -> realFmt, rest
                 | [] -> fmtStr, fmtArgs
 
+        // `fable_string:format` dispatches on the runtime value, where a char is an integer and so
+        // prints as its codepoint (`String.Format("{0}", '2')` gave "50"). The arguments are boxed
+        // to `obj` but their static type survives here, so encode chars to text up front — the same
+        // thing the `System.Console` replacement does.
+        let fmtArgs =
+            fmtArgs
+            |> List.map (fun arg ->
+                match Chars.tryAsChar arg with
+                | Some c -> Helper.LibCall(com, "fable_char", "to_string", String, [ c ], ?loc = r)
+                | None -> arg
+            )
+
         // When a single array argument is passed (e.g. from ParamArray),
         // pass it directly — format/2 already handles refs and lists.
         let argsList =
@@ -1399,6 +1417,11 @@ let private conversions
                 match args with
                 | [ a ] -> a
                 | _ -> Value(Null Type.Unit, None)
+
+        // `box c |> string` reaches here as a char under a boxing cast to `obj`. Peeling the cast
+        // puts it back on the `Type.Char` branch below, instead of falling through to
+        // `fable_convert:to_string`, which sees only the integer and prints the codepoint.
+        let arg = Chars.tryAsChar arg |> Option.defaultValue arg
 
         match arg.Type with
         | Type.String -> Some arg
@@ -2046,10 +2069,33 @@ let rec private getZero (com: ICompiler) (ctx: Context) (t: Type) =
     | ListSingleton(CustomOp com ctx None t "get_Zero" [] e) -> e
     | _ -> Value(Null Any, None)
 
+/// Apply an injected operator, dispatching to the type's own definition when it has one.
+///
+/// The adder and averager below are injected into `Seq.sum`/`Seq.average` at a *generic* type, so
+/// the operand can be a user type whose `+` is a static member. Emitting a bare `BinaryPlus` there
+/// prints an Erlang `+`, and `#{x => 1} + #{x => 0}` fails with `badarith`. The other targets route
+/// this through `applyOp`; Beam has no such function — its custom-operator dispatch is inlined in
+/// `operators` — so consult `CustomOp` directly, exactly as those call sites do.
+let private applyInjectedOp (com: ICompiler) (ctx: Context) t opName (args: Expr list) fallback =
+    let argTypes = args |> List.map (fun a -> a.Type)
+
+    match (|CustomOp|_|) com ctx None t opName args argTypes with
+    | ValueSome e -> e
+    | ValueNone -> fallback ()
+
 let private makeAddFunction (com: ICompiler) (ctx: Context) t =
     let x = makeUniqueIdent com ctx t "x"
     let y = makeUniqueIdent com ctx t "y"
-    let body = makeBinOp None t (IdentExpr x) (IdentExpr y) BinaryPlus
+
+    let body =
+        applyInjectedOp
+            com
+            ctx
+            t
+            Operators.addition
+            [ IdentExpr x; IdentExpr y ]
+            (fun () -> makeBinOp None t (IdentExpr x) (IdentExpr y) BinaryPlus)
+
     Delegate([ x; y ], body, None, Tags.empty)
 
 let private makeGenericAdder (com: ICompiler) ctx t =
@@ -2063,7 +2109,16 @@ let private makeGenericAverager (com: ICompiler) ctx t =
     let divideFn =
         let x = makeUniqueIdent com ctx t "x"
         let i = makeUniqueIdent com ctx (Int32.Number) "i"
-        let body = makeBinOp None t (IdentExpr x) (IdentExpr i) BinaryDivide
+
+        let body =
+            applyInjectedOp
+                com
+                ctx
+                t
+                Operators.divideByInt
+                [ IdentExpr x; IdentExpr i ]
+                (fun () -> makeBinOp None t (IdentExpr x) (IdentExpr i) BinaryDivide)
+
         Delegate([ x; i ], body, None, Tags.empty)
 
     objExpr

--- a/src/fable-library-beam/fable_string.erl
+++ b/src/fable-library-beam/fable_string.erl
@@ -48,6 +48,7 @@
     format/2,
     console_writeline/1,
     console_write/1,
+    format_any/1,
     substring/2, substring/3,
     get_slice/3
 ]).
@@ -122,6 +123,7 @@
 -spec format(binary(), list() | reference() | term()) -> binary().
 -spec console_writeline(term()) -> ok.
 -spec console_write(term()) -> ok.
+-spec format_any(term()) -> binary().
 
 insert(Str, Idx, Value) ->
     iolist_to_binary([binary:part(Str, 0, Idx), Value, binary:part(Str, Idx, byte_size(Str) - Idx)]).
@@ -993,7 +995,7 @@ format_raw(Type, _Prec, Value) when Type =:= $b; Type =:= $B ->
         false -> <<"false">>
     end;
 format_raw($A, _Prec, Value) ->
-    iolist_to_binary(io_lib:format("~p", [Value]));
+    format_any(Value);
 format_raw($O, _Prec, Value) ->
     to_string(Value);
 format_raw(_, _Prec, Value) ->
@@ -1110,3 +1112,180 @@ console_write(Value) when is_boolean(Value) ->
     io:format(<<"~ts">>, [atom_to_binary(Value)]);
 console_write(Value) ->
     io:format(<<"~tp">>, [Value]).
+
+%%% ---------------------------------------------------------------------------
+%%% F# structured formatting (`%A`)
+%%% ---------------------------------------------------------------------------
+%%
+%% `%A` renders a value in F# syntax. On the other Fable targets the generated types carry a real
+%% `ToString` for this (a JS record is a class instance, a Python record defines `__str__`), so the
+%% formatter just calls it. Beam has nothing to call: a record is a bare map, a union a bare tagged
+%% tuple, neither carrying any back-pointer to its type. Reflection cannot help either — every
+%% `fable_reflection` accessor takes a type-info map, and there is none to be had from the value.
+%%
+%% So this reads the *shape* of the term. Several F# types share a shape on Beam, and where they do
+%% the clause comments below say which way the ambiguity resolves and what that costs. The rules
+%% otherwise mirror `fable-library-ts/Types.ts` (`seqToString`/`unionToString`/`recordToString`) so
+%% the targets stay aligned.
+%%
+%% Known limitations, all of them shape ambiguities rather than bugs:
+%%   * `char` is an `integer()` and prints as its codepoint. Documented in FABLE-BEAM.md.
+%%   * Record field and union case names come back from lowercased Erlang atoms, so their original
+%%     casing is reconstructed by convention (`my_case` -> `MyCase`) and is a guess.
+%%   * Record fields print in Erlang term order (atoms sort alphabetically), not in declaration
+%%     order, because a map does not remember the order its keys went in.
+%%   * An F# `Set` is an ordset, i.e. a plain list, and renders as a list rather than `set [...]`.
+%%   * `option` is erased, so `Some x` renders as `x` — the same collapse JS and Python have.
+%%
+%% Recovering the first three needs the argument's static type threaded from the `%A` call site,
+%% which is where it still exists; nothing about the runtime value can supply it.
+
+%% Depth cap. Erlang terms are acyclic, but an array is a ref cell into the process dictionary and
+%% those *can* form a cycle (`R = new_ref([]), put(R, [R])`). Falling back to `~tp` at the cap keeps
+%% a pathological term terminating instead of looping.
+-define(FORMAT_ANY_MAX_DEPTH, 24).
+
+%% Element cap, matching `seqToString`'s in fable-library-ts.
+-define(FORMAT_ANY_MAX_ITEMS, 100).
+
+%% `unicode:characters_to_binary/1` rather than `iolist_to_binary/1`: the `~tp` fallbacks below can
+%% yield codepoints above 255, which `iolist_to_binary/1` rejects outright.
+format_any(Value) ->
+    unicode:characters_to_binary(fmt_any(Value, 0)).
+
+fmt_any(Value, Depth) when Depth > ?FORMAT_ANY_MAX_DEPTH ->
+    io_lib:format("~tp", [Value]);
+%% Strings are quoted but *not* escaped: .NET prints `%A` of `he said "hi"` as `"he said "hi""`.
+fmt_any(Value, _Depth) when is_binary(Value) ->
+    [$", Value, $"];
+fmt_any(Value, _Depth) when is_boolean(Value) ->
+    atom_to_binary(Value);
+%% `undefined` is the erased `None`.
+fmt_any(undefined, _Depth) ->
+    <<"None">>;
+fmt_any(Value, _Depth) when is_integer(Value) ->
+    integer_to_binary(Value);
+fmt_any(Value, _Depth) when is_float(Value) ->
+    %% `1.0` must stay `1.0` — `fable_convert:to_string/1` renders whole floats as integers, which
+    %% is right for `string x` but would make `%A` lose the type.
+    float_to_binary(Value, [short]);
+%% A bare atom is a fieldless union case (`Empty`), the only way one reaches here.
+fmt_any(Value, _Depth) when is_atom(Value) ->
+    pascal_case(atom_to_binary(Value));
+fmt_any(Value, Depth) when is_list(Value) ->
+    [$[, fmt_items(Value, Depth, <<"; ">>), $]];
+%% A `byte[]` is an atomics object behind a `{byte_array, Size, Ref}` tag. Matched ahead of the
+%% general tuple clause, which would otherwise read that tag as a union case named `ByteArray`.
+fmt_any({byte_array, _, _} = Value, Depth) ->
+    fmt_array(fable_utils:byte_array_to_list(Value), Depth);
+fmt_any(Value, Depth) when is_tuple(Value) ->
+    fmt_tuple(Value, Depth);
+fmt_any(Value, Depth) when is_reference(Value) ->
+    fmt_ref(Value, Depth);
+fmt_any(Value, Depth) when is_map(Value) ->
+    fmt_map(Value, Depth);
+fmt_any(Value, _Depth) when is_function(Value) ->
+    <<"<fun>">>;
+%% Pids, ports, anything unrecognised falls back to Erlang's own term printing — which is what `%A`
+%% did for *every* value before, so this can never be worse than the old behaviour. `~tp` rather
+%% than `~p` so the fallback stays unicode-aware, matching `console_write`/`console_writeline`.
+fmt_any(Value, _Depth) ->
+    io_lib:format("~tp", [Value]).
+
+%% A tagged tuple is a union case; anything else is an F# tuple.
+%%
+%% The two are genuinely indistinguishable when a tuple's first element is itself a fieldless union
+%% case: `(Empty, 1)` is `{empty, 1}`, exactly the shape of a one-field case `Empty 1`, and renders
+%% as the latter. Booleans and `None` are excluded because those atoms are common as tuple heads
+%% (`(true, 1)`) and are never union tags.
+fmt_tuple(Value, Depth) ->
+    case tuple_to_list(Value) of
+        [Tag | Fields] when
+            is_atom(Tag), Fields =/= [], Tag =/= true, Tag =/= false, Tag =/= undefined
+        ->
+            fmt_union(pascal_case(atom_to_binary(Tag)), Fields, Depth);
+        Elements ->
+            [$(, fmt_items(Elements, Depth, <<", ">>), $)]
+    end.
+
+%% `Named "x"` for one field, `Case (a, b)` for several. A single field is parenthesised only when
+%% its own rendering contains a space, so `Circle 1.0` stays bare but `Wrapped (Named "q")` does
+%% not run together — the rule `unionToString` uses in fable-library-ts.
+fmt_union(Name, [Field], Depth) ->
+    Rendered = iolist_to_binary(fmt_any(Field, Depth + 1)),
+
+    case binary:match(Rendered, <<" ">>) of
+        nomatch -> [Name, $\s, Rendered];
+        _ -> [Name, <<" (">>, Rendered, $)]
+    end;
+fmt_union(Name, Fields, Depth) ->
+    [Name, <<" (">>, fmt_items(Fields, Depth, <<", ">>), $)].
+
+%% An array is a ref cell into the process dictionary holding its elements. A class instance and a
+%% ref-wrapped byte array reach here the same way, and are handed back to `fmt_any` on their
+%% contents.
+fmt_ref(Value, Depth) ->
+    case get(Value) of
+        Stored when is_list(Stored) ->
+            fmt_array(Stored, Depth);
+        undefined ->
+            %% Not one of ours — a raw `make_ref()`, which prints as `#Ref<...>`.
+            io_lib:format("~tp", [Value]);
+        Stored ->
+            fmt_any(Stored, Depth + 1)
+    end.
+
+fmt_array(Elements, Depth) ->
+    [<<"[|">>, fmt_items(Elements, Depth, <<"; ">>), <<"|]">>].
+
+%% A map is a record when every key is an atom, since record field names are compiled to atoms and
+%% an F# `Map`'s keys are runtime values (binaries, integers, tuples). A `Map<SomeEnum, _>` would be
+%% misread as a record, and an empty map is reported as `map []` because there is nothing to look at.
+fmt_map(Value, Depth) ->
+    Keys = maps:keys(Value),
+
+    case Keys =/= [] andalso lists:all(fun erlang:is_atom/1, Keys) of
+        true ->
+            %% `{ Name = "bob"` / newline+2 spaces / `  Age = 7 }`, as .NET and fable-library-ts do.
+            Fields = [
+                [pascal_case(atom_to_binary(K)), <<" = ">>, fmt_any(maps:get(K, Value), Depth + 1)]
+             || K <- Keys
+            ],
+            [<<"{ ">>, lists:join(<<"\n  ">>, Fields), <<" }">>];
+        false ->
+            Pairs = [
+                [$(, fmt_any(K, Depth + 1), <<", ">>, fmt_any(maps:get(K, Value), Depth + 1), $)]
+             || K <- Keys
+            ],
+            [<<"map [">>, lists:join(<<"; ">>, Pairs), $]]
+    end.
+
+%% Render up to ?FORMAT_ANY_MAX_ITEMS elements, then `; ...` — an unbounded `%A` of a large
+%% collection is never what a failure message wants.
+fmt_items(Elements, Depth, Separator) ->
+    {Shown, Rest} = split_at(Elements, ?FORMAT_ANY_MAX_ITEMS, []),
+    Rendered = lists:join(Separator, [fmt_any(E, Depth + 1) || E <- Shown]),
+
+    case Rest of
+        [] -> Rendered;
+        _ -> [Rendered, Separator, <<"...">>]
+    end.
+
+split_at([], _N, Acc) ->
+    {lists:reverse(Acc), []};
+split_at(Rest, 0, Acc) ->
+    {lists:reverse(Acc), Rest};
+split_at([H | T], N, Acc) ->
+    split_at(T, N - 1, [H | Acc]).
+
+%% Rebuild an F# name from the Erlang atom it was compiled to: `my_case` -> `MyCase`. The compiler
+%% lowercases and snake-cases on the way down and that is not injective, so this is a convention,
+%% not a recovery — `ABc` comes back as `Abc`.
+pascal_case(Name) ->
+    Parts = binary:split(Name, <<"_">>, [global]),
+    iolist_to_binary([capitalize(P) || P <- Parts, P =/= <<>>]).
+
+capitalize(<<First/utf8, Rest/binary>>) ->
+    <<(string:uppercase(<<First/utf8>>))/binary, Rest/binary>>;
+capitalize(Empty) ->
+    Empty.

--- a/src/fable-library-beam/fable_string.erl
+++ b/src/fable-library-beam/fable_string.erl
@@ -1148,10 +1148,22 @@ console_write(Value) ->
 %% Element cap, matching `seqToString`'s in fable-library-ts.
 -define(FORMAT_ANY_MAX_ITEMS, 100).
 
-%% `unicode:characters_to_binary/1` rather than `iolist_to_binary/1`: the `~tp` fallbacks below can
-%% yield codepoints above 255, which `iolist_to_binary/1` rejects outright.
 format_any(Value) ->
-    unicode:characters_to_binary(fmt_any(Value, 0)).
+    flatten(fmt_any(Value, 0)).
+
+%% Collapse a rendering to a binary. `unicode:characters_to_binary/1` rather than
+%% `iolist_to_binary/1`: the `~tp` fallbacks below can yield codepoints above 255, which
+%% `iolist_to_binary/1` rejects outright with `badarg`.
+%%
+%% It signals bad input by *returning* `{error, _, _}` rather than raising, and a tuple escaping
+%% from here would fail somewhere far away — `format_any/1` is specced to return a `binary()`. The
+%% only way to get one is a binary that is not valid UTF-8, which an F# `string` never is; falling
+%% back to Erlang's own term printing keeps that hypothetical honest rather than crashing.
+flatten(Rendering) ->
+    case unicode:characters_to_binary(Rendering) of
+        Bin when is_binary(Bin) -> Bin;
+        _ -> iolist_to_binary(io_lib:format("~tp", [Rendering]))
+    end.
 
 fmt_any(Value, Depth) when Depth > ?FORMAT_ANY_MAX_DEPTH ->
     io_lib:format("~tp", [Value]);
@@ -1212,7 +1224,7 @@ fmt_tuple(Value, Depth) ->
 %% its own rendering contains a space, so `Circle 1.0` stays bare but `Wrapped (Named "q")` does
 %% not run together — the rule `unionToString` uses in fable-library-ts.
 fmt_union(Name, [Field], Depth) ->
-    Rendered = iolist_to_binary(fmt_any(Field, Depth + 1)),
+    Rendered = flatten(fmt_any(Field, Depth + 1)),
 
     case binary:match(Rendered, <<" ">>) of
         nomatch -> [Name, $\s, Rendered];

--- a/src/fable-library-beam/fable_string.erl
+++ b/src/fable-library-beam/fable_string.erl
@@ -1136,6 +1136,10 @@ console_write(Value) ->
 %%     order, because a map does not remember the order its keys went in.
 %%   * An F# `Set` is an ordset, i.e. a plain list, and renders as a list rather than `set [...]`.
 %%   * `option` is erased, so `Some x` renders as `x` — the same collapse JS and Python have.
+%%   * An F# `ref` cell is the same process-dictionary reference an array is, so `ref 5` renders as
+%%     `5` and `ref [1, 2]` as `[|1; 2|]`, never as `{ contents = ... }`.
+%%   * A `decimal` is a fixed-scale integer and prints as its scaled value; a `DateTime` is a
+%%     `{Ticks, Kind}` tuple and prints as one. Both are in the FABLE-BEAM.md table.
 %%
 %% Recovering the first three needs the argument's static type threaded from the `%A` call site,
 %% which is where it still exists; nothing about the runtime value can supply it.
@@ -1233,9 +1237,13 @@ fmt_union(Name, [Field], Depth) ->
 fmt_union(Name, Fields, Depth) ->
     [Name, <<" (">>, fmt_items(Fields, Depth, <<", ">>), $)].
 
-%% An array is a ref cell into the process dictionary holding its elements. A class instance and a
-%% ref-wrapped byte array reach here the same way, and are handed back to `fmt_any` on their
-%% contents.
+%% An array is a ref cell into the process dictionary holding its elements. A class instance, a
+%% ref-wrapped byte array and an F# `ref` cell reach here the same way, and are handed back to
+%% `fmt_any` on their contents.
+%%
+%% Nothing distinguishes those, so a `ref` holding a list is rendered as an array and one holding a
+%% scalar as the scalar — never as `{ contents = ... }`. A `ref` holding `undefined` (an erased
+%% `None`) is indistinguishable from a key that was never stored, and falls through to `#Ref<...>`.
 fmt_ref(Value, Depth) ->
     case get(Value) of
         Stored when is_list(Stored) ->

--- a/tests/Beam/CharTests.fs
+++ b/tests/Beam/CharTests.fs
@@ -284,3 +284,26 @@ let ``test Char.TryParse fails with longer string`` () =
 //     Char.IsSurrogatePair(str,0) |> equal false
 //     Char.IsSurrogatePair(str,1) |> equal true
 //     Char.IsSurrogatePair(str,2) |> equal false
+
+// --- Boxed chars reaching a string conversion ---
+//
+// A `char` is a plain `integer()` on Beam, so any conversion that dispatches on the runtime value
+// alone renders the codepoint instead of the character. These sites see the static type through the
+// boxing cast and encode the char up front. Where the cast is *not* visible — a boxed char piped
+// into `string`, bound to an `obj` first, or reaching `%A`/`%O` through printf's curried runtime —
+// the type is genuinely gone by then; see "char at a generic type" in FABLE-BEAM.md.
+
+[<Fact>]
+let ``test string of a directly boxed char works`` () =
+    let c = '2'
+    string (box c) |> equal "2"
+
+[<Fact>]
+let ``test String.Format of a char works`` () =
+    let c = '2'
+    String.Format("{0}", c) |> equal "2"
+    String.Format("{0}", box c) |> equal "2"
+
+[<Fact>]
+let ``test String.Format of a non-ASCII char works`` () =
+    String.Format("{0}", '✗') |> equal "✗"

--- a/tests/Beam/SeqTests.fs
+++ b/tests/Beam/SeqTests.fs
@@ -983,19 +983,17 @@ let ``test Seq.sum works with char`` () =
 let ``test Seq.sumBy works with char`` () =
     [ 'a'; 'b' ] |> Seq.sumBy id |> int |> equal 195
 
-// TODO: Seq.sum with custom types causes badarith in Beam (Zero + operator not inlined properly)
-// [<Fact>]
-// let ``test Seq.sum with non numeric types works`` () =
-//     let p1 = {x=1; y=10}
-//     let p2 = {x=2; y=20}
-//     [p1; p2] |> Seq.sum |> (=) {x=3;y=30} |> equal true
+[<Fact>]
+let ``test Seq.sum with non numeric types works`` () =
+    let p1 = {x=1; y=10}
+    let p2 = {x=2; y=20}
+    [p1; p2] |> Seq.sum |> (=) {x=3;y=30} |> equal true
 
-// TODO: Seq.sumBy with custom types causes badarith in Beam
-// [<Fact>]
-// let ``test Seq.sumBy with non numeric types works`` () =
-//     let p1 = {x=1; y=10}
-//     let p2 = {x=2; y=20}
-//     [p1; p2] |> Seq.sumBy SeqPoint.Neg |> (=) {x = -3; y = -30} |> equal true
+[<Fact>]
+let ``test Seq.sumBy with non numeric types works`` () =
+    let p1 = {x=1; y=10}
+    let p2 = {x=2; y=20}
+    [p1; p2] |> Seq.sumBy SeqPoint.Neg |> (=) {x = -3; y = -30} |> equal true
 
 [<Fact>]
 let ``test Seq.sumBy with numeric projection works`` () =

--- a/tests/Beam/StringTests.fs
+++ b/tests/Beam/StringTests.fs
@@ -1237,3 +1237,42 @@ let ``test %A on a map works`` () =
 let ``test %A survives non-ASCII text`` () =
     sprintf "%A" "✓ é" |> equal "\"✓ é\""
     sprintf "%A" [ "✗" ] |> equal "[\"✗\"]"
+
+[<Fact>]
+let ``test %A on a Result works`` () =
+    sprintf "%A" (Ok 1: Result<int, string>) |> equal "Ok 1"
+    sprintf "%A" (Error "x": Result<int, string>) |> equal "Error \"x\""
+
+[<Fact>]
+let ``test %A on a byte array prints its elements`` () =
+    // A `byte[]` is an atomics object behind a `{byte_array, Size, Ref}` tag, which the general
+    // tuple clause would otherwise read as a union case named `ByteArray`. Only the brackets are
+    // asserted, not the whole string: .NET suffixes byte literals (`[|1uy; 2uy|]`) and Beam has no
+    // element type to recover the suffix from. The `[|` is what distinguishes the two renderings.
+    let rendered = sprintf "%A" [| 1uy; 2uy |]
+    rendered.StartsWith "[|" |> equal true
+    rendered.EndsWith "|]" |> equal true
+    rendered.Contains "1" |> equal true
+    rendered.Contains "2" |> equal true
+
+[<Fact>]
+let ``test %A caps a long collection`` () =
+    // Both .NET and Beam stop at 100 elements and append `; ...`. Asserted by shape rather than
+    // literally because .NET also hard-wraps the line at ~80 columns and Beam does not.
+    let rendered = sprintf "%A" [ 1..150 ]
+    rendered.EndsWith "...]" |> equal true
+    rendered.Contains "; 100" |> equal true
+    rendered.Contains "101" |> equal false
+
+[<Fact>]
+let ``test %A terminates on a cyclic value`` () =
+    // An array is a ref cell on Beam, and ref cells *can* form a cycle where plain Erlang terms
+    // cannot. What is asserted is only that the formatter terminates and renders an array at all:
+    // .NET detects the cycle immediately and prints `[|...|]`, while Beam unwinds to its depth cap
+    // first, so the two strings genuinely differ. A regression here hangs the suite rather than
+    // failing it, which is what makes the test worth having.
+    let arr: obj array = Array.zeroCreate 1
+    arr.[0] <- box arr
+    let rendered = sprintf "%A" arr
+    rendered.StartsWith "[|" |> equal true
+    rendered.EndsWith "|]" |> equal true

--- a/tests/Beam/StringTests.fs
+++ b/tests/Beam/StringTests.fs
@@ -1153,3 +1153,87 @@ let ``test Seq.toList over string works`` () =
 [<Fact>]
 let ``test Seq.length over string works`` () =
     "Hello" |> Seq.length |> equal 5
+
+// --- Structured formatting (%A) ---
+//
+// `%A` renders in F# syntax. On Beam there is no runtime type information to consult — a record is
+// a bare Erlang map, a union a bare tagged tuple — so the formatter reads the term's shape. The
+// expectations below are .NET's, except where a comment names a shape ambiguity it cannot see past.
+
+type FmtShape =
+    | FmtCircle of float
+    | FmtNamed of string
+    | FmtPair of int * string
+    | FmtEmpty
+
+type FmtRecord = { FmtName: string; FmtAge: int }
+
+[<Fact>]
+let ``test %A on primitives works`` () =
+    sprintf "%A" 42 |> equal "42"
+    sprintf "%A" 1.5 |> equal "1.5"
+    // A whole float keeps its point, unlike `string 1.0`
+    sprintf "%A" 1.0 |> equal "1.0"
+    sprintf "%A" true |> equal "true"
+
+[<Fact>]
+let ``test %A quotes strings`` () =
+    sprintf "%A" "hi" |> equal "\"hi\""
+    sprintf "%A" "" |> equal "\"\""
+
+[<Fact>]
+let ``test %A on a list works`` () =
+    sprintf "%A" [ "a"; "b" ] |> equal "[\"a\"; \"b\"]"
+    sprintf "%A" [ 1; 2 ] |> equal "[1; 2]"
+    sprintf "%A" ([]: int list) |> equal "[]"
+
+[<Fact>]
+let ``test %A on an array prints its elements`` () =
+    // An array is a ref cell on Beam, so this used to print an opaque `#Ref<0.41...>`
+    sprintf "%A" [| "a" |] |> equal "[|\"a\"|]"
+    sprintf "%A" [| 1; 2 |] |> equal "[|1; 2|]"
+
+[<Fact>]
+let ``test %A on a tuple works`` () =
+    sprintf "%A" ("a", 1) |> equal "(\"a\", 1)"
+
+[<Fact>]
+let ``test %A on a union works`` () =
+    sprintf "%A" (FmtNamed "x") |> equal "FmtNamed \"x\""
+    sprintf "%A" (FmtCircle 1.0) |> equal "FmtCircle 1.0"
+    sprintf "%A" FmtEmpty |> equal "FmtEmpty"
+    sprintf "%A" (FmtPair(1, "b")) |> equal "FmtPair (1, \"b\")"
+
+[<Fact>]
+let ``test %A parenthesises a nested union payload`` () =
+    sprintf "%A" [ FmtNamed "q" ] |> equal "[FmtNamed \"q\"]"
+
+[<Fact>]
+let ``test %A on a record names its fields`` () =
+    // Only the field renderings are asserted, not the whole string: Beam prints fields in Erlang
+    // term order (atoms sort alphabetically) rather than declaration order, because a map does not
+    // remember the order its keys went in. The rest of the shape is common to both.
+    let rendered = sprintf "%A" { FmtName = "bob"; FmtAge = 7 }
+    rendered.Contains "FmtName = \"bob\"" |> equal true
+    rendered.Contains "FmtAge = 7" |> equal true
+    rendered.StartsWith "{ " |> equal true
+    rendered.EndsWith " }" |> equal true
+
+[<Fact>]
+let ``test %A on None works`` () =
+    // `Some x` is not asserted: `option` is erased on Beam, so it collapses to `x` where .NET
+    // prints `Some x` — the same deviation JS and Python have.
+    sprintf "%A" (None: string option) |> equal "None"
+
+[<Fact>]
+let ``test %A nests`` () =
+    sprintf "%A" [ FmtNamed "q"; FmtEmpty ] |> equal "[FmtNamed \"q\"; FmtEmpty]"
+
+[<Fact>]
+let ``test %A on a map works`` () =
+    sprintf "%A" (Map.ofList [ "a", 1 ]) |> equal "map [(\"a\", 1)]"
+
+[<Fact>]
+let ``test %A survives non-ASCII text`` () =
+    sprintf "%A" "✓ é" |> equal "\"✓ é\""
+    sprintf "%A" [ "✗" ] |> equal "[\"✗\"]"


### PR DESCRIPTION
## Summary

`%A` on the Beam target was stubbed to Erlang's `~p`, so every structured value leaked its runtime representation. Arrays were worse than merely wrong — being ref cells, they printed as an opaque `#Ref<0.414...>`, total information loss. This matters more than a cosmetic formatter usually would: `%A` is what test frameworks use to describe values in failure messages.

| value | .NET | Beam before | Beam after |
| --- | --- | --- | --- |
| `"hi"` | `"hi"` | `<<"hi">>` | `"hi"` |
| `[ "a"; "b" ]` | `["a"; "b"]` | `[<<"a">>,<<"b">>]` | `["a"; "b"]` |
| `{ Name = "bob"; Age = 7 }` | `{ Name = "bob"`<br>`  Age = 7 }` | `#{age => 7,name => <<"bob">>}` | `{ Age = 7`<br>`  Name = "bob" }` |
| `Named "x"` | `Named "x"` | `{named,<<"x">>}` | `Named "x"` |
| `[\| "a" \|]` | `[\|"a"\|]` | **`#Ref<0.4141907157...>`** | `[\|"a"\|]` |

## Why it reads shapes rather than using reflection

The other targets get this free: their generated types carry a real `ToString` (a JS record is a class instance, a Python record defines `__str__`). Beam has nothing to call — a record is a bare Erlang map, a union a bare tagged tuple. Reflection cannot help either: every `fable_reflection` accessor takes a type-info map, and a runtime value cannot produce one.

So `fable_string:format_any/1` dispatches on the term's shape, following the rules in `fable-library-ts/Types.ts` (`seqToString`/`unionToString`/`recordToString`) so the targets stay aligned. It is cycle-safe (depth cap), caps output at 100 elements, and falls back to Erlang's own term printing for anything unrecognised — so it can never be worse than before.

### Accepted deviations

Where several F# types share one Erlang shape the ambiguity is unresolvable: record field **order** (a map does not remember insertion order) and **casing** (names compile to lowercased atoms), `Some x` (option is erased — JS and Python collapse it too), `Set` (an ordset, i.e. a plain list), and `char` (an `integer()`).

Four more are worse, in that the value comes out unreadable rather than merely wrongly styled — a `ref` cell is the same process-dictionary reference an array is, a `decimal` is a fixed-scale integer, and a `DateTime` is a `{Ticks, Kind}` tuple:

| value | .NET | Beam |
| --- | --- | --- |
| `ref 5` | `{ contents = 5 }` | `5` |
| `ref [ 1; 2 ]` | `{ contents = [1; 2] }` | `[\|1; 2\|]` |
| `1.0M` | `1.0M` | `10000000000000000000000000000` |
| `DateTime(...)` | `1/2/2024 3:04:05 AM` | `(638396498450000000, 1)` |

All of them still print at least as well as the `~p` dump they replace, and every row above was checked against both a `dotnet fsi` reference and `format_any/1` directly.

Recovering the first three needs the argument's static type threaded from the call site — `PrintfFormat<'Printer, _, _, _>` carries it in `CallInfo.GenericArgs`. That is machinery no target has today; `FABLE-BEAM.md` records what it would take. Tests assert only what .NET also produces, so none of them encode a Beam deviation.

## Also fixed

- **`Seq.sum`/`Seq.average` over a custom type raised `badarith`.** Not `getZero` — its `CustomOp` branch is identical to the other targets and matches fine. `makeAddFunction` emitted a bare `BinaryPlus` where the others route through `applyOp`; Beam has no `applyOp`, so the new `applyInjectedOp` consults `CustomOp` the way the inline dispatch in `operators` already does. Fixes the averager's `DivideByInt` too, and re-enables two disabled tests.
- **`String.Format("{0}", c)` and `string (box c)`** printed a char's codepoint; both see the static type through the boxing cast. `box c |> string` and a char bound to `obj` first cannot be fixed at the call site — the type is gone by then — and are documented alongside the existing generic-char limitation.
- **`~p` vs `~tp`** — `%A`'s fallback now matches the console paths, so the two cannot disagree under `+pc unicode`.
- **Entry-point tests** decoded the child's stdout with the ambient console encoding — UTF-8 on the Linux CI runner, the console codepage on Windows, mangling the non-ASCII assertions locally. Now decoded as UTF-8 explicitly, and the captured output is reported on failure instead of just `expected: true / actual: false`.

## Testing

`./build.sh test beam` green: .NET 2614 passed / 0 failed, Erlang 2633 PASS / 0 FAIL, entry-point program tests passed. Every row of the tables above was verified against a `dotnet fsi` reference.

The edge cases that had been checked only by hand are now tests: a `Result`, a byte array (whose `{byte_array, _, _}` clause exists to pre-empt the general tuple clause), the 100-element cap, and termination on a cyclic array. The last three assert by shape rather than literally — .NET hard-wraps long collections at ~80 columns, suffixes byte literals `1uy`, and detects a cycle at depth 1 where Beam unwinds to its cap — so none of them encode a Beam deviation either. The cyclic one is worth having because a regression there *hangs* the suite rather than failing it.

One bug in the first cut of this: `fmt_union` collapsed a single field with `iolist_to_binary/1`, which is exactly what `format_any/1` avoids. Under `+pc unicode` the depth-cap `~tp` fallback emits codepoints above 255 (`✓` is 10003) and `iolist_to_binary/1` rejects those with `badarg`; sub-255 non-ASCII came back as latin-1 mojibake instead. Both sites now share a `flatten/1` helper, which also keeps `format_any/1` honest about its `-spec`: `characters_to_binary/1` signals bad input by *returning* `{error, _, _}` rather than raising, so a tuple could previously have escaped and failed far from the cause.

## Note for reviewers

This branch has been merged with `main` to pick up #4815, which fixed the module-level `Arg` collision this description previously flagged as needing its own issue. That PR added four entry-point assertions in the `expect ... true (output.Contains ...)` form this branch replaces with `expectContains`; the merge keeps every assertion, converted to the new form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
