### PR TITLE
fix(beam): escape quotes and backslashes in quoted atoms

### DIFF
--- a/src/Fable.Transforms/Beam/Prelude.fs
+++ b/src/Fable.Transforms/Beam/Prelude.fs
@@ -497,6 +497,13 @@ module Naming =
         checkErlKeywords disambiguated
 
     /// Quote an Erlang atom if it needs quoting (starts with uppercase, contains special chars, etc.)
+    ///
+    /// Inside the quotes a `\` and a `'` have to be escaped, or what comes back is not the atom that
+    /// was asked for. `'it's'` is a syntax error; `'back\slash'` is worse, because Erlang reads the
+    /// same escape sequences in a quoted atom as in a string and `\s` means space — so it compiles,
+    /// silently, to the atom `back lash`. Both are reachable: `[<CompiledName>]` reaches the atom
+    /// text verbatim (`unionCaseTagName`, and `[<StringEnum>]` cases on top of it), and
+    /// `sanitizeErlangName` only strips these characters on the paths that go through it.
     let quoteErlangAtom (name: string) =
         if name.Length = 0 then
             "''"
@@ -507,7 +514,10 @@ module Naming =
         then
             name
         else
-            $"'%s{name}'"
+            // Backslashes first — otherwise the ones the second replace adds get escaped again.
+            let escaped = name.Replace("\\", @"\\").Replace("'", @"\'")
+
+            $"'%s{escaped}'"
 
     let sanitizeErlangVar (name: string) =
         // Remove/replace characters invalid in Erlang variable names

--- a/tests/Beam/ReflectionTests.fs
+++ b/tests/Beam/ReflectionTests.fs
@@ -866,3 +866,35 @@ let ``test MakeUnion honours CompiledName on a union case`` () =
     let case, fields = FSharpValue.GetUnionFields(box value, typeof<CompiledNameUnion>)
     case.Name |> equal "Renamed"
     fields |> equal [| box 42 |]
+
+// === Union case tags whose CompiledName needs escaping inside a quoted atom ===
+// `[<CompiledName>]` reaches the Erlang atom verbatim, and a quoted atom reads the same escape
+// sequences a string does. An unescaped `'` closed the atom early (`'it's'` — a syntax error) and
+// an unescaped `\` started an escape sequence (`'back\slash'` compiled silently to `back lash`,
+// because `\s` is Erlang's escape for a space).
+
+type EscapedTagUnion =
+    | [<CompiledName("it's")>] Apostrophe of int
+    | [<CompiledName("back\\slash")>] Backslash of int
+
+[<Fact>]
+let ``test union case tags escape quotes and backslashes`` () =
+    let describe (x: EscapedTagUnion) =
+        match x with
+        | Apostrophe i -> "a" + string i
+        | Backslash i -> "b" + string i
+
+    describe (Apostrophe 1) |> equal "a1"
+    describe (Backslash 2) |> equal "b2"
+
+    // Reflection embeds the same tag codegen emits, so a round-trip through MakeUnion has to land
+    // on the case the pattern matches look for.
+    let cases = FSharpType.GetUnionCases typeof<EscapedTagUnion>
+    let backslash = cases |> Array.find (fun c -> c.Name = "Backslash")
+    let value = FSharpValue.MakeUnion(backslash, [| box 7 |]) |> unbox<EscapedTagUnion>
+
+    describe value |> equal "b7"
+
+    let case, fields = FSharpValue.GetUnionFields(box value, typeof<EscapedTagUnion>)
+    case.Name |> equal "Backslash"
+    fields |> equal [| box 7 |]


### PR DESCRIPTION
## Problem

`quoteErlangAtom` wraps a name in single quotes without escaping its contents. A quoted Erlang atom reads the same escape sequences a string does, so two characters break it — and `[<CompiledName>]` reaches the atom text verbatim (via `unionCaseTagName`), which makes both user-reachable:

```fsharp
type Quoted =
    | [<CompiledName("it's")>] Apostrophe of int
    | [<CompiledName("back\\slash")>] Backslash of int
```

```erlang
'it's'          %% syntax error — the ' closes the atom early
'back\slash'    %% compiles, but `\s` is Erlang's escape for a space
```

The second is the one that matters: it compiles cleanly and yields the atom `back lash`. Codegen and the `erl_tag` in reflection metadata both go through this function, so they agree on the wrong name and nothing surfaces the mismatch.

## Fix

Escape `\` then `'` inside the quotes (backslash first, or the ones the second replace adds get escaped again).

Scope is narrow: `quoteErlangAtom` is only reached from `AtomLit` printing in `ErlangPrinter`. Module, export and function-clause names print raw and always come from `sanitizeErlangName`, which strips these characters already.

## Test

`tests/Beam/ReflectionTests.fs` gains a DU carrying both hostile `[<CompiledName>]`s, next to the existing `CompiledName`/`erl_tag` regression test. It covers pattern matching *and* a `MakeUnion` → match round-trip, so the reflection tag has to land on the same atom codegen emits.

## Verification

- Reproduced on the branch baseline first: the generated module failed to compile, and `'back\slash'` was visible in the output.
- After the fix, `erlang:atom_to_binary` round-trips `it's`, `back\slash` and `both'and\` exactly.
- Beam suite: **2659 passed, 0 failed** (.NET 2637 / Erlang 2659), plus the entry-point program tests. Fantomas clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)