### PR TITLE
refactor(python): tidy integer prefix matching and add parse regression tests

### DIFF
--- a/src/fable-library-py/src/ints.rs
+++ b/src/fable-library-py/src/ints.rs
@@ -1067,9 +1067,9 @@ fn determine_radix(string: &str, style: i32, default_radix: i32) -> i32 {
     // `get` returns None when the string is shorter than two bytes or the
     // boundary falls inside a multi-byte character, so this never panics
     match string.get(..2) {
-        Some("0x") | Some("0X") => 16,
-        Some("0b") | Some("0B") => 2,
-        Some("0o") | Some("0O") => 8,
+        Some("0x" | "0X") => 16,
+        Some("0b" | "0B") => 2,
+        Some("0o" | "0O") => 8,
         _ => default_radix,
     }
 }
@@ -1091,15 +1091,15 @@ fn trim_whitespace(string: &str, style: i32) -> &str {
 /// Removes numeric prefixes (0x, 0b, 0o) when radix is not decimal
 #[inline]
 fn remove_prefix(string: &str, radix: i32) -> &str {
-    if radix != 10 {
-        match string.get(..2) {
-            Some("0x") | Some("0X") | Some("0b") | Some("0B") | Some("0o") | Some("0O") => {
-                &string[2..]
-            }
-            _ => string,
-        }
-    } else {
-        string
+    if radix == 10 {
+        return string;
+    }
+
+    // `get` never panics on a multi-byte boundary; `&string[2..]` is only
+    // reached after matching a two-byte ASCII prefix, so byte 2 is a boundary
+    match string.get(..2) {
+        Some("0x" | "0X" | "0b" | "0B" | "0o" | "0O") => &string[2..],
+        _ => string,
     }
 }
 

--- a/src/fable-library-py/tests/test_ints.py
+++ b/src/fable-library-py/tests/test_ints.py
@@ -56,6 +56,10 @@ def test_uint64_create() -> None:
     assert uint64(uint32(-1)) == 4294967295
 
 
+# NumberStyles.Any (511) has no AllowHexSpecifier, so it reaches the prefix
+# check in `determine_radix`. NumberStyles.HexNumber (515) short-circuits to
+# radix 16 and reaches the prefix check in `remove_prefix` instead. Both used
+# to panic on a multi-byte first character.
 @pytest.mark.parametrize(
     "style",
     [

--- a/tests/Js/Main/ConvertTests.fs
+++ b/tests/Js/Main/ConvertTests.fs
@@ -160,6 +160,8 @@ let tests =
         (fun () -> Int32.Parse("1FFFFFFFF", System.Globalization.NumberStyles.HexNumber)) |> throwsError ""
         (fun () -> Int32.Parse("5foo", System.Globalization.NumberStyles.HexNumber)) |> throwsError ""
         (fun () -> Int32.Parse("foo5", System.Globalization.NumberStyles.HexNumber)) |> throwsError ""
+        // Multi-byte UTF-8 input must fail to parse, not crash (see #4823)
+        (fun () -> Int32.Parse("–", System.Globalization.NumberStyles.HexNumber)) |> throwsError ""
 
     testCase "System.Int64.Parse works" <| fun () ->
         Int64.Parse("5") |> equal 5L
@@ -207,6 +209,10 @@ let tests =
         tryParse Int32.TryParse 0 "X9TRE34" |> equal (false, 0)
         tryParse Int32.TryParse 0 "9SayWhat12Huh" |> equal (false, 0)
         tryParse Int32.TryParse 0 "-1" |> equal (true, -1)
+        // Multi-byte UTF-8 input must fail to parse, not crash (see #4823)
+        tryParse Int32.TryParse 0 "–" |> equal (false, 0)
+        tryParse Int32.TryParse 0 "é" |> equal (false, 0)
+        tryParse Int32.TryParse 0 "𝟙" |> equal (false, 0)
 
     testCase "BigInt.TryParse works" <| fun () ->
         tryParse bigint.TryParse 0I "4234523548923954" |> equal (true, 4234523548923954I)

--- a/tests/Python/TestConvert.fs
+++ b/tests/Python/TestConvert.fs
@@ -160,6 +160,8 @@ let ``test System.Int32.Parse with hex works`` () =
     (fun () -> Int32.Parse("1FFFFFFFF", System.Globalization.NumberStyles.HexNumber)) |> throwsError ""
     (fun () -> Int32.Parse("5foo", System.Globalization.NumberStyles.HexNumber)) |> throwsError ""
     (fun () -> Int32.Parse("foo5", System.Globalization.NumberStyles.HexNumber)) |> throwsError ""
+    // Multi-byte UTF-8 input must fail to parse, not crash (see #4823)
+    (fun () -> Int32.Parse("–", System.Globalization.NumberStyles.HexNumber)) |> throwsError ""
 
 [<Fact>]
 let ``test System.Int64.Parse works`` () =
@@ -214,6 +216,10 @@ let ``test System.Int32.TryParse works`` () =
     tryParse Int32.TryParse 0 "X9TRE34" |> equal (false, 0)
     tryParse Int32.TryParse 0 "9SayWhat12Huh" |> equal (false, 0)
     tryParse Int32.TryParse 0 "-1" |> equal (true, -1)
+    // Multi-byte UTF-8 input must fail to parse, not crash (see #4823)
+    tryParse Int32.TryParse 0 "–" |> equal (false, 0)
+    tryParse Int32.TryParse 0 "é" |> equal (false, 0)
+    tryParse Int32.TryParse 0 "𝟙" |> equal (false, 0)
 
 [<Fact>]
 let ``test BigInt.TryParse works`` () =


### PR DESCRIPTION
Follow-up to #4825 (fixes the review notes from that PR). **No behavior change** — cleanup plus regression coverage.

### Rust cleanup (`src/fable-library-py/src/ints.rs`)

- Collapse the prefix matches in `determine_radix` and `remove_prefix` to nested or-patterns (`Some("0x" | "0X")`), and give `remove_prefix` an early return for the radix-10 case. The prefix arm now fits on one line instead of the wrapped block rustfmt was forced into at 104 chars.
- Move the boundary-safety justification onto the `&string[2..]` line, where the invariant actually lives: it is only reached after matching a two-byte ASCII prefix, so byte 2 is guaranteed to be a char boundary.

### Test readability (`src/fable-library-py/tests/test_ints.py`)

The parametrized `511`/`515` styles are not redundant, but nothing said so. Added a comment: `NumberStyles.Any` (511) has no `AllowHexSpecifier` and so reaches the prefix check in `determine_radix`, while `NumberStyles.HexNumber` (515) short-circuits to radix 16 and reaches the one in `remove_prefix` instead — one checked-slice site each.

### End-to-end regression coverage

#4823 was reported as an F#-level `Int32.TryParse` failure, but #4825 only covered it natively. Added the multi-byte cases to the F# suites for both Python and JS (`tests/Python/TestConvert.fs`, `tests/Js/Main/ConvertTests.fs`), covering 2-, 3-, and 4-byte characters plus the `NumberStyles.HexNumber` path that exercises the second slice site:

```fsharp
tryParse Int32.TryParse 0 "–" |> equal (false, 0)
tryParse Int32.TryParse 0 "é" |> equal (false, 0)
tryParse Int32.TryParse 0 "𝟙" |> equal (false, 0)
(fun () -> Int32.Parse("–", System.Globalization.NumberStyles.HexNumber)) |> throwsError ""
```

### Verification

- All four new assertions were checked against .NET first via `dotnet fsi` — `TryParse` returns `(false, 0)` for each, and `Parse("–", HexNumber)` throws `FormatException`.
- `./build.sh test python` — 2405 passed. Confirmed the new cases are present in the transpiled `temp/tests/Python/test_convert.py` rather than silently dropped.
- Native `pytest tests/test_ints.py` — 33 passed against a freshly built extension.
- Directly exercised the restructured `remove_prefix` across every prefix form (`0x`/`0X`/`0o`/`0b`, bare, and hex-style `5f`/`FFFFFFFF`/`0x1F`) — results identical to before the refactor.
- `cargo fmt --check` reports the same 35 pre-existing diffs at identical locations with and without this change, so no new formatting drift.

### Not included

While reviewing, one adjacent pre-existing bug surfaced that is out of scope here: `preprocess_numeric_string` calls `determine_radix` on the **untrimmed** string but `remove_prefix` on the **trimmed** one, so `" 0x1F"` with `AllowLeadingWhite` detects radix 10 and then fails to parse with the prefix still attached. Worth its own issue if the prefix form is meant to be supported alongside leading whitespace (`tests/Python/TestConvert.fs` does cover the prefix form without whitespace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
