### PR TITLE
fix(python): keep original F# field names in record reflection

### DIFF
--- a/src/Fable.Transforms/Python/Fable2Python.Reflection.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.Reflection.fs
@@ -38,13 +38,29 @@ let private transformRecordReflectionInfo com ctx r (ent: Fable.Entity) generics
             else
                 let typeInfo, stmts = transformTypeInfo com ctx r genMap fi.FieldType
 
-                let name =
+                // The runtime attribute/slot name is snake_cased (Python convention), but reflection
+                // must report the pristine F# field name so `PropertyInfo.Name` matches .NET and the
+                // other backends. When the two differ we emit a 3rd tuple element carrying the slot
+                // name; value access (get_value/make_record in fable-library-py) reads that for the
+                // actual attribute. This mirrors the Beam target's `name`/`erl_name` split.
+                let slotName =
                     if Util.shouldUseRecordFieldNaming ent then
                         fi.Name |> Naming.toFieldSnakeCase |> Helpers.clean
                     else
                         fi.Name |> Naming.toSnakeCase |> Helpers.clean
 
-                Some(Expression.tuple [ Expression.stringConstant name; typeInfo ], stmts)
+                let fieldTuple =
+                    if slotName = fi.Name then
+                        Expression.tuple [ Expression.stringConstant fi.Name; typeInfo ]
+                    else
+                        Expression.tuple
+                            [
+                                Expression.stringConstant fi.Name
+                                typeInfo
+                                Expression.stringConstant slotName
+                            ]
+
+                Some(fieldTuple, stmts)
         )
         |> Seq.toList
         |> Helpers.unzipArgs

--- a/src/fable-library-py/fable_library/reflection.py
+++ b/src/fable-library-py/fable_library/reflection.py
@@ -16,9 +16,22 @@ from .util import combine_hash_codes, equal_arrays_with
 Constructor = type[Any]
 
 EnumCase = tuple[str, IntegerTypes]
-FieldInfo = tuple[str, "TypeInfo"]
+# A field's reflection tuple is (fsharp_name, type). Targets that mangle field names for the
+# runtime representation (Python snake_cases record slots) emit an optional 3rd element carrying
+# the actual attribute/slot name, so `PropertyInfo.Name` (element 0) can stay the pristine F# name
+# while value access resolves the real attribute. Older compiled output emits the 2-tuple form.
+FieldInfo = tuple[str, "TypeInfo"] | tuple[str, "TypeInfo", str]
 PropertyInfo = FieldInfo
 ParameterInfo = FieldInfo
+
+
+def _field_attr_name(field: FieldInfo) -> str:
+    """Runtime attribute/slot name for a reflection field.
+
+    Element 0 is the F# field name reported by `PropertyInfo.Name`; when a 3rd element is present
+    it is the (possibly mangled) attribute name used for the actual `getattr`/`setattr`.
+    """
+    return field[2] if len(field) > 2 else field[0]
 
 
 @dataclass
@@ -192,7 +205,7 @@ def create_instance(t: TypeInfo, consArgs: Array[Any]) -> Any:
 
 
 def get_value(propertyInfo: PropertyInfo, v: Any) -> Any:
-    return getattr(v, str(propertyInfo[0]))
+    return getattr(v, _field_attr_name(propertyInfo))
 
 
 def name(info: FieldInfo | (TypeInfo | CaseInfo)) -> str:
@@ -394,7 +407,7 @@ def get_record_field(v: Any, field: FieldInfo) -> Any:
 
     if isinstance(v, dict):
         return v[field[0]]
-    return getattr(v, field[0])
+    return getattr(v, _field_attr_name(field))
 
 
 def get_tuple_fields(v: tuple[Any, ...]) -> Array[Any]:

--- a/tests/Python/TestReflection.fs
+++ b/tests/Python/TestReflection.fs
@@ -239,62 +239,9 @@ let ``test reflection functions accept allowAccessToPrivateRepresentation`` () =
     info.Name |> equal "IntCase"
     fields.[0] |> equal (box 5)
 
-#if FABLE_COMPILER
-[<Fact>]
-let ``test FSharp.Reflection Record`` () =
-    let typ = typeof<MyRecord>
-    let record = { String = "a"; Int = 1 }
-    let recordTypeFields = FSharpType.GetRecordFields typ
-    let recordValueFields = FSharpValue.GetRecordFields record
-
-    let expectedRecordFields =
-        [|
-            "string", box "a"
-            "int", box 1
-        |]
-
-    let recordFields =
-        recordTypeFields
-        |> Array.map (fun field -> field.Name)
-        |> flip Array.zip recordValueFields
-
-    let isRecord = FSharpType.IsRecord typ
-    let matchRecordFields = recordFields = expectedRecordFields
-    let matchIndividualRecordFields =
-        Array.zip recordTypeFields recordValueFields
-        |> Array.forall (fun (info, value) ->
-            FSharpValue.GetRecordField(record, info) = value
-        )
-    let canMakeSameRecord =
-        unbox<MyRecord> (FSharpValue.MakeRecord(typ, recordValueFields)) = record
-
-    let all = isRecord && matchRecordFields && matchIndividualRecordFields && canMakeSameRecord
-    all |> equal true
-
-[<Fact>]
-let ``test PropertyInfo.GetValue works`` () =
-    let value: obj = { Firstname = "Maxime"; Age = 12 } :> obj
-
-    let theType: System.Type = typeof<RecordGetValueType>
-
-    // now we want to print out the fields
-    let fieldNameToValue: Map<string, obj> =
-        match theType with
-        | t when FSharpType.IsRecord t ->
-            FSharpType.GetRecordFields(t)
-            |> Seq.fold
-                (fun acc field ->
-                    let fieldValue = field.GetValue value
-                    acc.Add (field.Name, fieldValue)
-                )
-                Map.empty
-        | _ -> Map.empty
-
-    let expected = "map [(age, 12); (firstname, Maxime)]"
-
-    equal expected (sprintf "%O" fieldNameToValue)
-
-#else
+// Reflection reports the pristine F# field names on every backend (Python keeps the snake_case
+// runtime slots but records the original name in the reflection TypeInfo), so these no longer
+// need a FABLE_COMPILER fork — the assertions match .NET.
 [<Fact>]
 let ``test FSharp.Reflection Record`` () =
     let typ = typeof<MyRecord>
@@ -326,6 +273,28 @@ let ``test FSharp.Reflection Record`` () =
     let all = isRecord && matchRecordFields && matchIndividualRecordFields && canMakeSameRecord
     all |> equal true
 
+// Multi-word PascalCase and acronym fields: reflection must report the original F# names
+// byte-identical to .NET/JS even though the Python runtime slots are snake_cased
+// (first_name / httpstatus / id). Reading each field by its reflected PropertyInfo must still
+// resolve the mangled slot.
+type MangledFieldsRecord = { FirstName: string; HTTPStatus: int; ID: int }
+
+[<Fact>]
+let ``test Record reflection keeps original F# field names`` () =
+    let typ = typeof<MangledFieldsRecord>
+    let record = { FirstName = "a"; HTTPStatus = 200; ID = 7 }
+    let fields = FSharpType.GetRecordFields typ
+
+    fields |> Array.map (fun f -> f.Name)
+    |> equal [| "FirstName"; "HTTPStatus"; "ID" |]
+
+    // The reflected PropertyInfo still reads the (snake_cased) runtime slot.
+    fields |> Array.map (fun f -> f.GetValue record)
+    |> equal [| box "a"; box 200; box 7 |]
+
+    unbox<MangledFieldsRecord> (FSharpValue.MakeRecord(typ, [| box "b"; box 404; box 9 |]))
+    |> equal { FirstName = "b"; HTTPStatus = 404; ID = 9 }
+
 [<Fact>]
 let ``test PropertyInfo.GetValue works`` () =
     let value: obj = { Firstname = "Maxime"; Age = 12 } :> obj
@@ -348,7 +317,6 @@ let ``test PropertyInfo.GetValue works`` () =
     let expected = "map [(Age, 12); (Firstname, Maxime)]"
 
     equal expected (sprintf "%O" fieldNameToValue)
-#endif
 
 [<Fact>]
 let ``test Comparing anonymous record types works`` () =


### PR DESCRIPTION
## Problem

Python is the only Fable target that mangles record field names in the **reflection `TypeInfo`**, not just the runtime slots. For `type Rec = { FirstName: string; HTTPStatus: int; ID: int }`:

| Backend | `FSharpType.GetRecordFields(t).[i].Name` |
| --- | --- |
| .NET / Fable JS/TS / Fable Beam | `FirstName`, `HTTPStatus`, `ID` |
| **Fable Python** (before) | `first_name`, `httpstatus`, `id` |

The transform is lossy (`httpstatus` could be `HttpStatus`/`HTTPStatus`/`Httpstatus`), so any reflection-driven serializer on Python can't reproduce the wire format that .NET and the JS/TS backend produce. Beam already demonstrates the intended design: snake_case runtime map keys, but a **pristine** F# name in the reflection metadata (`name`/`erl_name` split).

## Fix

- **Compiler** (`Fable2Python.Reflection.fs`): emit `fi.Name` (pristine) as the reflection field name, adding the snake_case slot as an optional **3rd tuple element**, only when it differs from the F# name.
- **Runtime** (`fable-library-py/reflection.py`): widen `FieldInfo` to `tuple[str, TypeInfo] | tuple[str, TypeInfo, str]`; `get_value` / `get_record_field` resolve the attribute via a new `_field_attr_name` helper (element `2` if present, else `0`). Backward-compatible with already-published 2-tuple output.
- Union reflection already kept the pristine name — this brings records in line.

## Tests

- Collapsed the `#if FABLE_COMPILER` fork in `TestReflection.fs` that enshrined the mangled names (`"string"`/`"int"`, `map [(age..)]`) down to the single .NET-matching version.
- Added `test Record reflection keeps original F# field names` covering `{ FirstName; HTTPStatus; ID }`: reflected names equal the F# names, and `GetValue`/`MakeRecord` still resolve the mangled slots.

All 2418 Python tests pass; Pyright clean (0 errors, no `# type: ignore`).

## Notes

`src/fable-library-py` is PyPI-distributed; this is backward-compatible within the minor version — the library still reads old 2-tuple reflection output, and `PropertyInfo.Name` semantics only become *more* correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)