### PR TITLE
fix(standalone): match fcs-fable's assembly identity to what callers look up

### DIFF
--- a/src/fcs-fable/TcImports_shim.fs
+++ b/src/fcs-fable/TcImports_shim.fs
@@ -49,16 +49,26 @@ module TcImports =
             |> GetResourceNameAndSignatureDataFuncs
             |> List.map snd
 
+        /// FCS keys a CCU on its signature-data resource name, not always the IL manifest name
+        let sigDataCcuName ilModule =
+            ilModule.Resources.AsList()
+            |> GetResourceNameAndSignatureDataFuncs
+            |> List.tryHead
+            |> Option.map fst
+
         let optDataReaders ilModule =
             ilModule.Resources.AsList()
             |> GetResourceNameAndOptimizationDataFuncs
             |> List.map snd
 
+        /// No file system here: an assembly's file name is the name it was requested under
+        let moduleFileName (ccuName: string) =
+            if ccuName.EndsWith(".dll", System.StringComparison.OrdinalIgnoreCase)
+            then ccuName
+            else ccuName + ".dll"
+
         let LoadMod (ccuName: string) =
-            let fileName =
-                if ccuName.EndsWith(".dll", System.StringComparison.OrdinalIgnoreCase)
-                then ccuName
-                else ccuName + ".dll"
+            let fileName = moduleFileName ccuName
             let bytes = readAllBytes fileName
             let opts: ILReaderOptions =
                   { metadataOnly = MetadataOnlyFlag.Yes
@@ -95,7 +105,7 @@ module TcImports =
             let ilModule = memoize_mod.Apply ccuName
             let ilShortAssemName = ilModule.ManifestOfAssembly.Name
             let ilScopeRef = ILScopeRef.Assembly (mkSimpleAssemblyRef ilShortAssemName)
-            let fileName = ilModule.Name //TODO: try with ".sigdata" extension
+            let fileName = moduleFileName ccuName //TODO: try with ".sigdata" extension
             match sigDataReaders ilModule with
             | [] -> None
             | (readerA, readerB)::_ -> Some (GetSignatureData (fileName, ilScopeRef, Some ilModule, readerA, readerB))
@@ -104,7 +114,7 @@ module TcImports =
             let ilModule = memoize_mod.Apply ccuName
             let ilShortAssemName = ilModule.ManifestOfAssembly.Name
             let ilScopeRef = ILScopeRef.Assembly (mkSimpleAssemblyRef ilShortAssemName)
-            let fileName = ilModule.Name //TODO: try with ".optdata" extension
+            let fileName = moduleFileName ccuName //TODO: try with ".optdata" extension
             match optDataReaders ilModule with
             | [] -> None
             | (readerA, readerB)::_ -> Some (GetOptimizationData (fileName, ilScopeRef, Some ilModule, readerA, readerB))
@@ -145,7 +155,7 @@ module TcImports =
             let ilModule = memoize_mod.Apply ccuName
             let ilShortAssemName = ilModule.ManifestOfAssembly.Name
             let ilScopeRef = ILScopeRef.Assembly (mkSimpleAssemblyRef ilShortAssemName)
-            let fileName = ilModule.Name
+            let fileName = moduleFileName ccuName
             let invalidateCcu = new Event<_>()
             let ccu = Import.ImportILAssembly(
                         tcImports.GetImportMap, m, auxModuleLoader, tcConfig.xmlDocInfoLoader, ilScopeRef,
@@ -158,7 +168,7 @@ module TcImports =
             let ilModule = memoize_mod.Apply ccuName
             let ilShortAssemName = ilModule.ManifestOfAssembly.Name
             let ilScopeRef = ILScopeRef.Assembly (mkSimpleAssemblyRef ilShortAssemName)
-            let fileName = ilModule.Name
+            let fileName = moduleFileName ccuName
             let GetRawTypeForwarders ilModule =
                 match ilModule.Manifest with 
                 | Some manifest -> manifest.ExportedTypes
@@ -195,7 +205,8 @@ module TcImports =
                     let findCcuInfo name = tcImports.FindCcu (m, name)
                     Some (data.OptionalFixup findCcuInfo) )
 
-            let ccu = CcuThunk.Create(ilShortAssemName, ccuData)
+            let pickledCcuName = sigDataCcuName ilModule |> Option.defaultValue ilShortAssemName
+            let ccu = CcuThunk.Create(pickledCcuName, ccuData)
             let ccuInfo = mkCcuInfo ilScopeRef ilModule ccu
             let ccuOptInfo = { ccuInfo with FSharpOptimizationData = optdata }
             ccuOptInfo, sigdata


### PR DESCRIPTION
@ncave I sent a PR in your fork to forward the fix and not lose it on the next synchronization.

https://github.com/ncave/fsharp/pull/17

## Explanations

Two places where fcs-fable disagrees with FCS about an assembly's name. Both only bite when the IL module name differs from the name callers use, which never happens for ordinary assemblies - but `fable precompile` writes `Fable.Precompiled.dll` from a project called something else, and its module calls itself `Fable.Precompiled.exe`.

### 1. CCU name (`GetCcuFS`)

FCS names a CCU from the signature-data resource - `CompilerImports.fs` does `CcuThunk.Create(ccuName, ccuData)` with `ccuName` from `GetResourceNameAndSignatureDataFuncs`. fcs-fable used `ilModule.ManifestOfAssembly.Name`.

Pickled data refers to its own CCU by the name it was pickled under. Registered under the manifest name, that reference stays an unresolved thunk and any type reached through it raises `UnresolvedPathReferenceNoRange` while type-checking.

### 2. Assembly file name (`LoadMod`, `LoadSigData`, `LoadOptData`, `GetCcuIL`, `GetCcuFS`)

`ccuData.FileName` was `ilModule.Name`. There is no file system here - an assembly is known by the name handed to `readAllBytes` - so anything looking one up by path misses. Concretely, `TryGetEntity`'s fallback into a precompiled assembly always returned `None`.

### Effect

Referencing a `fable precompile` assembly from fable-standalone works. Before, it failed on any type that assembly defined.

Consumed by https://github.com/fable-compiler/Fable/pull/4898, where `./build.sh test standalone` is green (3076 tests).