### PR TITLE
fix(rust): support `string` on a tuple

### DIFF
--- a/src/Fable.Transforms/Rust/Replacements.fs
+++ b/src/Fable.Transforms/Rust/Replacements.fs
@@ -265,7 +265,7 @@ let convertTo com (ctx: Context) r t (args: Expr list) =
         addWarning com ctx.InlinePath r "Unsupported conversion"
         TypeCast(args.Head, t)
 
-let toString com (ctx: Context) r (args: Expr list) =
+let rec toString com (ctx: Context) r (args: Expr list) =
     match args with
     | [] ->
         "toString is called with empty args"
@@ -275,6 +275,20 @@ let toString com (ctx: Context) r (args: Expr list) =
         | String -> head
         | Char -> Helper.LibCall(com, "String", "ofChar", String, [ head ])
         | Boolean -> Helper.LibCall(com, "String", "ofBoolean", String, [ head ])
+        // Rust has no Display for tuples, and the orphan rule rules out adding
+        // one. Building the text here also matches .NET more closely than a
+        // derived Debug would: each element goes through its own ToString, so a
+        // string element is unquoted and a bool prints as True/False.
+        | Tuple(genArgs, _) when not (List.isEmpty genArgs) ->
+            let element i genArg =
+                toString com ctx r [ Get(head, TupleIndex i, genArg, r) ]
+
+            let separated =
+                genArgs
+                |> List.mapi element
+                |> List.reduce (fun acc part -> add (add acc (makeStrConst ", ")) part)
+
+            add (add (makeStrConst "(") separated) (makeStrConst ")")
         | Number(BigInt, _) -> Helper.LibCall(com, "BigInt", "toString", String, args)
         | Number(Decimal, _) -> Helper.LibCall(com, "Decimal", "toString", String, args)
         // | Array _ | List _ ->

--- a/tests/Rust/tests/src/TupleTests.fs
+++ b/tests/Rust/tests/src/TupleTests.fs
@@ -103,3 +103,13 @@ let ``Can create tuples of single element`` () =
     let t1b = Tuple.Create "b"
     t1.Item1 |> equal 4
     t1b.Item1 |> equal "b"
+
+// Rust has no Display for tuples and the orphan rule rules out adding one, so
+// `string` on a tuple did not compile. Building the text from each element's own
+// ToString also matches .NET, where a string element is unquoted and a bool
+// prints as True -- neither of which a derived Debug would give.
+[<Fact>]
+let ``string on a tuple matches .NET`` () =
+    string (1, 2) |> equal "(1, 2)"
+    string (1, "a", true) |> equal "(1, a, True)"
+    string ((1, 2), 3) |> equal "((1, 2), 3)"


### PR DESCRIPTION
Rust has no Display for tuples and the orphan rule rules out adding one, so it did not compile. Built from the elements instead, each through its own ToString, which also matches .NET where a derived Debug would not: (1, a, True) rather than (1, "a", true).