### PR TITLE
chore: add format specifiers to interpolated string holes

### DIFF
--- a/src/Fable.Compiler/MSBuildCrackerResolver.fs
+++ b/src/Fable.Compiler/MSBuildCrackerResolver.fs
@@ -99,10 +99,10 @@ module private MSBuildCrackerResolver =
                         failwith
                             $"""Failed to parse MSBuild output
 JSON:
-{targetFrameworkJson}
+%s{targetFrameworkJson}
 
 Exception:
-{ex}
+%O{ex}
 """
 
                 let tf, tfs =
@@ -161,10 +161,10 @@ Exception:
                     failwith
                         $"""Failed to parse MSBuild output
 JSON:
-{json}
+%s{json}
 
 Exception:
-{ex}
+%O{ex}
 """
 
             let items = jsonDocument.RootElement.GetProperty "Items"

--- a/src/Fable.Transforms/FSharp2Fable.fs
+++ b/src/Fable.Transforms/FSharp2Fable.fs
@@ -565,7 +565,7 @@ let private transformUnionCaseTest
                 match fableType with
                 | Fable.Any ->
                     return
-                        $"Erased union case '{unionCase.Name}' is typed as 'obj' which cannot be tested at runtime (type test always evaluates to true). Use a more specific type or TypeScriptTaggedUnion instead."
+                        $"Erased union case '%s{unionCase.Name}' is typed as 'obj' which cannot be tested at runtime (type test always evaluates to true). Use a more specific type or TypeScriptTaggedUnion instead."
                         |> addErrorAndReturnNull com ctx.InlinePath r
                 | _ ->
                     let kind = fableType |> Fable.TypeTest


### PR DESCRIPTION
Resolves all 5 open [code scanning alerts](https://github.com/fable-compiler/Fable/security/code-scanning), which are the same rule: `GRA-INTERPOLATED-001` — *"Interpolated hole expression without format detected. Use prefix with the correct % to enforce type safety."*

| Alert | Location |
| --- | --- |
| [#1553](https://github.com/fable-compiler/Fable/security/code-scanning/1553) | `src/Fable.Transforms/FSharp2Fable.fs:568` |
| [#903](https://github.com/fable-compiler/Fable/security/code-scanning/903) | `src/Fable.Compiler/MSBuildCrackerResolver.fs:167` |
| [#902](https://github.com/fable-compiler/Fable/security/code-scanning/902) | `src/Fable.Compiler/MSBuildCrackerResolver.fs:164` |
| [#901](https://github.com/fable-compiler/Fable/security/code-scanning/901) | `src/Fable.Compiler/MSBuildCrackerResolver.fs:105` |
| [#900](https://github.com/fable-compiler/Fable/security/code-scanning/900) | `src/Fable.Compiler/MSBuildCrackerResolver.fs:102` |

Each untyped hole gets the specifier matching its value: `%s` for the two `string` holes (`targetFrameworkJson`, `json`, `unionCase.Name`) and `%O` for the two `exn` holes (`ex`), which keeps the existing `ToString()`-based rendering.

Output text is unchanged; this is purely about making the interpolations type-checked.

Verified with `dotnet build src/Fable.Compiler/Fable.Compiler.fsproj` (succeeds, 0 warnings — this also covers `Fable.Transforms`) and `dotnet fantomas --check` on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)