### PR TITLE
chore(beam): assert StartChild overlap instead of duration

### DIFF
--- a/tests/Beam/AsyncTests.fs
+++ b/tests/Beam/AsyncTests.fs
@@ -101,49 +101,51 @@ let ``test Async.StartChild works`` () =
 
 [<Fact>]
 let ``test Async.StartChild runs children concurrently`` () =
-    // Prove concurrency by *comparing* the same work run concurrently against
-    // sequentially on the same runner, rather than checking wall-clock against
-    // an absolute threshold. An absolute bound is inherently flaky: BEAM
-    // process-spawn plus async-trampoline overhead on a loaded CI runner is
-    // unbounded, so any fixed threshold eventually fails a genuinely-concurrent
-    // run. Here both runs pay the same overhead, so the ~500ms saved by real
-    // concurrency (one 500ms sleep instead of two) dominates scheduling jitter.
+    // Assert that the children's execution *intervals overlap*, rather than that
+    // the whole computation finished quickly.
     //
-    // Note: unlike JS/Python, the BEAM children run in *separate processes*
-    // (see fable_async:start_child), so the shared-mutable-state ordering test
-    // those targets use cannot observe concurrency here — timing is the only
-    // signal available.
-    let sleeper n = async {
-        do! Async.Sleep 500
-        return n
+    // Measuring duration -- against either an absolute threshold or a sequential
+    // control run -- is unfixably flaky here, because on a loaded runner the
+    // scheduling jitter is larger than the signal. Measured on a 2-core box under
+    // load, this pair of 500ms sleeps took anywhere from 504ms to 1580ms wall
+    // clock, so a genuinely-concurrent run routinely outlasts a sequential one and
+    // no choice of threshold separates them.
+    //
+    // Overlap is immune to that. Jitter delays both children together, so a
+    // common-mode delay cancels out of `min(end) - max(start)` while it is exactly
+    // what a duration measures. Under the same load that made the duration vary by
+    // ~1080ms, the overlap stayed within 500-984ms.
+    //
+    // Note: unlike JS/Python, the BEAM children run in *separate processes* (see
+    // fable_async:start_child), so the shared-mutable-state ordering test those
+    // targets use cannot observe them. A MailboxProcessor cannot bridge the gap
+    // either -- fable_mailbox holds its queue in the process dictionary, so a
+    // child's Post lands in the child's own copy. Timestamps returned by value
+    // from each child are the one channel that does cross the process boundary.
+    let stamped n =
+        async {
+            let t0 = System.DateTime.UtcNow.Ticks
+            do! Async.Sleep 500
+            let t1 = System.DateTime.UtcNow.Ticks
+            return n, t0, t1
+        }
+    // Both children are started before either is awaited, so their sleeps should
+    // run at the same time.
+    let comp = async {
+        let! c1 = Async.StartChild(stamped 1)
+        let! c2 = Async.StartChild(stamped 2)
+        let! (n1, a0, a1) = c1
+        let! (n2, b0, b1) = c2
+        let overlapMs = (min a1 b1 - max a0 b0) / TimeSpan.TicksPerMillisecond
+        return n1 + n2, overlapMs
     }
-    // Concurrent: both children started before either is awaited (~500ms).
-    let concurrent = async {
-        let sw = System.Diagnostics.Stopwatch.StartNew()
-        let! c1 = Async.StartChild(sleeper 1)
-        let! c2 = Async.StartChild(sleeper 2)
-        let! r1 = c1
-        let! r2 = c2
-        sw.Stop()
-        return r1 + r2, sw.ElapsedMilliseconds
-    }
-    // Sequential: each child awaited to completion before the next starts (~1000ms).
-    let sequential = async {
-        let sw = System.Diagnostics.Stopwatch.StartNew()
-        let! c1 = Async.StartChild(sleeper 1)
-        let! r1 = c1
-        let! c2 = Async.StartChild(sleeper 2)
-        let! r2 = c2
-        sw.Stop()
-        return r1 + r2, sw.ElapsedMilliseconds
-    }
-    let sumC, elapsedC = Async.RunSynchronously concurrent
-    let sumS, elapsedS = Async.RunSynchronously sequential
-    equal 3 sumC
-    equal 3 sumS
-    // The concurrent run must save at least half of the ~500ms overlap versus
-    // the sequential one; requiring only half leaves ample slack for jitter.
-    (elapsedC + 250L < elapsedS) |> equal true
+    let sum, overlapMs = Async.RunSynchronously comp
+    equal 3 sum
+    // Concurrent execution overlaps by the full ~500ms sleep. Were StartChild to
+    // regress to running each child only once awaited, the second child would
+    // start as the first one ended and the overlap would be 0 (verified: 0ms on
+    // both .NET and BEAM). The 250ms threshold sits midway between the two.
+    (overlapMs > 250L) |> equal true
 
 [<Fact>]
 let ``test Async.StartChild applies timeout`` () =


### PR DESCRIPTION
Third attempt at the flaky `Async.StartChild runs children concurrently` test. This one is based on measuring why the first two failed, rather than adjusting the budget again.

## The test was failing on .NET, not BEAM

Worth stating up front, because it reframes the problem: the failure is on the **.NET reference leg** (`Fable.Tests.Beam.dll (net10.0)`), before any Erlang runs. It is not a BEAM defect.

## Why the previous two fixes didn't work

- #4841 raised the absolute threshold 500ms → 750ms.
- #4848 replaced it with a comparative one: concurrent must beat a sequential control run by 250ms.

I reproduced the failure locally by running the full `tests/Beam` .NET leg pinned to 2 cores under CPU load — 1 in 3 runs failed. Instrumenting it gives the reason:

| | min | max | overshoot |
| --- | --- | --- | --- |
| concurrent run (nominal ~500ms) | 504 | **1580** | up to **+1080ms** |
| sequential control (nominal ~1000ms) | 1003 | 2495 | up to +1495ms |

**The jitter (~1080ms) is larger than the signal (500ms).** A genuinely-concurrent run routinely takes longer than a sequential one — the actual CI failure was `concurrent=1580` vs `sequential=1007`. No threshold, absolute or comparative, separates distributions that overlap that much.

So the comparative rewrite in #4848 wasn't a weaker version of the right fix; it was the same fix with **twice the exposure**, since it ran the clock twice. Under my load harness it would have failed **5 of 12** runs.

## The fix: measure overlap, not duration

Each child timestamps itself around its sleep and returns the pair by value; the test asserts `min(end) - max(start) > 250ms`.

This works because **jitter delays both children together**, so a common-mode delay cancels out of an overlap — while it is exactly what a duration measures. Same 12 runs, same load:

| | min | max | result |
| --- | --- | --- | --- |
| duration-based (old) | 504 | 1555 | **5 of 12 fail** |
| overlap-based (new) | **500** | 984 | **0 of 12 fail** |

The fixed test then passed **12/12** under the load that broke the old one 5 times in 12.

## It still fails for the reason it exists

I verified the regression it guards against still trips it. If `StartChild` regressed to running each child only when awaited, the second child starts as the first ends and overlap is **0ms** — confirmed 0ms on both .NET and BEAM. The 250ms threshold sits midway between that and the ~500ms of real concurrency, so there is 250ms of margin on each side, now on a quantity that doesn't absorb jitter.

Bonus: it's ~1s faster, needing one timed run instead of two.

## Why timestamps-by-value, and not the JS/Python approach

BEAM children are genuinely separate processes (`fable_async:start_child` calls `spawn`), so the shared-mutable-state ordering test that JS/Python use cannot observe them.

I also tried a `MailboxProcessor` as a portable channel and it silently returned an empty result. The cause: `fable_mailbox` keeps its queue in the **process dictionary** (`put`/`get`), so a child's `Post` lands in the child's own copy and the parent's agent never sees it. That's arguably a limitation worth its own issue, but it's out of scope here. Timestamps returned by value are the one channel that crosses the process boundary.

## Verification

- Full `./build.sh test beam` green end to end: .NET **2636/2636**, and the BEAM leg reports `PASS fable_tests_beam_async_tests:test_async_start_child_runs_children_concurrently`.
- 12/12 under the 2-core load harness that reproduced the original failure.
- Regression shape verified to yield 0ms overlap on both runtimes.
- `dotnet fantomas --check` clean.

Test-only change; no compiler or runtime library code touched.