### PR TITLE
feat(standalone)!: reference a precompiled library

### DIFF
--- a/src/fable-standalone/src/Interfaces.fs
+++ b/src/fable-standalone/src/Interfaces.fs
@@ -47,6 +47,13 @@ type SourceMapping = int * int * int * int * string option
 
 type IChecker = interface end
 
+/// Root modules from a `fable precompile` output. Inline members of the library cannot be called:
+/// FCS hands Fable a call rather than an expansion, and their bodies are not readable here.
+type IPrecompiledInfo =
+    /// Must be the name the precompiled assembly is referenced under, plus ".dll"
+    abstract DllPath: string
+    abstract TryGetRootModule: normalizedFullPath: string -> string option
+
 type IParseAndCheckResults =
     abstract OtherFSharpOptions: string[]
     abstract Errors: Error[]
@@ -72,7 +79,8 @@ type IFableManager =
         projectFileName: string *
         fileNames: string[] *
         sources: string[] *
-        ?otherFSharpOptions: string[] ->
+        ?otherFSharpOptions: string[] *
+        ?precompiledInfo: IPrecompiledInfo ->
             IParseAndCheckResults
 
     abstract ParseAndCheckFileInProject:
@@ -81,7 +89,8 @@ type IFableManager =
         projectFileName: string *
         fileNames: string[] *
         sources: string[] *
-        ?otherFSharpOptions: string[] ->
+        ?otherFSharpOptions: string[] *
+        ?precompiledInfo: IPrecompiledInfo ->
             IParseAndCheckResults
 
     abstract GetErrors: parseResults: IParseAndCheckResults -> Error[]

--- a/src/fable-standalone/src/Main.fs
+++ b/src/fable-standalone/src/Main.fs
@@ -154,7 +154,21 @@ let makeCompiler fableLibrary typedArrays language fsharpOptions project fileNam
 
     CompilerImpl(fileName, project, options, fableLibrary)
 
-let makeProject (projectOptions: FSharpProjectOptions) (checkResults: FSharpCheckProjectResults) =
+let private toCompilerPrecompiledInfo (info: IPrecompiledInfo) =
+    { new PrecompiledInfo with
+        member _.DllPath = info.DllPath
+
+        member _.TryGetRootModule(normalizedFullPath) =
+            info.TryGetRootModule(normalizedFullPath)
+
+        member _.TryGetInlineExpr(_) = None
+    }
+
+let makeProject
+    (projectOptions: FSharpProjectOptions)
+    (checkResults: FSharpCheckProjectResults)
+    (precompiledInfo: IPrecompiledInfo option)
+    =
     // let errors = com.GetFormattedLogs() |> Map.tryFind "error"
     // if errors.IsSome then failwith (errors.Value |> String.concat "\n")
     let optimize = projectOptions.OtherOptions |> Array.exists ((=) "--optimize+")
@@ -172,15 +186,23 @@ let makeProject (projectOptions: FSharpProjectOptions) (checkResults: FSharpChec
         projectOptions,
         implFiles,
         checkResults.ProjectContext.GetReferencedAssemblies(),
-        addLog
+        addLog,
+        ?precompiledInfo = (precompiledInfo |> Option.map toCompilerPrecompiledInfo)
     )
 
-let parseAndCheckProject (checker: InteractiveChecker) projectFileName fileNames sources otherFSharpOptions =
+let parseAndCheckProject
+    (checker: InteractiveChecker)
+    projectFileName
+    fileNames
+    sources
+    otherFSharpOptions
+    precompiledInfo
+    =
     let checkResults = checker.ParseAndCheckProject(projectFileName, fileNames, sources)
 
     let projectOptions = makeProjOptions projectFileName fileNames otherFSharpOptions
 
-    let project = lazy (makeProject projectOptions checkResults)
+    let project = lazy (makeProject projectOptions checkResults precompiledInfo)
     ParseAndCheckResults(project, None, None, checkResults, otherFSharpOptions)
 
 let parseAndCheckFileInProject
@@ -190,13 +212,14 @@ let parseAndCheckFileInProject
     fileNames
     sources
     otherFSharpOptions
+    precompiledInfo
     =
     let results, checkResults, projectResults =
         checker.ParseAndCheckFileInProject(fileName, projectFileName, fileNames, sources)
 
     let projectOptions = makeProjOptions projectFileName fileNames otherFSharpOptions
 
-    let project = lazy (makeProject projectOptions projectResults)
+    let project = lazy (makeProject projectOptions projectResults precompiledInfo)
 
     ParseAndCheckResults(project, Some results, Some checkResults, projectResults, otherFSharpOptions)
 
@@ -440,19 +463,29 @@ let init () =
             let c = checker :?> CheckerImpl
             c.Checker.ClearCache()
 
-        member _.ParseAndCheckProject(checker, projectFileName, fileNames, sources, ?otherFSharpOptions) =
-            let c = checker :?> CheckerImpl
-            let otherFSharpOptions = defaultArg otherFSharpOptions [||]
-
-            parseAndCheckProject c.Checker projectFileName fileNames sources otherFSharpOptions :> IParseAndCheckResults
-
-        member _.ParseAndCheckFileInProject
-            (checker, fileName, projectFileName, fileNames, sources, ?otherFSharpOptions)
+        member _.ParseAndCheckProject
+            (checker, projectFileName, fileNames, sources, ?otherFSharpOptions, ?precompiledInfo)
             =
             let c = checker :?> CheckerImpl
             let otherFSharpOptions = defaultArg otherFSharpOptions [||]
 
-            parseAndCheckFileInProject c.Checker fileName projectFileName fileNames sources otherFSharpOptions
+            parseAndCheckProject c.Checker projectFileName fileNames sources otherFSharpOptions precompiledInfo
+            :> IParseAndCheckResults
+
+        member _.ParseAndCheckFileInProject
+            (checker, fileName, projectFileName, fileNames, sources, ?otherFSharpOptions, ?precompiledInfo)
+            =
+            let c = checker :?> CheckerImpl
+            let otherFSharpOptions = defaultArg otherFSharpOptions [||]
+
+            parseAndCheckFileInProject
+                c.Checker
+                fileName
+                projectFileName
+                fileNames
+                sources
+                otherFSharpOptions
+                precompiledInfo
             :> IParseAndCheckResults
 
         member _.GetErrors(results: IParseAndCheckResults) = results.Errors

--- a/src/fable-standalone/src/Worker/Shared.fs
+++ b/src/fable-standalone/src/Worker/Shared.fs
@@ -12,13 +12,29 @@ type FSharpCodeFile =
         Content: string
     }
 
+type PrecompiledFile =
+    {
+        /// Absolute path of the F# source, as recorded in precompiled_info.json
+        Path: string
+        RootModule: string
+        OutPath: string
+    }
+
+type PrecompiledInfo =
+    {
+        CompilerVersion: string
+        Files: PrecompiledFile[]
+    }
+
 type WorkerRequest =
     /// * refsExtraSuffix: e.g. add .txt extension to enable gzipping in Github Pages
+    /// * precompiledInfo: from `fable precompile`; name its assembly in extraRefs as well
     | CreateChecker of
         refsDirUrl: string *
         extraRefs: string[] *
         refsExtraSuffix: string option *
-        otherFSharpOptions: string[]
+        otherFSharpOptions: string[] *
+        precompiledInfo: PrecompiledInfo option
     | ParseCode of fsharpCode: string * otherFSharpOptions: string[]
     | ParseFile of file: string * fsharpCode: FSharpCodeFile[] * otherFSharpOptions: string[]
     | CompileCode of fsharpCode: string * language: string * otherFSharpOptions: string[]

--- a/src/fable-standalone/src/Worker/Worker.fs
+++ b/src/fable-standalone/src/Worker/Worker.fs
@@ -42,10 +42,15 @@ type FableState =
         References: string[]
         Reader: string -> byte[]
         OtherFSharpOptions: string[]
+        PrecompiledInfo: Map<string, PrecompiledFile> option
     }
 
 type FableStateConfig =
-    | Init of refsDirUrl: string * extraRefs: string[] * refsExtraSuffix: string option
+    | Init of
+        refsDirUrl: string *
+        extraRefs: string[] *
+        refsExtraSuffix: string option *
+        precompiledInfo: PrecompiledInfo option
     | Initialized of FableState
 
 type State =
@@ -71,7 +76,7 @@ let private fableLibraryDir (language: string) =
     | "erlang" -> "fable-library-beam"
     | _ -> "fable-library-js"
 
-type SourceWriter(sourceMaps: bool, language: string) =
+type SourceWriter(sourceMaps: bool, language: string, precompiledInfo: Map<string, PrecompiledFile> option) =
     let sb = System.Text.StringBuilder()
 
     interface Fable.Standalone.IWriter with
@@ -79,6 +84,13 @@ type SourceWriter(sourceMaps: bool, language: string) =
             async { return sb.Append(str) |> ignore }
 
         member _.MakeImportPath(path) =
+            // An import into a precompiled library points at the .fs it came from
+            let path =
+                precompiledInfo
+                |> Option.bind (Map.tryFind path)
+                |> Option.map (fun file -> file.OutPath)
+                |> Option.defaultValue path
+
             match language with
             | "Python" -> path.Replace("/", ".").Replace("-", "_").Replace(".py", "").ToLowerInvariant()
             | _ -> path
@@ -91,11 +103,22 @@ type SourceWriter(sourceMaps: bool, language: string) =
 let makeFableState (config: FableStateConfig) otherFSharpOptions =
     async {
         match config with
-        | Init(refsDirUrl, extraRefs, refsExtraSuffix) ->
+        | Init(refsDirUrl, extraRefs, refsExtraSuffix, precompiledInfo) ->
             let getBlobUrl name =
                 refsDirUrl.TrimEnd('/') + "/" + name + ".dll" + (defaultArg refsExtraSuffix "")
 
             let manager = FableInit.init ()
+
+            // A precompiled library is only readable by the Fable that wrote it
+            let precompiledFiles =
+                precompiledInfo
+                |> Option.map (fun info ->
+                    if info.CompilerVersion <> manager.Version then
+                        failwith
+                            $"Library was precompiled using Fable v%s{info.CompilerVersion} but you're using v%s{manager.Version}. Please use same version."
+
+                    info.Files |> Array.map (fun f -> f.Path, f) |> Map
+                )
 
             let references = Array.append Fable.Metadata.coreAssemblies extraRefs
 
@@ -112,6 +135,7 @@ let makeFableState (config: FableStateConfig) otherFSharpOptions =
                     References = references
                     Reader = reader
                     OtherFSharpOptions = otherFSharpOptions
+                    PrecompiledInfo = precompiledFiles
                 }
 
         | Initialized fable ->
@@ -167,11 +191,21 @@ let private emitFile fable (parseResults: IParseAndCheckResults) fileName langua
                 ()
 
         // Print target language AST
-        let writer = new SourceWriter(Array.contains "--sourceMaps" fableOptions, language)
+        let writer =
+            new SourceWriter(Array.contains "--sourceMaps" fableOptions, language, fable.PrecompiledInfo)
 
         do! fable.Manager.PrintTargetAst(res, writer)
 
         return writer.Result, res.FableErrors, fableTransformTime
+    }
+
+let private toManagerPrecompiledInfo (files: Map<string, PrecompiledFile>) =
+    { new IPrecompiledInfo with
+        // Fable.Naming.fablePrecompile; the worker cannot reference Fable.Transforms
+        member _.DllPath = "Fable.Precompiled.dll"
+
+        member _.TryGetRootModule(normalizedFullPath) =
+            Map.tryFind normalizedFullPath files |> Option.map (fun f -> f.RootModule)
     }
 
 let private compileCode fable fileName fsharpNames fsharpCodes language otherFSharpOptions =
@@ -190,7 +224,8 @@ let private compileCode fable fileName fsharpNames fsharpCodes language otherFSh
                         PROJECT_NAME,
                         fsharpNames,
                         fsharpCodes,
-                        otherFSharpOptions
+                        otherFSharpOptions,
+                        ?precompiledInfo = (fable.PrecompiledInfo |> Option.map toManagerPrecompiledInfo)
                     )
                 )
                 ()
@@ -230,7 +265,8 @@ let private compileFiles fable fsharpNames fsharpCodes (filesToEmit: string[]) l
                         PROJECT_NAME,
                         fsharpNames,
                         fsharpCodes,
-                        otherFSharpOptions
+                        otherFSharpOptions,
+                        ?precompiledInfo = (fable.PrecompiledInfo |> Option.map toManagerPrecompiledInfo)
                     )
                 )
                 ()
@@ -275,10 +311,11 @@ let rec loop (box: MailboxProcessor<WorkerRequest>) (state: State) =
 
         match state.Fable, msg with
 
-        | None, CreateChecker(refsDirUrl, extraRefs, refsExtraSuffix, otherFSharpOptions) ->
+        | None, CreateChecker(refsDirUrl, extraRefs, refsExtraSuffix, otherFSharpOptions, precompiledInfo) ->
 
             try
-                let! fable = makeFableState (Init(refsDirUrl, extraRefs, refsExtraSuffix)) otherFSharpOptions
+                let! fable =
+                    makeFableState (Init(refsDirUrl, extraRefs, refsExtraSuffix, precompiledInfo)) otherFSharpOptions
 
                 state.Worker.Post(Loaded fable.Manager.Version)
                 return! loop box { state with Fable = Some fable }

--- a/src/fable-standalone/test/worker/run.mjs
+++ b/src/fable-standalone/test/worker/run.mjs
@@ -100,7 +100,7 @@ const fixture = Array.from({ length: fileCount }, (_, i) => ({
 const sizeKb = Math.round(fixture.reduce((n, f) => n + f.Content.length, 0) / 1024)
 console.log(`worker: ${path.relative(process.cwd(), dist)}`)
 
-post(["CreateChecker", "file:///assemblies", [], null, []])
+post(["CreateChecker", "file:///assemblies", [], null, [], null])
 await answer("Loaded")
 console.log(`checker ready (${fs.readdirSync(libDir).filter((f) => f.endsWith(".dll")).length} assemblies)`)
 


### PR DESCRIPTION
Allows fable-standalone to reference precompiled library.

This is opening the path to support `inline` in REPL environment 