### PR TITLE
fix(python): stop shipping build artifacts and ship the PEP 561 marker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,6 +179,15 @@ jobs:
         if: matrix.platform == 'ubuntu-latest'
         run: ./build.sh fable-library --python
 
+      # PEP 561 requires the marker inside the package directory. CopyStage filters
+      # by extension, so it is easy to drop again; without it mypy refuses to read
+      # the core/*.pyi stubs at all.
+      - name: PEP 561 marker survives staging
+        if: matrix.platform == 'ubuntu-latest'
+        run: |
+          test -f temp/fable-library-py/fable_library/py.typed \
+            || { echo "::error::fable_library/py.typed missing from staged package; stubs would be inert for mypy"; exit 1; }
+
       - name: Fable Library - Python (Windows)
         if: matrix.platform == 'windows-latest'
         run: .\build.bat fable-library --python

--- a/src/Fable.Build/FableLibrary/Python.fs
+++ b/src/Fable.Build/FableLibrary/Python.fs
@@ -31,6 +31,12 @@ type BuildFableLibraryPython(?skipCore: bool, ?postFableBuildStage: unit -> unit
         Directory.GetFiles(this.LibraryDir, "*") |> Shell.copyFiles this.BuildDir
         Directory.GetFiles(this.SourceDir, "*.py") |> Shell.copyFiles this.OutDir
 
+        // PEP 561 marker. It has to sit *inside* the package directory for type
+        // checkers to read the stubs at all, and the `*.py` filter above drops it --
+        // which is why every published wheel so far has shipped `core/*.pyi` that no
+        // consumer could see.
+        [ Path.Combine(this.SourceDir, "py.typed") ] |> Shell.copyFiles this.OutDir
+
         // Python extension modules
         Directory.GetFiles(Path.Combine(this.SourceDir, "core"), "*")
         |> Shell.copyFiles (Path.Combine(this.OutDir, "core"))

--- a/src/fable-library-py/py.typed
+++ b/src/fable-library-py/py.typed
@@ -1,1 +1,0 @@
-# PEP-0561 -- https://www.python.org/dev/peps/pep-0561/

--- a/src/fable-library-py/pyproject.toml
+++ b/src/fable-library-py/pyproject.toml
@@ -23,19 +23,31 @@ dev = [
     "pydantic>=2.13.4",
 ]
 
-[tool.hatch.build.targets.sdist]
-include = ["./fable_library"]
-
-[tool.hatch.build.targets.wheel]
-include = ["./fable_library"]
-
-[tool.hatch.build.targets.wheel.sources]
-"./fable_library" = "fable_library"
+# Note: there is deliberately no [tool.hatch.*] config here. `build-backend` below
+# is maturin, so hatch settings would be dead config that merely *looks* like it
+# governs what ships -- which is a good way for a packaging bug to go unnoticed.
 
 [tool.maturin]
 python-source = "."                        # Look at project root
 module-name = "fable_library.core._core"   # Full module path
 features = ["pyo3/extension-module"]
+
+# `Fable.Library.Python.fsproj` lives inside the package directory, so `dotnet build`
+# drops MSBuild output into `fable_library/obj/`. With `python-source = "."` maturin
+# would package that wholesale, and one of those paths contains a comma
+# (`.NETCoreApp,Version=v10.0.AssemblyAttributes.fs`) -- RECORD is CSV, so the
+# resulting wheel is rejected by `uv pip install` as malformed. `pip` is lenient
+# enough to survive it, which makes the failure look intermittent.
+#
+# None of this shows up in a clean CI checkout, only for contributors who have run
+# `dotnet build`. Excluding here fixes it regardless of build order; deleting `obj/`
+# in the build script would not, since it regenerates on the next build.
+exclude = [
+    "fable_library/obj/**/*",
+    "**/__pycache__/**/*",
+    "fable_library/*.fs",
+    "fable_library/*.fsproj",
+]
 
 [tool.ty.environment]
 python-version = "3.12"
@@ -56,5 +68,5 @@ testpaths = ["tests", "tests-benchmark"]
 addopts = "--benchmark-columns=min,max,mean,stddev,iqr"
 
 [build-system]
-requires = ["hatchling", "maturin>=1.5,<2.0"]
+requires = ["maturin>=1.5,<2.0"]
 build-backend = "maturin"


### PR DESCRIPTION
Two packaging defects in `src/fable-library-py`, pulling in opposite directions: the wheel built **in the source tree** shipped far too much and was uninstallable, while the wheel **published to PyPI** shipped too little.

Neither shows up in `git status` — `.gitignore` has `[Oo]bj/`, so the offending files are invisible to git but still swept up by maturin.

## 1. The dev wheel was uninstallable

`Fable.Library.Python.fsproj` lives inside the package directory, so `dotnet build` drops MSBuild output into `fable_library/obj/`. With `python-source = "."` maturin packaged it wholesale — and one of those paths contains a comma:

```
fable_library/obj/Debug/net10.0/.NETCoreApp,Version=v10.0.AssemblyAttributes.fs
```

`RECORD` is CSV, so that is four fields where three are expected:

```
Caused by: RECORD file is invalid
Caused by: CSV error: record 76 (line: 77, byte: 6817):
           found record with 4 fields, but the previous record has 3 fields
```

`pip` is lenient enough to survive this; `uv pip install` is not — which makes it look intermittent. It blocked building a local `fable-library` to benchmark against a released version.

The same wheel also carried 13 F# sources and 22 `__pycache__` entries, including **another interpreter's** bytecode (`array_.cpython-312.pyc` inside a cp314 wheel) — a stale-cache hazard inside an artifact whose whole purpose is to be a clean build.

Fixed with an explicit `exclude` in `[tool.maturin]`, which holds regardless of build order. Deleting `obj/` in the build script would not: it regenerates on the next `dotnet build` and breaks again for the next person.

| | entries | build artifacts | installs |
|---|---|---|---|
| before | 120 | 52 | ❌ |
| after | 68 | 0 | ✅ |

The sdist is covered by the same config (92 entries, 0 junk).

## 2. The published wheel's type stubs were inert

Under PEP 561 the marker must sit *inside* the package directory. `CopyStage` copied `GetFiles(SourceDir, "*.py")`, so `fable_library/py.typed` was dropped, while the distribution-root copy was staged to a location where PEP 561 does not look. Every released version has therefore shipped `core/*.pyi` stubs that mypy would not read.

Verified against an installed wheel, with and without the marker:

```
with:    error: Incompatible types in assignment
         (expression has type "Int32", variable has type "str")

without: error: Skipping analyzing "fable_library.core": module is installed,
         but missing library stubs or py.typed marker
```

**Narrower than it first appears:** pyright reads the stubs either way, since `useLibraryCodeForTypes` defaults to true. It is mypy that gets nothing; `py.typed` is what makes the stubs authoritative rather than inferred.

The inert distribution-root `py.typed` is removed rather than left to suggest the marker was handled.

## 3. Vestigial build config

Dropped `[tool.hatch.build.targets.*]` and `hatchling` from `build-system.requires`. `build-backend` is maturin, so those settings did nothing — while looking exactly like they governed what ships. Two build backends configured in one file is a good way for a packaging bug to go unnoticed.

## On CI coverage

Added **one line** to `build-python`, which already stages the library: assert `py.typed` survives. That guards the regression class that actually occurred — a `CopyStage` extension filter silently dropping a file — and is also the code this PR changes, so it is the most likely thing to break again. It costs nothing in a job that already runs the staging step.

**Deliberately not guarded: wheel contents.** A clean checkout has no `obj/` or `__pycache__`, so any guard must dirty the tree first. I tried to make it cheap via `maturin sdist` (0.3s, no Rust compile) and measured that it does not work — maturin honours gitignore for sdists:

| | entries | junk |
|---|---|---|
| sdist, `exclude` present | 92 | 0 |
| sdist, `exclude = []` | 105 | 13 — all `.fs`, **zero `obj/`** |

A cheap guard would pass while the actual breakage went through. Only a full wheel build reproduces it: minutes of CI per PR to protect a static config block that now carries its own explanation, against a break that never reached the published artifact.

## Not addressed

Moving the `.fsproj` out of `fable_library/` would remove the cause rather than filter it. But Fable is invoked on the *directory* (`CmdLine.appendRaw sourceDir`), and 12 F# sources plus 8 linked files from `fable-library-ts` live there — so `sourceDir` conflates "where the F# project is" with "where the Python package is". That is a restructure, not a packaging fix, and belongs on its own.

## Verification

```sh
# reproduce, then confirm
cd src/fable-library-py
dotnet build fable_library/Fable.Library.Python.fsproj
python -c "import compileall; compileall.compile_dir('fable_library')"
uv run --frozen maturin build --release --out dist
uv pip install --no-cache --target /tmp/check dist/*.whl   # succeeds

./build.sh fable-library --python
test -f temp/fable-library-py/fable_library/py.typed
```

- 2418 Python tests, 270 fable-library-py tests
- wheel and sdist clean and installable; marker present in the staged layout
- PEP 561 behaviour confirmed with mypy against a real venv install, both with and without the marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)