### PR TITLE
fix(all): Allow private inline functions to use private values

### DIFF
--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -2445,9 +2445,6 @@ module Util =
             else
                 Some(entityIdent com ent.Ref)
 
-    /// An inline function that is not visible outside of the file declaring it can only be called
-    /// from that file, so `resolveInlineExpr` turns the references in its body back into plain
-    /// identifiers instead of imports. This makes it safe for its body to use private members.
     let private isInlinedInDeclaringFileOnly (ctx: Context) =
         match ctx.PrecompilingInlineFunction with
         | Some inlineMemb -> not (isNotPrivate inlineMemb)
@@ -2502,13 +2499,10 @@ module Util =
                     com.AddWatchDependency(file)
 
                 // Private values are not exported so they can't be imported by call sites in other files.
-                // We need to handle it manually because Fable handle resolve inline function itself.
-                // Inline functions that cannot escape their own file are fine, and inline functions
-                // reached through another one are checked by `checkInlinedPrivateAccess` instead, once
-                // the file the body is expanded into is known.
+                // We need to handle it manually because Fable handle resolve inline function itself
                 if
                     com.IsPrecompilingInlineFunction
-                    && memb.Accessibility.IsPrivate
+                    && not (isNotPrivate memb)
                     && not (isInlinedInDeclaringFileOnly ctx)
                 then
                     $"The value '%s{memb.DisplayName}' was marked inline but its implementation makes use of an internal or private function which is not sufficiently accessible"

--- a/src/Fable.Transforms/FSharp2Fable.Util.fs
+++ b/src/Fable.Transforms/FSharp2Fable.Util.fs
@@ -2445,6 +2445,14 @@ module Util =
             else
                 Some(entityIdent com ent.Ref)
 
+    /// An inline function that is not visible outside of the file declaring it can only be called
+    /// from that file, so `resolveInlineExpr` turns the references in its body back into plain
+    /// identifiers instead of imports. This makes it safe for its body to use private members.
+    let private isInlinedInDeclaringFileOnly (ctx: Context) =
+        match ctx.PrecompilingInlineFunction with
+        | Some inlineMemb -> not (isNotPrivate inlineMemb)
+        | None -> false
+
     let memberIdent (com: Compiler) (ctx: Context) r typ (memb: FSharpMemberOrFunctionOrValue) membRef =
         let r = r |> Option.map (fun r -> { r with identifierName = Some memb.DisplayName })
 
@@ -2494,12 +2502,19 @@ module Util =
                     com.AddWatchDependency(file)
 
                 // Private values are not exported so they can't be imported by call sites in other files.
-                // We need to handle it manually because Fable handle resolve inline function itself
-                if com.IsPrecompilingInlineFunction && memb.Accessibility.IsPrivate then
+                // We need to handle it manually because Fable handle resolve inline function itself.
+                // Inline functions that cannot escape their own file are fine, and inline functions
+                // reached through another one are checked by `checkInlinedPrivateAccess` instead, once
+                // the file the body is expanded into is known.
+                if
+                    com.IsPrecompilingInlineFunction
+                    && memb.Accessibility.IsPrivate
+                    && not (isInlinedInDeclaringFileOnly ctx)
+                then
                     $"The value '%s{memb.DisplayName}' was marked inline but its implementation makes use of an internal or private function which is not sufficiently accessible"
                     |> addError com [] r
 
-                makeInternalMemberImport com typ membRef memberName file
+                makeInternalMemberImport com typ membRef memberName file r
 
     let getFunctionMemberRef (memb: FSharpMemberOrFunctionOrValue) =
         match memb.DeclaringEntity with

--- a/src/Fable.Transforms/FSharp2Fable.fs
+++ b/src/Fable.Transforms/FSharp2Fable.fs
@@ -2301,6 +2301,7 @@ type InlineExprInfo =
         FileName: string
         ScopeIdents: Set<string>
         ResolvedIdents: Dictionary<string, string>
+        IsFileLocal: bool
     }
 
 let resolveInlineIdent (ctx: Context) (info: InlineExprInfo) (ident: Fable.Ident) =
@@ -2322,22 +2323,17 @@ let resolveInlineIdent (ctx: Context) (info: InlineExprInfo) (ident: Fable.Ident
     else
         ident
 
-/// When an inline function is precompiled, references to members of its own file are turned into
-/// imports because the file the body will be expanded into is not known yet. Private members are
-/// not exported, so such an import is only valid when the body ends up in the declaring file.
-///
-/// A private inline function can only be called from its own file, so `memberIdent` lets its body
-/// reference private members. It can still escape the file when an inline function that is exported
-/// calls it, which is what this check catches. Direct calls (a single entry in the inline path) come
-/// from an exported inline function, already reported by `memberIdent` when it was precompiled.
-let checkInlinedPrivateAccess (com: IFableCompiler) (ctx: Context) (importInfo: Fable.ImportInfo) r =
-    match importInfo.Kind, ctx.InlinePath with
-    | Fable.MemberImport membRef, _ :: _ :: _ ->
+let checkInlinedPrivateAccess
+    (com: IFableCompiler)
+    (ctx: Context)
+    (info: InlineExprInfo)
+    (importInfo: Fable.ImportInfo)
+    r
+    =
+    match importInfo.Kind, info.IsFileLocal with
+    | Fable.MemberImport membRef, true ->
         match com.TryGetMember(membRef) with
-        // IsPublic is the same predicate the code generators use to decide whether a member is
-        // exported, so it also covers members hidden by a signature file, not just `private` ones.
         | Some memb when not memb.IsPublic ->
-            // Internal imports carry no range, fall back to the body of the inline function
             let r =
                 match r, ctx.InlinePath with
                 | None, { ToRange = toRange } :: _ -> toRange
@@ -2539,10 +2535,7 @@ let resolveInlineExpr (com: IFableCompiler) ctx info expr =
             if isImportToSameFile then
                 Fable.IdentExpr { makeTypedIdent t importInfo.Selector with Range = r }
             else
-                // Private members are not exported, so they can only be reached from the file
-                // declaring them. Reaching this point means the inline body is being expanded
-                // in another file, where the import cannot be resolved.
-                checkInlinedPrivateAccess com ctx importInfo r
+                checkInlinedPrivateAccess com ctx info importInfo r
 
                 let path = fixImportedRelativePath com importInfo.Path info.FileName
 
@@ -2760,6 +2753,7 @@ type FableCompiler(com: Compiler) =
                 FileName = inExpr.FileName
                 ScopeIdents = inExpr.ScopeIdents
                 ResolvedIdents = Dictionary()
+                IsFileLocal = inExpr.IsFileLocal
             }
 
         let ctx, bindings, forceInlineMap =
@@ -3033,6 +3027,7 @@ let getInlineExprs fileName (declarations: FSharpImplementationFileDeclaration l
                             FileName = fileName
                             GenericArgs = genArgs
                             ScopeIdents = set ctx.UsedNamesInDeclarationScope
+                            IsFileLocal = not (isNotPrivate memb)
                         }
                     )
                 ]

--- a/src/Fable.Transforms/FSharp2Fable.fs
+++ b/src/Fable.Transforms/FSharp2Fable.fs
@@ -2322,6 +2322,32 @@ let resolveInlineIdent (ctx: Context) (info: InlineExprInfo) (ident: Fable.Ident
     else
         ident
 
+/// When an inline function is precompiled, references to members of its own file are turned into
+/// imports because the file the body will be expanded into is not known yet. Private members are
+/// not exported, so such an import is only valid when the body ends up in the declaring file.
+///
+/// A private inline function can only be called from its own file, so `memberIdent` lets its body
+/// reference private members. It can still escape the file when an inline function that is exported
+/// calls it, which is what this check catches. Direct calls (a single entry in the inline path) come
+/// from an exported inline function, already reported by `memberIdent` when it was precompiled.
+let checkInlinedPrivateAccess (com: IFableCompiler) (ctx: Context) (importInfo: Fable.ImportInfo) r =
+    match importInfo.Kind, ctx.InlinePath with
+    | Fable.MemberImport membRef, _ :: _ :: _ ->
+        match com.TryGetMember(membRef) with
+        // IsPublic is the same predicate the code generators use to decide whether a member is
+        // exported, so it also covers members hidden by a signature file, not just `private` ones.
+        | Some memb when not memb.IsPublic ->
+            // Internal imports carry no range, fall back to the body of the inline function
+            let r =
+                match r, ctx.InlinePath with
+                | None, { ToRange = toRange } :: _ -> toRange
+                | _ -> r
+
+            $"The value '%s{memb.DisplayName}' was marked inline but its implementation makes use of an internal or private function which is not sufficiently accessible"
+            |> addError com ctx.InlinePath r
+        | _ -> ()
+    | _ -> ()
+
 let resolveInlinedCallInfo com (ctx: Context) info (callInfo: Fable.CallInfo) =
     { callInfo with
         ThisArg = Option.map (resolveInlineExpr com ctx info) callInfo.ThisArg
@@ -2513,6 +2539,11 @@ let resolveInlineExpr (com: IFableCompiler) ctx info expr =
             if isImportToSameFile then
                 Fable.IdentExpr { makeTypedIdent t importInfo.Selector with Range = r }
             else
+                // Private members are not exported, so they can only be reached from the file
+                // declaring them. Reaching this point means the inline body is being expanded
+                // in another file, where the import cannot be resolved.
+                checkInlinedPrivateAccess com ctx importInfo r
+
                 let path = fixImportedRelativePath com importInfo.Path info.FileName
 
                 Fable.Import({ importInfo with Path = path }, t, r)

--- a/src/Fable.Transforms/Global/Compiler.fs
+++ b/src/Fable.Transforms/Global/Compiler.fs
@@ -58,6 +58,7 @@ type InlineExpr =
         FileName: string
         GenericArgs: string list
         ScopeIdents: Set<string>
+        IsFileLocal: bool
     }
 
 type CompilerPlugins = { MemberDeclarationPlugins: Map<Fable.EntityRef, System.Type> }

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -1263,7 +1263,7 @@ module AST =
         LibraryImportInfo.Create(isInstanceMember = false, isModuleMember = true)
         |> makeImportLibWithInfo com t memberName moduleName
 
-    let private makeInternalImport (com: Compiler) t (selector: string) (path: string) kind =
+    let private makeInternalImport (com: Compiler) t (selector: string) (path: string) range kind =
         let path =
             if com.CurrentFile = path then
                 "./" + Path.GetFileName(path)
@@ -1277,14 +1277,14 @@ module AST =
                 Kind = kind
             },
             t,
-            None
+            range
         )
 
-    let makeInternalMemberImport com t membRef (selector: string) (path: string) =
-        MemberImport(membRef) |> makeInternalImport com t selector path
+    let makeInternalMemberImport com t membRef (selector: string) (path: string) range =
+        MemberImport(membRef) |> makeInternalImport com t selector path range
 
     let makeInternalClassImport com entRef (selector: string) (path: string) =
-        ClassImport(entRef) |> makeInternalImport com Any selector path
+        ClassImport(entRef) |> makeInternalImport com Any selector path None
 
     let makeCallInfo thisArg args sigArgTypes =
         CallInfo.Create(?thisArg = thisArg, args = args, sigArgTypes = sigArgTypes)

--- a/tests/Integration/Compiler/CompilerMessagesTests.fs
+++ b/tests/Integration/Compiler/CompilerMessagesTests.fs
@@ -7,6 +7,10 @@ open Fable.Tests.Compiler.Util.Compiler
 
 let private compile source = Compiler.Cached.compile Compiler.Settings.standard source
 
+/// Compiles `library` as `Library.fs`, just before `source`
+let private compileWithLibrary library source =
+  Compiler.Cached.compileWithLibrary Compiler.Settings.standard library source
+
 let tests =
   testList "Compiler Messages" [
     testCase "Compile Console.WriteLine" <| fun _ ->
@@ -105,6 +109,70 @@ let version = Semver.SemVersion.Parse("1.0.0", 1024)
 """
       compile source
       |> Assert.Exists.errorWith "Cannot reference member from .dll reference, Fable packages must include F# sources"
+      |> ignore
+
+    testCase "Private inline function referencing private value succeeds" <| fun _ ->
+      let source =
+        """
+let private x = 1
+let inline private y () = x
+let z = y ()
+"""
+      compile source
+      |> Assert.Is.success
+      |> ignore
+
+    testCase "Private inline function referencing private function succeeds" <| fun _ ->
+      let source =
+        """
+let private add a b = a + b
+let inline private addOne x = add x 1
+let z = addOne 41
+"""
+      compile source
+      |> Assert.Is.success
+      |> ignore
+
+    testCase "Private inline function in nested module referencing private value succeeds" <| fun _ ->
+      let source =
+        """
+module Nested =
+    let private x = 1
+    let inline private y () = x
+    let z = y ()
+"""
+      compile source
+      |> Assert.Is.success
+      |> ignore
+
+    testCase "Private inline function referencing private value is not inlined in another file" <| fun _ ->
+      // `y` cannot be called from another file, but `z` drags its body along
+      let library =
+        """
+module Library
+
+let private x = 1
+let inline private y () = x
+let inline z () = y ()
+"""
+      let source = "let res = Library.z ()"
+      compileWithLibrary library source
+      |> Assert.Exists.errorWith "was marked inline but its implementation makes use of an internal or private function"
+      |> ignore
+
+    testCase "Inline function referencing non-private value from another file succeeds" <| fun _ ->
+      let library =
+        """
+module Library
+
+let x = 1
+let internal w = 2
+let inline private y () = x + w
+let inline z () = y ()
+"""
+      let source = "let res = Library.z ()"
+      compileWithLibrary library source
+      |> Assert.Is.success
       |> ignore
 
     testCase "Duplicate attached member names emit a warning" <| fun _ ->

--- a/tests/Integration/Compiler/CompilerMessagesTests.fs
+++ b/tests/Integration/Compiler/CompilerMessagesTests.fs
@@ -7,9 +7,11 @@ open Fable.Tests.Compiler.Util.Compiler
 
 let private compile source = Compiler.Cached.compile Compiler.Settings.standard source
 
-/// Compiles `library` as `Library.fs`, just before `source`
 let private compileWithLibrary library source =
   Compiler.Cached.compileWithLibrary Compiler.Settings.standard library source
+
+let private compileWithSignedLibrary signature library source =
+  Compiler.Cached.compileWithSignedLibrary Compiler.Settings.standard signature library source
 
 let tests =
   testList "Compiler Messages" [
@@ -145,8 +147,7 @@ module Nested =
       |> Assert.Is.success
       |> ignore
 
-    testCase "Private inline function referencing private value is not inlined in another file" <| fun _ ->
-      // `y` cannot be called from another file, but `z` drags its body along
+    testCase "Private inline function referencing private value errors when inlined in another file" <| fun _ ->
       let library =
         """
 module Library
@@ -157,6 +158,26 @@ let inline z () = y ()
 """
       let source = "let res = Library.z ()"
       compileWithLibrary library source
+      |> Assert.Are.errors 1
+      |> Assert.Exists.errorWith "was marked inline but its implementation makes use of an internal or private function"
+      |> ignore
+
+    testCase "Inline function referencing private value is reported once, not once per call site" <| fun _ ->
+      let library =
+        """
+module Library
+
+let private x = 1
+let inline w () = x
+let inline z () = w ()
+"""
+      let source =
+        """
+let a = Library.z ()
+let b = Library.z ()
+"""
+      compileWithLibrary library source
+      |> Assert.Are.errors 1
       |> Assert.Exists.errorWith "was marked inline but its implementation makes use of an internal or private function"
       |> ignore
 
@@ -172,6 +193,66 @@ let inline z () = y ()
 """
       let source = "let res = Library.z ()"
       compileWithLibrary library source
+      |> Assert.Is.success
+      |> ignore
+
+    testCase "Inline function referencing value hidden by a signature file errors when inlined in another file" <| fun _ ->
+      let signature =
+        """
+module Library
+
+val inline z: unit -> int
+"""
+      let library =
+        """
+module Library
+
+let x = 1
+let inline z () = x
+"""
+      let source = "let res = Library.z ()"
+      compileWithSignedLibrary signature library source
+      |> Assert.Are.errors 1
+      |> Assert.Exists.errorWith "was marked inline but its implementation makes use of an internal or private function"
+      |> ignore
+
+    testCase "Inline function hidden by a signature file referencing hidden value succeeds" <| fun _ ->
+      let signature =
+        """
+module Library
+
+val res: int
+"""
+      let library =
+        """
+module Library
+
+let x = 1
+let inline z () = x
+let res = z ()
+"""
+      let source = "let res = Library.res"
+      compileWithSignedLibrary signature library source
+      |> Assert.Is.success
+      |> ignore
+
+    testCase "Inline function referencing value exposed by a signature file succeeds" <| fun _ ->
+      let signature =
+        """
+module Library
+
+val x: int
+val inline z: unit -> int
+"""
+      let library =
+        """
+module Library
+
+let x = 1
+let inline z () = x
+"""
+      let source = "let res = Library.z ()"
+      compileWithSignedLibrary signature library source
       |> Assert.Is.success
       |> ignore
 

--- a/tests/Integration/Compiler/TestProject/.gitignore
+++ b/tests/Integration/Compiler/TestProject/.gitignore
@@ -1,1 +1,2 @@
 Program.fs
+Library.fs

--- a/tests/Integration/Compiler/TestProject/TestProject.fsproj
+++ b/tests/Integration/Compiler/TestProject/TestProject.fsproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="Library.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/tests/Integration/Compiler/TestProjectSignature/.gitignore
+++ b/tests/Integration/Compiler/TestProjectSignature/.gitignore
@@ -1,0 +1,3 @@
+Library.fsi
+Library.fs
+Program.fs

--- a/tests/Integration/Compiler/TestProjectSignature/TestProjectSignature.fsproj
+++ b/tests/Integration/Compiler/TestProjectSignature/TestProjectSignature.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <RollForward>Major</RollForward>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Library.fsi" />
+    <Compile Include="Library.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../../../src/Fable.Core/Fable.Core.fsproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Integration/Compiler/Util/Compiler.fs
+++ b/tests/Integration/Compiler/Util/Compiler.fs
@@ -27,40 +27,56 @@ module Compiler =
   /// NOTE: NOT threadsafe
   ///       -> don't use `parallel`
   module Cached =
-    let projDir = IO.Path.Join(__SOURCE_DIRECTORY__, "../TestProject" ) |> Path.normalizeFullPath
-    let projFile = IO.Path.Join(projDir, "TestProject.fsproj" ) |> Path.normalizeFullPath
-    let sourceFile = IO.Path.Join(projDir, "Program.fs" ) |> Path.normalizeFullPath
-    /// Compiled before `Program.fs`, for the tests that need more than one file
-    let libraryFile = IO.Path.Join(projDir, "Library.fs" ) |> Path.normalizeFullPath
+    type private CachedProject(name: string) =
+        let projDir = IO.Path.Join(__SOURCE_DIRECTORY__, "../" + name) |> Path.normalizeFullPath
+        let projFile = IO.Path.Join(projDir, name + ".fsproj") |> Path.normalizeFullPath
 
-    let cliArgs =
-        let compilerOptions = CompilerOptionsHelper.Make()
-        { CliArgs.ProjectFile = projFile
-          FableLibraryPath = None
-          RootDir = projDir
-          Configuration = "Debug"
-          OutDir = None
-          IsWatch = false
-          Precompile = false
-          PrecompiledLib = None
-          PrintAst = false
-          SourceMaps = false
-          SourceMapsRoot = None
-          NoRestore = false
-          NoCache = false
-          NoGitignore = false
-          NoParallelTypeCheck = false
-          Exclude = ["Fable.Core"]
-          Replace = Map.empty
-          RunProcess = None
-          CompilerOptions = compilerOptions
-          Verbosity = Verbosity.Normal }
+        let cliArgs =
+            let compilerOptions = CompilerOptionsHelper.Make()
+            { CliArgs.ProjectFile = projFile
+              FableLibraryPath = None
+              RootDir = projDir
+              Configuration = "Debug"
+              OutDir = None
+              IsWatch = false
+              Precompile = false
+              PrecompiledLib = None
+              PrintAst = false
+              SourceMaps = false
+              SourceMapsRoot = None
+              NoRestore = false
+              NoCache = false
+              NoGitignore = false
+              NoParallelTypeCheck = false
+              Exclude = ["Fable.Core"]
+              Replace = Map.empty
+              RunProcess = None
+              CompilerOptions = compilerOptions
+              Verbosity = Verbosity.Normal }
 
-    let mutable private state = State.Create(cliArgs, recompileAllFiles=true)
+        let mutable state = State.Create(cliArgs, recompileAllFiles=true)
+
+        member _.Compile(files: (string * string) list) =
+            for (fileName, content) in files do
+                IO.File.WriteAllText(IO.Path.Join(projDir, fileName), content)
+
+            let result =
+                state
+                |> startCompilationAsync
+                |> Async.RunSynchronously
+
+            match result with
+            | Error(_msg, logs) -> Array.toList logs
+            | Ok(newState, logs) ->
+                state <- newState
+                Array.toList logs
+
+    let private project = CachedProject("TestProject")
+    let private projectWithSignature = CachedProject("TestProjectSignature")
 
     let private emptyLibrary = "module Library" + Environment.NewLine
 
-    let compileWithLibrary settings (library: string) source =
+    let private programFile settings source =
         let preamble =
           [
             yield! settings.Opens |> List.map (sprintf "open %s")
@@ -69,22 +85,22 @@ module Compiler =
           ]
           |> String.concat Environment.NewLine
 
-        let source = preamble + source
-        IO.File.WriteAllText(libraryFile, library)
-        IO.File.WriteAllText(sourceFile, source)
+        preamble + source
 
-        let result =
-            state
-            |> startCompilationAsync
-            |> Async.RunSynchronously
-
-        match result with
-        | Error(_msg, logs) -> Array.toList logs
-        | Ok(newState, logs) ->
-            state <- newState
-            Array.toList logs
+    let compileWithLibrary settings (library: string) source =
+        project.Compile [
+          "Library.fs", library
+          "Program.fs", programFile settings source
+        ]
 
     let compile settings source = compileWithLibrary settings emptyLibrary source
+
+    let compileWithSignedLibrary settings (signature: string) (library: string) source =
+        projectWithSignature.Compile [
+          "Library.fsi", signature
+          "Library.fs", library
+          "Program.fs", programFile settings source
+        ]
 
   module Assert =
     open Util.Testing

--- a/tests/Integration/Compiler/Util/Compiler.fs
+++ b/tests/Integration/Compiler/Util/Compiler.fs
@@ -30,6 +30,8 @@ module Compiler =
     let projDir = IO.Path.Join(__SOURCE_DIRECTORY__, "../TestProject" ) |> Path.normalizeFullPath
     let projFile = IO.Path.Join(projDir, "TestProject.fsproj" ) |> Path.normalizeFullPath
     let sourceFile = IO.Path.Join(projDir, "Program.fs" ) |> Path.normalizeFullPath
+    /// Compiled before `Program.fs`, for the tests that need more than one file
+    let libraryFile = IO.Path.Join(projDir, "Library.fs" ) |> Path.normalizeFullPath
 
     let cliArgs =
         let compilerOptions = CompilerOptionsHelper.Make()
@@ -56,7 +58,9 @@ module Compiler =
 
     let mutable private state = State.Create(cliArgs, recompileAllFiles=true)
 
-    let compile settings source =
+    let private emptyLibrary = "module Library" + Environment.NewLine
+
+    let compileWithLibrary settings (library: string) source =
         let preamble =
           [
             yield! settings.Opens |> List.map (sprintf "open %s")
@@ -66,6 +70,7 @@ module Compiler =
           |> String.concat Environment.NewLine
 
         let source = preamble + source
+        IO.File.WriteAllText(libraryFile, library)
         IO.File.WriteAllText(sourceFile, source)
 
         let result =
@@ -78,6 +83,8 @@ module Compiler =
         | Ok(newState, logs) ->
             state <- newState
             Array.toList logs
+
+    let compile settings source = compileWithLibrary settings emptyLibrary source
 
   module Assert =
     open Util.Testing


### PR DESCRIPTION
Allows a `private inline` function to call other `private` functions and values in the same file.

- A refinement to the restriction added in https://github.com/fable-compiler/Fable/pull/4701 
- Fixes https://github.com/roboz0r/XParsec/issues/14