### PR TITLE
fix(all): error on member reference from a source-less dll

### DIFF
--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -2445,7 +2445,7 @@ module Util =
             else
                 Some(entityIdent com ent.Ref)
 
-    let memberIdent (com: Compiler) r typ (memb: FSharpMemberOrFunctionOrValue) membRef =
+    let memberIdent (com: Compiler) (ctx: Context) r typ (memb: FSharpMemberOrFunctionOrValue) membRef =
         let r = r |> Option.map (fun r -> { r with identifierName = Some memb.DisplayName })
 
         let memberName, hasOverloadSuffix = getMemberDeclarationName com memb
@@ -2463,31 +2463,43 @@ module Util =
             | _ -> memberName
 
         let file =
-            memb.DeclaringEntity
-            |> Option.bind (fun ent -> FsEnt.Ref(ent).SourcePath)
+            match memb.DeclaringEntity with
             // Cases when .DeclaringEntity returns None are rare (see #237)
             // We assume the member belongs to the current file
-            |> Option.defaultValue com.CurrentFile
+            | None -> Some com.CurrentFile
+            | Some ent -> FsEnt.Ref(ent).SourcePath
 
-        // If precompiling inline function always reference with Import and not as IdentExpr
-        if not com.IsPrecompilingInlineFunction && file = com.CurrentFile then
-            { makeTypedIdent typ memberName with
-                Range = r
-                IsMutable = memb.IsMutable
-            }
-            |> Fable.IdentExpr
-        else
-            // If the overload suffix changes, we need to recompile the files that call this member
-            if hasOverloadSuffix then
-                com.AddWatchDependency(file)
+        match file with
+        // A quotation keeps the reference as metadata, so it needs no import
+        | None when not ctx.CapturingQuotation ->
+            let name =
+                match memb.DeclaringEntity with
+                | Some ent -> FsEnt.FullName ent + "." + memb.DisplayName
+                | None -> memb.DisplayName
 
-            // Private values are not exported so they can't be imported by call sites in other files.
-            // We need to handle it manually because Fable handle resolve inline function itself
-            if com.IsPrecompilingInlineFunction && memb.Accessibility.IsPrivate then
-                $"The value '%s{memb.DisplayName}' was marked inline but its implementation makes use of an internal or private function which is not sufficiently accessible"
-                |> addError com [] r
+            $"Cannot reference member from .dll reference, Fable packages must include F# sources: %s{name}"
+            |> addErrorAndReturnNull com [] r
+        | file ->
+            let file = Option.defaultValue com.CurrentFile file
+            // If precompiling inline function always reference with Import and not as IdentExpr
+            if not com.IsPrecompilingInlineFunction && file = com.CurrentFile then
+                { makeTypedIdent typ memberName with
+                    Range = r
+                    IsMutable = memb.IsMutable
+                }
+                |> Fable.IdentExpr
+            else
+                // If the overload suffix changes, we need to recompile the files that call this member
+                if hasOverloadSuffix then
+                    com.AddWatchDependency(file)
 
-            makeInternalMemberImport com typ membRef memberName file
+                // Private values are not exported so they can't be imported by call sites in other files.
+                // We need to handle it manually because Fable handle resolve inline function itself
+                if com.IsPrecompilingInlineFunction && memb.Accessibility.IsPrivate then
+                    $"The value '%s{memb.DisplayName}' was marked inline but its implementation makes use of an internal or private function which is not sufficiently accessible"
+                    |> addError com [] r
+
+                makeInternalMemberImport com typ membRef memberName file
 
     let getFunctionMemberRef (memb: FSharpMemberOrFunctionOrValue) =
         match memb.DeclaringEntity with
@@ -3135,7 +3147,7 @@ module Util =
                 else
                     callInfo
 
-            memberIdent com r membTyp memb membRef |> makeCall r typ callInfo
+            memberIdent com ctx r membTyp memb membRef |> makeCall r typ callInfo
 
         | Emitted com ctx r typ (Some callInfo) emitted, _ -> emitted
         | Imported com ctx r typ (Some callInfo) imported -> imported
@@ -3203,7 +3215,7 @@ module Util =
 
         | _, Some entity when isModuleValueForCalls com entity memb ->
             let typ = makeType ctx.GenericArgs memb.FullType
-            memberIdent com r typ memb membRef
+            memberIdent com ctx r typ memb membRef
 
         // (optional, Dart only) Call the implicit constructor instead of the mangled one
         | _, Some entity when com.Options.Language = Dart && memb.IsImplicitConstructor ->
@@ -3215,7 +3227,7 @@ module Util =
             let typ = makeType ctx.GenericArgs memb.FullType
             let retTyp = makeType ctx.GenericArgs memb.ReturnParameter.Type
             let callInfo = { callInfo with Tags = "value" :: callInfo.Tags }
-            let callExpr = memberIdent com r typ memb membRef |> makeCall r retTyp callInfo
+            let callExpr = memberIdent com ctx r typ memb membRef |> makeCall r retTyp callInfo
 
             let fableMember = FsMemberFunctionOrValue(memb)
             // TODO: Move plugin application to FableTransforms
@@ -3256,4 +3268,4 @@ module Util =
         | Emitted com ctx r typ None emitted, _ -> emitted
         | Imported com ctx r typ None imported -> imported
         | Try (tryGetIdentFromScope ctx r (Some typ)) expr, _ -> expr
-        | _ -> getValueMemberRef v |> memberIdent com r typ v
+        | _ -> getValueMemberRef v |> memberIdent com ctx r typ v

--- a/tests/Integration/Compiler/CompilerMessagesTests.fs
+++ b/tests/Integration/Compiler/CompilerMessagesTests.fs
@@ -98,6 +98,15 @@ let z = y ()
       |> Assert.Is.success
       |> ignore
 
+    testCase "Referencing a member from a package without F# sources emits an error" <| fun _ ->
+      let source =
+        """
+let version = Semver.SemVersion.Parse("1.0.0", 1024)
+"""
+      compile source
+      |> Assert.Exists.errorWith "Cannot reference member from .dll reference, Fable packages must include F# sources"
+      |> ignore
+
     testCase "Duplicate attached member names emit a warning" <| fun _ ->
       let source =
         """

--- a/tests/Integration/Compiler/TestProject/TestProject.fsproj
+++ b/tests/Integration/Compiler/TestProject/TestProject.fsproj
@@ -12,6 +12,8 @@
 
   <ItemGroup>
     <ProjectReference Include="../../../../src/Fable.Core/Fable.Core.fsproj" />
+    <!-- A package that ships no F# sources, so Fable cannot emit imports for its members -->
+    <PackageReference Include="Semver" Version="3.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## The bug

Referencing a member of a package that ships only a `.dll` (no `fable/` sources) produced **broken output with no diagnostic at all**. Compiling a project referencing `Semver`:

```fsharp
let version = Semver.SemVersion.Parse("1.0.0", 1024)
```

emitted

```js
export const version = Semver_SemVersion_Parse_Z18115A39("1.0.0", 1024);
```

`Semver_SemVersion_Parse_Z18115A39` is referenced and never imported, so the module throws `ReferenceError` the moment it runs. Fable reported success.

## Cause

`memberIdent` resolved the defining file with:

```fsharp
memb.DeclaringEntity
|> Option.bind (fun ent -> FsEnt.Ref(ent).SourcePath)
|> Option.defaultValue com.CurrentFile
```

`EntityRef.SourcePath` is `None` for `Fable.AssemblyPath`, so the fallback - which exists for the rare case where `DeclaringEntity` is `None` (#237) - also caught members from a source-less dll. `file = com.CurrentFile` then held, and Fable emitted a bare `IdentExpr` instead of an import.

Entities already report this properly: `entityIdentWithSuffix` raises *"Cannot reference entity from .dll reference, Fable packages must include F# sources"*. Only members lacked the equivalent guard.

## Fix

Separate the two reasons `SourcePath` can be `None`, and error on the dll one, reusing the existing wording so members and entities read alike. `FsEnt.Ref(ent)` is still evaluated exactly once.

Quotations are exempt: `QuotationEmitter` turns the reference into .NET metadata rather than a call, so nothing needs importing. Without that exemption `QuotationTests.fs` reports ~16 spurious errors for members like `Operators.(+)` - which is how the exemption was found.

## Tests

New case in `CompilerMessagesTests.fs`. It needs a source-less dll to reference, so `TestProject.fsproj` gains a `PackageReference` to `Semver` - already used by `Fable.Build`, so nothing new is downloaded, and `SemVersion.Parse` is a plain static member outside `System.` so Replacements does not intercept it.

Green on every suite: JavaScript 3085, TypeScript 2862, Python 2458, Dart 1337, Rust 2507, BEAM, integration 117.