### PR TITLE
fix(python): honor custom Equals and GetHashCode in structural values

### DIFF
--- a/src/fable-library-py/fable_library/record.py
+++ b/src/fable-library-py/fable_library/record.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from .bases import ComparableBase, EquatableBase, HashableBase, StringableBase
 from .core import int32
 from .protocols import IComparable
-from .util import compare, equals
+from .util import combine_hash_codes, compare, equals, structural_hash
 
 
 def record_compare_to(self: Record, other: Record) -> int:
@@ -90,8 +90,11 @@ def record_to_string(self: Record) -> str:
 
 
 def record_get_hashcode(self: Record) -> int:
+    # Hash each field with `structural_hash` rather than hashing a Python tuple,
+    # so fields that only implement F# `GetHashCode` are hashed by value.
     slots = type(self).__slots__
-    return hash(tuple(getattr(self, fixed_field) for fixed_field in slots))
+    hashes = [structural_hash(getattr(self, fixed_field)) for fixed_field in slots]
+    return int(combine_hash_codes(hashes))
 
 
 class Record(StringableBase, EquatableBase, ComparableBase, HashableBase, IComparable):
@@ -128,6 +131,12 @@ class Record(StringableBase, EquatableBase, ComparableBase, HashableBase, ICompa
 
     def GetHashCode(self) -> int32:
         return int32(record_get_hashcode(self))
+
+    def __hash__(self) -> int:
+        # EquatableBase declares __eq__, so Python implicitly sets __hash__ to
+        # None on it, and that None shadows HashableBase.__hash__ in the MRO.
+        # Redefine it here so records stay hashable through GetHashCode.
+        return int(self.GetHashCode())
 
     # -------------------------------------------------------------------------
     # IComparable - Comparison (used by ComparableBase)

--- a/src/fable-library-py/fable_library/union.py
+++ b/src/fable-library-py/fable_library/union.py
@@ -11,7 +11,7 @@ from .array_ import Array
 from .bases import ComparableBase, EquatableBase, HashableBase, StringableBase
 from .core import int32
 from .protocols import IComparable
-from .util import compare
+from .util import combine_hash_codes, compare, equal_arrays, number_hash, structural_hash
 
 
 class Union(StringableBase, EquatableBase, ComparableBase, HashableBase, IComparable):
@@ -80,7 +80,9 @@ class Union(StringableBase, EquatableBase, ComparableBase, HashableBase, ICompar
             return False
 
         if self.tag == other.tag:
-            return self.fields == other.fields
+            # Compare fields with F# equality, not Python `==`, so fields that
+            # only implement `Equals` are compared by value.
+            return equal_arrays(self.fields, other.fields)
 
         return False
 
@@ -89,7 +91,18 @@ class Union(StringableBase, EquatableBase, ComparableBase, HashableBase, ICompar
     # -------------------------------------------------------------------------
 
     def GetHashCode(self) -> int32:
-        return int32(hash((self.tag, *self.fields)))
+        # Hash the tag and each field structurally instead of hashing a Python
+        # tuple, which would hash fields that only implement F# `GetHashCode`
+        # by identity.
+        hashes = [number_hash(self.tag)]
+        hashes.extend(structural_hash(x) for x in self.fields)
+        return combine_hash_codes(hashes)
+
+    def __hash__(self) -> int:
+        # EquatableBase declares __eq__, so Python implicitly sets __hash__ to
+        # None on it, and that None shadows HashableBase.__hash__ in the MRO.
+        # Redefine it here so union values stay hashable through GetHashCode.
+        return int(self.GetHashCode())
 
     # -------------------------------------------------------------------------
     # IComparable - Comparison (used by ComparableBase)
@@ -131,13 +144,16 @@ def tagged_union(tag: int):
     Additionally sets:
     - cls.tag = tag (numeric case discriminator)
     - cls.fields property (list of field values for backwards compat)
-    - cls.__hash__ from HashableBase (dataclass sets it to None when
-      generating __eq__, which would make union values unhashable)
+
+    The dataclass is created with `eq=False` so that `Union.Equals` (F#
+    equality) is inherited instead of the generated `__eq__`, which would
+    compare fields with Python `==`. That also keeps dataclass from setting
+    `__hash__` to None, so union values stay hashable via `Union.__hash__`.
     """
 
     def decorator[T](cls: type[T]) -> type[T]:
         # Apply dataclass internally
-        dc_cls: Any = dataclass(cls)
+        dc_cls: Any = dataclass(cls, eq=False)
 
         # Set the tag
         dc_cls.tag = tag
@@ -150,11 +166,6 @@ def tagged_union(tag: int):
             return Array[Any]([getattr(self, name) for name in field_names])
 
         dc_cls.fields = fields
-
-        # dataclass() generates __eq__ and therefore sets __hash__ to None.
-        # Restore the hash protocol so union values stay hashable via
-        # GetHashCode, e.g. when a union is a field of another union.
-        dc_cls.__hash__ = HashableBase.__hash__
 
         return dc_cls
 

--- a/src/fable-library-py/fable_library/util.py
+++ b/src/fable-library-py/fable_library/util.py
@@ -622,15 +622,14 @@ class ObjectRef:
 
 
 def safe_hash(x: Any) -> int32:
-    return (
-        int32.ZERO
-        if x is None
-        else int32(hash(x))
-        if is_hashable_py(x)
-        else x.GetHashCode()
-        if is_hashable(x)
-        else number_hash(ObjectRef.id(x))
-    )
+    """Hash a declared type that may or may not implement GetHashCode.
+
+    F# `GetHashCode` takes precedence over Python's `__hash__`: an F# class
+    that overrides `Equals`/`GetHashCode` does not opt into the Python
+    protocols, so checking `__hash__` first would reach the inherited
+    `object.__hash__` and hash by identity instead.
+    """
+    return identity_hash(x)
 
 
 def string_hash(s: str) -> int32:
@@ -666,7 +665,35 @@ def combine_hash_codes(hashes: list[int32]) -> int32:
 
 
 def structural_hash(x: Any) -> int32:
-    return int32(hash(x))
+    """Hash a value using F# structural semantics.
+
+    Like `safe_hash`, F# `GetHashCode` wins over Python's `__hash__` so that
+    custom equality and hash overrides are honored. Arrays and tuples are
+    hashed element-wise instead of through Python's `hash`, which would fall
+    back to identity for their items.
+    """
+    if x is None:
+        return int32.ZERO
+
+    if isinstance(x, bool):
+        return int32.ONE if x else int32.ZERO
+
+    if isinstance(x, str):
+        return string_hash(x)
+
+    if is_hashable(x):
+        return x.GetHashCode()
+
+    if isinstance(x, int | float):
+        return number_hash(x)
+
+    if isinstance(x, Array | tuple | list):
+        return array_hash(cast(Iterable[object], x))
+
+    if is_hashable_py(x):
+        return int32(hash(x))
+
+    return number_hash(ObjectRef.id(x))
 
 
 def array_hash(xs: Iterable[object]) -> int32:

--- a/tests/Js/Main/ComparisonTests.fs
+++ b/tests/Js/Main/ComparisonTests.fs
@@ -70,6 +70,22 @@ type Status =
 type MyClass(v) =
     member val Value: int = v with get, set
 
+// See https://github.com/fable-compiler/Fable/issues/4834
+type CustomValue(value: int, label: string) =
+    member _.Value = value
+    member _.Label = label
+
+    override _.Equals(other) =
+        match other with
+        | :? CustomValue as other -> value = other.Value
+        | _ -> false
+
+    override _.GetHashCode() = value
+
+type WrappedUnion = WrappedUnion of CustomValue
+
+type WrappedRecord = { Value: CustomValue }
+
 [<CustomEquality; NoComparison>]
 type FuzzyInt =
     | FuzzyInt of int
@@ -506,6 +522,22 @@ let tests =
     testCase "GetHashCode with objects that overwrite it works" <| fun () ->
         (Test(1).GetHashCode(), Test(1).GetHashCode()) ||> equal
         (Test(2).GetHashCode(), Test(1).GetHashCode()) ||> notEqual
+
+    testCase "Custom Equals and GetHashCode are used by structural values" <| fun () -> // See #4834
+        let left = CustomValue(1, "left")
+        let right = CustomValue(1, "right")
+
+        left = right |> equal true
+        hash left = hash right |> equal true
+
+        WrappedUnion left = WrappedUnion right |> equal true
+        hash (WrappedUnion left) = hash (WrappedUnion right) |> equal true
+
+        { Value = left } = { Value = right } |> equal true
+        hash { Value = left } = hash { Value = right } |> equal true
+
+        [| left |] = [| right |] |> equal true
+        hash [| left |] = hash [| right |] |> equal true
 
     testCase "GetHashCode with same object works" <| fun () ->
         let o = OTest(1)

--- a/tests/Python/TestComparison.fs
+++ b/tests/Python/TestComparison.fs
@@ -69,6 +69,22 @@ type Status =
 type MyClass(v) =
     member val Value: int = v with get, set
 
+// See https://github.com/fable-compiler/Fable/issues/4834
+type CustomValue(value: int, label: string) =
+    member _.Value = value
+    member _.Label = label
+
+    override _.Equals(other) =
+        match other with
+        | :? CustomValue as other -> value = other.Value
+        | _ -> false
+
+    override _.GetHashCode() = value
+
+type WrappedUnion = WrappedUnion of CustomValue
+
+type WrappedRecord = { Value: CustomValue }
+
 [<Fact>]
 let ``test PhysicalEquality works`` () = // See #3998
     let r1 = ResizeArray([1; 2])
@@ -580,6 +596,23 @@ let ``test Classes must use identity hashing by default`` () =
 // let ``test GetHashCode with lists works`` () =
 //     ([1; 2].GetHashCode(), [1; 2].GetHashCode()) ||> equal
 //     ([2; 1].GetHashCode(), [1; 2].GetHashCode()) ||> notEqual
+
+[<Fact>]
+let ``test Custom Equals and GetHashCode are used by structural values`` () = // See #4834
+    let left = CustomValue(1, "left")
+    let right = CustomValue(1, "right")
+
+    left = right |> equal true
+    hash left = hash right |> equal true
+
+    WrappedUnion left = WrappedUnion right |> equal true
+    hash (WrappedUnion left) = hash (WrappedUnion right) |> equal true
+
+    { Value = left } = { Value = right } |> equal true
+    hash { Value = left } = hash { Value = right } |> equal true
+
+    [| left |] = [| right |] |> equal true
+    hash [| left |] = hash [| right |] |> equal true
 
 [<Fact>]
 let ``GetHashCode with primitives works`` () =


### PR DESCRIPTION
Fixes #4834

## Problem

An F# class can override `Equals` and `GetHashCode` without opting into Python's `__eq__` and `__hash__` protocols. The Python runtime checked the Python protocols first, so such a class reached the inherited `object.__hash__` (identity hash), and that identity hash leaked into unions, records and arrays. Union equality was also field-wise Python `==`.

Running the reproduction from the issue on `main`:

```text
class equality: true
class hash: false     <- expected true
union equality: false <- expected true
union hash: false     <- expected true
record equality: true
record hash: false    <- expected true
array equality: true
array hash: false     <- expected true
```

All eight now print `true`, matching .NET and the JS/TS targets.

## Changes

This is solution 1 from the issue — correct the existing helpers, so already-generated Python code is fixed by upgrading `fable-library`. No compiler changes. The Python runtime now mirrors the TypeScript one.

`fable_library/util.py`
- `safe_hash` delegates to `identity_hash`, so F# `GetHashCode` wins over Python `__hash__` (it was the other way round).
- `structural_hash` was `int32(hash(x))`. It now dispatches like TS `structuralHash`: `None`/bool/str, then `GetHashCode`, then numbers, then element-wise `array_hash` for `Array`/tuple/list, then Python hash, then identity. `array_hash` is fixed by the same change. As a side effect, `structural_hash` on a Python `list` no longer raises `TypeError`.

`fable_library/union.py`
- `Union.Equals` compares fields with `equal_arrays` (F# `equals`) instead of Python `==`.
- `Union.GetHashCode` combines `number_hash(tag)` with `structural_hash` per field instead of hashing a Python tuple.
- `@tagged_union` builds the dataclass with `eq=False`, so case classes inherit F# equality rather than dataclass field-wise `==`.

`fable_library/record.py`
- `record_get_hashcode` combines per-field `structural_hash` instead of hashing a Python tuple.

### Incidental fix

`EquatableBase` declares `__eq__`, so Python implicitly sets `EquatableBase.__hash__ = None`, and that `None` shadows `HashableBase.__hash__` in the MRO. #4805 worked around this inside `@tagged_union`; with `eq=False` that workaround no longer applies, so `__hash__` is now defined on `Union` and `Record` directly. This also fixes records: 9 of the 106 generated record classes in the Python test output have no emitted `__hash__` and were unhashable from Python.

## Tests

Added `Custom Equals and GetHashCode are used by structural values` to `tests/Python/TestComparison.fs` and `tests/Js/Main/ComparisonTests.fs`. JS/TS already behaved correctly, so that one is a regression guard.

- Python: 2417 passed (was 2416). Pyright unchanged at 34 errors / 45 warnings, and clean on the three modified library files. `ruff format --check` clean.
- JavaScript: 3081 passed. TypeScript: 2860 passed.

## Performance

Measured on the path Fable actually generates for union equality (`util.equals`), 200k iterations:

| | before | after |
|---|---|---|
| `equals(a, b)` | 1.45 µs | 1.29 µs |
| `safe_hash(a)` | 0.81 µs | 1.28 µs |
| Python `a == b` | 0.06 µs | 1.19 µs |

The compiled path is slightly faster. Python-level `==` on a union case is slower because dataclass tuple comparison is replaced by F# equality — that is the point of the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
