### PR TITLE
fix(standalone): compile each file on a fresh stack

### DIFF
--- a/src/Fable.Build/Test/Standalone.fs
+++ b/src/Fable.Build/Test/Standalone.fs
@@ -43,6 +43,12 @@ let handleStandaloneFast () =
 
     Command.Run("node", testArgs, workingDirectory = standaloneBuildDest)
 
+/// The worker is only reachable through the bundles in dist, so they have to be built first
+let private handleWorker (args: string list) =
+    Build.Standalone.handle args
+    Command.Run("node", "test/worker/run.mjs", workingDirectory = Workspace.ProjectDir.fable_standalone)
+
 let handle (args: string list) =
     BuildFableLibraryJavaScript().Run()
     handleStandaloneFast ()
+    handleWorker args

--- a/src/fable-standalone/src/Worker/Worker.fs
+++ b/src/fable-standalone/src/Worker/Worker.fs
@@ -176,6 +176,12 @@ let private compileCode fable fileName fsharpNames fsharpCodes language otherFSh
                         else
                             None
 
+                    // Fable's JS Async runs each bind's continuation inside the caller's frame and
+                    // only unwinds every 2000 of them, so printing the previous file leaves this one
+                    // partway up a sawtooth. Sleep resumes from a timer callback, i.e. an empty
+                    // stack, which CompileToTargetAst needs because it recurses over the whole AST.
+                    do! Async.Sleep 0
+
                     let (res, fableTransformTime) =
                         measureTime
                             (fun () ->
@@ -205,6 +211,11 @@ let private compileCode fable fileName fsharpNames fsharpCodes language otherFSh
 
         return (compiledCode, errors, stats)
     }
+
+let private describeError (er: exn) =
+    match er?stack with
+    | null -> er.Message
+    | stack -> er.Message + "\n" + string<obj> stack
 
 let private combineStats (a: CompileStats) (b: CompileStats) : CompileStats =
     {
@@ -307,7 +318,7 @@ let rec loop (box: MailboxProcessor<WorkerRequest>) (state: State) =
                 CompilationFinished(compiledCode, language, errors, stats) |> state.Worker.Post
             with er ->
                 JS.console.error er
-                CompilerCrashed er.Message |> state.Worker.Post
+                CompilerCrashed(describeError er) |> state.Worker.Post
 
             return! loop box state
 
@@ -341,7 +352,7 @@ let rec loop (box: MailboxProcessor<WorkerRequest>) (state: State) =
                 CompilationsFinished(code, language, errors, stats) |> state.Worker.Post
             with er ->
                 JS.console.error er
-                CompilerCrashed er.Message |> state.Worker.Post
+                CompilerCrashed(describeError er) |> state.Worker.Post
 
             return! loop box state
 

--- a/src/fable-standalone/test/worker/README.md
+++ b/src/fable-standalone/test/worker/README.md
@@ -1,0 +1,48 @@
+# Worker harness
+
+Drives `dist/worker.min.js` from Node, over the same Thoth-encoded protocol it speaks in a browser
+(`src/Worker/Shared.fs`). The worker only needs four browser globals - `self`, `importScripts`,
+`postMessage` and `fetch` - so a `vm` context is enough to run the real published artifact outside a
+browser, which is otherwise the only place it can be exercised.
+
+It runs as part of `./build.sh test standalone`, which is what CI calls. To iterate on it directly:
+
+```bash
+./build.sh standalone                 # or worker-js, to rebuild just the worker
+node src/fable-standalone/test/worker/run.mjs
+```
+
+Options:
+
+| Option | Meaning |
+| --- | --- |
+| `--files 12` | how many files to compile (default 6) |
+| `--dist <path>` | a different build, e.g. an unpacked npm tarball |
+| `--metadata <path>` | assemblies directory (defaults to `src/fable-metadata/lib`) |
+
+The fixture is generated, so nothing is downloaded.
+
+## What it checks
+
+Beyond "the compile finished and returned a module per file", it measures the **stack headroom the
+compiler is handed for each file** and fails if it drifts between files.
+
+That is not an abstract worry. A browser worker gets a smaller stack than Node does - roughly what
+`node --stack-size=700` gives - and Fable's JS `Async` runs each bind's continuation inside the
+caller's frame, unwinding only every 2000 of them (`Trampoline.maxTrampolineCallCount`). Printing a
+file binds once per top-level declaration, so before this was fixed each file was handed whatever
+the previous file's printing had left:
+
+```text
+headroom fell from 12501 to 6165 frames across 6 files (12501, 10389, 8277, 6165, 11151, 9039)
+```
+
+Half the stack gone, and then the deeply recursive `CompileToTargetAst` runs on what remains. In
+Node that only showed up under `--stack-size=400`; in a browser worker it was a
+`CompilerCrashed: Maximum call stack size exceeded` that no one could reproduce off-browser.
+
+To see the margin directly, lower Node's stack to something browser-shaped:
+
+```bash
+node --stack-size=300 src/fable-standalone/test/worker/run.mjs
+```

--- a/src/fable-standalone/test/worker/run.mjs
+++ b/src/fable-standalone/test/worker/run.mjs
@@ -1,0 +1,135 @@
+// Drives dist/worker.min.js from Node, over the same Thoth-encoded messages a browser sends.
+//
+//   node run.mjs                      compile the fixture, check stack headroom
+//   node run.mjs --files 12           more files
+//   node run.mjs --dist <path>        a different build (e.g. an unpacked npm tarball)
+//   node --stack-size=300 run.mjs     a browser worker gets roughly 700-810 of these
+
+import fs from "node:fs"
+import path from "node:path"
+import vm from "node:vm"
+
+const HERE = path.dirname(new URL(import.meta.url).pathname)
+
+const arg = (name, fallback) => {
+    const i = process.argv.indexOf(`--${name}`)
+    return i >= 0 ? process.argv[i + 1] : fallback
+}
+
+const dist = path.resolve(arg("dist", path.join(HERE, "../../dist")))
+const libDir = path.resolve(arg("metadata", path.join(HERE, "../../../fable-metadata/lib")))
+const fileCount = Number(arg("files", "6"))
+
+for (const [what, where] of [["worker", path.join(dist, "worker.min.js")], ["assemblies", libDir]]) {
+    if (!fs.existsSync(where)) {
+        console.error(`No ${what} at ${where}. Run './build.sh standalone' first, or pass --dist.`)
+        process.exit(1)
+    }
+}
+
+let onMessage = null
+const answers = []
+const headroom = []
+
+const ctx = {
+    console,
+    setTimeout, clearTimeout, setInterval, clearInterval, queueMicrotask,
+    performance, crypto, TextDecoder, TextEncoder,
+    addEventListener: (kind, fn) => { if (kind === "message") onMessage = fn },
+    postMessage: (msg) => answers.push(msg),
+    importScripts: (p) => vm.runInContext(fs.readFileSync(path.join(dist, p), "utf8"), ctx, { filename: p }),
+    fetch: async (url) => {
+        const file = path.join(libDir, path.basename(url))
+        if (!fs.existsSync(file)) return { ok: false, status: 404, statusText: `no such assembly: ${url}` }
+        const b = fs.readFileSync(file)
+        return { ok: true, arrayBuffer: async () => b.buffer.slice(b.byteOffset, b.byteOffset + b.byteLength) }
+    },
+    reportHeadroom: (frames) => headroom.push(frames),
+}
+ctx.self = ctx
+ctx.globalThis = ctx
+vm.createContext(ctx)
+
+vm.runInContext(fs.readFileSync(path.join(dist, "worker.min.js"), "utf8"), ctx, { filename: "worker.min.js" })
+
+// init() is called lazily on CreateChecker, so wrapping it here catches every compile
+vm.runInContext(`
+    __FABLE_STANDALONE__.init = ((init) => () => {
+        const manager = init()
+        const compile = manager.CompileToTargetAst.bind(manager)
+        manager.CompileToTargetAst = function (...args) {
+            let frames = 0
+            const down = () => { frames++; down() }
+            try { down() } catch { }
+            reportHeadroom(frames)
+            return compile(...args)
+        }
+        return manager
+    })(__FABLE_STANDALONE__.init)
+`, ctx)
+
+const post = (request) => onMessage({ data: JSON.stringify(request) })
+
+async function answer(expected) {
+    for (;;) {
+        while (answers.length) {
+            const parsed = JSON.parse(answers.shift())
+            if (parsed[0] === expected) return parsed
+            if (parsed[0] === "CompilerCrashed") throw new Error(`CompilerCrashed: ${parsed[1]}`)
+            if (parsed[0] === "LoadFailed") throw new Error("LoadFailed")
+        }
+        await new Promise((r) => setTimeout(r, 0))
+    }
+}
+
+const fixture = Array.from({ length: fileCount }, (_, i) => ({
+    Name: `Module${i}.fs`,
+    Content: [
+        `module Module${i}`,
+        "",
+        ...Array.from({ length: 60 }, (_, j) => [
+            `let value${j} (input: int) =`,
+            `    let doubled = input * 2`,
+            `    let name = sprintf "%s-%i" "item" doubled`,
+            `    let items = [ for k in 1..doubled -> k, name ]`,
+            `    items |> List.filter (fun (k, _) -> k % 2 = 0) |> List.map fst |> List.sum`,
+        ].join("\n")),
+    ].join("\n"),
+}))
+
+const sizeKb = Math.round(fixture.reduce((n, f) => n + f.Content.length, 0) / 1024)
+console.log(`worker: ${path.relative(process.cwd(), dist)}`)
+
+post(["CreateChecker", "file:///assemblies", [], null, []])
+await answer("Loaded")
+console.log(`checker ready (${fs.readdirSync(libDir).filter((f) => f.endsWith(".dll")).length} assemblies)`)
+
+console.log(`CompileFiles: ${fixture.length} files, ${sizeKb} KB`)
+const started = Date.now()
+post(["CompileFiles", fixture, "javascript", []])
+const [, modules, , errors] = await answer("CompilationsFinished")
+console.log(`  ${modules.length} modules in ${((Date.now() - started) / 1000).toFixed(1)}s`)
+
+const failures = []
+if (modules.length !== fixture.length) failures.push(`expected ${fixture.length} modules, got ${modules.length}`)
+
+const hard = (errors ?? []).filter((e) => !e.IsWarning)
+if (hard.length) failures.push(`${hard.length} compile error(s), first: ${hard[0].Message}`)
+
+// V8 caps the stack in bytes, so a frame count is only comparable against another count from this
+// same probe - hence a share of the first file rather than of any absolute capacity
+const [first, ...rest] = headroom
+const worst = Math.min(...headroom)
+const kept = Math.round((worst / first) * 100)
+console.log(`  stack headroom: ${first} frames on the first file, worst file kept ${kept}%`)
+if (rest.length && kept < 95) {
+    failures.push(`the worst file was handed ${kept}% of the stack the first one got ` +
+        `(${headroom.join(", ")}) - a compile is running on a stack the one before it used up`)
+}
+
+if (failures.length) {
+    console.error("\nFAILED")
+    for (const f of failures) console.error(`  - ${f}`)
+    process.exit(1)
+}
+console.log("\nOK")


### PR DESCRIPTION
This make Fable standalone able to compile bigger file/project especially in small environment like web worker. 