### PR TITLE
fix(python): avoid UTF-8 boundary panic in integer parsing

### DIFF
--- a/src/fable-library-py/src/ints.rs
+++ b/src/fable-library-py/src/ints.rs
@@ -1064,16 +1064,13 @@ fn determine_radix(string: &str, style: i32, default_radix: i32) -> i32 {
         return 16;
     }
 
-    // Single length check followed by pattern match
-    if string.len() >= 2 {
-        match &string[..2] {
-            "0x" | "0X" => 16,
-            "0b" | "0B" => 2,
-            "0o" | "0O" => 8,
-            _ => default_radix,
-        }
-    } else {
-        default_radix
+    // `get` returns None when the string is shorter than two bytes or the
+    // boundary falls inside a multi-byte character, so this never panics
+    match string.get(..2) {
+        Some("0x") | Some("0X") => 16,
+        Some("0b") | Some("0B") => 2,
+        Some("0o") | Some("0O") => 8,
+        _ => default_radix,
     }
 }
 
@@ -1094,9 +1091,11 @@ fn trim_whitespace(string: &str, style: i32) -> &str {
 /// Removes numeric prefixes (0x, 0b, 0o) when radix is not decimal
 #[inline]
 fn remove_prefix(string: &str, radix: i32) -> &str {
-    if radix != 10 && string.len() >= 2 {
-        match &string[..2] {
-            "0x" | "0X" | "0b" | "0B" | "0o" | "0O" => &string[2..],
+    if radix != 10 {
+        match string.get(..2) {
+            Some("0x") | Some("0X") | Some("0b") | Some("0B") | Some("0o") | Some("0O") => {
+                &string[2..]
+            }
             _ => string,
         }
     } else {

--- a/src/fable-library-py/tests/test_ints.py
+++ b/src/fable-library-py/tests/test_ints.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 
 import pytest
 
-from fable_library.core import byte, int16, int32, int64, sbyte, uint16, uint32, uint64
+from fable_library.core import FSharpRef, byte, int16, int32, int64, sbyte, uint16, uint32, uint64
 from pydantic import BaseModel
 
 
@@ -54,6 +54,20 @@ def test_uint64_create() -> None:
     assert uint64(uint64(42)) == 42
     assert uint64(uint64(1)) == 1
     assert uint64(uint32(-1)) == 4294967295
+
+
+@pytest.mark.parametrize(
+    "style",
+    [
+        pytest.param(511, id="any"),
+        pytest.param(515, id="hex-number"),
+    ],
+)
+def test_int32_try_parse_multibyte_unicode_returns_false(style: int) -> None:
+    result = FSharpRef(0)
+
+    assert int32.try_parse("–", style, result) is False
+    assert result.contents == 0
 
 
 def test_byte_add() -> None:


### PR DESCRIPTION
Fixes #4823

The Python integer parser checks for `0x`, `0b`, and `0o` prefixes by slicing the first two bytes of a Rust `str`. This is safe for ASCII, but byte index 2 can fall inside a multi-byte UTF-8 character. In that case, `Int32.TryParse` raises a `PanicException` instead of returning `false`.

Use `str::get(..2)` in `determine_radix` and `remove_prefix`, so an invalid character boundary is treated like a non-prefix. The remaining `&string[2..]` is safe because it is only reached after matching a two-byte ASCII prefix. Prefix handling is otherwise unchanged.

Add native regression coverage for the `NumberStyles.Any` and `NumberStyles.HexNumber` paths, which exercise the two checked-slice locations.