### PR TITLE
chore: ignore Babel major bumps in tests/React

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -85,6 +85,12 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "react-dom"
         update-types: ["version-update:semver-major"]
+      # Babel 8 plugins require @babel/core@^8, but jest still pulls in
+      # @babel/core@7.x transitively — upgrading them independently breaks
+      # npm install (peer conflict). Move the whole toolchain to Babel 8
+      # manually when jest supports it.
+      - dependency-name: "@babel/*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "cargo"
     directory: "/src/fable-library-rust"


### PR DESCRIPTION
## Problem

Dependabot PR #4830 broke the `build-javascript` CI job with an `npm ci` ERESOLVE failure. It grouped two **Babel 8** major bumps into `/tests/React`:

- `@babel/plugin-transform-modules-commonjs`: 7.29.7 → 8.0.1
- `@babel/plugin-transform-react-jsx`: 7.29.7 → 8.0.1

Both v8 plugins declare `peer @babel/core@^8.0.0`, but `@babel/core` is only present transitively via **jest 30** (`babel-jest → babel-preset-jest → …`), which is pinned to `@babel/core@7.29.0`. npm can't satisfy `^8` and `^7` at once, so the install aborts.

The Babel plugins can't be upgraded to v8 independently — the whole Babel graph (including jest's transitive `@babel/core`) has to move together.

## Fix

Add an ignore rule for `@babel/*` semver-major bumps in the `/tests/React` npm ecosystem, mirroring the existing `react`/`react-dom`/`typescript` major-hold rules. When jest supports Babel 8, we move the toolchain manually.

Closes #4830.

🤖 Generated with [Claude Code](https://claude.com/claude-code)