### PR TITLE
chore(beam): make Async.StartChild concurrency test load-relative

### DIFF
--- a/tests/Beam/AsyncTests.fs
+++ b/tests/Beam/AsyncTests.fs
@@ -101,17 +101,24 @@ let ``test Async.StartChild works`` () =
 
 [<Fact>]
 let ``test Async.StartChild runs children concurrently`` () =
-    // Each child sleeps 500ms. Started before either is awaited, they run in
-    // parallel (separate BEAM processes), so total time is ~500ms, not ~1000ms.
-    // The threshold sits at the midpoint (750ms) with a wide margin on both
-    // sides so process-scheduling overhead on a loaded CI runner cannot turn a
-    // genuinely-concurrent run into a false failure, while a regression to
-    // sequential execution (~1000ms) is still caught.
+    // Prove concurrency by *comparing* the same work run concurrently against
+    // sequentially on the same runner, rather than checking wall-clock against
+    // an absolute threshold. An absolute bound is inherently flaky: BEAM
+    // process-spawn plus async-trampoline overhead on a loaded CI runner is
+    // unbounded, so any fixed threshold eventually fails a genuinely-concurrent
+    // run. Here both runs pay the same overhead, so the ~500ms saved by real
+    // concurrency (one 500ms sleep instead of two) dominates scheduling jitter.
+    //
+    // Note: unlike JS/Python, the BEAM children run in *separate processes*
+    // (see fable_async:start_child), so the shared-mutable-state ordering test
+    // those targets use cannot observe concurrency here — timing is the only
+    // signal available.
     let sleeper n = async {
         do! Async.Sleep 500
         return n
     }
-    let comp = async {
+    // Concurrent: both children started before either is awaited (~500ms).
+    let concurrent = async {
         let sw = System.Diagnostics.Stopwatch.StartNew()
         let! c1 = Async.StartChild(sleeper 1)
         let! c2 = Async.StartChild(sleeper 2)
@@ -120,9 +127,23 @@ let ``test Async.StartChild runs children concurrently`` () =
         sw.Stop()
         return r1 + r2, sw.ElapsedMilliseconds
     }
-    let sum, elapsed = Async.RunSynchronously comp
-    equal 3 sum
-    (elapsed < 750L) |> equal true
+    // Sequential: each child awaited to completion before the next starts (~1000ms).
+    let sequential = async {
+        let sw = System.Diagnostics.Stopwatch.StartNew()
+        let! c1 = Async.StartChild(sleeper 1)
+        let! r1 = c1
+        let! c2 = Async.StartChild(sleeper 2)
+        let! r2 = c2
+        sw.Stop()
+        return r1 + r2, sw.ElapsedMilliseconds
+    }
+    let sumC, elapsedC = Async.RunSynchronously concurrent
+    let sumS, elapsedS = Async.RunSynchronously sequential
+    equal 3 sumC
+    equal 3 sumS
+    // The concurrent run must save at least half of the ~500ms overlap versus
+    // the sequential one; requiring only half leaves ample slack for jitter.
+    (elapsedC + 250L < elapsedS) |> equal true
 
 [<Fact>]
 let ``test Async.StartChild applies timeout`` () =


### PR DESCRIPTION
## Problem

`Fable.Tests.AsyncTests.test Async.StartChild runs children concurrently` is **still flaking on `main`** after #4841 ([failing run](https://github.com/fable-compiler/Fable/actions/runs/30024848489/job/89266563646)):

```
Failed Fable.Tests.AsyncTests.test Async.StartChild runs children concurrently
Expected: True / Actual: False   at AsyncTests.fs:line 125
```

The failure line moved 121→125, confirming #4841's threshold bump (500→750ms) **is** in the run — it just delayed the next flake rather than fixing it.

The root cause is structural, not a matter of picking a bigger number: the test asserts wall-clock against an **absolute** bound (`elapsed < 750`). BEAM process-spawn plus async-trampoline scheduling overhead on a loaded CI runner is **unbounded**, so *any* fixed threshold eventually fails a genuinely-concurrent run.

Timing is used here (unlike JS/Python, which prove concurrency via shared-mutable-state ordering) because BEAM's `start_child` runs each child in a **separate spawned process** (`fable_async.erl` `start_child/2`) — mutations in the child's heap aren't visible to the parent, so the ordering trick can't observe concurrency on BEAM.

## Fix

Replace the absolute check with a **relative** comparison — the same two-child workload run both ways on the same runner:

- **Concurrent** (both started before either is awaited) ≈ 500ms
- **Sequential** (each awaited to completion before the next starts) ≈ 1000ms
- Assert `elapsedC + 250 < elapsedS`

Both runs pay identical spawn/scheduling overhead, so the ~500ms saved by real concurrency dominates jitter, and the 250ms margin is a *relative* swing between two adjacent runs — far less likely than the old absolute overspend. A regression to sequential execution is still caught (the gap collapses).

## Verification

Both suites pass locally:
- .NET: `Passed! - Failed: 0, Passed: 2629`
- Transpiled BEAM: `PASS ...test_async_start_child_runs_children_concurrently`

🤖 Generated with [Claude Code](https://claude.com/claude-code)