### PR TITLE
fix(beam): make reflection metadata agree with record/union codegen

### DIFF
--- a/src/Fable.Transforms/Beam/Fable2Beam.Reflection.fs
+++ b/src/Fable.Transforms/Beam/Fable2Beam.Reflection.fs
@@ -54,8 +54,12 @@ let reflectionGenArgVar (index: int) = $"Gen%d{index}"
 /// `name` is the F# field name, which is what `PropertyInfo.Name` must report; `erl_name` is the
 /// sanitized name the field is actually keyed by in the record map. Same split as the `name` /
 /// `erl_tag` pair on union case infos.
+///
+/// `erl_name` must be derived with the very same function `NewRecord` codegen keys the map with
+/// (`sanitizeFieldName`) — `sanitizeErlangName` trims the trailing underscore that disambiguates
+/// lowercase-first names, so `{ alpha: string }` would be written as `alpha_` but read as `alpha`.
 let private makePropertyInfo (fieldName: string) (typeInfo: Beam.ErlExpr) =
-    let erlName = Fable.Beam.Naming.sanitizeErlangName fieldName
+    let erlName = Fable.Beam.Naming.sanitizeFieldName fieldName
 
     Beam.ErlExpr.Map
         [
@@ -65,8 +69,11 @@ let private makePropertyInfo (fieldName: string) (typeInfo: Beam.ErlExpr) =
         ]
 
 /// Build a CaseInfo map: #{tag => N, name => <<"CaseName">>, erl_tag => case_name, fields => [...]}
-let private makeCaseInfo (tag: int) (caseName: string) (fields: Beam.ErlExpr list) =
-    let erlTag = Fable.Beam.Naming.sanitizeErlangName caseName
+///
+/// `compiledName` is the case's `[<CompiledName>]`, if any: the atom the constructor actually
+/// emits, which `erl_tag` has to match for `MakeUnion`/`GetUnionFields` to agree with codegen.
+let private makeCaseInfo (tag: int) (compiledName: string option) (caseName: string) (fields: Beam.ErlExpr list) =
+    let erlTag = Fable.Beam.Naming.unionCaseTagName compiledName caseName
 
     Beam.ErlExpr.Map
         [
@@ -304,7 +311,7 @@ and private makeCasesEntry com r genMap expanding (ent: Entity) =
                     makePropertyInfo fi.Name typeInfo
                 )
 
-            makeCaseInfo i uci.Name caseFields
+            makeCaseInfo i uci.CompiledName uci.Name caseFields
         )
 
     atomLit "cases", makeThunk cases

--- a/src/Fable.Transforms/Beam/Fable2Beam.fs
+++ b/src/Fable.Transforms/Beam/Fable2Beam.fs
@@ -139,10 +139,7 @@ let private getUnionCaseAtomExpr (com: IBeamCompiler) (ref: EntityRef) (tag: int
     | Some entity ->
         let uci = entity.UnionCases[tag]
 
-        let atomName =
-            match uci.CompiledName with
-            | Some name -> name
-            | None -> sanitizeErlangName uci.Name
+        let atomName = unionCaseTagName uci.CompiledName uci.Name
 
         let isFieldless = uci.UnionCaseFields.IsEmpty
         Some(atomName, isFieldless)
@@ -2174,10 +2171,7 @@ and transformReceive (com: IBeamCompiler) (ctx: Context) (emitInfo: EmitInfo) (t
                 entity.UnionCases
                 |> List.mapi (fun tag uci ->
                     // Determine atom tag: CompiledName if set, otherwise snake_case of Name
-                    let atomName =
-                        match uci.CompiledName with
-                        | Some name -> name
-                        | None -> sanitizeErlangName uci.Name
+                    let atomName = unionCaseTagName uci.CompiledName uci.Name
 
                     let fields = uci.UnionCaseFields
                     let fieldCount = fields.Length

--- a/src/Fable.Transforms/Beam/Prelude.fs
+++ b/src/Fable.Transforms/Beam/Prelude.fs
@@ -66,7 +66,10 @@ module Naming =
 
         sb.ToString()
 
-    let sanitizeErlangName (name: string) =
+    /// Drop the characters an F# name may carry that an unquoted Erlang atom cannot
+    /// (`base'`, `op_$0020`, `Foo.Bar`, ...). Every name that ends up as an atom has to go
+    /// through this, or the printer emits something like `'base'_'` — invalid Erlang.
+    let private stripNonAtomChars (name: string) =
         // Decode $XXXX hex sequences from F# compiled names (e.g. $0020 -> space -> _)
         Regex.Replace(
             name,
@@ -81,10 +84,21 @@ module Naming =
         )
         |> fun s ->
             s.Replace("'", "").Replace("$", "_").Replace("@", "").Replace(".", "_").Replace("`", "_").Replace("-", "_")
+
+    let sanitizeErlangName (name: string) =
+        stripNonAtomChars name
         |> toSnakeCase
         |> fun s -> Regex.Replace(s, "_+", "_")
         |> fun s -> s.Trim('_')
         |> checkErlKeywords
+
+    /// The atom a union case is tagged with at runtime: `[<CompiledName>]` verbatim when present,
+    /// otherwise the snake_cased case name. Codegen and the `erl_tag` in reflection metadata must
+    /// both go through this, or reflection looks up a tag the constructor never emitted.
+    let unionCaseTagName (compiledName: string option) (caseName: string) =
+        match compiledName with
+        | Some name -> name
+        | None -> sanitizeErlangName caseName
 
     let moduleNameFromFile (filePath: string) =
         Fable.Path.GetFileNameWithoutExtension(filePath)
@@ -467,8 +481,12 @@ module Naming =
     /// Convert a field name to a safe Erlang atom (snake_case + keyword escaping).
     /// camelCase names get a trailing '_' to avoid collision with PascalCase names
     /// (e.g., firstName -> first_name_, FirstName -> first_name).
+    ///
+    /// This is the single source of truth for the key a record/anonymous-record field is stored
+    /// under in the runtime map: both `NewRecord` codegen and the `erl_name` the reflection
+    /// metadata advertises must go through it, or reflection reads a key that was never written.
     let sanitizeFieldName (name: string) =
-        let snakeName = toSnakeCase name
+        let snakeName = stripNonAtomChars name |> toSnakeCase
 
         let disambiguated =
             if name.Length > 0 && System.Char.IsLower(name.[0]) then

--- a/src/fable-library-beam/fable_reflection.erl
+++ b/src/fable-library-beam/fable_reflection.erl
@@ -188,9 +188,17 @@ get_function_elements(TypeInfo) ->
 %% TypeInfo is injected by the compiler since Erlang maps don't preserve order.
 %% Fields are keyed in the record map by `erl_name`, the sanitized name; `name` holds the
 %% F# name that PropertyInfo.Name reports and is not a valid key.
+%% A record map carries no type tag, so the compiler can only inject a usable TypeInfo when the
+%% argument's static type is the record type. Passing a plain `obj` (the result of MakeRecord, say)
+%% yields the TypeInfo for System.Object, which has no `fields` — report that rather than letting
+%% the lookup fail as an opaque {badkey,fields}.
 get_record_fields_value(Record, TypeInfo) ->
-    Fields = force(maps:get(fields, TypeInfo)),
-    [maps:get(maps:get(erl_name, F), Record) || F <- Fields].
+    case maps:find(fields, TypeInfo) of
+        {ok, Thunk} ->
+            [maps:get(maps:get(erl_name, F), Record) || F <- force(Thunk)];
+        error ->
+            erlang:error({record_type_unknown_at_compile_time, maps:get(fullname, TypeInfo, undefined)})
+    end.
 
 %% FSharpValue.GetRecordField(record, propertyInfo) — get single field value.
 get_record_field_value(Record, PropInfo) ->

--- a/tests/Beam/ReflectionTests.fs
+++ b/tests/Beam/ReflectionTests.fs
@@ -752,3 +752,117 @@ let ``test reflection over a record with an erased field from another file works
     |> equal true
 
     fields.[1].PropertyType |> equal typeof<string>
+
+// === Value-level reflection over non-PascalCase field names ===
+// Beam keys a record map with `sanitizeFieldName`, which appends a trailing `_` to lowercase-first
+// names so `firstName` and `FirstName` can coexist as atoms. The reflection metadata used to derive
+// `erl_name` with `sanitizeErlangName`, which strips that underscore — so a lowercase-first field
+// was written as `alpha_` but read back as `alpha`. Every reflection test above uses PascalCase
+// fields, which is exactly why the split went unnoticed.
+
+type LowerFirstRecord = { alpha: string; beta: int }
+
+type KeywordRecord = { end_: int; fun_: int }
+
+type CaseCollidingRecord = { name: string; Name: string }
+
+type AsyncApi =
+    {
+        getNumbers: unit -> Async<int list>
+        greet: string -> Async<string>
+    }
+
+[<Fact>]
+let ``test GetRecordFields works with lowercase-first field names`` () =
+    let record = { alpha = "a"; beta = 1 }
+    FSharpValue.GetRecordFields record |> equal [| box "a"; box 1 |]
+
+[<Fact>]
+let ``test PropertyInfo.GetValue works with lowercase-first field names`` () =
+    let record = { alpha = "a"; beta = 1 }
+    let fields = FSharpType.GetRecordFields typeof<LowerFirstRecord>
+    fields.[0].GetValue(box record) |> equal (box "a")
+    fields.[1].GetValue(box record) |> equal (box 1)
+    FSharpValue.GetRecordField(record, fields.[0]) |> equal (box "a")
+
+[<Fact>]
+let ``test MakeRecord with lowercase-first field names is readable by the compiled accessor`` () =
+    // Reading the result back through `r.alpha` (not through reflection) is what catches the
+    // silent-corruption direction: MakeRecord keying the map by a name codegen never writes.
+    let built =
+        FSharpValue.MakeRecord(typeof<LowerFirstRecord>, [| box "a"; box 1 |])
+        |> unbox<LowerFirstRecord>
+
+    built.alpha |> equal "a"
+    built.beta |> equal 1
+    built |> equal { alpha = "a"; beta = 1 }
+
+[<Fact>]
+let ``test reflection round-trips a record with Erlang keyword field names`` () =
+    let record = { end_ = 1; fun_ = 2 }
+    let values = FSharpValue.GetRecordFields record
+    values |> equal [| box 1; box 2 |]
+
+    let built = FSharpValue.MakeRecord(typeof<KeywordRecord>, values) |> unbox<KeywordRecord>
+    built.end_ |> equal 1
+    built.fun_ |> equal 2
+
+[<Fact>]
+let ``test reflection keeps camelCase and PascalCase fields distinct`` () =
+    let record = { name = "lower"; Name = "upper" }
+    let values = FSharpValue.GetRecordFields record
+    values |> equal [| box "lower"; box "upper" |]
+
+    let built =
+        FSharpValue.MakeRecord(typeof<CaseCollidingRecord>, values)
+        |> unbox<CaseCollidingRecord>
+
+    built.name |> equal "lower"
+    built.Name |> equal "upper"
+
+[<Fact>]
+let ``test reflection reads camelCase fields holding async functions`` () =
+    // The shape a remoting API contract takes: a record of `... -> Async<'T>` fields, whose names
+    // are idiomatically camelCase, invoked through the PropertyInfo that reflection hands back.
+    let api =
+        {
+            getNumbers = fun () -> async { return [ 1; 2; 3 ] }
+            greet = fun name -> async { return "hi " + name }
+        }
+
+    let props = FSharpType.GetRecordFields typeof<AsyncApi>
+    props |> Array.map (fun p -> p.Name) |> equal [| "getNumbers"; "greet" |]
+
+    let greet =
+        (props |> Array.find (fun p -> p.Name = "greet")).GetValue(box api)
+        |> unbox<string -> Async<string>>
+
+    greet "bob" |> Async.RunSynchronously |> equal "hi bob"
+
+    let getNumbers =
+        (props |> Array.find (fun p -> p.Name = "getNumbers")).GetValue(box api)
+        |> unbox<unit -> Async<int list>>
+
+    getNumbers () |> Async.RunSynchronously |> equal [ 1; 2; 3 ]
+
+// === Union case tags declared with CompiledName ===
+// Codegen tags a case with its `[<CompiledName>]` verbatim; reflection's `erl_tag` used to always
+// snake_case the F# name, so MakeUnion built a tag the pattern matches never look for.
+
+type CompiledNameUnion =
+    | [<CompiledName("custom_tag")>] Renamed of int
+    | Plain of string
+
+[<Fact>]
+let ``test MakeUnion honours CompiledName on a union case`` () =
+    let cases = FSharpType.GetUnionCases typeof<CompiledNameUnion>
+    let renamed = cases |> Array.find (fun c -> c.Name = "Renamed")
+    let value = FSharpValue.MakeUnion(renamed, [| box 42 |]) |> unbox<CompiledNameUnion>
+
+    match value with
+    | Renamed i -> i |> equal 42
+    | Plain _ -> failwith "expected Renamed"
+
+    let case, fields = FSharpValue.GetUnionFields(box value, typeof<CompiledNameUnion>)
+    case.Name |> equal "Renamed"
+    fields |> equal [| box 42 |]


### PR DESCRIPTION
## The bug

Record construction and record reflection sanitized field names with **two different functions**, and they disagree for any record field whose F# name starts with a lowercase letter.

`NewRecord` keys the record map with `sanitizeFieldName`, which appends a trailing `_` to lowercase-first names so `firstName` and `FirstName` can coexist as atoms. `makePropertyInfo` derived `erl_name` — documented as "the sanitized name the field is actually keyed by in the record map" — with `sanitizeErlangName`, which trims exactly that underscore.

```fsharp
type Lower = { alpha: string; beta: int }
let l = { alpha = "a"; beta = 1 }

FSharpValue.GetRecordFields (box l)                              // {badkey,alpha}
(FSharpType.GetRecordFields typeof<Lower>).[0].GetValue (box l)  // {badkey,alpha}

// silent corruption: MakeRecord "succeeds", then explodes at the first field access
let built = FSharpValue.MakeRecord(typeof<Lower>, [| box "a"; box 1 |]) |> unbox<Lower>
built.alpha                                                      // {badkey,alpha_}
```

The two failures point in opposite directions, which confirms the split: `MakeRecord` builds `#{alpha => ...}` (reflection's name) while the compiled accessor reads `alpha_` (codegen's name). PascalCase fields are unaffected, since both functions then agree on `description`/`count` — which is why every existing reflection test, all of which use PascalCase fields, missed it.

The real-world shape that hits it on every field is a remoting-style API contract, whose fields are idiomatically camelCase:

```fsharp
type IServer =
    { getNumbers: unit -> Async<int list>
      greet: string -> Async<string> }
```

JS and Python are unaffected; only Beam.

## The fix

Derive `erl_name` with `sanitizeFieldName` — the same function codegen keys the map with — and document it as the single source of truth for record-map keys so the two cannot drift again.

Two further fixes fall out of that:

- **`sanitizeFieldName` was missing the character cleanup that `sanitizeErlangName` does.** A field named `` base' `` produced the atom `base'_`, printed as `'base'_'` — invalid Erlang, which broke compilation of the existing `PatternMatchTests`. This was already latent for any *record* with such a field, since codegen keyed the map with it too. The cleanup is now factored into `stripNonAtomChars` and both sanitizers route through it.

- **Union `erl_tag` ignored `[<CompiledName>]`.** Codegen tags a case with its `CompiledName` verbatim, but reflection always snake_cased the F# name, so `MakeUnion` built a tag no pattern match looks for. Both now go through a shared `unionCaseTagName`.

## Secondary

`FSharpValue.GetRecordFields` on a value whose type is not statically known (the `obj` returned by `MakeRecord`) still cannot work — a Beam record map carries no type tag, so no TypeInfo is recoverable at runtime — but it now reports `{record_type_unknown_at_compile_time, FullName}` instead of an opaque `{badkey,fields}`. Rejecting it at compile time with a proper diagnostic is still open; Beam's `Replacements.fs` has no warning path today.

## Tests

Seven tests added to `tests/Beam/ReflectionTests.fs`, covering what the PascalCase-only suite could not:

1. `GetRecordFields` / `PropertyInfo.GetValue` / `GetRecordField` on a lowercase-first record.
2. `MakeRecord` on that record, read back through the **compiled accessor** (`r.alpha`), not through reflection — this is what catches the silent-corruption direction.
3. A record of Erlang keyword fields (`{ end_: int; fun_: int }`), to be sure `checkErlKeywords` still composes.
4. A `{ name: string; Name: string }` record, pinning that the disambiguating underscore still keeps the two apart.
5. A camelCase record of `... -> Async<'T>` fields invoked through the returned `PropertyInfo` — the remoting shape above.
6. `MakeUnion` / `GetUnionFields` on a case carrying `[<CompiledName>]`.

Verified:

- `dotnet test tests/Beam` (ReflectionTests filter) — 78 passed on .NET, new tests included.
- `./build.sh test beam` — **2658 passed, 0 failed**.

All changes are confined to `src/Fable.Transforms/Beam/` and `src/fable-library-beam/`; no shared files touched, so no other target is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
