### PR TITLE
fix(all): recompile when a source file is added or its output is missing

### DIFF
--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -979,12 +979,9 @@ let private areCompiledFilesUpToDate (state: State) (filesToCompile: string[]) =
 
                     upToDate
                 else
-                    // A source with no output must be compiled: it may be newly added, or
-                    // its output may have been deleted. `getFilesToCompile` already selected
-                    // it for that reason, so reporting it as up-to-date here would skip the
-                    // compilation it just asked for and leave the output missing.
-                    // (A file whose generated code is empty is never written, so it also
-                    // lands here and costs this project the skip-compilation shortcut.)
+                    // A missing output means the source is new or its output was deleted, so it
+                    // must be compiled. A file generating empty code is never written and also
+                    // lands here, costing that project the skip-compilation shortcut.
                     Log.verbose (lazy $"Output file {File.relPathToCurDir outPath} does not exist")
 
                     false

--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -965,7 +965,7 @@ let private areCompiledFilesUpToDate (state: State) (filesToCompile: string[]) =
             )
             |> Array.forall (fun source ->
                 let outPath = getOutPath state.CliArgs pathResolver source
-                // Empty files are not written to disk so we only check date for existing files
+
                 if IO.File.Exists(outPath) then
                     foundCompiledFile <- true
 
@@ -979,7 +979,15 @@ let private areCompiledFilesUpToDate (state: State) (filesToCompile: string[]) =
 
                     upToDate
                 else
-                    true
+                    // A source with no output must be compiled: it may be newly added, or
+                    // its output may have been deleted. `getFilesToCompile` already selected
+                    // it for that reason, so reporting it as up-to-date here would skip the
+                    // compilation it just asked for and leave the output missing.
+                    // (A file whose generated code is empty is never written, so it also
+                    // lands here and costs this project the skip-compilation shortcut.)
+                    Log.verbose (lazy $"Output file {File.relPathToCurDir outPath} does not exist")
+
+                    false
             )
         // If we don't find compiled files, assume we need recompilation
         upToDate && foundCompiledFile

--- a/src/Fable.Compiler/ProjectCracker.fs
+++ b/src/Fable.Compiler/ProjectCracker.fs
@@ -837,23 +837,17 @@ let loadPrecompiledInfo (opts: CrackerOptions) otherOptions sourceFiles =
         Some info, otherOptions, sourceFiles
     | None -> None, otherOptions, sourceFiles
 
-/// Files besides the project file itself that take part in its MSBuild evaluation
-/// and so can change its `<Compile Include>` list: explicit `<Import Project="..."/>`
-/// targets (transitively) and the implicit Directory.Build.props/targets and
-/// Directory.Packages.props found by walking up from the project directory.
-///
-/// Without these, adding a source file through a shared .props leaves every
-/// .fsproj timestamp untouched, and the cached project options — including the
-/// now-stale source list — are reused.
+/// Transitive `<Import Project="..."/>` targets plus the implicit Directory.Build.props/targets
+/// and Directory.Packages.props found upwards. These can change the `<Compile Include>` list
+/// without touching any .fsproj timestamp, so the cache must invalidate on them too.
 let private getProjectImports (projFile: string) : string list =
     let imports = ResizeArray()
     let visited = HashSet<string>(StringComparer.OrdinalIgnoreCase)
 
-    // Only the directory macros are expanded. An import path built from any other
-    // property cannot be resolved without evaluating MSBuild, so it is skipped:
-    // missing an import costs a stale cache, guessing wrong costs a bogus path.
+    // Paths built from other properties are skipped below: missing an import costs
+    // a stale cache, guessing wrong costs a bogus path.
     let expandMacros (fileDir: string) (path: string) =
-        let withSep = fileDir + string IO.Path.DirectorySeparatorChar
+        let withSep = fileDir + string<char> IO.Path.DirectorySeparatorChar
 
         path.Replace("$(MSBuildThisFileDirectory)", withSep).Replace("$(MSBuildProjectDirectory)", withSep)
 
@@ -935,8 +929,7 @@ let getFullProjectOpts (resolver: ProjectCrackerResolver) (opts: CrackerOptions)
             cacheInfo.Version = Literals.VERSION
             && cacheInfo.Exclude = opts.Exclude
             && cacheInfo.FableOptions.Language = opts.FableOptions.Language
-            // A .props/.targets that a project imports can add or remove source
-            // files without the .fsproj itself ever being touched
+            // An imported .props/.targets can add or remove source files with no .fsproj touched
             && ([ cacheInfo.ProjectPath; yield! cacheInfo.References ]
                 |> List.collect getProjectImports
                 |> List.forall isOlderThanCache)

--- a/src/Fable.Compiler/ProjectCracker.fs
+++ b/src/Fable.Compiler/ProjectCracker.fs
@@ -837,6 +837,79 @@ let loadPrecompiledInfo (opts: CrackerOptions) otherOptions sourceFiles =
         Some info, otherOptions, sourceFiles
     | None -> None, otherOptions, sourceFiles
 
+/// Files besides the project file itself that take part in its MSBuild evaluation
+/// and so can change its `<Compile Include>` list: explicit `<Import Project="..."/>`
+/// targets (transitively) and the implicit Directory.Build.props/targets and
+/// Directory.Packages.props found by walking up from the project directory.
+///
+/// Without these, adding a source file through a shared .props leaves every
+/// .fsproj timestamp untouched, and the cached project options — including the
+/// now-stale source list — are reused.
+let private getProjectImports (projFile: string) : string list =
+    let imports = ResizeArray()
+    let visited = HashSet<string>(StringComparer.OrdinalIgnoreCase)
+
+    // Only the directory macros are expanded. An import path built from any other
+    // property cannot be resolved without evaluating MSBuild, so it is skipped:
+    // missing an import costs a stale cache, guessing wrong costs a bogus path.
+    let expandMacros (fileDir: string) (path: string) =
+        let withSep = fileDir + string IO.Path.DirectorySeparatorChar
+
+        path.Replace("$(MSBuildThisFileDirectory)", withSep).Replace("$(MSBuildProjectDirectory)", withSep)
+
+    let rec collectFrom (file: string) =
+        // Guard against import cycles and repeated visits
+        if visited.Add(file) && IO.File.Exists(file) then
+            let fileDir = IO.Path.GetDirectoryName(file: string)
+
+            let importPaths =
+                try
+                    XDocument.Load(file).Descendants()
+                    |> Seq.filter (fun el -> el.Name.LocalName = "Import")
+                    |> Seq.choose (fun el ->
+                        match el.Attribute(XName.Get "Project") with
+                        | null -> None
+                        | attr -> Some(expandMacros fileDir attr.Value)
+                    )
+                    // Unresolved properties or wildcards need a real MSBuild evaluation
+                    |> Seq.filter (fun path -> not (path.Contains("$(") || path.Contains("*")))
+                    |> Seq.toList
+                with _ ->
+                    // A malformed or unreadable project is the cracker's problem, not ours
+                    []
+
+            for importPath in importPaths do
+                let fullPath =
+                    if IO.Path.IsPathRooted(importPath) then
+                        importPath
+                    else
+                        IO.Path.Combine(fileDir, importPath)
+
+                let fullPath = IO.Path.GetFullPath(fullPath)
+
+                if IO.File.Exists(fullPath) then
+                    imports.Add(fullPath)
+                    collectFrom fullPath
+
+    collectFrom (IO.Path.GetFullPath(projFile))
+
+    // Implicit imports the SDK adds for every project
+    let projDir = IO.Path.GetDirectoryName(IO.Path.GetFullPath(projFile))
+
+    for implicitFile in
+        [
+            "Directory.Build.props"
+            "Directory.Build.targets"
+            "Directory.Packages.props"
+        ] do
+        match File.tryFindUpwards implicitFile projDir with
+        | Some path ->
+            imports.Add(path)
+            collectFrom path
+        | None -> ()
+
+    List.ofSeq imports
+
 let getFullProjectOpts (resolver: ProjectCrackerResolver) (opts: CrackerOptions) : CrackerResponse =
     if not (IO.File.Exists(opts.ProjFile)) then
         Fable.FableError("Project file does not exist: " + opts.ProjFile) |> raise
@@ -862,6 +935,11 @@ let getFullProjectOpts (resolver: ProjectCrackerResolver) (opts: CrackerOptions)
             cacheInfo.Version = Literals.VERSION
             && cacheInfo.Exclude = opts.Exclude
             && cacheInfo.FableOptions.Language = opts.FableOptions.Language
+            // A .props/.targets that a project imports can add or remove source
+            // files without the .fsproj itself ever being touched
+            && ([ cacheInfo.ProjectPath; yield! cacheInfo.References ]
+                |> List.collect getProjectImports
+                |> List.forall isOlderThanCache)
             && ([ cacheInfo.ProjectPath; yield! cacheInfo.References ]
                 |> List.forall (fun fsproj ->
                     if IO.File.Exists(fsproj) && isOlderThanCache fsproj then

--- a/tests/Integration/Integration/CacheInvalidationTests.fs
+++ b/tests/Integration/Integration/CacheInvalidationTests.fs
@@ -4,9 +4,8 @@ open System
 open System.IO
 open Expecto
 
-/// A project whose compile order lives in an imported .props, so that adding a
-/// source file leaves the .fsproj timestamp untouched. Written to a temp
-/// directory because these tests have to mutate the project between compilations.
+/// A project whose compile order lives in an imported .props, so adding a source file
+/// leaves the .fsproj timestamp untouched. In a temp dir: these tests mutate the project.
 let private createProject (dir: string) =
     Directory.CreateDirectory(dir) |> ignore
 
@@ -35,14 +34,12 @@ let private createProject (dir: string) =
 
     File.WriteAllText(Path.Combine(dir, "Lib.fs"), "module Lib\n\nlet greeting = \"hello\"\n")
 
-    // A second file so that deleting one output still leaves another behind: the
-    // up-to-date check already forces a recompilation when it finds no generated
-    // file at all, which would mask the case under test.
+    // A second file, so deleting one output leaves another behind: with none left, the
+    // "no compiled files found" guard forces a recompilation and masks the case under test.
     File.WriteAllText(Path.Combine(dir, "Main.fs"), "module Main\n\nlet run () = printfn \"%s\" Lib.greeting\n")
 
-/// The cache is invalidated by comparing timestamps, so a file rewritten within
-/// the same tick as the previous compilation could be seen as unchanged. Nudge
-/// the timestamp forward to keep the test from flaking.
+/// Cache invalidation compares timestamps, so a file rewritten within the same tick as the
+/// previous compilation could look unchanged. Nudge it forward to keep the test from flaking.
 let private writeNewer (path: string) (content: string) =
     File.WriteAllText(path, content)
     File.SetLastWriteTime(path, DateTime.Now.AddSeconds(2.0))
@@ -76,10 +73,8 @@ let tests =
     testList
         "CacheInvalidation"
         [
-            // A `<Compile Include>` arriving through an imported .props leaves every
-            // .fsproj timestamp untouched, so the project options cache used to be
-            // reused with a stale source list: the new module was never generated and
-            // the build still reported success.
+            // A `<Compile Include>` arriving through an imported .props touches no .fsproj
+            // timestamp, so the options cache used to be reused with a stale source list.
             testCase "Source file added via an imported .props is compiled"
             <| fun () ->
                 withTempProject
@@ -107,9 +102,8 @@ let tests =
                             "The file added through the imported .props should have been generated"
                     )
 
-            // `getFilesToCompile` selects a source whose output is missing, so the
-            // up-to-date check must not then report that same file as up-to-date and
-            // skip the compilation it just asked for.
+            // `getFilesToCompile` selects a source whose output is missing, so the up-to-date
+            // check must not then skip the compilation it just asked for.
             testCase "Deleted output file is regenerated"
             <| fun () ->
                 withTempProject

--- a/tests/Integration/Integration/CacheInvalidationTests.fs
+++ b/tests/Integration/Integration/CacheInvalidationTests.fs
@@ -1,0 +1,127 @@
+module Fable.Tests.CacheInvalidation
+
+open System
+open System.IO
+open Expecto
+
+/// A project whose compile order lives in an imported .props, so that adding a
+/// source file leaves the .fsproj timestamp untouched. Written to a temp
+/// directory because these tests have to mutate the project between compilations.
+let private createProject (dir: string) =
+    Directory.CreateDirectory(dir) |> ignore
+
+    File.WriteAllText(
+        Path.Combine(dir, "Test.fsproj"),
+        """<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RollForward>Major</RollForward>
+  </PropertyGroup>
+  <Import Project="Tests.props" />
+</Project>
+"""
+    )
+
+    File.WriteAllText(
+        Path.Combine(dir, "Tests.props"),
+        """<Project>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Lib.fs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Main.fs" />
+  </ItemGroup>
+</Project>
+"""
+    )
+
+    File.WriteAllText(Path.Combine(dir, "Lib.fs"), "module Lib\n\nlet greeting = \"hello\"\n")
+
+    // A second file so that deleting one output still leaves another behind: the
+    // up-to-date check already forces a recompilation when it finds no generated
+    // file at all, which would mask the case under test.
+    File.WriteAllText(Path.Combine(dir, "Main.fs"), "module Main\n\nlet run () = printfn \"%s\" Lib.greeting\n")
+
+/// The cache is invalidated by comparing timestamps, so a file rewritten within
+/// the same tick as the previous compilation could be seen as unchanged. Nudge
+/// the timestamp forward to keep the test from flaking.
+let private writeNewer (path: string) (content: string) =
+    File.WriteAllText(path, content)
+    File.SetLastWriteTime(path, DateTime.Now.AddSeconds(2.0))
+
+let private compile (dir: string) (outDir: string) =
+    Fable.Cli.Entry.main
+        [|
+            Path.Combine(dir, "Test.fsproj")
+            "--cwd"
+            dir
+            "--lang"
+            "javascript"
+            "--outDir"
+            outDir
+        |]
+
+let private withTempProject name (f: string -> string -> unit) =
+    let unique = Guid.NewGuid().ToString("N")
+    let dir = Path.Combine(Path.GetTempPath(), $"fable-cache-tests-%s{name}-%s{unique}")
+
+    try
+        createProject dir
+        f dir (Path.Combine(dir, "out"))
+    finally
+        try
+            Directory.Delete(dir, true)
+        with _ ->
+            ()
+
+let tests =
+    testList
+        "CacheInvalidation"
+        [
+            // A `<Compile Include>` arriving through an imported .props leaves every
+            // .fsproj timestamp untouched, so the project options cache used to be
+            // reused with a stale source list: the new module was never generated and
+            // the build still reported success.
+            testCase "Source file added via an imported .props is compiled"
+            <| fun () ->
+                withTempProject
+                    "added"
+                    (fun dir outDir ->
+                        Expect.equal (compile dir outDir) 0 "First compilation should succeed"
+
+                        writeNewer (Path.Combine(dir, "Scalars.fs")) "module Scalars\n\nlet tests = \"scalars\"\n"
+
+                        writeNewer
+                            (Path.Combine(dir, "Tests.props"))
+                            """<Project>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Lib.fs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Scalars.fs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Main.fs" />
+  </ItemGroup>
+</Project>
+"""
+
+                        Expect.equal (compile dir outDir) 0 "Second compilation should succeed"
+
+                        Expect.isTrue
+                            (File.Exists(Path.Combine(outDir, "Scalars.js")))
+                            "The file added through the imported .props should have been generated"
+                    )
+
+            // `getFilesToCompile` selects a source whose output is missing, so the
+            // up-to-date check must not then report that same file as up-to-date and
+            // skip the compilation it just asked for.
+            testCase "Deleted output file is regenerated"
+            <| fun () ->
+                withTempProject
+                    "deleted"
+                    (fun dir outDir ->
+                        Expect.equal (compile dir outDir) 0 "First compilation should succeed"
+
+                        let outFile = Path.Combine(outDir, "Lib.js")
+                        Expect.isTrue (File.Exists outFile) "Expected the first compilation to generate Lib.js"
+                        File.Delete outFile
+
+                        Expect.equal (compile dir outDir) 0 "Second compilation should succeed"
+                        Expect.isTrue (File.Exists outFile) "The deleted output file should have been regenerated"
+                    )
+        ]

--- a/tests/Integration/Integration/Fable.Tests.Integration.fsproj
+++ b/tests/Integration/Integration/Fable.Tests.Integration.fsproj
@@ -17,6 +17,7 @@
     <Compile Include="FileWatcherTests.fs" />
     <Compile Include="CliTests.fs" />
     <Compile Include="CompilationTests.fs" />
+    <Compile Include="CacheInvalidationTests.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
 </Project>

--- a/tests/Integration/Integration/Main.fs
+++ b/tests/Integration/Integration/Main.fs
@@ -6,6 +6,7 @@ let allTests =
     Cli.tests
     FileWatcher.tests
     CompilationTests.tests
+    CacheInvalidation.tests
   ]
 
 open Expecto


### PR DESCRIPTION
## Problem

Adding a `<Compile Include>` through an imported `.props` could leave a build broken while still reporting success — `Skipped compilation because all generated files are up-to-date!`, exit code 0, new module never generated. The failure surfaced far from its cause (Python: `TypeError: exceptions must derive from BaseException`; Beam: `'Scalars' is not defined`). Bad for CI: a pipeline that adds a file and reuses a warm cache green-lights a build whose new code was never compiled.

Two independent defects, both reproduced from source.

### 1. The project options cache ignored imported .props/.targets

Cache validity compared only `.fsproj` and reference timestamps. A `.props` adds `<Compile Include>` items without any `.fsproj` being touched, so the stale source list was reused. Adding the file directly to the `.fsproj` always worked.

Fixed by also invalidating on the files taking part in a project's MSBuild evaluation: transitive `<Import Project>`, plus `Directory.Build.props`/`.targets` and `Directory.Packages.props` found upwards. Only `$(MSBuildThisFileDirectory)` and `$(MSBuildProjectDirectory)` are expanded — an import path built from any other property is skipped, since missing an import costs a stale cache while guessing wrong costs a bogus path.

### 2. A missing output file counted as up-to-date

`getFilesToCompile` selects a source whose output does not exist (`Main.fs:945`), then `areCompiledFilesUpToDate` reported that same file as up-to-date (`Main.fs:981`) and skipped the compilation it had just asked for. No `.props` needed: delete any generated file and rebuild → skipped, exit 0, file still missing.

## Trade-off

A file whose generated code is empty is never written, so it is indistinguishable from one that was never compiled. Projects containing such a file lose the skip-compilation shortcut — real, not hypothetical (`module Empty` emits no output on JS/Dart/Beam), and measured at ~1.2s recompile instead of a skip. Normal projects still skip (0.23–0.28s), so the added import walk costs nothing measurable. Losing a shortcut is recoverable; silently shipping a half-generated build is not.

## Verification

Integration tests in `CacheInvalidationTests.fs` for both cases, checked in both directions — they fail without this change and pass with it. The deleted-output fixture has two source files on purpose: with one, the existing "no compiled files found" guard masks the bug.

Checked by hand on Python, JavaScript and Beam, which now behave identically: add via `.fsproj`, add via imported `.props`, a `.props` shared by two projects built in turn, remove from the compile list, deleted output regenerated.

Suites: Python 2458 passed, Integration 42 + 116 passed, fantomas clean.

## Not addressed

Found alongside, out of scope here. With the two cache defects fixed, both only surface on a compile that already exits non-zero and prints the error — noisy rather than silent.

- **Output files are written even when the compile fails** (reproduced standalone: exit 1, `a.py` written anyway). This is what poisons the output tree so the *next* run takes the skip path. Fable compiles each file as it type-checks, and project-wide diagnostics only arrive at `FSharpCompilationFinished`, so gating writes on "no errors" means buffering output or restructuring that pipeline.
- **The Python backend emits `raise 1`** — a non-exception — from F#'s error-recovery AST. A symptom of the above: generating code from an AST that failed type-checking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
