### PR TITLE
fix(js/ts,python): inline Option/ValueOption combinators to avoid closures and allocations

### DIFF
--- a/src/Fable.Transforms/FableTransforms.fs
+++ b/src/Fable.Transforms/FableTransforms.fs
@@ -230,10 +230,14 @@ let noSideEffectBeforeIdent identName expr =
         | Let(_, v, b) -> findIdentOrSideEffect v || findIdentOrSideEffect b
         | TypeCast(e, _)
         | Test(e, _, _) -> findIdentOrSideEffect e
-        | IfThenElse(cond, thenExpr, elseExpr, _) ->
-            findIdentOrSideEffect cond
-            || findIdentOrSideEffect thenExpr
-            || findIdentOrSideEffect elseExpr
+        // Only `cond` always runs; `thenExpr`/`elseExpr` are conditional, so treat them like
+        // WhileLoop/ForLoop/TryCatch/DecisionTree below (opaque, assume unsafe).
+        | IfThenElse(cond, _, _, _) ->
+            if findIdentOrSideEffect cond then
+                true
+            else
+                sideEffect <- true
+                true
         // TODO: Check member bodies in ObjectExpr
         | ObjectExpr _
         | LetRec _

--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -2235,9 +2235,9 @@ let optionModule isStruct (com: ICompiler) (ctx: Context) r (t: Type) (i: CallIn
     | "Flatten", args ->
         Helper.LibCall(com, "option", "flatten", t, args, i.SignatureArgTypes, ?loc = r)
         |> Some
-    | "Map", [ mapping; opt ] -> Options.map com ctx r isStruct mapping opt |> Some
-    | "Map2", [ mapping; opt1; opt2 ] -> Options.map2 com ctx r isStruct mapping opt1 opt2 |> Some
-    | "Map3", [ mapping; opt1; opt2; opt3 ] -> Options.map3 com ctx r isStruct mapping opt1 opt2 opt3 |> Some
+    | "Map", [ mapping; opt ] -> Options.map com ctx r t isStruct mapping opt |> Some
+    | "Map2", [ mapping; opt1; opt2 ] -> Options.map2 com ctx r t isStruct mapping opt1 opt2 |> Some
+    | "Map3", [ mapping; opt1; opt2; opt3 ] -> Options.map3 com ctx r t isStruct mapping opt1 opt2 opt3 |> Some
     | "Bind", [ binder; opt ] -> Options.bind com ctx r t isStruct binder opt |> Some
     | "Filter", [ predicate; opt ] -> Options.filter com ctx r isStruct predicate opt |> Some
     | "ToArray", [ arg ] -> toArray r t arg |> Some

--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -2232,9 +2232,14 @@ let optionModule isStruct (com: ICompiler) (ctx: Context) r (t: Type) (i: CallIn
     | ("ToObj" | "ToNullable"), _ -> Helper.LibCall(com, "option", "to_nullable", t, args, ?loc = r) |> Some
     | "IsSome", [ c ] -> Test(c, OptionTest true, r) |> Some
     | "IsNone", [ c ] -> Test(c, OptionTest false, r) |> Some
-    | ("Filter" | "Flatten" | "Map" | "Map2" | "Map3" | "Bind" as meth), args ->
-        Helper.LibCall(com, "option", Naming.lowerFirst meth, t, args, i.SignatureArgTypes, ?loc = r)
+    | "Flatten", args ->
+        Helper.LibCall(com, "option", "flatten", t, args, i.SignatureArgTypes, ?loc = r)
         |> Some
+    | "Map", [ mapping; opt ] -> Options.map com ctx r isStruct mapping opt |> Some
+    | "Map2", [ mapping; opt1; opt2 ] -> Options.map2 com ctx r isStruct mapping opt1 opt2 |> Some
+    | "Map3", [ mapping; opt1; opt2; opt3 ] -> Options.map3 com ctx r isStruct mapping opt1 opt2 opt3 |> Some
+    | "Bind", [ binder; opt ] -> Options.bind com ctx r t isStruct binder opt |> Some
+    | "Filter", [ predicate; opt ] -> Options.filter com ctx r isStruct predicate opt |> Some
     | "ToArray", [ arg ] -> toArray r t arg |> Some
     | "ToList", [ arg ] ->
         let args = args |> List.replaceLast (toArray None t)
@@ -2244,14 +2249,11 @@ let optionModule isStruct (com: ICompiler) (ctx: Context) r (t: Type) (i: CallIn
         Helper.LibCall(com, "seq", "fold_back", t, [ folder; toArray None t opt; state ], i.SignatureArgTypes, ?loc = r)
         |> Some
     | "DefaultValue", _ -> Helper.LibCall(com, "option", "default_arg", t, List.rev args, ?loc = r) |> Some
-    | "DefaultWith", _ ->
-        Helper.LibCall(com, "option", "default_arg_with", t, List.rev args, List.rev i.SignatureArgTypes, ?loc = r)
-        |> Some
+    | "DefaultWith", [ defThunk; opt ] -> Options.defaultWith com ctx r t defThunk opt |> Some
     | "OrElse", _ -> Helper.LibCall(com, "Option", "or_else", t, List.rev args, ?loc = r) |> Some
-    | "OrElseWith", _ ->
-        Helper.LibCall(com, "Option", "or_else_with", t, List.rev args, List.rev i.SignatureArgTypes, ?loc = r)
-        |> Some
-    | ("Count" | "Contains" | "Exists" | "Fold" | "ForAll" | "Iterate" as meth), _ ->
+    | "OrElseWith", [ ifNoneThunk; opt ] -> Options.orElseWith com ctx r t ifNoneThunk opt |> Some
+    | "Iterate", [ action; opt ] -> Options.iterate com ctx r t action opt |> Some
+    | ("Count" | "Contains" | "Exists" | "Fold" | "ForAll" as meth), _ ->
         let meth = Naming.lowerFirst meth
         let args = args |> List.replaceLast (toArray None t)
         let args = injectArg com ctx r "Seq" meth i.GenericArgs args

--- a/src/Fable.Transforms/Replacements.Util.fs
+++ b/src/Fable.Transforms/Replacements.Util.fs
@@ -637,11 +637,8 @@ module Options =
             )
 
     /// `Option.map`/`ValueOption.map`.
-    let map (com: ICompiler) ctx r isStruct (mapping: Expr) (opt: Expr) =
-        let retType =
-            match mapping.Type with
-            | LambdaType(_, ret) -> ret
-            | t -> t
+    let map (com: ICompiler) ctx r (t: Type) isStruct (mapping: Expr) (opt: Expr) =
+        let retType = innerType t
 
         bindOnce
             com
@@ -662,11 +659,8 @@ module Options =
             )
 
     /// `Option.map2`/`ValueOption.map2`.
-    let map2 (com: ICompiler) ctx r isStruct (mapping: Expr) (opt1: Expr) (opt2: Expr) =
-        let retType =
-            match mapping.Type with
-            | LambdaType(_, LambdaType(_, ret)) -> ret
-            | t -> t
+    let map2 (com: ICompiler) ctx r (t: Type) isStruct (mapping: Expr) (opt1: Expr) (opt2: Expr) =
+        let retType = innerType t
 
         bindOnce
             com
@@ -692,11 +686,8 @@ module Options =
             )
 
     /// `Option.map3`/`ValueOption.map3`.
-    let map3 (com: ICompiler) ctx r isStruct (mapping: Expr) (opt1: Expr) (opt2: Expr) (opt3: Expr) =
-        let retType =
-            match mapping.Type with
-            | LambdaType(_, LambdaType(_, LambdaType(_, ret))) -> ret
-            | t -> t
+    let map3 (com: ICompiler) ctx r (t: Type) isStruct (mapping: Expr) (opt1: Expr) (opt2: Expr) (opt3: Expr) =
+        let retType = innerType t
 
         bindOnce
             com
@@ -732,10 +723,7 @@ module Options =
 
     /// `Option.bind`/`ValueOption.bind`.
     let bind (com: ICompiler) ctx r (t: Type) isStruct (binder: Expr) (opt: Expr) =
-        let retType =
-            match binder.Type with
-            | LambdaType(_, Option(ret, _)) -> ret
-            | _ -> t
+        let retType = innerType t
 
         bindOnce
             com

--- a/src/Fable.Transforms/Replacements.Util.fs
+++ b/src/Fable.Transforms/Replacements.Util.fs
@@ -592,30 +592,49 @@ let rec namesof com ctx acc e =
 
 let curriedApply r t applied args = CurriedApply(applied, args, t, r)
 
-/// Builds Option/ValueOption replacements that apply a function argument (mapping, binder,
-/// predicate, thunk...) directly as AST rather than via a lib call, so a lambda literal
-/// argument beta-reduces away instead of allocating a closure.
+/// Builds Option/ValueOption replacements that apply a function argument directly as AST
+/// (not via a lib call), so a lambda literal beta-reduces away instead of allocating a closure.
 module Options =
     let innerType t =
         match t with
         | Option(genArg, _) -> genArg
         | t -> t
 
+    /// Binds `value` to a fresh ident evaluated eagerly, once, before `body` (which may
+    /// reference it only conditionally) - required if `value` can be side-effecting.
+    let bindOnce (com: ICompiler) ctx name (value: Expr) (body: Expr -> Expr) =
+        let ident = makeUniqueIdent com ctx value.Type name
+        Let(ident, value, body (IdentExpr ident))
+
     /// `let o = opt in if o is Some then someExpr(o, value(o)) else noneExpr`, binding `opt`
     /// once (it's used by both the test and the unwrap, and may be side-effecting).
     let matchOption (com: ICompiler) ctx r (opt: Expr) (someExpr: Expr -> Expr -> Expr) (noneExpr: Expr) =
-        let optIdent = makeUniqueIdent com ctx opt.Type "option"
-        let optExpr = IdentExpr optIdent
-        let unwrapped = Get(optExpr, OptionValue, innerType opt.Type, r)
-
-        let ifExpr =
-            IfThenElse(Test(optExpr, OptionTest true, r), someExpr optExpr unwrapped, noneExpr, r)
-
-        Let(optIdent, opt, ifExpr)
+        bindOnce
+            com
+            ctx
+            "option"
+            opt
+            (fun optExpr ->
+                let unwrapped = Get(optExpr, OptionValue, innerType opt.Type, r)
+                IfThenElse(Test(optExpr, OptionTest true, r), someExpr optExpr unwrapped, noneExpr, r)
+            )
 
     /// `Option.iter`/`ValueOption.iter`.
     let iterate (com: ICompiler) ctx r (t: Type) (action: Expr) (opt: Expr) =
-        matchOption com ctx r opt (fun _ unwrapped -> curriedApply r t action [ unwrapped ]) (Value(UnitConstant, None))
+        bindOnce
+            com
+            ctx
+            "action"
+            action
+            (fun actionExpr ->
+                matchOption
+                    com
+                    ctx
+                    r
+                    opt
+                    (fun _ unwrapped -> curriedApply r t actionExpr [ unwrapped ])
+                    (Value(UnitConstant, None))
+            )
 
     /// `Option.map`/`ValueOption.map`.
     let map (com: ICompiler) ctx r isStruct (mapping: Expr) (opt: Expr) =
@@ -624,16 +643,23 @@ module Options =
             | LambdaType(_, ret) -> ret
             | t -> t
 
-        matchOption
+        bindOnce
             com
             ctx
-            r
-            opt
-            (fun _ unwrapped ->
-                NewOption(curriedApply r retType mapping [ unwrapped ] |> Some, retType, isStruct)
-                |> makeValue r
+            "mapping"
+            mapping
+            (fun mappingExpr ->
+                matchOption
+                    com
+                    ctx
+                    r
+                    opt
+                    (fun _ unwrapped ->
+                        NewOption(curriedApply r retType mappingExpr [ unwrapped ] |> Some, retType, isStruct)
+                        |> makeValue r
+                    )
+                    (NewOption(None, retType, isStruct) |> makeValue r)
             )
-            (NewOption(None, retType, isStruct) |> makeValue r)
 
     /// `Option.map2`/`ValueOption.map2`.
     let map2 (com: ICompiler) ctx r isStruct (mapping: Expr) (opt1: Expr) (opt2: Expr) =
@@ -642,21 +668,28 @@ module Options =
             | LambdaType(_, LambdaType(_, ret)) -> ret
             | t -> t
 
-        let opt1Ident = makeUniqueIdent com ctx opt1.Type "option1"
-        let opt2Ident = makeUniqueIdent com ctx opt2.Type "option2"
-        let opt1Expr = IdentExpr opt1Ident
-        let opt2Expr = IdentExpr opt2Ident
-        let unwrapped1 = Get(opt1Expr, OptionValue, innerType opt1.Type, r)
-        let unwrapped2 = Get(opt2Expr, OptionValue, innerType opt2.Type, r)
-        let noneExpr = NewOption(None, retType, isStruct) |> makeValue r
+        bindOnce
+            com
+            ctx
+            "mapping"
+            mapping
+            (fun mappingExpr ->
+                let opt1Ident = makeUniqueIdent com ctx opt1.Type "option1"
+                let opt2Ident = makeUniqueIdent com ctx opt2.Type "option2"
+                let opt1Expr = IdentExpr opt1Ident
+                let opt2Expr = IdentExpr opt2Ident
+                let unwrapped1 = Get(opt1Expr, OptionValue, innerType opt1.Type, r)
+                let unwrapped2 = Get(opt2Expr, OptionValue, innerType opt2.Type, r)
+                let noneExpr = NewOption(None, retType, isStruct) |> makeValue r
 
-        let someExpr =
-            NewOption(curriedApply r retType mapping [ unwrapped1; unwrapped2 ] |> Some, retType, isStruct)
-            |> makeValue r
+                let someExpr =
+                    NewOption(curriedApply r retType mappingExpr [ unwrapped1; unwrapped2 ] |> Some, retType, isStruct)
+                    |> makeValue r
 
-        let inner = IfThenElse(Test(opt2Expr, OptionTest true, r), someExpr, noneExpr, r)
-        let outer = IfThenElse(Test(opt1Expr, OptionTest true, r), inner, noneExpr, r)
-        Let(opt1Ident, opt1, Let(opt2Ident, opt2, outer))
+                let inner = IfThenElse(Test(opt2Expr, OptionTest true, r), someExpr, noneExpr, r)
+                let outer = IfThenElse(Test(opt1Expr, OptionTest true, r), inner, noneExpr, r)
+                Let(opt1Ident, opt1, Let(opt2Ident, opt2, outer))
+            )
 
     /// `Option.map3`/`ValueOption.map3`.
     let map3 (com: ICompiler) ctx r isStruct (mapping: Expr) (opt1: Expr) (opt2: Expr) (opt3: Expr) =
@@ -665,25 +698,37 @@ module Options =
             | LambdaType(_, LambdaType(_, LambdaType(_, ret))) -> ret
             | t -> t
 
-        let opt1Ident = makeUniqueIdent com ctx opt1.Type "option1"
-        let opt2Ident = makeUniqueIdent com ctx opt2.Type "option2"
-        let opt3Ident = makeUniqueIdent com ctx opt3.Type "option3"
-        let opt1Expr = IdentExpr opt1Ident
-        let opt2Expr = IdentExpr opt2Ident
-        let opt3Expr = IdentExpr opt3Ident
-        let unwrapped1 = Get(opt1Expr, OptionValue, innerType opt1.Type, r)
-        let unwrapped2 = Get(opt2Expr, OptionValue, innerType opt2.Type, r)
-        let unwrapped3 = Get(opt3Expr, OptionValue, innerType opt3.Type, r)
-        let noneExpr = NewOption(None, retType, isStruct) |> makeValue r
+        bindOnce
+            com
+            ctx
+            "mapping"
+            mapping
+            (fun mappingExpr ->
+                let opt1Ident = makeUniqueIdent com ctx opt1.Type "option1"
+                let opt2Ident = makeUniqueIdent com ctx opt2.Type "option2"
+                let opt3Ident = makeUniqueIdent com ctx opt3.Type "option3"
+                let opt1Expr = IdentExpr opt1Ident
+                let opt2Expr = IdentExpr opt2Ident
+                let opt3Expr = IdentExpr opt3Ident
+                let unwrapped1 = Get(opt1Expr, OptionValue, innerType opt1.Type, r)
+                let unwrapped2 = Get(opt2Expr, OptionValue, innerType opt2.Type, r)
+                let unwrapped3 = Get(opt3Expr, OptionValue, innerType opt3.Type, r)
+                let noneExpr = NewOption(None, retType, isStruct) |> makeValue r
 
-        let someExpr =
-            NewOption(curriedApply r retType mapping [ unwrapped1; unwrapped2; unwrapped3 ] |> Some, retType, isStruct)
-            |> makeValue r
+                let someExpr =
+                    NewOption(
+                        curriedApply r retType mappingExpr [ unwrapped1; unwrapped2; unwrapped3 ]
+                        |> Some,
+                        retType,
+                        isStruct
+                    )
+                    |> makeValue r
 
-        let inner2 = IfThenElse(Test(opt3Expr, OptionTest true, r), someExpr, noneExpr, r)
-        let inner1 = IfThenElse(Test(opt2Expr, OptionTest true, r), inner2, noneExpr, r)
-        let outer = IfThenElse(Test(opt1Expr, OptionTest true, r), inner1, noneExpr, r)
-        Let(opt1Ident, opt1, Let(opt2Ident, opt2, Let(opt3Ident, opt3, outer)))
+                let inner2 = IfThenElse(Test(opt3Expr, OptionTest true, r), someExpr, noneExpr, r)
+                let inner1 = IfThenElse(Test(opt2Expr, OptionTest true, r), inner2, noneExpr, r)
+                let outer = IfThenElse(Test(opt1Expr, OptionTest true, r), inner1, noneExpr, r)
+                Let(opt1Ident, opt1, Let(opt2Ident, opt2, Let(opt3Ident, opt3, outer)))
+            )
 
     /// `Option.bind`/`ValueOption.bind`.
     let bind (com: ICompiler) ctx r (t: Type) isStruct (binder: Expr) (opt: Expr) =
@@ -692,46 +737,76 @@ module Options =
             | LambdaType(_, Option(ret, _)) -> ret
             | _ -> t
 
-        matchOption
+        bindOnce
             com
             ctx
-            r
-            opt
-            (fun _ unwrapped -> curriedApply r t binder [ unwrapped ])
-            (NewOption(None, retType, isStruct) |> makeValue r)
+            "binder"
+            binder
+            (fun binderExpr ->
+                matchOption
+                    com
+                    ctx
+                    r
+                    opt
+                    (fun _ unwrapped -> curriedApply r t binderExpr [ unwrapped ])
+                    (NewOption(None, retType, isStruct) |> makeValue r)
+            )
 
     /// `Option.filter`/`ValueOption.filter`.
     let filter (com: ICompiler) ctx r isStruct (predicate: Expr) (opt: Expr) =
         let valueType = innerType opt.Type
         let noneExpr = NewOption(None, valueType, isStruct) |> makeValue r
 
-        matchOption
+        bindOnce
             com
             ctx
-            r
-            opt
-            (fun optExpr unwrapped -> IfThenElse(curriedApply r Boolean predicate [ unwrapped ], optExpr, noneExpr, r))
-            noneExpr
+            "predicate"
+            predicate
+            (fun predicateExpr ->
+                matchOption
+                    com
+                    ctx
+                    r
+                    opt
+                    (fun optExpr unwrapped ->
+                        IfThenElse(curriedApply r Boolean predicateExpr [ unwrapped ], optExpr, noneExpr, r)
+                    )
+                    noneExpr
+            )
 
     /// `Option.defaultWith`/`ValueOption.defaultWith`.
     let defaultWith (com: ICompiler) ctx r (t: Type) (defThunk: Expr) (opt: Expr) =
-        matchOption
+        bindOnce
             com
             ctx
-            r
-            opt
-            (fun _ unwrapped -> unwrapped)
-            (curriedApply r t defThunk [ Value(UnitConstant, None) ])
+            "defThunk"
+            defThunk
+            (fun defThunkExpr ->
+                matchOption
+                    com
+                    ctx
+                    r
+                    opt
+                    (fun _ unwrapped -> unwrapped)
+                    (curriedApply r t defThunkExpr [ Value(UnitConstant, None) ])
+            )
 
     /// `Option.orElseWith`/`ValueOption.orElseWith`.
     let orElseWith (com: ICompiler) ctx r (t: Type) (ifNoneThunk: Expr) (opt: Expr) =
-        matchOption
+        bindOnce
             com
             ctx
-            r
-            opt
-            (fun optExpr _ -> optExpr)
-            (curriedApply r t ifNoneThunk [ Value(UnitConstant, None) ])
+            "ifNoneThunk"
+            ifNoneThunk
+            (fun ifNoneThunkExpr ->
+                matchOption
+                    com
+                    ctx
+                    r
+                    opt
+                    (fun optExpr _ -> optExpr)
+                    (curriedApply r t ifNoneThunkExpr [ Value(UnitConstant, None) ])
+            )
 
 let compose (com: ICompiler) ctx r t (f1: Expr) (f2: Expr) =
     let argType, retType =

--- a/src/Fable.Transforms/Replacements.Util.fs
+++ b/src/Fable.Transforms/Replacements.Util.fs
@@ -592,6 +592,147 @@ let rec namesof com ctx acc e =
 
 let curriedApply r t applied args = CurriedApply(applied, args, t, r)
 
+/// Builds Option/ValueOption replacements that apply a function argument (mapping, binder,
+/// predicate, thunk...) directly as AST rather than via a lib call, so a lambda literal
+/// argument beta-reduces away instead of allocating a closure.
+module Options =
+    let innerType t =
+        match t with
+        | Option(genArg, _) -> genArg
+        | t -> t
+
+    /// `let o = opt in if o is Some then someExpr(o, value(o)) else noneExpr`, binding `opt`
+    /// once (it's used by both the test and the unwrap, and may be side-effecting).
+    let matchOption (com: ICompiler) ctx r (opt: Expr) (someExpr: Expr -> Expr -> Expr) (noneExpr: Expr) =
+        let optIdent = makeUniqueIdent com ctx opt.Type "option"
+        let optExpr = IdentExpr optIdent
+        let unwrapped = Get(optExpr, OptionValue, innerType opt.Type, r)
+
+        let ifExpr =
+            IfThenElse(Test(optExpr, OptionTest true, r), someExpr optExpr unwrapped, noneExpr, r)
+
+        Let(optIdent, opt, ifExpr)
+
+    /// `Option.iter`/`ValueOption.iter`.
+    let iterate (com: ICompiler) ctx r (t: Type) (action: Expr) (opt: Expr) =
+        matchOption com ctx r opt (fun _ unwrapped -> curriedApply r t action [ unwrapped ]) (Value(UnitConstant, None))
+
+    /// `Option.map`/`ValueOption.map`.
+    let map (com: ICompiler) ctx r isStruct (mapping: Expr) (opt: Expr) =
+        let retType =
+            match mapping.Type with
+            | LambdaType(_, ret) -> ret
+            | t -> t
+
+        matchOption
+            com
+            ctx
+            r
+            opt
+            (fun _ unwrapped ->
+                NewOption(curriedApply r retType mapping [ unwrapped ] |> Some, retType, isStruct)
+                |> makeValue r
+            )
+            (NewOption(None, retType, isStruct) |> makeValue r)
+
+    /// `Option.map2`/`ValueOption.map2`.
+    let map2 (com: ICompiler) ctx r isStruct (mapping: Expr) (opt1: Expr) (opt2: Expr) =
+        let retType =
+            match mapping.Type with
+            | LambdaType(_, LambdaType(_, ret)) -> ret
+            | t -> t
+
+        let opt1Ident = makeUniqueIdent com ctx opt1.Type "option1"
+        let opt2Ident = makeUniqueIdent com ctx opt2.Type "option2"
+        let opt1Expr = IdentExpr opt1Ident
+        let opt2Expr = IdentExpr opt2Ident
+        let unwrapped1 = Get(opt1Expr, OptionValue, innerType opt1.Type, r)
+        let unwrapped2 = Get(opt2Expr, OptionValue, innerType opt2.Type, r)
+        let noneExpr = NewOption(None, retType, isStruct) |> makeValue r
+
+        let someExpr =
+            NewOption(curriedApply r retType mapping [ unwrapped1; unwrapped2 ] |> Some, retType, isStruct)
+            |> makeValue r
+
+        let inner = IfThenElse(Test(opt2Expr, OptionTest true, r), someExpr, noneExpr, r)
+        let outer = IfThenElse(Test(opt1Expr, OptionTest true, r), inner, noneExpr, r)
+        Let(opt1Ident, opt1, Let(opt2Ident, opt2, outer))
+
+    /// `Option.map3`/`ValueOption.map3`.
+    let map3 (com: ICompiler) ctx r isStruct (mapping: Expr) (opt1: Expr) (opt2: Expr) (opt3: Expr) =
+        let retType =
+            match mapping.Type with
+            | LambdaType(_, LambdaType(_, LambdaType(_, ret))) -> ret
+            | t -> t
+
+        let opt1Ident = makeUniqueIdent com ctx opt1.Type "option1"
+        let opt2Ident = makeUniqueIdent com ctx opt2.Type "option2"
+        let opt3Ident = makeUniqueIdent com ctx opt3.Type "option3"
+        let opt1Expr = IdentExpr opt1Ident
+        let opt2Expr = IdentExpr opt2Ident
+        let opt3Expr = IdentExpr opt3Ident
+        let unwrapped1 = Get(opt1Expr, OptionValue, innerType opt1.Type, r)
+        let unwrapped2 = Get(opt2Expr, OptionValue, innerType opt2.Type, r)
+        let unwrapped3 = Get(opt3Expr, OptionValue, innerType opt3.Type, r)
+        let noneExpr = NewOption(None, retType, isStruct) |> makeValue r
+
+        let someExpr =
+            NewOption(curriedApply r retType mapping [ unwrapped1; unwrapped2; unwrapped3 ] |> Some, retType, isStruct)
+            |> makeValue r
+
+        let inner2 = IfThenElse(Test(opt3Expr, OptionTest true, r), someExpr, noneExpr, r)
+        let inner1 = IfThenElse(Test(opt2Expr, OptionTest true, r), inner2, noneExpr, r)
+        let outer = IfThenElse(Test(opt1Expr, OptionTest true, r), inner1, noneExpr, r)
+        Let(opt1Ident, opt1, Let(opt2Ident, opt2, Let(opt3Ident, opt3, outer)))
+
+    /// `Option.bind`/`ValueOption.bind`.
+    let bind (com: ICompiler) ctx r (t: Type) isStruct (binder: Expr) (opt: Expr) =
+        let retType =
+            match binder.Type with
+            | LambdaType(_, Option(ret, _)) -> ret
+            | _ -> t
+
+        matchOption
+            com
+            ctx
+            r
+            opt
+            (fun _ unwrapped -> curriedApply r t binder [ unwrapped ])
+            (NewOption(None, retType, isStruct) |> makeValue r)
+
+    /// `Option.filter`/`ValueOption.filter`.
+    let filter (com: ICompiler) ctx r isStruct (predicate: Expr) (opt: Expr) =
+        let valueType = innerType opt.Type
+        let noneExpr = NewOption(None, valueType, isStruct) |> makeValue r
+
+        matchOption
+            com
+            ctx
+            r
+            opt
+            (fun optExpr unwrapped -> IfThenElse(curriedApply r Boolean predicate [ unwrapped ], optExpr, noneExpr, r))
+            noneExpr
+
+    /// `Option.defaultWith`/`ValueOption.defaultWith`.
+    let defaultWith (com: ICompiler) ctx r (t: Type) (defThunk: Expr) (opt: Expr) =
+        matchOption
+            com
+            ctx
+            r
+            opt
+            (fun _ unwrapped -> unwrapped)
+            (curriedApply r t defThunk [ Value(UnitConstant, None) ])
+
+    /// `Option.orElseWith`/`ValueOption.orElseWith`.
+    let orElseWith (com: ICompiler) ctx r (t: Type) (ifNoneThunk: Expr) (opt: Expr) =
+        matchOption
+            com
+            ctx
+            r
+            opt
+            (fun optExpr _ -> optExpr)
+            (curriedApply r t ifNoneThunk [ Value(UnitConstant, None) ])
+
 let compose (com: ICompiler) ctx r t (f1: Expr) (f2: Expr) =
     let argType, retType =
         match t with

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -2425,18 +2425,14 @@ let optionModule isStruct (com: ICompiler) (ctx: Context) r (t: Type) (i: CallIn
         |> Some
     | "IsSome", [ c ] -> Test(c, OptionTest true, r) |> Some
     | "IsNone", [ c ] -> Test(c, OptionTest false, r) |> Some
-    | ("Filter" | "Flatten" | "Map" | "Map2" | "Map3" | "Bind" as meth), args ->
-        Helper.LibCall(
-            com,
-            "Option",
-            Naming.lowerFirst meth,
-            t,
-            args,
-            i.SignatureArgTypes,
-            genArgs = i.GenericArgs,
-            ?loc = r
-        )
+    | "Flatten", args ->
+        Helper.LibCall(com, "Option", "flatten", t, args, i.SignatureArgTypes, genArgs = i.GenericArgs, ?loc = r)
         |> Some
+    | "Map", [ mapping; opt ] -> Options.map com ctx r isStruct mapping opt |> Some
+    | "Map2", [ mapping; opt1; opt2 ] -> Options.map2 com ctx r isStruct mapping opt1 opt2 |> Some
+    | "Map3", [ mapping; opt1; opt2; opt3 ] -> Options.map3 com ctx r isStruct mapping opt1 opt2 opt3 |> Some
+    | "Bind", [ binder; opt ] -> Options.bind com ctx r t isStruct binder opt |> Some
+    | "Filter", [ predicate; opt ] -> Options.filter com ctx r isStruct predicate opt |> Some
     | "ToArray", [ arg ] -> toArray r t arg |> Some
     | "ToList", [ arg ] ->
         let args = args |> List.replaceLast (toArray None t)
@@ -2454,32 +2450,11 @@ let optionModule isStruct (com: ICompiler) (ctx: Context) r (t: Type) (i: CallIn
         )
         |> Some
     | "DefaultValue", _ -> Helper.LibCall(com, "Option", "defaultArg", t, List.rev args, ?loc = r) |> Some
-    | "DefaultWith", _ ->
-        Helper.LibCall(
-            com,
-            "Option",
-            "defaultArgWith",
-            t,
-            List.rev args,
-            List.rev i.SignatureArgTypes,
-            genArgs = i.GenericArgs,
-            ?loc = r
-        )
-        |> Some
+    | "DefaultWith", [ defThunk; opt ] -> Options.defaultWith com ctx r t defThunk opt |> Some
     | "OrElse", _ -> Helper.LibCall(com, "Option", "orElse", t, List.rev args, ?loc = r) |> Some
-    | "OrElseWith", _ ->
-        Helper.LibCall(
-            com,
-            "Option",
-            "orElseWith",
-            t,
-            List.rev args,
-            List.rev i.SignatureArgTypes,
-            genArgs = i.GenericArgs,
-            ?loc = r
-        )
-        |> Some
-    | ("Count" | "Contains" | "Exists" | "Fold" | "ForAll" | "Iterate" as meth), _ ->
+    | "OrElseWith", [ ifNoneThunk; opt ] -> Options.orElseWith com ctx r t ifNoneThunk opt |> Some
+    | "Iterate", [ action; opt ] -> Options.iterate com ctx r t action opt |> Some
+    | ("Count" | "Contains" | "Exists" | "Fold" | "ForAll" as meth), _ ->
         let meth = Naming.lowerFirst meth
         let args = args |> List.replaceLast (toArray None t)
         let args = injectArg com ctx r "Seq" meth i.GenericArgs args

--- a/src/Fable.Transforms/Replacements.fs
+++ b/src/Fable.Transforms/Replacements.fs
@@ -2428,9 +2428,9 @@ let optionModule isStruct (com: ICompiler) (ctx: Context) r (t: Type) (i: CallIn
     | "Flatten", args ->
         Helper.LibCall(com, "Option", "flatten", t, args, i.SignatureArgTypes, genArgs = i.GenericArgs, ?loc = r)
         |> Some
-    | "Map", [ mapping; opt ] -> Options.map com ctx r isStruct mapping opt |> Some
-    | "Map2", [ mapping; opt1; opt2 ] -> Options.map2 com ctx r isStruct mapping opt1 opt2 |> Some
-    | "Map3", [ mapping; opt1; opt2; opt3 ] -> Options.map3 com ctx r isStruct mapping opt1 opt2 opt3 |> Some
+    | "Map", [ mapping; opt ] -> Options.map com ctx r t isStruct mapping opt |> Some
+    | "Map2", [ mapping; opt1; opt2 ] -> Options.map2 com ctx r t isStruct mapping opt1 opt2 |> Some
+    | "Map3", [ mapping; opt1; opt2; opt3 ] -> Options.map3 com ctx r t isStruct mapping opt1 opt2 opt3 |> Some
     | "Bind", [ binder; opt ] -> Options.bind com ctx r t isStruct binder opt |> Some
     | "Filter", [ predicate; opt ] -> Options.filter com ctx r isStruct predicate opt |> Some
     | "ToArray", [ arg ] -> toArray r t arg |> Some

--- a/src/fable-library-ts/Option.ts
+++ b/src/fable-library-ts/Option.ts
@@ -102,8 +102,7 @@ export function orElse<T>(opt: Option<T>, ifNone: Option<T>): Option<T> {
   return opt == null ? ifNone : opt;
 }
 
-// Only used by Replacements.Util.fs's curry/uncurry helpers, not by the F# `Option.map`
-// replacement itself (that one builds AST directly, see `Replacements.Util.fs`'s `Options` module).
+// Only used by Replacements.Util.fs's curry/uncurry helpers, not by `Option.map` itself.
 export function map<T, U>(mapping: (arg: T) => U, opt: Option<T>): Option<U> {
   return (opt != null) ? some(mapping(value(opt))) : undefined;
 }

--- a/src/fable-library-ts/Option.ts
+++ b/src/fable-library-ts/Option.ts
@@ -98,40 +98,14 @@ export function defaultArg<T>(opt: Option<T>, defaultValue: T): T {
   return (opt != null) ? value(opt) : defaultValue;
 }
 
-export function defaultArgWith<T>(opt: Option<T>, defThunk: () => T): T {
-  return (opt != null) ? value(opt) : defThunk();
-}
-
 export function orElse<T>(opt: Option<T>, ifNone: Option<T>): Option<T> {
   return opt == null ? ifNone : opt;
 }
 
-export function orElseWith<T>(opt: Option<T>, ifNoneThunk: () => Option<T>): Option<T> {
-  return opt == null ? ifNoneThunk() : opt;
-}
-
-export function filter<T>(predicate: (arg: T) => boolean, opt: Option<T>): Option<T> {
-  return (opt != null) ? (predicate(value(opt)) ? opt : undefined) : opt;
-}
-
+// Only used by Replacements.Util.fs's curry/uncurry helpers, not by the F# `Option.map`
+// replacement itself (that one builds AST directly, see `Replacements.Util.fs`'s `Options` module).
 export function map<T, U>(mapping: (arg: T) => U, opt: Option<T>): Option<U> {
   return (opt != null) ? some(mapping(value(opt))) : undefined;
-}
-
-export function map2<T1, T2, U>(
-  mapping: (arg1: T1, arg2: T2) => Option<U>,
-  opt1: Option<T1>, opt2: Option<T2>): Option<U> {
-  return (opt1 != null && opt2 != null) ? mapping(value(opt1), value(opt2)) : undefined;
-}
-
-export function map3<T1, T2, T3, U>(
-  mapping: (arg1: T1, arg2: T2, arg3: T3) => Option<U>,
-  opt1: Option<T1>, opt2: Option<T2>, opt3: Option<T3>): Option<U> {
-  return (opt1 != null && opt2 != null && opt3 != null) ? mapping(value(opt1), value(opt2), value(opt3)) : undefined;
-}
-
-export function bind<T, U>(binder: (arg: T) => Option<U>, opt: Option<T>): Option<U> {
-  return opt != null ? binder(value(opt)) : undefined;
 }
 
 export function tryOp<T, U>(op: (x: T) => U, arg: T): Option<U> {

--- a/tests/Integration/Integration/data/optionInlining/OptionCombinators.fs
+++ b/tests/Integration/Integration/data/optionInlining/OptionCombinators.fs
@@ -1,9 +1,7 @@
 module OptionCombinators
 
-// Regression fixture: Option/ValueOption module functions that take a function argument
-// (Iterate, Map, Map2, Map3, Bind, Filter, DefaultWith, OrElseWith) must apply that
-// argument directly - not via a lib call - so a lambda literal beta-reduces away instead
-// of allocating a closure. See `Options` in Fable.Transforms/Replacements.Util.fs.
+// Regression fixture: a lambda passed to these Option/ValueOption functions must beta-reduce
+// away, not allocate a closure. See `Options` in Fable.Transforms/Replacements.Util.fs.
 
 let iter (opt: int option) (log: int -> unit) =
     opt |> Option.iter (fun x -> log x)

--- a/tests/Integration/Integration/data/optionInlining/OptionCombinators.fs
+++ b/tests/Integration/Integration/data/optionInlining/OptionCombinators.fs
@@ -1,0 +1,33 @@
+module OptionCombinators
+
+// Regression fixture: Option/ValueOption module functions that take a function argument
+// (Iterate, Map, Map2, Map3, Bind, Filter, DefaultWith, OrElseWith) must apply that
+// argument directly - not via a lib call - so a lambda literal beta-reduces away instead
+// of allocating a closure. See `Options` in Fable.Transforms/Replacements.Util.fs.
+
+let iter (opt: int option) (log: int -> unit) =
+    opt |> Option.iter (fun x -> log x)
+
+let map (opt: int option) =
+    opt |> Option.map (fun x -> x + 1)
+
+let map2 (opt1: int option) (opt2: int option) =
+    (opt1, opt2) ||> Option.map2 (fun a b -> a + b)
+
+let map3 (opt1: int option) (opt2: int option) (opt3: int option) =
+    (opt1, opt2, opt3) |||> Option.map3 (fun a b c -> a + b + c)
+
+let bind (opt: int option) =
+    opt |> Option.bind (fun x -> Some(x + 1))
+
+let filter (opt: int option) =
+    opt |> Option.filter (fun x -> x > 0)
+
+let defaultWith (opt: int option) =
+    opt |> Option.defaultWith (fun () -> 1)
+
+let orElseWith (opt: int option) =
+    opt |> Option.orElseWith (fun () -> Some 1)
+
+let valueOptionIter (opt: int voption) (log: int -> unit) =
+    opt |> ValueOption.iter (fun x -> log x)

--- a/tests/Integration/Integration/data/optionInlining/OptionCombinators.jsx.expected
+++ b/tests/Integration/Integration/data/optionInlining/OptionCombinators.jsx.expected
@@ -1,0 +1,109 @@
+
+
+export function iter(opt, log) {
+    const option_1 = opt;
+    if (option_1 != null) {
+        log(option_1);
+    }
+}
+
+export function map(opt) {
+    const option_1 = opt;
+    if (option_1 != null) {
+        return option_1 + 1;
+    }
+    else {
+        return undefined;
+    }
+}
+
+export function map2(opt1, opt2) {
+    const option1 = opt1;
+    const option2 = opt2;
+    if (option1 != null) {
+        if (option2 != null) {
+            return option1 + option2;
+        }
+        else {
+            return undefined;
+        }
+    }
+    else {
+        return undefined;
+    }
+}
+
+export function map3(opt1, opt2, opt3) {
+    const option1 = opt1;
+    const option2 = opt2;
+    const option3 = opt3;
+    if (option1 != null) {
+        if (option2 != null) {
+            if (option3 != null) {
+                return (option1 + option2) + option3;
+            }
+            else {
+                return undefined;
+            }
+        }
+        else {
+            return undefined;
+        }
+    }
+    else {
+        return undefined;
+    }
+}
+
+export function bind(opt) {
+    const option_1 = opt;
+    if (option_1 != null) {
+        return option_1 + 1;
+    }
+    else {
+        return undefined;
+    }
+}
+
+export function filter(opt) {
+    const option_1 = opt;
+    if (option_1 != null) {
+        if (option_1 > 0) {
+            return option_1;
+        }
+        else {
+            return undefined;
+        }
+    }
+    else {
+        return undefined;
+    }
+}
+
+export function defaultWith(opt) {
+    const option_1 = opt;
+    if (option_1 != null) {
+        return option_1 | 0;
+    }
+    else {
+        return 1;
+    }
+}
+
+export function orElseWith(opt) {
+    const option_1 = opt;
+    if (option_1 != null) {
+        return option_1;
+    }
+    else {
+        return 1;
+    }
+}
+
+export function valueOptionIter(opt, log) {
+    const option = opt;
+    if (option != null) {
+        log(option);
+    }
+}
+

--- a/tests/Integration/Integration/data/optionInlining/optionInlining.fsproj
+++ b/tests/Integration/Integration/data/optionInlining/optionInlining.fsproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RollForward>Major</RollForward>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="OptionCombinators.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Fable.Core" Version="4.5.0" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Js/Main/OptionTests.fs
+++ b/tests/Js/Main/OptionTests.fs
@@ -113,6 +113,17 @@ let tests =
         getOnlyOnce() |> Option.iter (fun s -> if s = "Hello" then res <- true)
         equal true res
 
+    testCase "Option.iter doesn't call the action for None" <| fun () ->
+        let mutable calls = 0
+        None |> Option.iter (fun (_: int) -> calls <- calls + 1)
+        equal 0 calls
+
+    testCase "ValueOption.iter works" <| fun () ->
+        let mutable calls = 0
+        ValueSome 5 |> ValueOption.iter (fun x -> calls <- calls + x)
+        ValueNone |> ValueOption.iter (fun (x: int) -> calls <- calls + x)
+        equal 5 calls
+
     testCase "Option.map works" <| fun () ->
         let getOnlyOnce =
             let mutable value = Some "Alfonso"
@@ -125,6 +136,14 @@ let tests =
         (None, Some 3) ||> Option.map2 (+) |> equal None
         (Some 2, None) ||> Option.map2 (+) |> equal None
 
+    testCase "Option.map2 doesn't double-evaluate its option arguments" <| fun () ->
+        let mutable calls = 0
+        let getOnlyOnce x () =
+            calls <- calls + 1
+            Some x
+        (getOnlyOnce 2 (), getOnlyOnce 3 ()) ||> Option.map2 (+) |> equal (Some 5)
+        equal 2 calls
+
     testCase "Option.map3 works" <| fun () ->
         (Some 2, Some 3, Some 4) |||> Option.map3 (fun x y z -> x + y + z) |> equal (Some 9)
         (None, Some 3, Some 4) |||> Option.map3 (fun x y z -> x + y + z) |> equal None
@@ -136,6 +155,27 @@ let tests =
             let mutable value = Some "Alfonso"
             fun () -> match value with Some x -> value <- None; Some x | None -> None
         getOnlyOnce() |> Option.bind ((+) "Hello " >> Some) |> equal (Some "Hello Alfonso")
+
+    testCase "Option.map/map2/map3/bind/filter with nested options work" <| fun () ->
+        Some(Some 5) |> Option.map (fun inner -> inner) |> equal (Some(Some 5))
+        Some(None: int option) |> Option.map (fun inner -> inner) |> equal (Some None)
+        (Some(Some 2), Some(Some 3)) ||> Option.map2 (fun a b -> (a, b)) |> equal (Some(Some 2, Some 3))
+        (Some(Some 1), Some(Some 2), Some(Some 3)) |||> Option.map3 (fun a b c -> (a, b, c)) |> equal (Some(Some 1, Some 2, Some 3))
+        Some(Some 5) |> Option.bind (fun inner -> Some inner) |> equal (Some(Some 5))
+        Some(Some 5) |> Option.filter Option.isSome |> equal (Some(Some 5))
+
+    testCase "ValueOption.map/map2/map3/bind/filter/defaultWith/orElseWith work" <| fun () ->
+        ValueSome 5 |> ValueOption.map (fun x -> x + 1) |> equal (ValueSome 6)
+        ValueNone |> ValueOption.map (fun (x: int) -> x + 1) |> equal ValueNone
+        (ValueSome 2, ValueSome 3) ||> ValueOption.map2 (+) |> equal (ValueSome 5)
+        (ValueSome 2, ValueNone, ValueSome 4) |||> ValueOption.map3 (fun x y z -> x + y + z) |> equal ValueNone
+        ValueSome 5 |> ValueOption.bind (fun x -> ValueSome(x + 1)) |> equal (ValueSome 6)
+        ValueSome 5 |> ValueOption.filter (fun x -> x > 0) |> equal (ValueSome 5)
+        ValueSome 5 |> ValueOption.filter (fun x -> x < 0) |> equal ValueNone
+        ValueSome 5 |> ValueOption.defaultWith (fun () -> 1) |> equal 5
+        ValueNone |> ValueOption.defaultWith (fun () -> 1) |> equal 1
+        ValueSome 5 |> ValueOption.orElseWith (fun () -> ValueSome 1) |> equal (ValueSome 5)
+        ValueNone |> ValueOption.orElseWith (fun () -> ValueSome 1) |> equal (ValueSome 1)
 
     testCase "Option.contains works" <| fun () ->
         Some "test" |> Option.contains "test" |> equal true
@@ -151,6 +191,14 @@ let tests =
         Some 7 |> Option.filter (fun _ -> true)  |> Option.map string |> optionToString |> equal "Some 7"
         Some "A" |> Option.filter (fun _ -> false) |> optionToString |> equal "None"
         Some "A" |> Option.filter (fun _ -> true) |> optionToString |> equal "Some A"
+
+    testCase "Option.filter doesn't double-evaluate a side-effecting option expr" <| fun () ->
+        let mutable calls = 0
+        let getOnlyOnce () =
+            calls <- calls + 1
+            Some 5
+        getOnlyOnce () |> Option.filter (fun x -> x > 0) |> equal (Some 5)
+        equal 1 calls
 
     testCase "Option.fold works" <| fun () ->
         (5, None) ||> Option.fold (*) |> equal 5

--- a/tests/Js/Main/OptionTests.fs
+++ b/tests/Js/Main/OptionTests.fs
@@ -118,6 +118,23 @@ let tests =
         None |> Option.iter (fun (_: int) -> calls <- calls + 1)
         equal 0 calls
 
+    // Function arguments are evaluated eagerly, exactly once - only *invoking* them is
+    // conditional on Some/None.
+    testCase "Option.iter/defaultWith evaluate their function-producing argument exactly once, even on the branch that never calls it" <| fun () ->
+        let mutable calls = 0
+        let getAction () =
+            calls <- calls + 1
+            fun (_: int) -> ()
+        (None: int option) |> Option.iter (getAction ())
+        equal 1 calls
+
+        calls <- 0
+        let getThunk () =
+            calls <- calls + 1
+            fun () -> 1
+        Some 5 |> Option.defaultWith (getThunk ()) |> ignore
+        equal 1 calls
+
     testCase "ValueOption.iter works" <| fun () ->
         let mutable calls = 0
         ValueSome 5 |> ValueOption.iter (fun x -> calls <- calls + x)

--- a/tests/Python/TestOption.fs
+++ b/tests/Python/TestOption.fs
@@ -117,6 +117,19 @@ let ``test Option.iter works`` () =
     equal true res
 
 [<Fact>]
+let ``test Option.iter doesn't call the action for None`` () =
+    let mutable calls = 0
+    None |> Option.iter (fun (_: int) -> calls <- calls + 1)
+    equal 0 calls
+
+[<Fact>]
+let ``test ValueOption.iter works`` () =
+    let mutable calls = 0
+    ValueSome 5 |> ValueOption.iter (fun x -> calls <- calls + x)
+    ValueNone |> ValueOption.iter (fun (x: int) -> calls <- calls + x)
+    equal 5 calls
+
+[<Fact>]
 let ``test Option.map works`` () =
     let getOnlyOnce =
         let mutable value = Some "Alfonso"
@@ -131,6 +144,15 @@ let ``test Option.map2 works`` () =
     (Some 2, None) ||> Option.map2 (+) |> equal None
 
 [<Fact>]
+let ``test Option.map2 doesn't double-evaluate its option arguments`` () =
+    let mutable calls = 0
+    let getOnlyOnce x () =
+        calls <- calls + 1
+        Some x
+    (getOnlyOnce 2 (), getOnlyOnce 3 ()) ||> Option.map2 (+) |> equal (Some 5)
+    equal 2 calls
+
+[<Fact>]
 let ``test Option.map3 works`` () =
     (Some 2, Some 3, Some 4) |||> Option.map3 (fun x y z -> x + y + z) |> equal (Some 9)
     (None, Some 3, Some 4) |||> Option.map3 (fun x y z -> x + y + z) |> equal None
@@ -143,6 +165,29 @@ let ``test Option.bind works`` () =
         let mutable value = Some "Alfonso"
         fun () -> match value with Some x -> value <- None; Some x | None -> None
     getOnlyOnce() |> Option.bind ((+) "Hello " >> Some) |> equal (Some "Hello Alfonso")
+
+[<Fact>]
+let ``test Option.map/map2/map3/bind/filter with nested options work`` () =
+    Some(Some 5) |> Option.map (fun inner -> inner) |> equal (Some(Some 5))
+    Some(None: int option) |> Option.map (fun inner -> inner) |> equal (Some None)
+    (Some(Some 2), Some(Some 3)) ||> Option.map2 (fun a b -> (a, b)) |> equal (Some(Some 2, Some 3))
+    (Some(Some 1), Some(Some 2), Some(Some 3)) |||> Option.map3 (fun a b c -> (a, b, c)) |> equal (Some(Some 1, Some 2, Some 3))
+    Some(Some 5) |> Option.bind (fun inner -> Some inner) |> equal (Some(Some 5))
+    Some(Some 5) |> Option.filter Option.isSome |> equal (Some(Some 5))
+
+[<Fact>]
+let ``test ValueOption.map/map2/map3/bind/filter/defaultWith/orElseWith work`` () =
+    ValueSome 5 |> ValueOption.map (fun x -> x + 1) |> equal (ValueSome 6)
+    ValueNone |> ValueOption.map (fun (x: int) -> x + 1) |> equal ValueNone
+    (ValueSome 2, ValueSome 3) ||> ValueOption.map2 (+) |> equal (ValueSome 5)
+    (ValueSome 2, ValueNone, ValueSome 4) |||> ValueOption.map3 (fun x y z -> x + y + z) |> equal ValueNone
+    ValueSome 5 |> ValueOption.bind (fun x -> ValueSome(x + 1)) |> equal (ValueSome 6)
+    ValueSome 5 |> ValueOption.filter (fun x -> x > 0) |> equal (ValueSome 5)
+    ValueSome 5 |> ValueOption.filter (fun x -> x < 0) |> equal ValueNone
+    ValueSome 5 |> ValueOption.defaultWith (fun () -> 1) |> equal 5
+    ValueNone |> ValueOption.defaultWith (fun () -> 1) |> equal 1
+    ValueSome 5 |> ValueOption.orElseWith (fun () -> ValueSome 1) |> equal (ValueSome 5)
+    ValueNone |> ValueOption.orElseWith (fun () -> ValueSome 1) |> equal (ValueSome 1)
 
 [<Fact>]
 let ``test Option.contains works`` () =
@@ -160,6 +205,15 @@ let ``test Option.filter works`` () =
     Some 7 |> Option.filter (fun _ -> true)  |> Option.map string |> optionToString |> equal "Some 7"
     Some "A" |> Option.filter (fun _ -> false) |> optionToString |> equal "None"
     Some "A" |> Option.filter (fun _ -> true) |> optionToString |> equal "Some A"
+
+[<Fact>]
+let ``test Option.filter doesn't double-evaluate a side-effecting option expr`` () =
+    let mutable calls = 0
+    let getOnlyOnce () =
+        calls <- calls + 1
+        Some 5
+    getOnlyOnce () |> Option.filter (fun x -> x > 0) |> equal (Some 5)
+    equal 1 calls
 
 [<Fact>]
 let ``test Option.fold works`` () =

--- a/tests/Python/TestOption.fs
+++ b/tests/Python/TestOption.fs
@@ -123,6 +123,22 @@ let ``test Option.iter doesn't call the action for None`` () =
     equal 0 calls
 
 [<Fact>]
+let ``test Option.iter/defaultWith evaluate their function-producing argument exactly once, even on the branch that never calls it`` () =
+    let mutable calls = 0
+    let getAction () =
+        calls <- calls + 1
+        fun (_: int) -> ()
+    (None: int option) |> Option.iter (getAction ())
+    equal 1 calls
+
+    calls <- 0
+    let getThunk () =
+        calls <- calls + 1
+        fun () -> 1
+    Some 5 |> Option.defaultWith (getThunk ()) |> ignore
+    equal 1 calls
+
+[<Fact>]
 let ``test ValueOption.iter works`` () =
     let mutable calls = 0
     ValueSome 5 |> ValueOption.iter (fun x -> calls <- calls + x)


### PR DESCRIPTION
By building the replacement using AST directly, we allow the code to be candidate to `InlineIfLambda` which improves performances and can be critical for some library chasing that path.