### PR TITLE
perf(python): back int64 arrays with typed storage

### DIFF
--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -30,15 +30,13 @@ let (|TypedArrayCompatible|_|) (com: Compiler) (arrayKind: ArrayKind) t =
         | UInt32 -> ValueSome "UInt32ArrayCons"
         | Float32 -> ValueSome "Float32ArrayCons"
         | Float64 -> ValueSome "Float64ArrayCons"
-        // Don't use typed array for int64 until we remove our int64 polyfill
-        // and use JS BigInt to represent int64
-        //        | Int64 -> Some "BigInt64ArrayCons"
-        //        | UInt64 -> Some "BigUint64ArrayCons"
+        // Unlike JavaScript, which has no typed array for int64 while it polyfills the
+        // type, Python backs these with `Vec<i64>`/`Vec<u64>` in the Rust core.
+        | Int64 -> ValueSome "Int64ArrayCons"
+        | UInt64 -> ValueSome "UInt64ArrayCons"
         | Int128
         | UInt128
         | Float16
-        | Int64
-        | UInt64
         | BigInt
         | Decimal
         | NativeInt

--- a/tests/Python/TestArray.fs
+++ b/tests/Python/TestArray.fs
@@ -1461,3 +1461,36 @@ let ``test Array.randomSampleBy works`` () =
     Array.distinct sample |> Array.length |> equal 3
     throwsAnyError (fun () -> Array.randomSampleBy (fun () -> 1.0) 1 [|1; 2|] |> ignore)
     throwsAnyError (fun () -> Array.randomSampleBy (fun () -> -0.1) 1 [|1; 2|] |> ignore)
+
+[<Fact>]
+let ``test Int64 arrays roundtrip through their backing storage`` () =
+    let xs = [| 1L; -2L; 3L |]
+    Array.map (fun x -> x * 2L) xs |> equal [| 2L; -4L; 6L |]
+    Array.filter (fun x -> x > 0L) xs |> equal [| 1L; 3L |]
+    Array.append xs xs |> equal [| 1L; -2L; 3L; 1L; -2L; 3L |]
+    Array.rev xs |> equal [| 3L; -2L; 1L |]
+    Array.sort xs |> equal [| -2L; 1L; 3L |]
+    Array.sum xs |> equal 2L
+    Array.contains -2L xs |> equal true
+    Array.item 1 xs |> equal -2L
+    Array.map id xs = xs |> equal true
+
+[<Fact>]
+let ``test Int64 array values are not truncated`` () =
+    let xs = [| System.Int64.MinValue; 0L; System.Int64.MaxValue |]
+    Array.max xs |> equal System.Int64.MaxValue
+    Array.min xs |> equal System.Int64.MinValue
+    Array.sort xs |> equal [| System.Int64.MinValue; 0L; System.Int64.MaxValue |]
+    Array.rev (Array.rev xs) = xs |> equal true
+    Array.init 3 int64 |> equal [| 0L; 1L; 2L |]
+    Array.zeroCreate<int64> 2 |> equal [| 0L; 0L |]
+
+[<Fact>]
+let ``test UInt64 arrays roundtrip through their backing storage`` () =
+    let xs = [| 1UL; 2UL; System.UInt64.MaxValue |]
+    Array.map id xs |> equal xs
+    Array.filter (fun x -> x > 1UL) xs |> equal [| 2UL; System.UInt64.MaxValue |]
+    Array.max xs |> equal System.UInt64.MaxValue
+    Array.sort xs |> equal [| 1UL; 2UL; System.UInt64.MaxValue |]
+    Array.contains System.UInt64.MaxValue xs |> equal true
+    Array.zeroCreate<uint64> 2 |> equal [| 0UL; 0UL |]


### PR DESCRIPTION
`TypedArrayCompatible` in the Python `Replacements.fs` excluded `Int64`/`UInt64`
with a comment inherited from the JavaScript target:

```fsharp
// Don't use typed array for int64 until we remove our int64 polyfill
// and use JS BigInt to represent int64
```

That constraint has never applied to Python. The Rust core has backed these with
`NativeArray::Int64(Vec<i64>)` / `UInt64(Vec<u64>)` all along, and
`Int64ArrayCons` / `UInt64ArrayCons` are exported from `array_.py` — nothing had
ever emitted them.

The visible effect: `Array.map` over an `int64[]` emitted `map(f, xs, None)` and
fell back to boxed `Generic` storage, keeping one wrapper object per element.
Only array literals and `Seq.toArray` specialized, because those go through the
typed constructor rather than a library call — which is also why it looked fine
in passing.

## Effect

For int64 this is a win on both axes rather than a tradeoff, because int64
values are still pyo3 wrappers, so the boxing that specialization avoids is
real. 1000 elements, release core:

| storage | `a == b` | `sum(a)` | `a[500]` |
| --- | --- | --- | --- |
| Int64 | **0.09 µs** | **17.6 µs** | 22.5 ns |
| Generic | 8.53 µs | 33.6 µs | 20.0 ns |

Equality is 95× because `Vec<i64> == Vec<i64>` compares entirely in Rust, where
`Generic` walks element-by-element through Python. Memory drops from an 8-byte
pointer plus a wrapper object per element to a flat 8 bytes.

Storage kind before → after, via quicktest:

```
                    before     after
literal             Int64      Int64
Seq.toArray         Int64      Int64
Array.init          Generic    Int64
Array.zeroCreate    Generic    Int64
Array.map           Generic    Int64
Array.filter        Generic    Int64
Array.append        Generic    Int64
Array.rev           Generic    Int64
Array.sort          Generic    Int64
uint64 Array.map    Generic    UInt64
```

## Note on scope

Typed storage extracts to `i64`/`u64` and raises if the value does not fit,
where `Generic` accepts anything. For a statically-typed `int64[]` that is
unreachable, and the boundary values are covered by the new tests — but it is a
tightening, not a pure no-op, so it is worth knowing about.

This does not close the remaining specialization holes: `List.toArray`,
`Array.ofSeq` and `Set.toArray` still produce `Generic`, because those library
functions erase `'T` before they allocate and there is no cons for the call site
to pass. Fixing that means threading a parameter through F# sources shared with
other targets, so it is deliberately left out of here.

## Test plan

- [x] Python target suite with `--force-fable-library`: **2445 passed** (was 2442)
- [x] New `TestArray.fs` coverage — the file had **no** int64 tests at all, which
      is why this went unnoticed. Asserted against .NET first (228 array tests
      pass on .NET): value round-tripping through the storage, boundary values
      (`Int64.MinValue`/`MaxValue`, `UInt64.MaxValue`) that would expose a botched
      extraction, and structural equality — the operation the specialization is for
- [x] Quicktest verification of the storage kinds above, with values intact
      including `Int64.MaxValue` round-tripping as 9223372036854775807

🤖 Generated with [Claude Code](https://claude.com/claude-code)
