### PR TITLE
fix(beam): implement Async.AwaitTask

### DIFF
--- a/src/fable-library-beam/fable_async.erl
+++ b/src/fable-library-beam/fable_async.erl
@@ -12,6 +12,7 @@
     ignore/1,
     from_continuations/1,
     start_as_task/1,
+    await_task/1,
     cancellation_token/0,
     create_cancellation_token/0, create_cancellation_token/1,
     wrap_error/1
@@ -41,6 +42,7 @@
 -spec ignore(async(term())) -> async(ok).
 -spec from_continuations(fun()) -> async(term()).
 -spec start_as_task(async(term())) -> term().
+-spec await_task(async(term())) -> async(term()).
 -spec cancellation_token() -> async(reference() | undefined).
 -spec create_cancellation_token() -> reference().
 -spec create_cancellation_token(term()) -> reference().
@@ -314,6 +316,11 @@ from_continuations(F) ->
 %% StartAsTask: simplified — just run synchronously for now
 start_as_task(Computation) ->
     run_synchronously(Computation).
+
+%% AwaitTask: identity. On the Beam a Task and an Async share one representation
+%% (the `task` CE is compiled onto the async builder), so there is nothing to
+%% convert — the task *is* the async computation.
+await_task(Task) -> Task.
 
 %% CancellationToken: returns async that extracts cancel_token from context
 cancellation_token() ->

--- a/tests/Beam/TaskTests.fs
+++ b/tests/Beam/TaskTests.fs
@@ -74,3 +74,17 @@ let ``test task sequential composition works`` () =
         return a + b
     }
     tsk.Result |> equal 3
+
+[<Fact>]
+let ``test Async.AwaitTask works`` () =
+    let t = task { return 1 }
+    t |> Async.AwaitTask |> Async.RunSynchronously |> equal 1
+
+[<Fact>]
+let ``test Async.AwaitTask works inside async CE`` () =
+    let comp = async {
+        let! x = task { return 10 } |> Async.AwaitTask
+        let! y = task { return 20 } |> Async.AwaitTask
+        return x + y
+    }
+    comp |> Async.RunSynchronously |> equal 30


### PR DESCRIPTION
## Problem

`Async.AwaitTask` compiled to `fable_async:await_task/1`, which does not exist in the Beam runtime library. The call built cleanly and failed at runtime with `undef`:

```
{undef,[{fable_async,await_task,[#Fun<fable_async_builder.1.93784029>],[]}, ...
```

This comes from the catch-all at the end of `asyncs` in `src/Fable.Transforms/Beam/Replacements.fs`, which passes any unmapped `Async` member through to `fable_async` under its derived name, assuming a matching function exists.

## Fix

Implemented `await_task/1` as the identity. On the Beam a `Task` and an `Async` share one representation — the `task` CE is compiled onto the async builder — so there is nothing to convert. The crash dump above confirms it: the argument is already a `fable_async_builder` fun.

Added two tests in `tests/Beam/TaskTests.fs`: direct, and inside an `async` CE with `let!`.

## Scope

Other `Async` members reachable through the same catch-all (`Choice`, `OnCancel`, `TryCancelled`, `CancelDefaultToken`, `DefaultCancellationToken`, `SwitchToThreadPool`) are **not** Beam-specific gaps — `src/fable-library-ts/Async.ts` and `fable_library/async_.py` don't implement them either, and all three targets use the same catch-all shape. `AwaitTask` was the one member where Beam was genuinely behind: JS maps it explicitly to `awaitPromise` and Python has `await_task` in its runtime.

Deliberately left out of this PR:

- **A compile-time error for unsupported members.** A Beam-only error for calls that JS and Python also emit as broken would be a divergence rather than a fix; if wanted, it belongs in the shared layer across all targets.
- **A build-time check diffing emitted `fable_async:*` calls against the runtime's exports.** Good idea and cheap, but it has its own design questions (which targets, where in the build, how to handle the intentional gaps that would immediately light up red) — worth doing deliberately rather than bundling here.

## Verification

Full Beam suite green: 2635 Erlang tests pass / 0 fail; .NET side 2616/2616. Both new tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)