### PR TITLE
fix(beam): compile [<StringEnum>] cases to atoms instead of binaries

### DIFF
--- a/src/Fable.Transforms/Beam/FABLE-BEAM.md
+++ b/src/Fable.Transforms/Beam/FABLE-BEAM.md
@@ -1283,6 +1283,23 @@ alone eliminates the single hardest piece of the Fable.Python runtime.
   instead of `fable_utils:iface_get` dispatch. Method names are converted via
   `sanitizeErlangName` (camelCase → snake_case). Same pattern as JS/Python but with `:` call
   syntax instead of attribute access.
+- **`[<StringEnum>]` → atoms**: `[<StringEnum>]` means "a closed set of string-literal constants
+  for interop". On JS each case lowers to a string literal because that is what a JS API expects;
+  the Beam analogue is an **atom**, not a binary — the OTP functions such a binding targets (ETS
+  table types, `logger` levels, transport names, `gen_server` name registration) pattern-match
+  atoms and reject binaries. So on Beam a case compiles to a bare atom, quoted when the name is
+  not valid unquoted atom syntax (`[<CompiledName("Horizontal")>]` → `'Horizontal'`,
+  `CaseRules.KebabCase` → `'content-box'`). This makes `[<StringEnum>]` and a plain nullary DU
+  equivalent on Beam — both are bare atoms — which is the intended end state. Consequences:
+    - `[<CompiledValue(true|1|1.0)>]` cases are genuine bool/int/float constants rather than tags,
+      and keep their literal. An explicit `[<Emit>]` on a case still wins.
+    - The type no longer maps to `Fable.String` on Beam (`makeType` in `FSharp2Fable.Util.fs`), so
+      `string x` routes through `fable_convert:to_string` (giving the atom's text as a binary)
+      instead of erasing to a no-op that would hand an atom to code expecting a binary. Ordered
+      comparison also becomes declaration-order correct, since union values now reach
+      `compare_union` (see the DU ordering section above).
+    - `[<Erase>]` unions are deliberately *not* included: an erased case with no fields keeps its
+      binary. `[<Erase>]` means "no runtime representation", not "a constant tag".
 
 - **Async/Task CE**: CPS (Continuation-Passing Style) implementation. `Async<T>` is a function
   `fun(Ctx) -> ok end` with context map `#{on_success, on_error, on_cancel, cancel_token}`.

--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -1686,7 +1686,17 @@ module TypeHelpers =
                 | Choice1Of2 t -> t
                 | Choice2Of2 fullName -> makeRuntimeTypeWithMeasure genArgs fullName
             | fullName when tdef.IsMeasure -> Fable.Measure fullName
-            | _ when hasAttrib Atts.stringEnum tdef.Attributes && Compiler.Language <> TypeScript -> Fable.String
+            // A `[<StringEnum>]` value *is* a string at runtime, so the type follows the
+            // representation. Not on TypeScript, which keeps the literal-union type, and not on
+            // Beam, where the cases compile to atoms instead of binaries (see
+            // `transformStringEnumAsAtom`) — calling it a string there would make `string x`
+            // erase to a no-op and hand an atom to code expecting a binary.
+            | _ when
+                hasAttrib Atts.stringEnum tdef.Attributes
+                && Compiler.Language <> TypeScript
+                && Compiler.Language <> Beam
+                ->
+                Fable.String
             | _ ->
                 let genArgs = makeTypeGenArgsWithConstraints withConstraints ctxTypeArgs genArgs
 

--- a/src/Fable.Transforms/FSharp2Fable.fs
+++ b/src/Fable.Transforms/FSharp2Fable.fs
@@ -58,6 +58,43 @@ let private transformBaseConsCall
         // Other cases, like Emit will call directly the base expression
         | e -> e
 
+/// A `[<StringEnum>]` case as an Erlang atom.
+///
+/// `[<StringEnum>]` means "a closed set of string-literal constants for interop", and the Beam
+/// analogue of a JS string literal is an atom, not a binary: the OTP functions such a binding
+/// targets (ETS table types, `logger` levels, `gen_server` names, ...) pattern-match atoms and
+/// reject binaries. This is the representation a plain nullary DU already gets on Beam, so after
+/// this the two spellings are equivalent there.
+///
+/// `[<CompiledValue>]` cases are genuine bool/int/float constants rather than tags and keep their
+/// literal, and an explicit `[<Emit>]` on the case still wins — both fall through to the shared path.
+let private transformStringEnumAsAtom (rule: Fable.Core.CaseRules) (unionCase: FSharpUnionCase) =
+    let atom name =
+        let emitInfo: Fable.EmitInfo =
+            {
+                // Quoted unless it already matches Erlang's unquoted atom syntax: a case rule or a
+                // `[<CompiledName>]` can produce text (`content-box`, `Horizontal`) that needs it.
+                Macro = Fable.Beam.Naming.quoteErlangAtom name
+                IsStatement = false
+                CallInfo = Fable.CallInfo.Create()
+            }
+
+        Fable.Emit(emitInfo, Fable.Any, None)
+
+    match FsUnionCase.CompiledName unionCase, FsUnionCase.CompiledValue unionCase with
+    | Some name, _ -> atom name
+    | _, Some _ -> transformStringEnum rule unionCase
+    | None, None ->
+        match unionCase.Attributes |> tryFindAttrib Atts.emitAttr with
+        | Some _ -> transformStringEnum rule unionCase
+        | None -> Naming.applyCaseRule rule unionCase.Name |> atom
+
+/// The value a `[<StringEnum>]` case compiles to: an atom on Beam, a string literal everywhere else.
+let private transformStringEnumCase (com: Compiler) (rule: Fable.Core.CaseRules) (unionCase: FSharpUnionCase) =
+    match com.Options.Language with
+    | Beam -> transformStringEnumAsAtom rule unionCase
+    | _ -> transformStringEnum rule unionCase
+
 let private transformNewUnion com ctx r fsType (unionCase: FSharpUnionCase) (argExprs: Fable.Expr list) =
     match getUnionPattern fsType unionCase with
     | ErasedUnionCase -> makeTuple r false argExprs
@@ -109,7 +146,7 @@ let private transformNewUnion com ctx r fsType (unionCase: FSharpUnionCase) (arg
 
     | StringEnum(tdef, rule) ->
         match argExprs with
-        | [] -> transformStringEnum rule unionCase
+        | [] -> transformStringEnumCase com rule unionCase
         | _ ->
             $"StringEnum types cannot have fields: %O{tdef.TryFullName}"
             |> addErrorAndReturnNull com ctx.InlinePath r
@@ -604,7 +641,7 @@ let private transformUnionCaseTest
             let kind = Fable.ListTest(unionCase.CompiledName <> "Empty")
             return Fable.Test(unionExpr, kind, r)
 
-        | StringEnum(_, rule) -> return makeEqOp r unionExpr (transformStringEnum rule unionCase) BinaryEqual
+        | StringEnum(_, rule) -> return makeEqOp r unionExpr (transformStringEnumCase com rule unionCase) BinaryEqual
 
         | DiscriminatedUnion(tdef, _) ->
             let tag = unionCaseTag com tdef unionCase

--- a/tests/Beam/InteropTests.fs
+++ b/tests/Beam/InteropTests.fs
@@ -122,6 +122,35 @@ type MyCssOptions =
     | ContentBox
     | BorderBox
 
+/// `[<CompiledValue>]` cases are genuine bool/int/float constants, not tags,
+/// so they must keep their literal rather than becoming atoms.
+[<StringEnum; RequireQualifiedAccess>]
+type MyFlags =
+    | [<CompiledValue(true)>] On
+    | [<CompiledValue(false)>] Off
+
+/// The kind argument `ets:new/2` takes — an OTP function that pattern-matches atoms
+/// and rejects binaries.
+[<StringEnum; RequireQualifiedAccess>]
+type EtsTableKind =
+    | Set
+    | [<CompiledName("ordered_set")>] OrderedSet
+
+[<Emit("erlang:is_atom($0)")>]
+let isAtom (x: obj) : bool = nativeOnly
+
+[<Emit("erlang:is_boolean($0)")>]
+let isBoolean (x: obj) : bool = nativeOnly
+
+[<Emit("ets:new(fable_string_enum_probe, [$0, public])")>]
+let etsNew (kind: EtsTableKind) : obj = nativeOnly
+
+[<Emit("ets:info($0, type)")>]
+let etsTableKind (tab: obj) : EtsTableKind = nativeOnly
+
+[<Emit("ets:delete($0)")>]
+let etsDelete (tab: obj) : unit = nativeOnly
+
 // ============================================================
 // Erlang.receive tests
 // ============================================================
@@ -443,6 +472,84 @@ let ``test StringEnum with KebabCase works`` () =
     let value = MyCssOptions.ContentBox
     let expected: string = emitErlExpr () "<<\"content-box\">>"
     equal expected (string value)
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test StringEnum compiles to an atom, not a binary`` () =
+#if FABLE_COMPILER
+    // The Beam analogue of a JS string-literal constant is an atom: OTP functions that take
+    // a tag pattern-match atoms and reject binaries.
+    equal true (isAtom (box Vertical))
+    equal true (isAtom (box Horizontal))
+    equal true (isAtom (box UserInfo.UserLoginCount))
+    equal true (isAtom (box MyCssOptions.ContentBox))
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test StringEnum atom equals the bare atom written by hand`` () =
+#if FABLE_COMPILER
+    let vertical: MyStrings = emitErlExpr () "vertical"
+    // `[<CompiledName>]` is honoured verbatim, so this one needs quoting
+    let horizontal: MyStrings = emitErlExpr () "'Horizontal'"
+    // A kebab-cased name is not a valid unquoted atom either
+    let contentBox: MyCssOptions = emitErlExpr () "'content-box'"
+    equal vertical Vertical
+    equal horizontal Horizontal
+    equal contentBox MyCssOptions.ContentBox
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test StringEnum pattern matching round-trips`` () =
+#if FABLE_COMPILER
+    let describe (x: MyStrings) =
+        match x with
+        | Vertical -> "v"
+        | Horizontal -> "h"
+
+    equal "v" (describe Vertical)
+    equal "h" (describe Horizontal)
+
+    let box_ (x: MyCssOptions) =
+        match x with
+        | MyCssOptions.ContentBox -> 1
+        | MyCssOptions.BorderBox -> 2
+
+    equal 1 (box_ MyCssOptions.ContentBox)
+    equal 2 (box_ MyCssOptions.BorderBox)
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test StringEnum atom is accepted by an OTP call`` () =
+#if FABLE_COMPILER
+    let tab = etsNew EtsTableKind.OrderedSet
+    let kind = etsTableKind tab
+    etsDelete tab
+    equal EtsTableKind.OrderedSet kind
+#else
+    ()
+#endif
+
+[<Fact>]
+let ``test StringEnum with CompiledValue stays a literal`` () =
+#if FABLE_COMPILER
+    equal true (isBoolean (box MyFlags.On))
+    equal true (isBoolean (box MyFlags.Off))
+
+    let describe (x: MyFlags) =
+        match x with
+        | MyFlags.On -> "on"
+        | MyFlags.Off -> "off"
+
+    equal "on" (describe MyFlags.On)
+    equal "off" (describe MyFlags.Off)
 #else
     ()
 #endif


### PR DESCRIPTION
## Problem

`[<StringEnum>]` is the idiomatic Fable way to bind "a closed set of string-literal constants". On JS each case lowers to a string literal, which is exactly what a JS API expects. The Beam analogue of a JS string-literal constant is an **atom**, not a binary: the OTP functions such a binding targets — ETS table types, `logger` levels, transport/protocol names, `gen_server` name registration — pattern-match atoms and reject binaries.

Beam inherited the generic path, so every case became `<<"...">>` and the value was unusable against any of them:

```fsharp
[<StringEnum>]
type ProbeAccess =
    | Public
    | [<CompiledName("ordered_set")>] OrderedSet
```

```erlang
probe3() ->
    {<<"public"/utf8>>, <<"ordered_set"/utf8>>,
     erlang:is_atom(<<"public"/utf8>>), erlang:is_atom(<<"ordered_set"/utf8>>)}.
%% both is_atom calls return false
```

A plain nullary DU already compiles to an atom on Beam, `[<CompiledName>]` included — `[<StringEnum>]` simply never reached that representation.

## Fix

`transformStringEnum` is language-agnostic, and by the time `Fable2Beam` sees the value it is an ordinary string literal with no entity information left. So the fix goes where the `FSharpUnionCase` is still in hand: `transformStringEnumCase` dispatches on the language and, for Beam, emits a bare atom — quoted when the name is not valid unquoted atom syntax (`[<CompiledName("Horizontal")>]` → `'Horizontal'`, `CaseRules.KebabCase` → `'content-box'`). Construction and the equality that pattern matching lowers to share it, so both sides stay consistent.

It lives in `FSharp2Fable.fs` rather than `FSharp2Fable.Util.fs` because `Beam/Prelude.fs` compiles *after* Util but *before* it, which is what makes `quoteErlangAtom` reachable.

**The type mapping has to follow the representation.** `[<StringEnum>]` types were hard-mapped to `Fable.String`, and `ToString.toStringByType` has `Type.String -> Some arg` — so `string x` on a variable erased to a no-op and handed an atom to code expecting a binary. A StringEnum therefore no longer maps to `Fable.String` on Beam either, and `string x` routes through `fable_convert:to_string`. Ordered comparison becomes declaration-order correct as a side effect, since the values now reach `compare_union` instead of being compared as text:

```fsharp
compare Public OrderedSet   // -1 (F# declaration order); was 1 (alphabetical on the binaries)
```

`%A` also now prints `Public` rather than `"public"`, matching .NET.

## Scope

- `[<CompiledValue(true|1|1.0)>]` cases are genuine bool/int/float constants rather than tags and keep their literal. A case-level `[<Emit>]` still wins.
- `[<Erase>]` and `TypeScriptTaggedUnion` are deliberately **not** included. An erased case with no fields keeps its binary: `[<Erase>]` means "no runtime representation", not "a constant tag".
- **No other target is affected.** Non-Beam falls through to the untouched `transformStringEnum`, and the type-mapping change only adds a conjunct.

After this, `[<StringEnum>]` and a plain nullary DU are equivalent on Beam — the intended end state, documented in `FABLE-BEAM.md`, which had no recorded decision on `[<StringEnum>]` at all.

## Tests

Five new tests in `tests/Beam/InteropTests.fs`, alongside the four existing StringEnum tests which pass **unmodified** (`string value` still yields the binary they assert):

- `erlang:is_atom/1` is true for a plain case, a `[<CompiledName>]`-renamed one, and snake/kebab-cased ones
- the emitted atom equals a bare atom written by hand, including the two that need quoting
- pattern matching round-trips
- the atom is accepted by a real OTP call: `ets:new(T, [Kind])` asserted back through `ets:info(T, type)`
- `[<CompiledValue>]` bool cases stay literals

## Verification

- Beam suite: **2663 passed, 0 failed** (.NET 2641 / Erlang 2663), plus entry-point program tests.
- JavaScript suite: **3083 passed, 0 failed**.
- `typeof<ProbeAccess>.FullName` → `"QuickTest.ProbeAccess"` (was `System.String`), with no dangling reflection call — `isErasedOrStringEnumEntity` handles the now-`DeclaredType` case.
- Fantomas clean.

## Known consequence

A tuple whose first element is a StringEnum renders under `%A` as a union case — `(Public, OrderedSet, true, true)` prints `Public (OrderedSet, true, true)`. This is the documented tagless-representation ambiguity in `fable_string.erl` ("genuinely indistinguishable when a tuple's first element is itself a fieldless union case"); StringEnums now inherit it, as nullary DUs already did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)