### PR TITLE
feat(standalone)!: reference a precompiled library

### DIFF
--- a/src/Fable.Compiler/BrowserInlineExprs.fs
+++ b/src/Fable.Compiler/BrowserInlineExprs.fs
@@ -1,0 +1,38 @@
+/// The copy of a chunk of inline expressions that fable-standalone reads in a browser. Compiled
+/// into both this project and Fable.Standalone, so writer and reader cannot drift apart.
+module Fable.BrowserInlineExprs
+
+open Fable.AST
+open Thoth.Json.Core
+open Thoth.Json.Core.Auto
+
+#if FABLE_COMPILER
+open Thoth.Json.JavaScript
+#else
+open Thoth.Json.System.Text.Json
+#endif
+
+/// Every numeric type Fable.NumberValue carries that Thoth's auto coders do not cover on their own
+let private extra =
+    Extra.empty
+    |> Extra.withInt64
+    |> Extra.withUInt64
+    |> Extra.withDecimal
+    |> Extra.withBigInt
+    |> Extra.withCustom (fun (value: nativeint) -> Encode.int64 (int64 value)) (Decode.int64 |> Decode.map nativeint)
+    |> Extra.withCustom
+        (fun (value: unativeint) -> Encode.uint64 (uint64 value))
+        (Decode.uint64 |> Decode.map unativeint)
+
+let private decoder =
+    lazy (Decode.Auto.generateDecoder<(string * Fable.InlineExpr) array> (extra = extra))
+
+let fromString (json: string) : Result<(string * Fable.InlineExpr) array, string> = Decode.fromString decoder.Value json
+
+#if !FABLE_COMPILER
+let private encoder =
+    lazy (Encode.Auto.generateEncoder<(string * Fable.InlineExpr) array> (extra = extra))
+
+let toString (chunk: (string * Fable.InlineExpr) array) : string =
+    chunk |> encoder.Value |> Encode.toString 0
+#endif

--- a/src/Fable.Compiler/Fable.Compiler.fsproj
+++ b/src/Fable.Compiler/Fable.Compiler.fsproj
@@ -10,6 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <Compile Include="BrowserInlineExprs.fs" />
         <Compile Include="Util.fsi" />
         <Compile Include="Util.fs" />
         <Compile Include="Globbing.fsi" />
@@ -40,6 +41,8 @@
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="FSharp.SystemTextJson" Version="1.4.36" />
+        <PackageReference Include="Thoth.Json.Core.Auto" Version="0.1.1" />
+        <PackageReference Include="Thoth.Json.System.Text.Json" Version="0.4.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
     </ItemGroup>
 

--- a/src/Fable.Compiler/Util.fs
+++ b/src/Fable.Compiler/Util.fs
@@ -938,6 +938,11 @@ type PrecompiledInfoImpl(fableModulesDir: string, info: PrecompiledInfoJson) =
     static member GetInlineExprsPath(fableModulesDir, index: int) =
         IO.Path.Combine(fableModulesDir, "inline_exprs", $"inline_exprs_%d{index}.json")
 
+    /// A second copy of the same chunk for fable-standalone: the compact form above leans on
+    /// System.Text.Json and a side string pool, neither of which survives being Fable-compiled.
+    static member GetBrowserInlineExprsPath(fableModulesDir, index: int) =
+        IO.Path.Combine(fableModulesDir, "inline_exprs", $"inline_exprs_%d{index}.browser.json")
+
     static member Load(fableModulesDir: string) =
         try
             let precompiledInfoPath = PrecompiledInfoImpl.GetPath(fableModulesDir)
@@ -948,7 +953,9 @@ type PrecompiledInfoImpl(fableModulesDir: string, info: PrecompiledInfoJson) =
             Fable.AST.Fable.FableError($"Cannot load precompiled info from %s{fableModulesDir}: %s{e.Message}")
             |> raise
 
-    static member Save(files, inlineExprs, compilerOptions, fableModulesDir, fableLibDir) =
+    static member Save
+        (files, inlineExprs: (string * Fable.InlineExpr) array, compilerOptions, fableModulesDir, fableLibDir)
+        =
         let comparer =
             StringOrdinalComparer() :> System.Collections.Generic.IComparer<string>
 
@@ -969,6 +976,11 @@ type PrecompiledInfoImpl(fableModulesDir: string, info: PrecompiledInfoJson) =
             let path = PrecompiledInfoImpl.GetInlineExprsPath(fableModulesDir, i)
 
             Json.writeWithStringPool path chunk
+
+            IO.File.WriteAllText(
+                PrecompiledInfoImpl.GetBrowserInlineExprsPath(fableModulesDir, i),
+                Fable.BrowserInlineExprs.toString chunk
+            )
         )
 
         let precompiledInfoPath = PrecompiledInfoImpl.GetPath(fableModulesDir)

--- a/src/Fable.Compiler/Util.fsi
+++ b/src/Fable.Compiler/Util.fsi
@@ -173,11 +173,13 @@ type PrecompiledInfoImpl =
 
     static member GetInlineExprsPath: fableModulesDir: string * index: int -> string
 
+    static member GetBrowserInlineExprsPath: fableModulesDir: string * index: int -> string
+
     static member Load: fableModulesDir: string -> PrecompiledInfoImpl
 
     static member Save:
         files: Map<string, PrecompiledFileJson> *
-        inlineExprs: (string * 'a) array *
+        inlineExprs: (string * Fable.InlineExpr) array *
         compilerOptions: Fable.CompilerOptions *
         fableModulesDir: string *
         fableLibDir: string ->

--- a/src/fable-standalone/src/Fable.Standalone.fsproj
+++ b/src/fable-standalone/src/Fable.Standalone.fsproj
@@ -9,6 +9,9 @@
   <ItemGroup>
     <ProjectReference Include="../../fcs-fable/fcs-fable.fsproj" />
     <ProjectReference Include="../../Fable.Transforms/Rust/AST/Rust.AST.fsproj" />
+    <!-- Reads the inline expressions `fable precompile` writes for the browser -->
+    <PackageReference Include="Thoth.Json.Core.Auto" Version="0.1.1" />
+    <PackageReference Include="Thoth.Json.JavaScript" Version="0.5.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -75,6 +78,9 @@
     <Compile Include="../../Fable.Transforms/Beam/Fable2Beam.Reflection.fs" />
     <Compile Include="../../Fable.Transforms/Beam/Fable2Beam.fs" />
     <Compile Include="../../Fable.Transforms/Beam/ErlangPrinter.fs" />
+
+    <!-- Fable.Compiler -->
+    <Compile Include="../../Fable.Compiler/BrowserInlineExprs.fs" />
 
     <!-- Fable.Standalone -->
     <Compile Include="Interfaces.fs"/>

--- a/src/fable-standalone/src/Interfaces.fs
+++ b/src/fable-standalone/src/Interfaces.fs
@@ -47,12 +47,20 @@ type SourceMapping = int * int * int * int * string option
 
 type IChecker = interface end
 
-/// Root modules from a `fable precompile` output. Inline members of the library cannot be called:
-/// FCS hands Fable a call rather than an expansion, and their bodies are not readable here.
+/// Root modules and inline member bodies from a `fable precompile` output.
 type IPrecompiledInfo =
     /// Must be the name the precompiled assembly is referenced under, plus ".dll"
     abstract DllPath: string
     abstract TryGetRootModule: normalizedFullPath: string -> string option
+
+    /// The first member name of each inline-expression chunk, straight out of
+    /// precompiled_info.json. Leave it empty to compile without inline support, in which case
+    /// calling an inline member of the library reports that its body could not be found.
+    abstract InlineExprHeaders: string[]
+
+    /// Contents of the matching inline_exprs_<index>.browser.json. Called while compiling, so the
+    /// host has to be holding it already rather than fetching it here.
+    abstract ReadInlineExprsChunk: index: int -> string
 
 type IParseAndCheckResults =
     abstract OtherFSharpOptions: string[]

--- a/src/fable-standalone/src/Main.fs
+++ b/src/fable-standalone/src/Main.fs
@@ -154,14 +154,53 @@ let makeCompiler fableLibrary typedArrays language fsharpOptions project fileNam
 
     CompilerImpl(fileName, project, options, fableLibrary)
 
+/// `fable precompile` sorts inline expressions by member name, splits them into chunks and records
+/// the first name of each, so the chunk holding a name is the last header not sorting after it.
+let private findInlineExprsChunk (headers: string[]) (memberUniqueName: string) =
+    let mutable low = 0
+    let mutable high = headers.Length - 1
+    let mutable found = -1
+
+    while low <= high do
+        let mid = (low + high) / 2
+
+        if String.CompareOrdinal(headers[mid], memberUniqueName) <= 0 then
+            found <- mid
+            low <- mid + 1
+        else
+            high <- mid - 1
+
+    found
+
 let private toCompilerPrecompiledInfo (info: IPrecompiledInfo) =
+    let decodedChunks =
+        Collections.Generic.Dictionary<int, Map<string, Fable.InlineExpr>>()
+
     { new PrecompiledInfo with
         member _.DllPath = info.DllPath
 
         member _.TryGetRootModule(normalizedFullPath) =
             info.TryGetRootModule(normalizedFullPath)
 
-        member _.TryGetInlineExpr(_) = None
+        member _.TryGetInlineExpr(memberUniqueName) =
+            match findInlineExprsChunk info.InlineExprHeaders memberUniqueName with
+            | -1 -> None
+            | index ->
+                let chunk =
+                    match decodedChunks.TryGetValue(index) with
+                    | true, chunk -> chunk
+                    | false, _ ->
+                        let chunk =
+                            match Fable.BrowserInlineExprs.fromString (info.ReadInlineExprsChunk index) with
+                            | Ok exprs -> Map.ofArray exprs
+                            | Error error ->
+                                failwith
+                                    $"Cannot read the precompiled library's inline expressions (chunk %d{index}): %s{error}"
+
+                        decodedChunks[index] <- chunk
+                        chunk
+
+                Map.tryFind memberUniqueName chunk
     }
 
 let makeProject

--- a/src/fable-standalone/src/Worker/Shared.fs
+++ b/src/fable-standalone/src/Worker/Shared.fs
@@ -24,6 +24,11 @@ type PrecompiledInfo =
     {
         CompilerVersion: string
         Files: PrecompiledFile[]
+        /// First member name of each inline-expression chunk, from precompiled_info.json
+        InlineExprHeaders: string[]
+        /// Contents of each inline_exprs_<index>.browser.json, in the same order. Leave empty to
+        /// compile without inline support: calling an inline member then reports a missing body.
+        InlineExprChunks: string[]
     }
 
 type WorkerRequest =

--- a/src/fable-standalone/src/Worker/Worker.fs
+++ b/src/fable-standalone/src/Worker/Worker.fs
@@ -34,6 +34,13 @@ let measureTime f arg =
     let after: float = self?performance?now ()
     res, after - before
 
+type PrecompiledState =
+    {
+        Files: Map<string, PrecompiledFile>
+        InlineExprHeaders: string[]
+        InlineExprChunks: string[]
+    }
+
 type FableState =
     {
         Manager: IFableManager
@@ -42,7 +49,7 @@ type FableState =
         References: string[]
         Reader: string -> byte[]
         OtherFSharpOptions: string[]
-        PrecompiledInfo: Map<string, PrecompiledFile> option
+        PrecompiledInfo: PrecompiledState option
     }
 
 type FableStateConfig =
@@ -76,7 +83,7 @@ let private fableLibraryDir (language: string) =
     | "erlang" -> "fable-library-beam"
     | _ -> "fable-library-js"
 
-type SourceWriter(sourceMaps: bool, language: string, precompiledInfo: Map<string, PrecompiledFile> option) =
+type SourceWriter(sourceMaps: bool, language: string, precompiledInfo: PrecompiledState option) =
     let sb = System.Text.StringBuilder()
 
     interface Fable.Standalone.IWriter with
@@ -87,7 +94,7 @@ type SourceWriter(sourceMaps: bool, language: string, precompiledInfo: Map<strin
             // An import into a precompiled library points at the .fs it came from
             let path =
                 precompiledInfo
-                |> Option.bind (Map.tryFind path)
+                |> Option.bind (fun info -> Map.tryFind path info.Files)
                 |> Option.map (fun file -> file.OutPath)
                 |> Option.defaultValue path
 
@@ -117,7 +124,11 @@ let makeFableState (config: FableStateConfig) otherFSharpOptions =
                         failwith
                             $"Library was precompiled using Fable v%s{info.CompilerVersion} but you're using v%s{manager.Version}. Please use same version."
 
-                    info.Files |> Array.map (fun f -> f.Path, f) |> Map
+                    {
+                        Files = info.Files |> Array.map (fun f -> f.Path, f) |> Map
+                        InlineExprHeaders = info.InlineExprHeaders
+                        InlineExprChunks = info.InlineExprChunks
+                    }
                 )
 
             let references = Array.append Fable.Metadata.coreAssemblies extraRefs
@@ -199,13 +210,16 @@ let private emitFile fable (parseResults: IParseAndCheckResults) fileName langua
         return writer.Result, res.FableErrors, fableTransformTime
     }
 
-let private toManagerPrecompiledInfo (files: Map<string, PrecompiledFile>) =
+let private toManagerPrecompiledInfo (state: PrecompiledState) =
     { new IPrecompiledInfo with
         // Fable.Naming.fablePrecompile; the worker cannot reference Fable.Transforms
         member _.DllPath = "Fable.Precompiled.dll"
 
         member _.TryGetRootModule(normalizedFullPath) =
-            Map.tryFind normalizedFullPath files |> Option.map (fun f -> f.RootModule)
+            Map.tryFind normalizedFullPath state.Files |> Option.map (fun f -> f.RootModule)
+
+        member _.InlineExprHeaders = state.InlineExprHeaders
+        member _.ReadInlineExprsChunk(index) = state.InlineExprChunks[index]
     }
 
 let private compileCode fable fileName fsharpNames fsharpCodes language otherFSharpOptions =

--- a/tests/Integration/Integration/CompilationTests.fs
+++ b/tests/Integration/Integration/CompilationTests.fs
@@ -3,8 +3,58 @@
 open System.IO
 open System.Text.RegularExpressions
 open Expecto
+open Fable.Compiler.Util
 
 let private data = Path.Combine(__SOURCE_DIRECTORY__, "data")
+
+/// `fable precompile` writes each chunk of inline expressions twice: the compact copy the CLI
+/// reads, and the browser copy fable-standalone reads. This asks four things of every chunk:
+///
+/// 1. it is there at all, so a writer that silently stopped is caught
+/// 2. it decodes, through the very code fable-standalone runs in a browser - this is what catches
+///    a type the codec has no coder for
+/// 3. re-encoding what was decoded gives the file back, so reading it lost nothing
+/// 4. every expression in it matches the one the CLI reads from the compact copy, so the two
+///    cannot drift apart
+///
+/// This runs on .NET, so it covers the codec and its coders but not the JavaScript backend.
+/// It relies on Thoth.Json being cross-platform and implemented "correctly".
+///
+/// The worker harness under src/fable-standalone/test/worker covers that side.
+let private checkBrowserInlineExprs (precompiledDir: string) =
+    let fableModulesDir = Path.Combine(precompiledDir, "fable_modules")
+    let compact = PrecompiledInfoImpl.Load fableModulesDir :> Fable.Transforms.State.PrecompiledInfo
+
+    let chunks =
+        Seq.initInfinite id
+        |> Seq.map (fun i -> PrecompiledInfoImpl.GetBrowserInlineExprsPath(fableModulesDir, i))
+        |> Seq.takeWhile File.Exists
+        |> Seq.toList
+
+    // 1. written at all
+    Expect.isNonEmpty chunks "Expected precompile to write a browser copy of the inline expressions"
+
+    for path in chunks do
+        let json = File.ReadAllText path
+
+        // 2. readable by the browser codec
+        match Fable.BrowserInlineExprs.fromString json with
+        | Error error -> failtestf "Cannot read %s: %s" path error
+        | Ok exprs ->
+            Expect.isNonEmpty exprs $"No inline expression in {path}"
+
+            // 3. nothing lost on the way in
+            Expect.equal (Fable.BrowserInlineExprs.toString exprs) json $"Reading {path} back lost something"
+
+            // 4. the same expressions the CLI reads
+            for name, expr in exprs do
+                match compact.TryGetInlineExpr name with
+                | None -> failtestf "%s is in %s but not in the compact copy" name path
+                | Some fromCompact ->
+                    Expect.equal
+                        (Fable.BrowserInlineExprs.toString [| name, expr |])
+                        (Fable.BrowserInlineExprs.toString [| name, fromCompact |])
+                        $"%s{name} differs between the two copies"
 
 let tests =
     Directory.EnumerateDirectories(data)
@@ -35,6 +85,7 @@ let tests =
                                 [| "precompile"; libraryProject; "--outDir"; precompiledDir; "--noCache" |]
 
                         Expect.equal exitCode 0 "Expected precompile exit code to be 0"
+                        checkBrowserInlineExprs precompiledDir
                         [| "--precompiledLib"; precompiledDir |]
                     else
                         [||]


### PR DESCRIPTION
The browser cannot reuse the CLI's inline_exprs_N.json for two reasons. Integers lose precision: they are written as raw JSON numbers, and JSON.parse turns 9223372036854775807 into 9223372036854776000 before any decoder can see it. And the union encoding differs - FSharp.SystemTextJson writes ["Decimal"] and ["Some",x] where Thoth writes "Decimal" and the bare value - which would mean hand-writing a coder for every union in Fable.AST. (The string pool, by contrast, could have been undone with a custom coder.)

So fable precompile now also writes inline_exprs_N.browser.json, encoded and decoded through Thoth.Json.Core so both sides share one codec. It is bigger than the compact copy - no string pool - but that is the trade for supporting inline calls into a library from the browser, where a chunk is decoded once and cached (~70 ms, then ~10 ms per compile).

Writing both copies costs about 1 s of fixed cost on fable precompile, and nothing at all for a library with no inline members. Nothing else pays it: compiling against a precompiled library only reads. If that becomes a problem we can add a flag to pick which copies to emit.