### PR TITLE
fix(rust): decimal culture overloads, and mutables assigned in try/finally

### DIFF
--- a/src/Fable.Transforms/Rust/Fable2Rust.fs
+++ b/src/Fable.Transforms/Rust/Fable2Rust.fs
@@ -3208,8 +3208,39 @@ module Util =
         let addCapturedNames expr =
             capturedNames.UnionWith(FableTransforms.getCapturedNames expr)
 
+        // A try/with/finally lowers to closures on this target, but the Fable AST
+        // has no Lambda there, so the shared capture walk does not see those
+        // bodies as closure contexts. Everything they reference is captured all
+        // the same: without this a `let mutable` assigned in a finally block was
+        // emitted as a bare MutCell, and the closure mutated a clone of it.
+        let addTryCatchCaptures expr =
+            expr
+            |> deepExists (fun e ->
+                match e with
+                | Fable.TryCatch(body, catch, finalizer, _) ->
+                    [ Some body; catch |> Option.map snd; finalizer ]
+                    |> List.choose id
+                    |> List.iter (fun part ->
+                        part
+                        |> deepExists (fun inner ->
+                            match inner with
+                            | Fable.IdentExpr ident ->
+                                capturedNames.Add ident.Name |> ignore
+                                false
+                            | _ -> false
+                        )
+                        |> ignore
+                    )
+
+                    false
+                | _ -> false
+            )
+            |> ignore
+
         bindings |> List.iter (snd >> addCapturedNames)
         addCapturedNames letBody
+        bindings |> List.iter (snd >> addTryCatchCaptures)
+        addTryCatchCaptures letBody
         capturedNames
 
     let getScopedIdentCtx com ctx (ident: Fable.Ident) isArm isRef isBox isFunc usages =

--- a/src/Fable.Transforms/Rust/Replacements.fs
+++ b/src/Fable.Transforms/Rust/Replacements.fs
@@ -2221,7 +2221,37 @@ let parseNum (com: ICompiler) (ctx: Context) r t (i: CallInfo) (thisArg: Expr op
     | ("Compare" | "CompareTo" | "Equals" | "GetHashCode"), _ -> valueTypes com ctx r t i thisArg args
     | _ -> None
 
+/// Drops culture and style arguments from a call.
+///
+/// Rust's formatting and parsing are invariant, which is exactly what
+/// InvariantCulture asks for, so the overloads that take a provider are
+/// equivalent to the ones that do not. Passing the argument on was not: the
+/// runtime functions have no parameter for it, so `Decimal.Parse(s, style,
+/// culture)` reached a one-argument function and `d.ToString(culture)` put a
+/// provider where a format string belongs.
+///
+/// Filtering by argument type rather than by position leaves the arity of every
+/// other overload alone.
+let dropCultureArgs (args: Expr list) =
+    let isCultureOrStyle (e: Expr) =
+        match e.Type with
+        | DeclaredType(ent, _) ->
+            match ent.FullName with
+            | "System.Globalization.CultureInfo"
+            | "System.IFormatProvider" -> true
+            | _ -> false
+        | Number(_, NumberInfo.IsEnum ent) ->
+            match ent.FullName with
+            | "System.Globalization.NumberStyles"
+            | "System.Globalization.DateTimeStyles" -> true
+            | _ -> false
+        | _ -> false
+
+    args |> List.filter (isCultureOrStyle >> not)
+
 let decimals (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (thisArg: Expr option) (args: Expr list) =
+    let args = dropCultureArgs args
+
     match i.CompiledName, args with
     | (".ctor" | "MakeDecimal"), ([ low; mid; high; isNegative; scale ] as args) ->
         Helper.LibCall(com, "Decimal", "fromParts", t, args, i.SignatureArgTypes, ?loc = r)
@@ -2281,6 +2311,14 @@ let decimals (com: ICompiler) (ctx: Context) r (t: Type) (i: CallInfo) (thisArg:
     //     let format = makeStrConst ("{0:" + rustFmt + "}")
     //     "sprintf!" |> emitFormat com r t [format; thisArg.Value] |> Some
     | "ToString", _ ->
+        // For d.ToString(provider) the provider is the only argument, so dropping
+        // it leaves nothing for toString's decimal parameter; the receiver takes
+        // its place. d.ToString() already arrives with the receiver in args.
+        let args =
+            match args, thisArg with
+            | [], Some this -> [ this ]
+            | _ -> args
+
         Helper.LibCall(com, "Decimal", "toString", t, args, i.SignatureArgTypes, ?loc = r)
         |> Some
     | ("Compare" | "CompareTo" | "Equals" | "GetHashCode"), _ -> valueTypes com ctx r t i thisArg args

--- a/tests/Rust/tests/src/ControlFlowTests.fs
+++ b/tests/Rust/tests/src/ControlFlowTests.fs
@@ -183,3 +183,34 @@ let ``two-switch or-pattern with obj binding works`` () =
     // exercises the getZeroObj placeholder for a `dyn Any` binding on the two-switch path
     orPatObj (OA(box 9)) :? int |> equal true
     orPatObj (OB(box 11)) :? string |> equal false
+
+// A try/with/finally lowers to closures on this target, but the Fable AST has no
+// Lambda there, so the capture walk did not treat those bodies as closure
+// contexts. A `let mutable` assigned in a finally block was emitted as a bare
+// MutCell and the closure mutated a clone, so the write was silently lost.
+[<Fact>]
+let ``a mutable assigned in a finally block keeps its value`` () =
+    let mutable ran = false
+
+    let message =
+        try
+            try
+                failwith "inner"
+            finally
+                ran <- true
+        with ex ->
+            ex.Message
+
+    ran |> equal true
+    message |> equal "inner"
+
+[<Fact>]
+let ``a mutable assigned in a with handler keeps its value`` () =
+    let mutable ran = false
+
+    try
+        failwith "x"
+    with _ ->
+        ran <- true
+
+    ran |> equal true

--- a/tests/Rust/tests/src/ControlFlowTests.fs
+++ b/tests/Rust/tests/src/ControlFlowTests.fs
@@ -188,8 +188,25 @@ let ``two-switch or-pattern with obj binding works`` () =
 // Lambda there, so the capture walk did not treat those bodies as closure
 // contexts. A `let mutable` assigned in a finally block was emitted as a bare
 // MutCell and the closure mutated a clone, so the write was silently lost.
+//
+// The exception-free case runs everywhere; the ones below need a `with` that
+// actually catches, which no_std's try_catch does not do.
 [<Fact>]
 let ``a mutable assigned in a finally block keeps its value`` () =
+    let mutable ran = false
+
+    let message =
+        try
+            "body"
+        finally
+            ran <- true
+
+    ran |> equal true
+    message |> equal "body"
+
+#if !NO_STD_NO_EXCEPTIONS
+[<Fact>]
+let ``a mutable assigned in a finally block survives an exception`` () =
     let mutable ran = false
 
     let message =
@@ -214,3 +231,4 @@ let ``a mutable assigned in a with handler keeps its value`` () =
         ran <- true
 
     ran |> equal true
+#endif

--- a/tests/Rust/tests/src/ConvertTests.fs
+++ b/tests/Rust/tests/src/ConvertTests.fs
@@ -1584,3 +1584,29 @@ let ``System.Convert.ToFloat from bool works`` () =
     Convert.ToSingle(false) |> equal 0.f
     Convert.ToDouble(true) |> equal 1.
     Convert.ToDouble(false) |> equal 0.
+
+// The culture-taking overloads used to fail to compile: the provider was passed
+// on to runtime functions that have no parameter for it, so Decimal.Parse(s,
+// style, culture) reached a one-argument function and d.ToString(culture) put a
+// provider where the decimal belongs. Rust formatting and parsing are invariant,
+// which is what InvariantCulture asks for, so the argument is dropped.
+[<Fact>]
+let ``culture-taking overloads work`` () =
+    let d = 1234.5678M
+    d.ToString(System.Globalization.CultureInfo.InvariantCulture) |> equal "1234.5678"
+    d.ToString() |> equal "1234.5678"
+
+    System.Decimal.Parse(
+        "1234.5678",
+        System.Globalization.NumberStyles.Number,
+        System.Globalization.CultureInfo.InvariantCulture
+    )
+    |> equal 1234.5678M
+
+    System.Decimal.Parse("12.34", System.Globalization.CultureInfo.InvariantCulture)
+    |> equal 12.34M
+
+    System.DateTime
+        .Parse("2026-08-27T10:30:00.0000000", System.Globalization.CultureInfo.InvariantCulture)
+        .ToString("o")
+    |> equal "2026-08-27T10:30:00.0000000"


### PR DESCRIPTION
- d.ToString(provider), Decimal.Parse(s, provider) and Decimal.Parse(s, style, provider) now compile. The provider was forwarded to runtime functions that have no parameter for it, so Parse reached a one-argument function and ToString put an IFormatProvider where the decimal belongs. Rust parses and formats invariantly, which is what InvariantCulture asks for, so the culture and style arguments are dropped instead
- a `let mutable` assigned in a finally block was mutating a clone of its cell and silently losing the write. try/with/finally now count as the closure contexts they compile into, so the binding is ref-counted like any other captured mutable

The decimal half matters beyond convenience: the culture-less Decimal.Parse compiles but throws under a comma-separator locale such as fi-FI, so a library storing a decimal as text had no supported way to read it back.