### PR TITLE
fix(python): derive DateTime "O" format from the value, not the host timezone

### DIFF
--- a/src/fable-library-py/fable_library/date.py
+++ b/src/fable-library-py/fable_library/date.py
@@ -456,6 +456,52 @@ def date_to_string_with_custom_format(date: datetime, format: str, utc: bool) ->
     return result
 
 
+def _is_date_time_offset(date: datetime) -> bool:
+    # DateTimeOffset sets this marker on itself. It is checked by attribute
+    # rather than isinstance because date_offset imports this module, so
+    # importing it back here would be a cycle.
+    return getattr(date, "is_offset_value", False) is True
+
+
+def _offset_designator(offset: timedelta) -> str:
+    """Format a UTC offset the way .NET's "zzz" does: "+02:00", "-05:30"."""
+    total_minutes = round(offset.total_seconds() / 60)
+    sign = "-" if total_minutes < 0 else "+"
+    total_minutes = abs(total_minutes)
+    return f"{sign}{total_minutes // 60:02d}:{total_minutes % 60:02d}"
+
+
+def _roundtrip_zone_designator(date: datetime) -> str:
+    """Zone designator of the round-trip format, derived from the value alone.
+
+    Kind = Unspecified has none, Kind = Utc is "Z", and Kind = Local carries its
+    own offset. A DateTimeOffset always prints a numeric offset, even "+00:00".
+    """
+    offset = date.utcoffset()
+    if offset is None:
+        return ""
+
+    if date.tzinfo == UTC and not _is_date_time_offset(date):
+        return "Z"
+
+    return _offset_designator(offset)
+
+
+def _to_roundtrip_string(date: datetime) -> str:
+    """Round-trip ("O"/"o") format: "yyyy-MM-ddTHH:mm:ss.fffffff" plus a zone
+    designator.
+
+    The result depends only on the value, never on the host timezone. Python's
+    datetime only carries microseconds, so the seventh fractional digit is
+    always 0 rather than truncating the fraction to six digits.
+    """
+    return (
+        f"{date.year:04d}-{date.month:02d}-{date.day:02d}"
+        f"T{date.hour:02d}:{date.minute:02d}:{date.second:02d}"
+        f".{date.microsecond:06d}0{_roundtrip_zone_designator(date)}"
+    )
+
+
 def date_to_string_with_offset(date: datetime, format: str | None = None) -> str:
     utc = date.tzinfo == UTC
 
@@ -467,7 +513,7 @@ def date_to_string_with_offset(date: datetime, format: str | None = None) -> str
             else:
                 return date.strftime("%Y-%m-%dT%H:%M:%S.%f%z")
         case "O" | "o":
-            return date.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+            return _to_roundtrip_string(date)
         case "D":
             return to_long_date_string(date)
         case "d":
@@ -524,7 +570,7 @@ def date_to_string_with_kind(date: datetime, format: str | None = None) -> str:
         case "M" | "m":
             return to_month_day_string(date)
         case "O" | "o":
-            return date.astimezone().isoformat(timespec="milliseconds")
+            return _to_roundtrip_string(date)
         case "R" | "r":
             return to_rfc1123_string(date)
         case "s":

--- a/src/fable-library-py/fable_library/date_offset.py
+++ b/src/fable-library-py/fable_library/date_offset.py
@@ -14,6 +14,11 @@ from .time_span import TimeSpan, hours, microseconds, milliseconds, minutes, sec
 class DateTimeOffset(datetime):
     """A datetime subclass with an explicit offset, similar to .NET DateTimeOffset"""
 
+    # Lets the formatters in `date` tell a DateTimeOffset apart from a DateTime
+    # with Kind = Utc — a zero offset gives both the same tzinfo, but only the
+    # latter renders as "Z" in the round-trip format.
+    is_offset_value: bool = True
+
     def __new__(cls, dt: datetime, offset_milliseconds: int = 0):
         # Create new datetime instance using the values from the input datetime
         instance = super().__new__(

--- a/tests/Python/TestDateTime.fs
+++ b/tests/Python/TestDateTime.fs
@@ -542,19 +542,57 @@ let ``test DateTime.ToString("t") (lower) works`` () =
 
 [<Fact>]
 let ``test DateTime.ToString with Round-trip format works for Utc`` () =
-    let str = DateTime(2014, 9, 11, 16, 37, 2, DateTimeKind.Utc).ToString("O")
-    // FIXME: missing regex module
-    // System.Text.RegularExpressions.Regex.Replace(str, "0{3,}", "000")
-    // Hardcode the replace string so we can test that "O" format is supported
-    str.Replace("0000000Z", "000000Z")
-    |> equal "2014-09-11T16:37:02.000000Z"
+    DateTime(2014, 9, 11, 16, 37, 2, DateTimeKind.Utc).ToString("O")
+    |> equal "2014-09-11T16:37:02.0000000Z"
 
-    let str = DateTime(2014, 9, 11, 16, 37, 2, DateTimeKind.Utc).ToString("o")
-    // FIXME: missing regex module
-    // System.Text.RegularExpressions.Regex.Replace(str, "0{3,}", "000")
-    // Hardcode the replace string so we can test that "O" format is supported
-    str.Replace("0000000Z", "000000Z")
-    |> equal "2014-09-11T16:37:02.000000Z"
+    DateTime(2014, 9, 11, 16, 37, 2, DateTimeKind.Utc).ToString("o")
+    |> equal "2014-09-11T16:37:02.0000000Z"
+
+[<Fact>]
+let ``test DateTime.ToString with Round-trip format works for Unspecified`` () =
+    // The round-trip format must depend only on the value: an Unspecified
+    // DateTime carries no offset, so none is printed whatever the host timezone.
+    DateTime(2014, 9, 11, 16, 37, 2).ToString("O")
+    |> equal "2014-09-11T16:37:02.0000000"
+
+    DateTime(2014, 9, 11, 16, 37, 2, 345).ToString("o")
+    |> equal "2014-09-11T16:37:02.3450000"
+
+[<Fact>]
+let ``test DateTime.ToString with Round-trip format works for Local`` () =
+    // A Local DateTime prints its own offset, which follows the host timezone,
+    // so only the machine-independent part can be asserted literally.
+    let str = DateTime(2014, 9, 11, 16, 37, 2, DateTimeKind.Local).ToString("O")
+    str.Substring(0, 27) |> equal "2014-09-11T16:37:02.0000000"
+    str.Length |> equal 33
+    let sign = str.[27]
+    (sign = '+' || sign = '-') |> equal true
+    str.[30] |> equal ':'
+
+[<Fact>]
+let ``test DateTime.ToString with Round-trip format pads the fraction to 7 digits`` () =
+    // Sub-millisecond digits are padded on the right, not truncated.
+    DateTime(2014, 9, 11, 16, 37, 2, 345, DateTimeKind.Utc).ToString("O")
+    |> equal "2014-09-11T16:37:02.3450000Z"
+
+    DateTime(2014, 9, 11, 16, 37, 2, 345, 678, DateTimeKind.Utc).ToString("O")
+    |> equal "2014-09-11T16:37:02.3456780Z"
+
+[<Fact>]
+let ``test DateTime.ToString with Round-trip format round-trips the instant`` () =
+    let roundtrips (d: DateTime) =
+        let parsed = DateTime.Parse(d.ToString("O"), CultureInfo.InvariantCulture)
+        parsed.ToUniversalTime() |> equal (d.ToUniversalTime())
+
+    roundtrips (DateTime(2014, 9, 11, 16, 37, 2, 345))
+    roundtrips (DateTime(2014, 9, 11, 16, 37, 2, 345, DateTimeKind.Utc))
+    roundtrips (DateTime(2014, 9, 11, 16, 37, 2, 345, DateTimeKind.Local))
+
+    // An Unspecified value has no offset to interpret, so its Kind survives too
+    let unspecified = DateTime(2014, 9, 11, 16, 37, 2, 345)
+    let parsed = DateTime.Parse(unspecified.ToString("O"), CultureInfo.InvariantCulture)
+    parsed.Kind |> equal DateTimeKind.Unspecified
+    parsed |> equal unspecified
 
 [<Fact>]
 let ``test DateTime.ToString("R") works`` () =

--- a/tests/Python/TestDateTimeOffset.fs
+++ b/tests/Python/TestDateTimeOffset.fs
@@ -490,6 +490,26 @@ let ``test DateTimeOffset.ToString with custom format works`` () =
     |> equal "16:37"
 
 [<Fact>]
+let ``test DateTimeOffset.ToString with Round-trip format works`` () =
+    // A DateTimeOffset always prints its own numeric offset — even "+00:00",
+    // where a DateTime with Kind = Utc would print "Z" instead.
+    DateTimeOffset(2014, 9, 11, 16, 37, 2, TimeSpan.FromHours 2).ToString("O", CultureInfo.InvariantCulture)
+    |> equal "2014-09-11T16:37:02.0000000+02:00"
+
+    DateTimeOffset(2014, 9, 11, 16, 37, 2, TimeSpan.Zero).ToString("o", CultureInfo.InvariantCulture)
+    |> equal "2014-09-11T16:37:02.0000000+00:00"
+
+    DateTimeOffset(2014, 9, 11, 16, 37, 2, 345, TimeSpan.FromMinutes -330.0).ToString("O", CultureInfo.InvariantCulture)
+    |> equal "2014-09-11T16:37:02.3450000-05:30"
+
+[<Fact>]
+let ``test DateTimeOffset.ToString with Round-trip format round-trips`` () =
+    let d = DateTimeOffset(2014, 9, 11, 16, 37, 2, 345, TimeSpan.FromHours 2)
+    let parsed = DateTimeOffset.Parse(d.ToString("O", CultureInfo.InvariantCulture), CultureInfo.InvariantCulture)
+    parsed |> equal d
+    parsed.Offset |> equal d.Offset
+
+[<Fact>]
 let ``test DateTimeOffset.ToString("R") works`` () =
     // R always formats in UTC
     DateTimeOffset(2014, 9, 1, 16, 37, 2, TimeSpan.FromHours 2).ToString("R", CultureInfo.InvariantCulture)


### PR DESCRIPTION
## Problem

`"O"` is the *round-trip* specifier: its contract is that the string identifies the same value on the way back, and that it depends only on the value. On Python it depended on the machine's timezone.

```fsharp
DateTime(2026, 8, 3, 14, 30, 15).ToString("O")   // Kind = Unspecified
// .NET   : "2026-08-03T14:30:15.0000000"
// Python : "2026-08-03T14:30:15.000+02:00"      // <-- host offset, 3-digit fraction
```

`astimezone()` on the naive datetime backing `Kind = Unspecified` assumes local time and attaches the local offset, so the same value printed differently on a developer machine and on CI.

Investigating turned up three more failures on the same path:

| Value | Before | .NET / after |
|---|---|---|
| `Unspecified` | `…15.000+02:00` | `…15.0000000` |
| `Utc` | `…15.000000Z` | `…15.0000000Z` |
| `Local` | `…15.000000Z` | `…15.0000000+02:00` |
| `DateTimeOffset(+02:00)` | `…15.000000Z` | `…15.0000000+02:00` |
| `DateTimeOffset(-05:30)` | `…15.000000Z` | `…15.0000000-05:30` |
| Year 1 | `ValueError` crash | `0001-01-01T00:00:00.0000000` |

The `Local` and `DateTimeOffset` rows are the serious ones: the old code appended a literal `Z` to the offset-local wall clock, so the string named a **different instant** than the value — silent corruption rather than cosmetic drift. The fractional width was also inconsistent between the two paths (3 digits on one, 6 on the other; .NET always emits 7).

## Fix

A single `_to_roundtrip_string` in `date.py`, used by both the `with_kind` and `with_offset` dispatchers. The zone designator comes from the value alone — none for `Unspecified`, `Z` for `Utc`, the value's own offset for `Local` — and the fraction is always 7 digits, padding the seventh rather than truncating.

Fields are formatted directly instead of via `strftime`, which does not zero-pad years < 1000 on glibc.

One wrinkle: `timezone(timedelta(0))` *is* `datetime.UTC` in CPython, so a `DateTimeOffset` at `+00:00` cannot be told apart from `Kind = Utc` by `tzinfo` alone — yet .NET renders them differently (`+00:00` vs `Z`). Hence the `is_offset_value` marker on `DateTimeOffset`, checked by attribute rather than `isinstance` because `date_offset` imports `date` and importing back would trip `reportImportCycles: true`.

## Verification

- 2458 Python tests pass; the 9 new/updated tests pass on .NET first, all under `TZ=Europe/Oslo`.
- Expected strings were captured from `dotnet fsi` rather than assumed; Python now matches literally.
- TZ-invariance checked across `Europe/Oslo`, `UTC` and `America/New_York`.
- Round-trip preserves the instant for every kind. `Kind` survives only for `Unspecified` — confirmed correct, .NET's default `DateTime.Parse` converts both `Z` and `+hh:mm` to `Local`.
- No new Pyright errors (126 pre-existing, all in array/float files) and no new Ruff errors (4 pre-existing long lines).

The existing Utc test worked around the 6-digit output with `str.Replace("0000000Z", "000000Z")`; that is now an exact literal, so it actually pins the format.

## Notes

Found while adding `DateTime` support to [Fable.TypedJson](https://github.com/dbrattli/Fable.TypedJson), which guarantees a value serializes identically across Beam, Python, JS and .NET. `"O"` was the one construct that broke the guarantee.

Two related items deliberately left out of scope:

- **`TimeSpan` renders as raw ticks** under `%A`/`%O`/`str()` (`72000000000` instead of `02:00:00`), while `.ToString()` is correct — `printf` lives in the Rust core and falls back to Python's `str()`, which `TimeSpan(int)` does not override. The obvious fix (`__str__`/`__format__`) is blocked on `TimeOnly` being the *same* Python type, so one `__str__` cannot serve both (.NET wants `02:00:00` vs `14:30`). Needs a design call.
- **Beam's `format_roundtrip`** emits no designator for `Kind = Local` (`fable_date.erl:435-444`) where .NET emits `+02:00`. Beam's `DateTimeOffset` path is already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
