### PR TITLE
fix(beam): write package modules to the package's own src/

### DIFF
--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -160,8 +160,15 @@ module private Util =
             let fileName = Pipeline.Beam.moduleName cliArgs file + fileExt
 
             if Naming.isInFableModules file then
-                // Package and library sources in fable_modules: preserve the containing
-                // directory so each stays its own OTP app (fable_modules/<dep>/src/)
+                // Package and library sources in fable_modules: each package is its own OTP app,
+                // rooted at fable_modules/<dep>/, and its modules go in that app's src/.
+                //
+                // The subdirectory a source sits in is already encoded in the module name
+                // (`Sinks/Universal.fs` -> `..._sinks_universal`), so an app is always flat.
+                // Mirroring the subdirectory here would write to `<dep>/Sinks/src/`, which is not
+                // part of any app: `{project_app_dirs, [".", "fable_modules/*"]}` does not reach
+                // it, rebar3 compiles nothing there and says nothing, and the module surfaces as
+                // `undef` at runtime.
                 let projDir = IO.Path.GetDirectoryName cliArgs.ProjectFile
 
                 let outDir =
@@ -171,7 +178,24 @@ module private Util =
 
                 let absPath = Imports.getTargetAbsolutePath pathResolver file projDir outDir
                 let dir = IO.Path.GetDirectoryName(absPath)
-                IO.Path.Combine(dir, "src", fileName)
+                let segments = dir.Split([| '/'; '\\' |])
+
+                let appDir =
+                    // The app directory is the one segment below fable_modules; take the last
+                    // fable_modules in the path so a nested one wins over any in the outDir above.
+                    match segments |> Array.tryFindIndexBack ((=) Naming.fableModules) with
+                    | Some i when i + 1 < segments.Length ->
+                        String.Join(string IO.Path.DirectorySeparatorChar, segments.[.. i + 1])
+                    | _ ->
+                        // Falling back to `dir` here would silently reinstate the very layout this
+                        // branch exists to avoid, and the only symptom would be `undef` at runtime.
+                        Fable.FableError(
+                            $"Cannot locate the OTP app directory for {file}: expected output path {dir} "
+                            + $"to contain a '{Naming.fableModules}/<package>' segment"
+                        )
+                        |> raise
+
+                IO.Path.Combine(appDir, "src", fileName)
             else
                 // Project files: go into src/ so rebar3 picks them up
                 match cliArgs.OutDir with


### PR DESCRIPTION
## Problem

A NuGet package source in a subdirectory was written to `fable_modules/<pkg>/<subdir>/src/` instead of the package's own `src/`. No OTP app covers that path — `{project_app_dirs, [".", "fable_modules/*"]}` globs one level, and `<subdir>/` has no `.app.src` of its own — so rebar3 never compiled those files and reported nothing. `dotnet fable` succeeded, `rebar3 compile` succeeded, and the first symptom was `undef` at runtime on a module sitting right there in the output directory.

Project sources were already flat; only package sources mirrored their subdirectory. In one build of `Fable.Giraffe`'s Beam suite, 8 modules were stranded — including all seven `Fable.Beam.Otp.*` ones, so the bindings library ships a subdirectory of modules unreachable at runtime.

## Fix

Write package modules to `<pkg>/src/<module>.erl` regardless of source subdirectory. The module name already encodes the path (`Sinks/Universal.fs` → `scriptorium_parchment_sinks_universal`), so an app is flat by construction and there is no collision risk.

If the output path has no `fable_modules/<package>` segment to anchor on, this now fails with a `FableError` instead of falling back to the previous layout — that fallback would silently reinstate the exact bug being fixed, with `undef` at runtime as the only symptom.

Two alternatives from the report were considered and dropped: populating `{modules, [...]}` in the generated `.app.src` validates nothing, since rebar3 fills the module list in the generated `.app` from the compiled beams and ignores `.app.src`; and a post-emit assertion would guard an invariant that `getOutPath` — the only writer — now establishes five lines away.

## Verification

In-tree BEAM suite: **2633 passed, 0 failed**, plus both entry-point program tests.

Against `../Fable.Giraffe`'s Beam suite, with its `find`-based flatten workaround removed:

- zero nested `*/src/*.erl` under `fable_modules` (was 8 stranded modules)
- all seven `fable_beam_otp_*` plus `scriptorium_parchment_sinks_universal` compile into their app's `ebin`, and `code:ensure_loaded/1` resolves them
- suite: 37 passed / 8 skipped
- project layout unchanged: `test/shared/RoutingTests.fs` → `src/shared_routing_tests.erl`

No regression test in-tree: reproducing this needs a package with subdirectory sources in `fable_modules`, which the Beam test projects do not have.

## Note

This PR previously also carried an unrelated async-stacktrace fix. That has been split out into its own PR so this one can land on its own evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)