### PR TITLE
perf(python): hash numbers without the safeHash detour

### DIFF
--- a/src/Fable.Transforms/Python/Replacements.fs
+++ b/src/Fable.Transforms/Python/Replacements.fs
@@ -558,7 +558,10 @@ let identityHash com r (arg: Expr) =
         | Char
         | String
         | Builtin BclGuid -> "stringHash"
-        | Number((Decimal | BigInt | Int64 | UInt64), _) -> "safeHash"
+        // Every numeric width reaches the same `GetHashCode`, so routing the wider
+        // ones through `safeHash` only added a frame and its protocol check. This
+        // now matches `structuralHash`, which has always sent all of them to
+        // `numberHash`.
         | Number _
         | Builtin BclTimeSpan -> "numberHash"
         | List _ -> "safeHash"

--- a/src/fable-library-py/src/native_array.rs
+++ b/src/fable-library-py/src/native_array.rs
@@ -167,9 +167,11 @@ impl Clone for NativeArray {
 
 // Helper macro for filling storage
 //
-// The wrapper type is tried first so a same-type value costs no conversion dunder;
-// the primitive fallback accepts a plain Python int/float, which is how Int32 and
-// Float64 values are represented.
+// The wrapper type is tried first, which hits for the widths that are still pyo3
+// wrappers. Int32 and Float64 are plain Python ints and floats, so for those two
+// the wrapper arm always fails and the primitive fallback is the normal path —
+// which costs nothing measurable, because a failed `extract` is a Rust-level
+// `Err` rather than a constructed Python exception.
 macro_rules! fill_typed_vec {
     ($vec:expr, $value:expr, $target_index:expr, $count:expr, $type:ty, $prim:ty) => {{
         let typed_value: $prim = match $value.extract::<$type>() {

--- a/tests/Python/TestComparison.fs
+++ b/tests/Python/TestComparison.fs
@@ -656,3 +656,35 @@ let ``CompareTo with primitives works`` () =
     (1.).CompareTo(1.) |> equal 0
     (1.m).CompareTo(1.m) |> equal 0
     ("1").CompareTo("1") |> equal 0
+
+[<Fact>]
+let ``test GetHashCode with wide numeric types works`` () =
+    // These route through identity hashing, which used to take a different path
+    // than structural hashing for the widths below.
+    (5L).GetHashCode() |> equal ((5L).GetHashCode())
+    (5UL).GetHashCode() |> equal ((5UL).GetHashCode())
+    (5M).GetHashCode() |> equal ((5M).GetHashCode())
+    (5I).GetHashCode() |> equal ((5I).GetHashCode())
+    (5L).GetHashCode() = (6L).GetHashCode() |> equal false
+    (5UL).GetHashCode() = (6UL).GetHashCode() |> equal false
+    (5M).GetHashCode() = (6M).GetHashCode() |> equal false
+    (5I).GetHashCode() = (6I).GetHashCode() |> equal false
+
+[<Fact>]
+let ``test hashing wide numeric types agrees with GetHashCode`` () =
+    hash 5L |> equal ((5L).GetHashCode())
+    hash 5UL |> equal ((5UL).GetHashCode())
+    hash 5M |> equal ((5M).GetHashCode())
+    hash 5I |> equal ((5I).GetHashCode())
+
+[<Fact>]
+let ``test wide numeric types work as hash keys`` () =
+    let longs = System.Collections.Generic.HashSet<int64>([ 1L; 2L; 3L ])
+    longs.Contains 2L |> equal true
+    longs.Contains 9L |> equal false
+    let ulongs = System.Collections.Generic.HashSet<uint64>([ 1UL; 2UL ])
+    ulongs.Contains 2UL |> equal true
+    let decimals = System.Collections.Generic.HashSet<decimal>([ 1M; 2M ])
+    decimals.Contains 2M |> equal true
+    let bigs = System.Collections.Generic.HashSet<bigint>([ 1I; 2I ])
+    bigs.Contains 2I |> equal true

--- a/tests/Python/TestComparison.fs
+++ b/tests/Python/TestComparison.fs
@@ -679,12 +679,21 @@ let ``test hashing wide numeric types agrees with GetHashCode`` () =
 
 [<Fact>]
 let ``test wide numeric types work as hash keys`` () =
-    let longs = System.Collections.Generic.HashSet<int64>([ 1L; 2L; 3L ])
+    // Added one at a time rather than from a sequence: constructing a HashSet from
+    // an IEnumerable trips a known Pyright gap, the one that keeps test_hash_set.py
+    // in the CI exclude list.
+    let longs = System.Collections.Generic.HashSet<int64>()
+    longs.Add 1L |> ignore
+    longs.Add 2L |> ignore
+    longs.Add 2L |> equal false
     longs.Contains 2L |> equal true
     longs.Contains 9L |> equal false
-    let ulongs = System.Collections.Generic.HashSet<uint64>([ 1UL; 2UL ])
+    let ulongs = System.Collections.Generic.HashSet<uint64>()
+    ulongs.Add 2UL |> ignore
     ulongs.Contains 2UL |> equal true
-    let decimals = System.Collections.Generic.HashSet<decimal>([ 1M; 2M ])
+    let decimals = System.Collections.Generic.HashSet<decimal>()
+    decimals.Add 2M |> ignore
     decimals.Contains 2M |> equal true
-    let bigs = System.Collections.Generic.HashSet<bigint>([ 1I; 2I ])
+    let bigs = System.Collections.Generic.HashSet<bigint>()
+    bigs.Add 2I |> ignore
     bigs.Contains 2I |> equal true


### PR DESCRIPTION
Two small follow-ups from the array-storage investigation behind #4864. Both are
independently revertible.

## 1. `identityHash` sent wide numeric types through `safeHash`

```fsharp
| Number((Decimal | BigInt | Int64 | UInt64), _) -> "safeHash"
| Number _ | Builtin BclTimeSpan                 -> "numberHash"
```

Another grouping that makes sense for JavaScript, where these are polyfilled
objects, and not for Python — the same shape as the array-cons exclusion fixed
in #4864, in the same file.

Both routes end at the same `GetHashCode`. `safeHash` delegates to
`identity_hash`, which re-checks the hashable protocol before making the same
call, so the detour buys a frame and a check and returns an identical value:

| type | same value | `safeHash` | `numberHash` |
| --- | --- | --- | --- |
| Int64 | ✓ | 100.8 ns | **74.2 ns** |
| UInt64 | ✓ | 100.2 ns | **76.6 ns** |
| Decimal | ✓ | 243.5 ns | **133.3 ns** |
| BigInt | ✓ | 215.8 ns | **103.2 ns** |

I went in intending to move only Int64/UInt64 and checked whether the other two
had a reason to stay. They don't — all four are equivalent and all four are
faster, so the special case is dropped entirely. That also makes `identityHash`
agree with `structuralHash`, which has always sent every `Number` to
`numberHash`, and which is what the comment above the match already claimed
("These are the same for identity/structural hashing").

Worth a reviewer's eye: `identity_hash` maps `None` to `0` where `number_hash`
would not. That is unreachable for a `Number`-typed expression in F# — these are
non-nullable value types — but it is the one behavioural difference between the
two paths.

## 2. A comment whose rationale inverted

`fill_typed_vec!` said the wrapper type is tried first "so a same-type value
costs no conversion dunder". True when Int32/Float64 values were wrapper
objects; since they became plain ints and floats, the wrapper arm always fails
for exactly those two, so the sentence describes the opposite of the common
path.

Comment only — the order is fine. A failed pyo3 `extract` is a Rust-level `Err`
rather than a constructed Python exception: 68.1 ns when the wrapper arm fails
against 66.6 ns when it hits.

## Test plan

- [x] Python target suite with `--force-fable-library`: **2448 passed** (was 2445)
- [x] New `TestComparison.fs` coverage, asserted against .NET first (69 comparison
      tests pass on .NET): `GetHashCode` agrees with `hash`, distinguishes distinct
      values, and still works for `HashSet` keys — across all four types
- [x] Codegen verified in the emitted output: the new tests emit
      `number_hash(int64.FIVE)` where they previously emitted `safe_hash`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
