### PR TITLE
fix(beam): keep the original stacktrace when an async error is re-raised

### DIFF
--- a/src/fable-library-beam/fable_async.erl
+++ b/src/fable-library-beam/fable_async.erl
@@ -14,7 +14,9 @@
     start_as_task/1,
     cancellation_token/0,
     create_cancellation_token/0, create_cancellation_token/1,
-    wrap_error/1
+    wrap_error/1,
+    record_stacktrace/2,
+    clear_stacktrace/0
 ]).
 
 -type async_ctx() :: #{
@@ -44,6 +46,48 @@
 -spec cancellation_token() -> async(reference() | undefined).
 -spec create_cancellation_token() -> reference().
 -spec create_cancellation_token(term()) -> reference().
+-spec record_stacktrace(term(), erlang:stacktrace()) -> ok.
+-spec clear_stacktrace() -> ok.
+
+%% An error inside an async computation does not propagate as an exception: it is caught where it
+%% happens and handed to the context's `on_error` as a bare term, so by the time
+%% `run_synchronously` re-raises it the original stacktrace is long gone and the failure is
+%% reported at the re-raise instead of where it happened. Every catch site in the async runtime
+%% (here and in `fable_async_builder`) that hands an error onward therefore parks the stacktrace
+%% it caught, so the re-raise can restore it.
+%%
+%% A parked entry is tagged with the enclosing `run_synchronously` call's token and only that call
+%% can consume it. Untagged, a stacktrace parked for an error that was later *handled* (a
+%% `try_with` whose handler succeeded) would linger in the process dictionary and could be
+%% restored onto an unrelated later error that happened to be an equal term — attaching a
+%% plausible but wrong stacktrace, which is the very failure this mechanism exists to remove.
+-define(STACKTRACE_KEY, '$fable_async_stacktrace').
+-define(RUN_KEY, '$fable_async_run').
+
+%% @private Park the stacktrace of an error being handed to an `on_error` continuation.
+record_stacktrace(Err, Stacktrace) ->
+    case get(?RUN_KEY) of
+        %% Outside any run_synchronously nothing can restore it, and parking it would only leave
+        %% a stale entry behind in a long-lived process.
+        undefined ->
+            ok;
+        Run ->
+            put(?STACKTRACE_KEY, {Run, Err, Stacktrace}),
+            ok
+    end.
+
+%% @private Drop the parked stacktrace, if any. Called where an error is handled rather than
+%% propagated, so it cannot outlive the failure it belongs to.
+clear_stacktrace() ->
+    erase(?STACKTRACE_KEY),
+    ok.
+
+%% Re-raise with the stacktrace captured where the error was raised, when the parked one belongs
+%% to this error and to this run — `erlang:error/1` would build a fresh one pointing at this line.
+%% Errors that crossed a process boundary, or that were rewritten on the way up (`wrap_error`), do
+%% not match and fall back to a fresh stacktrace.
+reraise(Run, {Run, Err, Stacktrace}, Err) -> erlang:raise(error, Err, Stacktrace);
+reraise(_Run, _Parked, Err) -> erlang:error(Err).
 
 %% Default context: run inline in current process
 default_ctx(CancelToken) ->
@@ -130,6 +174,11 @@ run_synchronously(Computation) -> run_synchronously(Computation, undefined).
 run_synchronously(Computation, CancelToken) ->
     %% Use a unique ref as key to store result in process dict
     Ref = make_ref(),
+    %% Take over stacktrace parking for the duration of this run, handing it back afterwards so a
+    %% nested run (sequential/1, or one inside a child process) can neither consume nor clobber
+    %% the entry of the run it is nested in.
+    PrevRun = put(?RUN_KEY, Ref),
+    PrevParked = erase(?STACKTRACE_KEY),
     Ctx = #{
         on_success => fun(V) -> put(Ref, {ok, V}) end,
         on_error => fun(E) -> put(Ref, {error, E}) end,
@@ -139,12 +188,20 @@ run_synchronously(Computation, CancelToken) ->
     try
         Computation(Ctx)
     catch
-        _:Err -> put(Ref, {error, Err})
+        _:Err:Stacktrace ->
+            record_stacktrace(Err, Stacktrace),
+            put(Ref, {error, Err})
     end,
     Result = erase(Ref),
+    Parked = erase(?STACKTRACE_KEY),
+    put(?RUN_KEY, PrevRun),
+    case PrevParked of
+        undefined -> ok;
+        _ -> put(?STACKTRACE_KEY, PrevParked)
+    end,
     case Result of
         {ok, Value} -> Value;
-        {error, Error} -> erlang:error(Error);
+        {error, Error} -> reraise(Ref, Parked, Error);
         {cancelled} -> erlang:error(operation_cancelled);
         undefined -> erlang:error(async_no_result)
     end.
@@ -162,6 +219,8 @@ start_with_continuations(Comp, OnSuccess, OnError, OnCancel, Token) ->
     try
         Comp(Ctx)
     catch
+        %% No stacktrace parking here: the caller supplies OnError and receives the error term
+        %% directly, so there is no re-raise for a parked stacktrace to be restored onto.
         _:Err -> OnError(Err)
     end.
 

--- a/src/fable-library-beam/fable_async_builder.erl
+++ b/src/fable-library-beam/fable_async_builder.erl
@@ -68,7 +68,9 @@ bind(Computation, Binder) ->
                 try
                     (Binder(X))(Ctx)
                 catch
-                    _:Err -> (maps:get(on_error, Ctx))(Err)
+                    _:Err:St ->
+                        fable_async:record_stacktrace(Err, St),
+                        (maps:get(on_error, Ctx))(Err)
                 end
             end
         },
@@ -85,11 +87,16 @@ try_with(Computation, Handler) ->
     fun(Ctx) ->
         Ctx2 = Ctx#{
             on_error => fun(Err) ->
+                %% The error stops here, so a stacktrace parked for it by a deeper catch site must
+                %% not outlive it. If the handler itself fails, its own catch parks that one.
+                fable_async:clear_stacktrace(),
                 Err2 = fable_async:wrap_error(Err),
                 try
                     (Handler(Err2))(Ctx)
                 catch
-                    _:Err3 -> (maps:get(on_error, Ctx))(Err3)
+                    _:Err3:St ->
+                        fable_async:record_stacktrace(Err3, St),
+                        (maps:get(on_error, Ctx))(Err3)
                 end
             end
         },
@@ -97,11 +104,16 @@ try_with(Computation, Handler) ->
             Computation(Ctx2)
         catch
             _:Err ->
+                %% Handled here, not propagated: nothing downstream re-raises `Err`, so its
+                %% stacktrace is dropped rather than parked.
+                fable_async:clear_stacktrace(),
                 Err2 = fable_async:wrap_error(Err),
                 try
                     (Handler(Err2))(Ctx)
                 catch
-                    _:Err3 -> (maps:get(on_error, Ctx))(Err3)
+                    _:Err3:HandlerSt ->
+                        fable_async:record_stacktrace(Err3, HandlerSt),
+                        (maps:get(on_error, Ctx))(Err3)
                 end
         end
     end.
@@ -127,7 +139,8 @@ try_finally(Computation, Compensation) ->
         try
             Computation(Ctx2)
         catch
-            _:Err ->
+            _:Err:St ->
+                fable_async:record_stacktrace(Err, St),
                 Compensation(ok),
                 (maps:get(on_error, Ctx))(Err)
         end

--- a/tests/Beam/erl/async_stacktrace_tests.erl
+++ b/tests/Beam/erl/async_stacktrace_tests.erl
@@ -1,0 +1,75 @@
+%% Stacktrace handling in the async runtime.
+%%
+%% These are native Erlang tests rather than F# ones because they assert on Erlang stack frames,
+%% which have no counterpart on .NET — the F# suite runs there first, so it cannot express them.
+-module(async_stacktrace_tests).
+
+-export([
+    test_run_synchronously_keeps_original_stacktrace/0,
+    test_handled_stacktrace_is_not_reused/0,
+    test_nested_run_keeps_own_stacktrace/0
+]).
+
+%% The frame every test below looks for: an error raised at a known place in this module.
+boom(Term) -> erlang:error(Term).
+
+%% An async computation that raises from inside a bind, i.e. through the runtime's catch sites
+%% rather than straight out of run_synchronously.
+raising_async(Term) ->
+    fable_async_builder:bind(
+        fable_async_builder:return(ok),
+        fun(_) -> fun(_Ctx) -> boom(Term) end end
+    ).
+
+run_catching(Comp) ->
+    try fable_async:run_synchronously(Comp) of
+        Value -> {ok, Value}
+    catch
+        error:Err:Stacktrace -> {error, Err, Stacktrace}
+    end.
+
+has_boom_on_top([{?MODULE, boom, _, _} | _]) -> true;
+has_boom_on_top(_) -> false.
+
+%% The failure is reported where it happened, not at run_synchronously's re-raise.
+test_run_synchronously_keeps_original_stacktrace() ->
+    {error, boom_here, Stacktrace} = run_catching(raising_async(boom_here)),
+    case has_boom_on_top(Stacktrace) of
+        true -> ok;
+        false -> erlang:error({expected_original_frame_on_top, Stacktrace})
+    end.
+
+%% A stacktrace parked for an error that was *handled* must not be restored onto a later,
+%% unrelated error that happens to be an equal term.
+test_handled_stacktrace_is_not_reused() ->
+    Comp = fable_async_builder:bind(
+        %% Raise `same_term` and handle it: parks a stacktrace, then discards it.
+        fable_async_builder:try_with(
+            raising_async(same_term),
+            fun(_Err) -> fable_async_builder:return(ok) end
+        ),
+        %% Then fail with an equal term that carries no stacktrace of its own.
+        fun(_) ->
+            fable_async:from_continuations(
+                fun({_OnSuccess, OnError, _OnCancel}) -> OnError(same_term) end
+            )
+        end
+    ),
+    {error, same_term, Stacktrace} = run_catching(Comp),
+    case has_boom_on_top(Stacktrace) of
+        true -> erlang:error({stale_stacktrace_restored, Stacktrace});
+        false -> ok
+    end.
+
+%% A run nested inside another (here via sequential/1) must not consume or clobber the outer run's
+%% parked entry: the outer failure still reports its own origin.
+test_nested_run_keeps_own_stacktrace() ->
+    Comp = fable_async_builder:bind(
+        fable_async:sequential([fable_async_builder:return(ok)]),
+        fun(_) -> raising_async(outer_boom) end
+    ),
+    {error, outer_boom, Stacktrace} = run_catching(Comp),
+    case has_boom_on_top(Stacktrace) of
+        true -> ok;
+        false -> erlang:error({expected_original_frame_on_top, Stacktrace})
+    end.


### PR DESCRIPTION
Split out of #4817, where it rode along as an unrelated second fix.

## Problem

An error inside an async computation does not propagate as an exception: it is caught where it happens and handed to the context's `on_error` as a bare term. By the time `run_synchronously` re-raised it, the original stacktrace was long gone, so `erlang:error/1` built a *fresh* one and every async failure was reported at the re-raise line — a line whose only job is to re-raise.

```
before:  top frame: {fable_async,run_synchronously,2,[...,{line,147}]}
after:   top frame: {st_demo,boom,0,[{file,"st_demo.erl"},{line,4}]}
```

## Fix

Each catch site in `fable_async`/`fable_async_builder` that hands an error onward parks the stacktrace it caught, and the re-raise restores it when it belongs to that error. Errors that crossed a process boundary, or that were rewritten by `wrap_error`, fall back to a fresh stacktrace.

A parked entry is tagged with the enclosing `run_synchronously` call's token, and only that call can consume it. Untagged, a stacktrace parked for an error that was later *handled* (a `try_with` whose handler succeeded) would linger in the process dictionary and could be restored onto an unrelated later error that happened to be an equal term — attaching a plausible but wrong stacktrace, which is the very failure this mechanism exists to remove. `try_with` additionally drops the parked entry on the paths where it handles an error rather than propagating it.

`start_with_continuations` deliberately does not park: the caller supplies `OnError` and receives the error term directly, so there is no re-raise to restore onto. That is now stated in a comment rather than left as a silent gap.

## Tests

`tests/Beam/erl/async_stacktrace_tests.erl` — native Erlang rather than F#, because the assertions are about Erlang stack frames, which have no counterpart on .NET (the F# suite runs there first). Picked up automatically by `erl_test_runner`.

Each test discriminates against the relevant baseline:

| | `main` | tagging removed | this PR |
|---|---|---|---|
| original stacktrace kept | ❌ | ✅ | ✅ |
| handled stacktrace not reused | ✅ | ❌ | ✅ |
| nested run keeps own | ❌ | ✅ | ✅ |

## Verification

In-tree BEAM suite on this branch: **2636 passed, 0 failed** (2633 baseline + the 3 new tests), plus both entry-point program tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)