### PR TITLE
chore(beam): fix flaky Async.StartChild concurrency test

### DIFF
--- a/tests/Beam/AsyncTests.fs
+++ b/tests/Beam/AsyncTests.fs
@@ -101,10 +101,14 @@ let ``test Async.StartChild works`` () =
 
 [<Fact>]
 let ``test Async.StartChild runs children concurrently`` () =
-    // Each child sleeps 300ms. Started before either is awaited, they run in
-    // parallel (separate BEAM processes), so total time is ~300ms, not ~600ms.
+    // Each child sleeps 500ms. Started before either is awaited, they run in
+    // parallel (separate BEAM processes), so total time is ~500ms, not ~1000ms.
+    // The threshold sits at the midpoint (750ms) with a wide margin on both
+    // sides so process-scheduling overhead on a loaded CI runner cannot turn a
+    // genuinely-concurrent run into a false failure, while a regression to
+    // sequential execution (~1000ms) is still caught.
     let sleeper n = async {
-        do! Async.Sleep 300
+        do! Async.Sleep 500
         return n
     }
     let comp = async {
@@ -118,7 +122,7 @@ let ``test Async.StartChild runs children concurrently`` () =
     }
     let sum, elapsed = Async.RunSynchronously comp
     equal 3 sum
-    (elapsed < 500L) |> equal true
+    (elapsed < 750L) |> equal true
 
 [<Fact>]
 let ``test Async.StartChild applies timeout`` () =


### PR DESCRIPTION
## Problem

`Fable.Tests.AsyncTests.test Async.StartChild runs children concurrently` has been failing intermittently across BEAM CI builds (e.g. [this run](https://github.com/fable-compiler/Fable/actions/runs/29897812702/job/88851603019)):

```
Failed Fable.Tests.AsyncTests.test Async.StartChild runs children concurrently
Expected: True / Actual: False   at AsyncTests.fs:line 121
```

It's a flaky timing test, not a real regression — neither the test nor the `StartChild` implementation (added in #4760) changed recently. The test starts two children that each `Async.Sleep 300`, then asserts total `elapsed < 500L` to prove concurrency (~300ms concurrent vs ~600ms sequential). That threshold left only **200ms of slack** above the concurrent sleep, which BEAM process spawn + async trampoline scheduling overhead on a loaded CI runner can exceed.

## Fix

Bump each child's sleep to 500ms and the threshold to 750ms — the midpoint between the ~500ms concurrent and ~1000ms sequential times. Increasing the absolute sleep duration widens the margin on both sides (overhead is roughly constant): ~250ms of overhead tolerance for a genuinely-concurrent run, and ~250ms of margin to still catch a regression to sequential execution.

This test is BEAM-specific; other targets test `StartChild` functionally without a timing assertion, so nothing else changed.

## Verification

Both the .NET suite (`Passed! 2629`) and the transpiled BEAM run (`PASS ...runs_children_concurrently`) pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)