### PR TITLE
ci(python): run fable-library-py native tests in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,6 +191,45 @@ jobs:
         if: matrix.platform == 'windows-latest'
         run: .\build.bat test python
 
+  # Native/Rust-extension unit tests for the published fable-library package.
+  # These live in src/fable-library-py/tests and exercise hand-written sources
+  # (fable_library.core, .union, .util) only, so no F# transpilation is needed.
+  # Previously this ran in publish-pypi.yml, where a failure was only visible
+  # at release time and did not actually gate the publish.
+  test-fable-library-py:
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.12", "3.13", "3.14"]
+    runs-on: ${{ matrix.platform }}
+    env:
+      UV_LINK_MODE: copy
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Build extension and run tests
+        working-directory: ./src/fable-library-py
+        run: |
+          uv sync --frozen
+          uv run --frozen maturin develop --release
+          uv run --frozen pytest tests
+
   # Separate build job for Rust (will run in parallel)
   build-rust:
     timeout-minutes: 75

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -57,43 +57,10 @@ jobs:
           path: ./temp/fable-library-py
           retention-days: 1
 
-    test:
-      needs: build-fable-library
-      runs-on: ${{ matrix.os }}
-      timeout-minutes: 30
-      strategy:
-        matrix:
-          os: [ubuntu-latest, windows-latest, macos-latest]
-          python-version: ["3.12", "3.13", "3.14"]
-      env:
-        UV_LINK_MODE: copy
-
-      steps:
-        - uses: actions/checkout@v7
-        - name: Set up Python ${{ matrix.python-version }}
-          uses: actions/setup-python@v6
-          with:
-            python-version: ${{ matrix.python-version }}
-        - name: Install Rust
-          uses: dtolnay/rust-toolchain@stable
-        - name: Install uv
-          uses: astral-sh/setup-uv@v8.2.0
-        - name: Download fable-library-py
-          uses: actions/download-artifact@v8
-          with:
-            name: fable-library-py
-            path: ./src/fable-library-py
-        - name: Build and install
-          uses: PyO3/maturin-action@v1
-          with:
-            working-directory: ./src/fable-library-py
-            args: --release --features=pyo3/extension-module
-        - name: Test
-          run: |
-            cd src/fable-library-py
-            uv sync
-            uv run maturin develop --release
-            uv run pytest tests
+    # NOTE: the fable-library-py native test suite (src/fable-library-py/tests)
+    # runs in build.yml on every push/PR to main. It used to run here too, but
+    # it was never in `release`'s `needs`, so it gated nothing and only
+    # consumed runners the wheel jobs were queuing behind.
 
     linux:
       needs: build-fable-library


### PR DESCRIPTION
## Problem

The `src/fable-library-py/tests` suite (247 tests covering `fable_library.core`, `.union`, `.util` — i.e. the Rust extension) ran **only** in `publish-pypi.yml`. But that job was never listed in the `release` job's `needs`:

```yaml
release:
  needs: [linux, musllinux, windows, macos, sdist]   # no `test`
```

So it gated nothing. A failure was invisible until release time and did not stop the publish. It also occupied 9 runners that the wheel jobs were queuing behind, so it cost release wall-clock without buying release safety.

It was also the only place macOS and these native tests were covered at all — `build.yml`'s `build-python` matrix is `[ubuntu, windows]` and runs `./build.sh test python`, which pytests the *transpiled* suite in `temp/tests/py`, not these.

## Change

Move the suite to `build.yml` as `test-fable-library-py`, keeping the identical `[ubuntu, windows, macos] × [3.12, 3.13, 3.14]` matrix so no coverage is dropped. It now runs on every push/PR to `main`, where a break is cheap to catch.

The job is substantially cheaper than the old one:

- **No .NET, no `build.sh fable-library --python`.** These tests import only hand-written, git-tracked sources, never generated ones — so the transpile step and the artifact download are both unnecessary.
- **Extension is built once.** The old job ran `PyO3/maturin-action` *and* then `uv run maturin develop --release`, building it twice.
- **`uv` calls pass `--frozen`** (per `AGENTS.md`), so a stale `uv.lock` fails loudly rather than being silently rewritten.

`publish-pypi.yml` loses the `test` job, with a comment recording why.

## Verification

Both workflows parse, and `test` was not referenced by any `needs`, so no dangling edges. Suite runs clean locally:

```
247 passed in 4.29s
```

Real confirmation is this PR's own CI — the new job exercising all 9 matrix legs is the thing to watch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)