### PR TITLE
feat(all): Quotations: DerivedPatterns, and captured locals as Value nodes

### DIFF
--- a/src/Fable.Transforms/FableTransforms.fs
+++ b/src/Fable.Transforms/FableTransforms.fs
@@ -255,40 +255,56 @@ let noSideEffectBeforeIdent identName expr =
 
     findIdentOrSideEffect expr && not sideEffect
 
+/// A binding referenced from inside a quotation must not be inlined. `visit`
+/// deliberately does not rewrite quoted expressions, so the substitution would
+/// never reach that reference, and removing the binding would leave the captured
+/// value dangling.
+let isReferencedInsideQuote identName body =
+    body
+    |> deepExists (
+        function
+        | Quote(quotedExpr, _, _) -> countReferencesUntil 1 identName quotedExpr >= 1
+        | _ -> false
+    )
+
 let canInlineArg (com: Compiler) identName value body =
-    match value with
-    | Value((Null _ | UnitConstant | TypeInfo _ | BoolConstant _ | NumberConstant _ | CharConstant _), _) -> true
-    | Value(StringConstant s, _) ->
-        match com.Options.Language with
-        | Python ->
-            // Only inline short strings if they're referenced at most once,
-            // to avoid duplicating the literal in generated code (which can cause
-            // issues like property access on string literals in Python)
-            s.Length < 100 && countReferencesUntil 2 identName body <= 1
-        | _ -> s.Length < 100
-    | _ ->
-        let refCount = countReferencesUntil 2 identName body
+    if isReferencedInsideQuote identName body then
+        false
+    else
 
-        // Don't inline values that create new mutable state (e.g. ResizeArray(), mutable arrays)
-        // into closures: even though creation is side-effect-free, inlining into a closure
-        // called multiple times would create a new instance per call instead of sharing the
-        // single captured instance
-        let createsMutableState =
-            match value with
-            | Value(NewArray(_, _, kind), _) ->
-                match kind with
-                | MutableArray
-                | ResizeArray -> true
-                | ImmutableArray -> false
-            | _ -> false
+        match value with
+        | Value((Null _ | UnitConstant | TypeInfo _ | BoolConstant _ | NumberConstant _ | CharConstant _), _) -> true
+        | Value(StringConstant s, _) ->
+            match com.Options.Language with
+            | Python ->
+                // Only inline short strings if they're referenced at most once,
+                // to avoid duplicating the literal in generated code (which can cause
+                // issues like property access on string literals in Python)
+                s.Length < 100 && countReferencesUntil 2 identName body <= 1
+            | _ -> s.Length < 100
+        | _ ->
+            let refCount = countReferencesUntil 2 identName body
 
-        (refCount <= 1
-         && not (canHaveSideEffects com value)
-         && not (createsMutableState && isIdentCaptured identName body))
-        // If it can have side effects, make sure is at least referenced once so the expression is not erased
-        || (refCount = 1
-            && noSideEffectBeforeIdent identName body
-            && not (isIdentCaptured identName body))
+            // Don't inline values that create new mutable state (e.g. ResizeArray(), mutable arrays)
+            // into closures: even though creation is side-effect-free, inlining into a closure
+            // called multiple times would create a new instance per call instead of sharing the
+            // single captured instance
+            let createsMutableState =
+                match value with
+                | Value(NewArray(_, _, kind), _) ->
+                    match kind with
+                    | MutableArray
+                    | ResizeArray -> true
+                    | ImmutableArray -> false
+                | _ -> false
+
+            (refCount <= 1
+             && not (canHaveSideEffects com value)
+             && not (createsMutableState && isIdentCaptured identName body))
+            // If it can have side effects, make sure is at least referenced once so the expression is not erased
+            || (refCount = 1
+                && noSideEffectBeforeIdent identName body
+                && not (isIdentCaptured identName body))
 
 /// Returns arity of lambda (or lambda option) types
 let (|Arity|) typ =

--- a/src/Fable.Transforms/QuotationEmitter.fs
+++ b/src/Fable.Transforms/QuotationEmitter.fs
@@ -10,14 +10,20 @@ open Replacements.Util
 /// to construct a quotation AST. The input is the Fable.Expr captured
 /// inside a Quote node; the output is a Fable.Expr that calls the
 /// quotation runtime library to build the AST at runtime.
-let rec emitQuotedExpr (com: Compiler) (expr: Expr) : Expr =
+let rec private emitQuotedExprIn (com: Compiler) (bound: Set<string>) (expr: Expr) : Expr =
     match expr with
-    | Value(kind, r) -> emitQuotedValue com kind r
+    | Value(kind, r) -> emitQuotedValue com bound kind r
+
+    | IdentExpr ident when not (Set.contains ident.Name bound) ->
+        // Free in the quotation, so it is a local captured from the enclosing
+        // scope rather than a quotation variable. .NET splices the captured
+        // *value* in as a Value node; emitting a Var here instead left consumers
+        // with a name and no value to bind -- which is precisely what a query
+        // translator needs in order to turn a captured local into a parameter.
+        Helper.LibCall(com, "quotation", "mkValue", Any, [ IdentExpr ident; makeStrConst (typeToString ident.Type) ])
 
     | IdentExpr ident ->
-        // Reference to a variable already introduced by a lambda/let in the quotation.
-        // Emit: quotation.mkVar(Var)
-        // We need a var reference. Create a var and then wrap it.
+        // Bound by a lambda or let inside the quotation: a genuine Var.
         let varExpr =
             Helper.LibCall(
                 com,
@@ -47,14 +53,14 @@ let rec emitQuotedExpr (com: Compiler) (expr: Expr) : Expr =
                 ]
             )
 
-        let bodyExpr = emitQuotedExpr com body
+        let bodyExpr = emitQuotedExprIn com (Set.add arg.Name bound) body
         Helper.LibCall(com, "quotation", "mkLambda", Any, [ varExpr; bodyExpr ])
 
     | Delegate(args, body, _name, _tags) ->
         // Multi-arg delegate: nest as curried lambdas
-        let rec nestLambdas args body =
+        let rec nestLambdas bound args body =
             match args with
-            | [] -> emitQuotedExpr com body
+            | [] -> emitQuotedExprIn com bound body
             | (arg: Ident) :: rest ->
                 let varExpr =
                     Helper.LibCall(
@@ -69,10 +75,10 @@ let rec emitQuotedExpr (com: Compiler) (expr: Expr) : Expr =
                         ]
                     )
 
-                let innerBody = nestLambdas rest body
+                let innerBody = nestLambdas (Set.add arg.Name bound) rest body
                 Helper.LibCall(com, "quotation", "mkLambda", Any, [ varExpr; innerBody ])
 
-        nestLambdas args body
+        nestLambdas bound args body
 
     | Let(ident, value, body) ->
         let varExpr =
@@ -88,25 +94,25 @@ let rec emitQuotedExpr (com: Compiler) (expr: Expr) : Expr =
                 ]
             )
 
-        let valueExpr = emitQuotedExpr com value
-        let bodyExpr = emitQuotedExpr com body
+        let valueExpr = emitQuotedExprIn com bound value
+        let bodyExpr = emitQuotedExprIn com (Set.add ident.Name bound) body
 
         Helper.LibCall(com, "quotation", "mkLet", Any, [ varExpr; valueExpr; bodyExpr ])
 
     | IfThenElse(guardExpr, thenExpr, elseExpr, _r) ->
-        let guard = emitQuotedExpr com guardExpr
-        let thenE = emitQuotedExpr com thenExpr
-        let elseE = emitQuotedExpr com elseExpr
+        let guard = emitQuotedExprIn com bound guardExpr
+        let thenE = emitQuotedExprIn com bound thenExpr
+        let elseE = emitQuotedExprIn com bound elseExpr
         Helper.LibCall(com, "quotation", "mkIfThenElse", Any, [ guard; thenE; elseE ])
 
     | CurriedApply(applied, args, _typ, _r) ->
         // Emit nested applications: Application(Application(f, a1), a2)
-        let appliedExpr = emitQuotedExpr com applied
+        let appliedExpr = emitQuotedExprIn com bound applied
 
         args
         |> List.fold
             (fun acc arg ->
-                let argExpr = emitQuotedExpr com arg
+                let argExpr = emitQuotedExprIn com bound arg
                 Helper.LibCall(com, "quotation", "mkApplication", Any, [ acc; argExpr ])
             )
             appliedExpr
@@ -114,7 +120,7 @@ let rec emitQuotedExpr (com: Compiler) (expr: Expr) : Expr =
     | Call(callee, info, _typ, _r) ->
         let instanceExpr =
             match info.ThisArg with
-            | Some thisArg -> emitQuotedExpr com thisArg
+            | Some thisArg -> emitQuotedExprIn com bound thisArg
             // Static/operator call: no instance.
             | None -> mkNoInstanceExpr com
 
@@ -135,16 +141,16 @@ let rec emitQuotedExpr (com: Compiler) (expr: Expr) : Expr =
         else
             let methodExpr = makeStrConst methodName
             let declTypeExpr = makeStrConst declaringType
-            let argExprs = mkExprArray com (info.Args |> List.map (emitQuotedExpr com))
+            let argExprs = mkExprArray com (info.Args |> List.map (emitQuotedExprIn com bound))
             Helper.LibCall(com, "quotation", "mkCall", Any, [ instanceExpr; methodExpr; argExprs; declTypeExpr ])
 
     | Sequential exprs ->
         match exprs with
-        | [] -> emitQuotedExpr com (Value(UnitConstant, None))
-        | [ single ] -> emitQuotedExpr com single
+        | [] -> emitQuotedExprIn com bound (Value(UnitConstant, None))
+        | [ single ] -> emitQuotedExprIn com bound single
         | first :: rest ->
-            let restExpr = emitQuotedExpr com (Sequential rest)
-            let firstExpr = emitQuotedExpr com first
+            let restExpr = emitQuotedExprIn com bound (Sequential rest)
+            let firstExpr = emitQuotedExprIn com bound first
             Helper.LibCall(com, "quotation", "mkSequential", Any, [ firstExpr; restExpr ])
 
     | Operation(kind, _tags, _typ, _r) ->
@@ -195,13 +201,13 @@ let rec emitQuotedExpr (com: Compiler) (expr: Expr) : Expr =
         let methodExpr = makeStrConst opName
         let instanceExpr = mkNoInstanceExpr com
 
-        let argExprs = mkExprArray com (args |> List.map (emitQuotedExpr com))
+        let argExprs = mkExprArray com (args |> List.map (emitQuotedExprIn com bound))
 
         // Operators have no declaring type; pass an empty string.
         Helper.LibCall(com, "quotation", "mkCall", Any, [ instanceExpr; methodExpr; argExprs; makeStrConst "" ])
 
     | Get(expr, kind, _typ, _r) ->
-        let target = emitQuotedExpr com expr
+        let target = emitQuotedExprIn com bound expr
 
         match kind with
         | TupleIndex index -> Helper.LibCall(com, "quotation", "mkTupleGet", Any, [ target; makeIntConst index ])
@@ -227,8 +233,8 @@ let rec emitQuotedExpr (com: Compiler) (expr: Expr) : Expr =
             Helper.LibCall(com, "quotation", "mkValue", Any, [ makeStrConst msg; makeStrConst "string" ])
 
     | Set(expr, kind, _typ, value, _r) ->
-        let target = emitQuotedExpr com expr
-        let valueExpr = emitQuotedExpr com value
+        let target = emitQuotedExprIn com bound expr
+        let valueExpr = emitQuotedExprIn com bound value
 
         match kind with
         | ValueSet ->
@@ -242,7 +248,7 @@ let rec emitQuotedExpr (com: Compiler) (expr: Expr) : Expr =
 
     | TypeCast(innerExpr, _typ) ->
         // Coerce/cast: just emit the inner expression for now
-        emitQuotedExpr com innerExpr
+        emitQuotedExprIn com bound innerExpr
 
     | DecisionTree(decisionExpr, targets) ->
         // Inline each DecisionTreeSuccess leaf into its target body via nested Lets, turning
@@ -261,18 +267,18 @@ let rec emitQuotedExpr (com: Compiler) (expr: Expr) : Expr =
                 | e -> e
             )
 
-        emitQuotedExpr com inlined
+        emitQuotedExprIn com bound inlined
 
     | DecisionTreeSuccess(idx, boundValues, _typ) ->
         match boundValues with
-        | [] -> emitQuotedExpr com (Value(UnitConstant, None))
-        | [ single ] -> emitQuotedExpr com single
+        | [] -> emitQuotedExprIn com bound (Value(UnitConstant, None))
+        | [ single ] -> emitQuotedExprIn com bound single
         | _ ->
             let msg = "Unsupported quotation node: DecisionTreeSuccess"
             Helper.LibCall(com, "quotation", "mkValue", Any, [ makeStrConst msg; makeStrConst "string" ])
 
     | Test(testExpr, kind, _r) ->
-        let target = emitQuotedExpr com testExpr
+        let target = emitQuotedExprIn com bound testExpr
 
         // Note: real .NET quotations use dedicated UnionCaseTest/TypeTest node kinds here, not
         // Call — this emitter renders all of these as synthetic Calls instead (e.g. "get_IsCons",
@@ -282,7 +288,7 @@ let rec emitQuotedExpr (com: Compiler) (expr: Expr) : Expr =
         | UnionCaseTest tag ->
             // Represent as: (unionTag target) = tag
             let tagExpr = Helper.LibCall(com, "quotation", "mkUnionTag", Any, [ target ])
-            let tagConst = emitQuotedExpr com (makeIntConst tag)
+            let tagConst = emitQuotedExprIn com bound (makeIntConst tag)
 
             Helper.LibCall(
                 com,
@@ -364,7 +370,7 @@ and private mkNoInstanceExpr (com: Compiler) : Expr =
     // so isCall/isFieldGet don't conflate the two.
     mkNullExpr com "novalue"
 
-and private emitQuotedValue (com: Compiler) (kind: ValueKind) (_r: SourceLocation option) : Expr =
+and private emitQuotedValue (com: Compiler) (bound: Set<string>) (kind: ValueKind) (_r: SourceLocation option) : Expr =
     match kind with
     | BoolConstant b -> Helper.LibCall(com, "quotation", "mkValue", Any, [ makeBoolConst b; makeStrConst "bool" ])
 
@@ -388,7 +394,8 @@ and private emitQuotedValue (com: Compiler) (kind: ValueKind) (_r: SourceLocatio
         Helper.LibCall(com, "quotation", "mkValue", Any, [ Value(CharConstant c, None); makeStrConst "char" ])
 
     | NewTuple(values, _isStruct) ->
-        let emittedValues = mkExprArray com (values |> List.map (emitQuotedExpr com))
+        let emittedValues =
+            mkExprArray com (values |> List.map (emitQuotedExprIn com bound))
 
         Helper.LibCall(com, "quotation", "mkNewTuple", Any, [ emittedValues ])
 
@@ -398,7 +405,8 @@ and private emitQuotedValue (com: Compiler) (kind: ValueKind) (_r: SourceLocatio
             | Some ent -> ent.FullName
             | None -> entRef.FullName
 
-        let emittedValues = mkExprArray com (values |> List.map (emitQuotedExpr com))
+        let emittedValues =
+            mkExprArray com (values |> List.map (emitQuotedExprIn com bound))
 
         if com.Options.Language = Rust then
             // Rust needs the case name to build a real UnionCaseInfo; other targets keep (name, tag, fields).
@@ -429,7 +437,8 @@ and private emitQuotedValue (com: Compiler) (kind: ValueKind) (_r: SourceLocatio
             | Some ent -> ent.FSharpFields |> List.map (fun f -> makeStrConst f.Name) |> makeArray Any
             | None -> makeArray Any []
 
-        let emittedValues = mkExprArray com (values |> List.map (emitQuotedExpr com))
+        let emittedValues =
+            mkExprArray com (values |> List.map (emitQuotedExprIn com bound))
 
         if com.Options.Language = Rust then
             // Rust needs the record type name; other targets keep (fieldNames, values).
@@ -449,7 +458,7 @@ and private emitQuotedValue (com: Compiler) (kind: ValueKind) (_r: SourceLocatio
 
         match value with
         | Some v ->
-            let emitted = mkExprArray com [ emitQuotedExpr com v ]
+            let emitted = mkExprArray com [ emitQuotedExprIn com bound v ]
 
             Helper.LibCall(
                 com,
@@ -472,15 +481,15 @@ and private emitQuotedValue (com: Compiler) (kind: ValueKind) (_r: SourceLocatio
     | NewOption(value, _typ, _isStruct) ->
         match value with
         | Some v ->
-            let emitted = emitQuotedExpr com v
+            let emitted = emitQuotedExprIn com bound v
             Helper.LibCall(com, "quotation", "mkValue", Any, [ emitted; makeStrConst "option" ])
         | None -> mkNullExpr com "option"
 
     | NewList(headAndTail, _typ) ->
         match headAndTail with
         | Some(head, tail) ->
-            let headExpr = emitQuotedExpr com head
-            let tailExpr = emitQuotedExpr com tail
+            let headExpr = emitQuotedExprIn com bound head
+            let tailExpr = emitQuotedExprIn com bound tail
             Helper.LibCall(com, "quotation", "mkNewList", Any, [ headExpr; tailExpr ])
         | None -> mkNullExpr com "list"
 
@@ -549,3 +558,7 @@ and private mkExprArray (com: Compiler) (elements: Expr list) : Expr =
     match elements with
     | [] when com.Options.Language = Rust -> Helper.LibCall(com, "quotation", "emptyExprArray", Any, [])
     | _ -> makeArray Any elements
+
+/// Entry point. Nothing is bound at the top of a quotation, so any identifier
+/// still free by the time it is reached is a captured local.
+let emitQuotedExpr (com: Compiler) (expr: Expr) : Expr = emitQuotedExprIn com Set.empty expr

--- a/src/Fable.Transforms/Replacements.Util.fs
+++ b/src/Fable.Transforms/Replacements.Util.fs
@@ -1837,6 +1837,51 @@ module Quotations =
             Helper.LibCall(com, libModule, "isFieldGet", t, [ expr ], ?loc = r) |> Some
         | _ -> None
 
+    /// DerivedPatterns are the ones F# defines on top of Patterns. AndAlso and
+    /// OrElse matter because `&&` and `||` desugar to IfThenElse, so without them
+    /// a consumer has to re-derive that shape by hand; SpecificCall is how
+    /// operators are matched by identity rather than by compiled name.
+    let quotationDerivedPatterns
+        (libModule: string)
+        (com: ICompiler)
+        (ctx: Context)
+        r
+        (t: Type)
+        (i: CallInfo)
+        (_thisArg: Expr option)
+        (args: Expr list)
+        =
+        match i.CompiledName, args with
+        | ("AndAlsoPattern" | "|AndAlso|_|"), [ expr ] ->
+            Helper.LibCall(com, libModule, "isAndAlso", t, [ expr ], ?loc = r) |> Some
+        | ("OrElsePattern" | "|OrElse|_|"), [ expr ] ->
+            Helper.LibCall(com, libModule, "isOrElse", t, [ expr ], ?loc = r) |> Some
+        // SpecificCall is curried in FSharp.Core: applying it to the template
+        // returns the function that then tests the expression. Rather than have
+        // each runtime return a closure -- which the Rust backend uncurries back
+        // into a two-argument function -- the runtimes take both arguments and
+        // the partial application is built here.
+        | ("SpecificCallPattern" | "|SpecificCall|_|"), [ template ] ->
+            let exprType, resultType =
+                match t with
+                | LambdaType(argType, returnType) -> argType, returnType
+                | _ -> Any, Any
+
+            let exprIdent = makeUniqueIdent com ctx exprType "expr"
+
+            let body =
+                Helper.LibCall(
+                    com,
+                    libModule,
+                    "isSpecificCall",
+                    resultType,
+                    [ template; IdentExpr exprIdent ],
+                    ?loc = r
+                )
+
+            Lambda(exprIdent, body, None) |> Some
+        | _ -> None
+
     let tryQuotationCall
         (libModule: string)
         (com: ICompiler)
@@ -1853,6 +1898,7 @@ module Quotations =
         | Types.fsharpExprGeneric -> quotationExprs libModule com ctx r t info thisArg args
         | Types.fsharpVar -> quotationVars libModule com ctx r t info thisArg args
         | Types.patternsModule -> quotationPatterns libModule com ctx r t info thisArg args
+        | Types.derivedPatternsModule -> quotationDerivedPatterns libModule com ctx r t info thisArg args
         | "Microsoft.FSharp.Linq.RuntimeHelpers.LeafExpressionConverter" ->
             match info.CompiledName, args with
             | "EvaluateQuotation", [ expr ] -> Helper.LibCall(com, libModule, "evaluate", t, [ expr ], ?loc = r) |> Some

--- a/src/Fable.Transforms/Transforms.Util.fs
+++ b/src/Fable.Transforms/Transforms.Util.fs
@@ -493,6 +493,9 @@ module Types =
     let patternsModule = "Microsoft.FSharp.Quotations.PatternsModule"
 
     [<Literal>]
+    let derivedPatternsModule = "Microsoft.FSharp.Quotations.DerivedPatternsModule"
+
+    [<Literal>]
     let printfModule = "Microsoft.FSharp.Core.PrintfModule"
 
     [<Literal>]
@@ -1801,7 +1804,12 @@ module AST =
             | None -> body :: (Option.toList finalizer)
         | DecisionTree(expr, targets) -> expr :: (List.map snd targets)
         | DecisionTreeSuccess(_, boundValues, _) -> boundValues
-        | Quote _ -> [] // Quoted expressions are opaque data — don't traverse
+        // Quoted expressions must not be *rewritten* (see `visit` above, which
+        // leaves them alone), but analysis has to see inside them: a local that
+        // is only referenced from within a quotation is still referenced, and
+        // returning [] here let reference counting treat it as dead and drop the
+        // binding out from under the captured value.
+        | Quote(quotedExpr, _, _) -> [ quotedExpr ]
 
     let deepExists (f: Expr -> bool) expr =
         let rec deepExistsInner (exprs: ResizeArray<Expr>) =

--- a/src/fable-library-beam/fable_quotation.erl
+++ b/src/fable-library-beam/fable_quotation.erl
@@ -12,6 +12,7 @@
     is_let/1, is_if_then_else/1, is_call/1, is_sequential/1,
     is_new_tuple/1, is_new_union_case/1, is_new_record/1,
     is_tuple_get/1, is_field_get/1,
+    is_and_also/1, is_or_else/1, is_specific_call/2,
     evaluate/1,
     expr_to_string/1, get_free_vars/1, substitute/2
 ]).
@@ -311,3 +312,41 @@ sub({expr, if_then_else, Guard, Then, Else}, Fn) ->
 sub({expr, sequential, First, Second}, Fn) ->
     {expr, sequential, sub(First, Fn), sub(Second, Fn)};
 sub(E, _Fn) -> E.
+
+%% ===================================================================
+%% DerivedPatterns
+%% F# defines these on top of Patterns. AndAlso and OrElse recover the shape
+%% `&&` and `||` desugar into; SpecificCall matches a call by the identity of a
+%% template quotation rather than by compiled name.
+%% ===================================================================
+
+%% a andalso b  ==>  if a then b else false
+is_and_also({expr, if_then_else, G, T, {expr, value, false, _}}) -> {G, T};
+is_and_also(_) -> undefined.
+
+%% a orelse b  ==>  if a then true else b
+is_or_else({expr, if_then_else, G, {expr, value, true, _}, E}) -> {G, E};
+is_or_else(_) -> undefined.
+
+%% A template such as <@ (=) @> quotes as nested lambdas around the call, so the
+%% identifying Call node has to be dug out before comparing.
+template_call({expr, lambda, _, Body}) -> template_call(Body);
+template_call({expr, call, _, M, _, DT}) -> {M, DT};
+template_call(_) -> undefined.
+
+%% SpecificCall: returns {Instance, GenericArgs, Args}. The middle slot is F#'s
+%% generic-argument list; this runtime models types as names rather than
+%% System.Type, so it is always empty and callers match it with a wildcard.
+%% Takes both arguments; the partial application FSharp.Core expresses by
+%% currying is built by the replacement instead.
+is_specific_call(Template, {expr, call, I, M, A, DT}) ->
+    case template_call(Template) of
+        {M, DT} ->
+            Instance = case I of
+                {expr, value, _, <<"novalue">>} -> undefined;
+                _ -> I
+            end,
+            {Instance, [], deref(A)};
+        _ -> undefined
+    end;
+is_specific_call(_, _) -> undefined.

--- a/src/fable-library-dart/quotation.dart
+++ b/src/fable-library-dart/quotation.dart
@@ -656,3 +656,70 @@ Expr substitute(Expr expr, dynamic fn) {
 
   return sub(expr);
 }
+
+// ===================================================================
+// DerivedPatterns
+// F# defines these on top of Patterns. AndAlso and OrElse recover the
+// shape `&&` and `||` desugar into; SpecificCall matches a call by the
+// identity of a template quotation rather than by compiled name.
+// ===================================================================
+
+/// a && b  ==>  if a then b else false
+types.Some<types.Tuple2<dynamic, dynamic>>? isAndAlso(Expr expr) {
+  if (expr is ExprIfThenElse) {
+    final e = expr.elseExpr;
+    if (e is ExprValue && e.value == false) {
+      return types.Some<types.Tuple2<dynamic, dynamic>>(
+          types.Tuple2<dynamic, dynamic>(expr.guard, expr.thenExpr));
+    }
+  }
+  return null;
+}
+
+/// a || b  ==>  if a then true else b
+types.Some<types.Tuple2<dynamic, dynamic>>? isOrElse(Expr expr) {
+  if (expr is ExprIfThenElse) {
+    final t = expr.thenExpr;
+    if (t is ExprValue && t.value == true) {
+      return types.Some<types.Tuple2<dynamic, dynamic>>(
+          types.Tuple2<dynamic, dynamic>(expr.guard, expr.elseExpr));
+    }
+  }
+  return null;
+}
+
+/// A template such as <@ (=) @> quotes as nested lambdas around the call, so
+/// the identifying Call node has to be dug out before comparing.
+ExprCall? _templateCall(Expr expr) {
+  Expr current = expr;
+  while (current is ExprLambda) {
+    current = current.body;
+  }
+  return current is ExprCall ? current : null;
+}
+
+// Takes both arguments; the partial application FSharp.Core expresses by
+// currying is built by the replacement instead.
+// Dart checks the full generic shape at runtime, so this spells out the type the
+// F# signature declares: (Expr option * Type list * Expr list) option.
+types.Some<types.Tuple3<types.Some<dynamic>?, list.FSharpList<Type>, list.FSharpList<dynamic>>>?
+    isSpecificCall(Expr template, Expr expr) {
+  final wanted = _templateCall(template);
+  if (wanted == null || expr is! ExprCall) return null;
+  if (expr.method != wanted.method ||
+      expr.declaringType != wanted.declaringType) {
+    return null;
+  }
+  final inst = expr.instance;
+  final normalized =
+      (inst is ExprValue && inst.type == 'novalue') ? null : inst;
+  // The middle slot is F#'s generic-argument list. This runtime models types as
+  // names rather than System.Type, so it is always empty; callers match it with
+  // a wildcard.
+  return types.Some<
+          types.Tuple3<types.Some<dynamic>?, list.FSharpList<Type>, list.FSharpList<dynamic>>>(
+      types.Tuple3<types.Some<dynamic>?, list.FSharpList<Type>, list.FSharpList<dynamic>>(
+          normalized == null ? null : types.Some<dynamic>(normalized),
+          list.ofArray<Type>(const []),
+          list.ofArray<dynamic>(expr.args)));
+}

--- a/src/fable-library-rust/src/Quotation.fs
+++ b/src/fable-library-rust/src/Quotation.fs
@@ -583,3 +583,49 @@ let evaluate (e: FSharpExpr) : obj =
             box 0
 
     eval (ref Map.empty) e
+
+// --- DerivedPatterns ------------------------------------------------------
+// F# defines these on top of Patterns. AndAlso and OrElse recover the shape
+// `&&` and `||` desugar into; SpecificCall matches a call by the identity of a
+// template quotation rather than by compiled name.
+
+let private isBoolLit (want: bool) (e: FSharpExpr) =
+    match e with
+    | ExprValue(value, "bool") -> unbox<bool> value = want
+    | _ -> false
+
+/// a && b  ==>  if a then b else false
+let isAndAlso (e: FSharpExpr) =
+    match e with
+    | ExprIfThenElse(g, t, el) when isBoolLit false el -> Some(g, t)
+    | _ -> None
+
+/// a || b  ==>  if a then true else b
+let isOrElse (e: FSharpExpr) =
+    match e with
+    | ExprIfThenElse(g, t, el) when isBoolLit true t -> Some(g, el)
+    | _ -> None
+
+/// A template such as <@ (=) @> quotes as nested lambdas around the call, so
+/// the identifying Call node has to be dug out before comparing.
+let rec private templateCall (e: FSharpExpr) =
+    match e with
+    | ExprLambda(_, body) -> templateCall body
+    | ExprCall(_, m, _, dt) -> Some(m, dt)
+    | _ -> None
+
+/// Takes both arguments; the partial application that FSharp.Core expresses by
+/// currying is built by the replacement instead (see quotationDerivedPatterns).
+let isSpecificCall (template: FSharpExpr) (e: FSharpExpr) =
+    match templateCall template, e with
+    | Some(wantedName, wantedType), ExprCall(instance, m, args, dt) when m = wantedName && dt = wantedType ->
+        let inst =
+            match instance with
+            | ExprValue(_, "novalue") -> None
+            | _ -> Some instance
+
+        // The middle slot is F#'s generic-argument list (Type list), which erases
+        // to obj on targets with no System.Type runtime, so the element type has
+        // to be obj rather than anything narrower.
+        Some(inst, (List.empty<obj>), List.ofArray args)
+    | _ -> None

--- a/src/fable-library-ts/quotation.ts
+++ b/src/fable-library-ts/quotation.ts
@@ -664,3 +664,51 @@ export function exprFromJSON(json: any): Expr {
         default: return new ExprValue(json, "unknown");
     }
 }
+
+// ===================================================================
+// DerivedPatterns
+// F# defines these on top of Patterns. AndAlso and OrElse recover the
+// shape `&&` and `||` desugar into; SpecificCall matches a call by the
+// identity of a template quotation rather than by compiled name.
+// ===================================================================
+
+export function isAndAlso(expr: Expr): [Expr, Expr] | undefined {
+    // a && b  ==>  if a then b else false
+    if (expr instanceof ExprIfThenElse
+        && expr.elseExpr instanceof ExprValue
+        && expr.elseExpr.value === false) {
+        return [expr.guard, expr.thenExpr];
+    }
+    return undefined;
+}
+
+export function isOrElse(expr: Expr): [Expr, Expr] | undefined {
+    // a || b  ==>  if a then true else b
+    if (expr instanceof ExprIfThenElse
+        && expr.thenExpr instanceof ExprValue
+        && expr.thenExpr.value === true) {
+        return [expr.guard, expr.elseExpr];
+    }
+    return undefined;
+}
+
+/// A template such as <@ (=) @> quotes as nested lambdas around the call, so
+/// the identifying Call node has to be dug out before comparing.
+function templateCall(expr: Expr): ExprCall | undefined {
+    let current: Expr = expr;
+    while (current instanceof ExprLambda) { current = current.body; }
+    return current instanceof ExprCall ? current : undefined;
+}
+
+// Takes both arguments; the partial application FSharp.Core expresses by
+// currying is built by the replacement instead.
+export function isSpecificCall(template: Expr, expr: Expr): [Expr | null, FSharpList<string>, FSharpList<Expr>] | undefined {
+    const wanted = templateCall(template);
+    if (wanted === undefined || !(expr instanceof ExprCall)) return undefined;
+    if (expr.method !== wanted.method || expr.declaringType !== wanted.declaringType) return undefined;
+    const instance = (expr.instance instanceof ExprValue && expr.instance.type === "novalue") ? null : expr.instance;
+    // The middle slot is F#'s generic-argument list. The runtime models types as
+    // names rather than System.Type, so it is always empty here; callers written
+    // against Fable match it with a wildcard.
+    return [instance, ofArray([]), ofArray(expr.args)];
+}

--- a/tests/Beam/QuotationTests.fs
+++ b/tests/Beam/QuotationTests.fs
@@ -4,6 +4,7 @@ open Fable.Tests.Util
 open Util.Testing
 open Microsoft.FSharp.Quotations
 open Microsoft.FSharp.Quotations.Patterns
+open Microsoft.FSharp.Quotations.DerivedPatterns
 open Microsoft.FSharp.Linq.RuntimeHelpers
 
 type QuotationTestUnion =
@@ -283,3 +284,33 @@ let ``test Call on an instance whose value is null keeps a Some instance`` () =
 
     if not (hasSomeInstancePropertyGet q) then
         failwith "Expected a PropertyGet with a Some instance, even though its value is null"
+
+// DerivedPatterns: AndAlso and OrElse recover the shape `&&` and `||` desugar
+// into, and SpecificCall matches a call by the identity of a template quotation
+// rather than by its compiled name. All three previously reported
+// "not supported by Fable".
+type private DpRec = { Country: string; Balance: float; Id: int }
+
+let rec private dpToSql (e: Expr) : string =
+    match e with
+    | Lambda(_, body) -> dpToSql body
+    | AndAlso(l, r) -> "(" + dpToSql l + " AND " + dpToSql r + ")"
+    | OrElse(l, r) -> "(" + dpToSql l + " OR " + dpToSql r + ")"
+    | SpecificCall <@ (=) @> (_, _, [ l; r ]) -> "(" + dpToSql l + " = " + dpToSql r + ")"
+    | SpecificCall <@ (>) @> (_, _, [ l; r ]) -> "(" + dpToSql l + " > " + dpToSql r + ")"
+    | SpecificCall <@ (<) @> (_, _, [ l; r ]) -> "(" + dpToSql l + " < " + dpToSql r + ")"
+    // Bound as a wildcard: PropertyGet exposes a PropertyInfo on Rust but the
+    // bare name on the other targets, and this test is about DerivedPatterns.
+    | PropertyGet _ -> "col"
+    | Value _ -> "?"
+    | _ -> "<unsupported>"
+
+[<Fact>]
+let ``test DerivedPatterns AndAlso, OrElse and SpecificCall work`` () =
+    dpToSql <@ fun (c: DpRec) -> c.Country = "UK" @> |> equal "(col = ?)"
+
+    dpToSql <@ fun (c: DpRec) -> c.Country = "UK" && c.Balance > 100.0 @>
+    |> equal "((col = ?) AND (col > ?))"
+
+    dpToSql <@ fun (c: DpRec) -> c.Id < 5 || c.Balance > 1.0 @>
+    |> equal "((col < ?) OR (col > ?))"

--- a/tests/Dart/src/QuotationTests.fs
+++ b/tests/Dart/src/QuotationTests.fs
@@ -3,6 +3,7 @@ module Fable.Tests.Dart.Quotation
 open Util
 open Microsoft.FSharp.Quotations
 open Microsoft.FSharp.Quotations.Patterns
+open Microsoft.FSharp.Quotations.DerivedPatterns
 open Microsoft.FSharp.Linq.RuntimeHelpers
 
 type C =
@@ -13,6 +14,27 @@ type Cfg =
     static member Version = 42
 
 type MutableRec = { mutable Value: int }
+
+
+// DerivedPatterns: AndAlso and OrElse recover the shape `&&` and `||` desugar
+// into, and SpecificCall matches a call by the identity of a template quotation
+// rather than by its compiled name. All three previously reported
+// "not supported by Fable".
+type private DpRec = { Country: string; Balance: float; Id: int }
+
+let rec private dpToSql (e: Expr) : string =
+    match e with
+    | Lambda(_, body) -> dpToSql body
+    | AndAlso(l, r) -> "(" + dpToSql l + " AND " + dpToSql r + ")"
+    | OrElse(l, r) -> "(" + dpToSql l + " OR " + dpToSql r + ")"
+    | SpecificCall <@ (=) @> (_, _, [ l; r ]) -> "(" + dpToSql l + " = " + dpToSql r + ")"
+    | SpecificCall <@ (>) @> (_, _, [ l; r ]) -> "(" + dpToSql l + " > " + dpToSql r + ")"
+    | SpecificCall <@ (<) @> (_, _, [ l; r ]) -> "(" + dpToSql l + " < " + dpToSql r + ")"
+    // Bound as a wildcard: PropertyGet exposes a PropertyInfo on Rust but the
+    // bare name on the other targets, and this test is about DerivedPatterns.
+    | PropertyGet _ -> "col"
+    | Value _ -> "?"
+    | _ -> "<unsupported>"
 
 let tests() =
     testCase "Simple integer value quotation" <| fun () ->
@@ -217,3 +239,10 @@ let tests() =
                 <@ let r = { Value = 1 }: MutableRec in r.Value <- 5; r.Value @>
 
         equal 5 (result :?> int)
+
+    testCase "DerivedPatterns AndAlso, OrElse and SpecificCall work" <| fun () ->
+        dpToSql <@ fun (c: DpRec) -> c.Country = "UK" @> |> equal "(col = ?)"
+        dpToSql <@ fun (c: DpRec) -> c.Country = "UK" && c.Balance > 100.0 @>
+        |> equal "((col = ?) AND (col > ?))"
+        dpToSql <@ fun (c: DpRec) -> c.Id < 5 || c.Balance > 1.0 @>
+        |> equal "((col < ?) OR (col > ?))"

--- a/tests/Js/Main/QuotationTests.fs
+++ b/tests/Js/Main/QuotationTests.fs
@@ -300,4 +300,25 @@ let tests =
         |> equal "((col = ?) AND (col > ?))"
         dpToSql <@ fun (c: DpRec) -> c.Id < 5 || c.Balance > 1.0 @>
         |> equal "((col < ?) OR (col > ?))"
+
+    // A local captured by a quotation is spliced in as a Value holding its value,
+    // the way .NET does. It used to come through as a Var carrying only a name.
+    testCase "a captured local is a Value, not a Var" <| fun () ->
+        let captured = "SE"
+        let describe (e: Expr) =
+            match e with
+            | Lambda(_, body) ->
+                match body with
+                | Value(v, _) -> "Value:" + unbox<string> v
+                | Var v -> "Var:" + v.Name
+                | _ -> "other"
+            | _ -> "not a lambda"
+        describe <@ fun (_: int) -> captured @> |> equal "Value:SE"
+        describe <@ fun (_: int) -> "SE" @> |> equal "Value:SE"
+        // Checks that a bound variable is still a Var, not its name: JavaScript
+        // renames the lambda argument (x -> x_10), so the name is not portable.
+        (match <@ fun (x: string) -> x @> with
+         | Lambda(_, Var _) -> "Var"
+         | _ -> "?")
+        |> equal "Var"
   ]

--- a/tests/Js/Main/QuotationTests.fs
+++ b/tests/Js/Main/QuotationTests.fs
@@ -2,6 +2,7 @@ module Fable.Tests.Quotation
 
 open Microsoft.FSharp.Quotations
 open Microsoft.FSharp.Quotations.Patterns
+open Microsoft.FSharp.Quotations.DerivedPatterns
 open Util.Testing
 
 #if FABLE_COMPILER
@@ -18,6 +19,27 @@ let inline quotTestDouble x = x * 2
 type QuotationIndexerTest(values: int[]) =
     member _.Item
         with get (i: int) = values.[i]
+
+
+// DerivedPatterns: AndAlso and OrElse recover the shape `&&` and `||` desugar
+// into, and SpecificCall matches a call by the identity of a template quotation
+// rather than by its compiled name. All three previously reported
+// "not supported by Fable".
+type private DpRec = { Country: string; Balance: float; Id: int }
+
+let rec private dpToSql (e: Expr) : string =
+    match e with
+    | Lambda(_, body) -> dpToSql body
+    | AndAlso(l, r) -> "(" + dpToSql l + " AND " + dpToSql r + ")"
+    | OrElse(l, r) -> "(" + dpToSql l + " OR " + dpToSql r + ")"
+    | SpecificCall <@ (=) @> (_, _, [ l; r ]) -> "(" + dpToSql l + " = " + dpToSql r + ")"
+    | SpecificCall <@ (>) @> (_, _, [ l; r ]) -> "(" + dpToSql l + " > " + dpToSql r + ")"
+    | SpecificCall <@ (<) @> (_, _, [ l; r ]) -> "(" + dpToSql l + " < " + dpToSql r + ")"
+    // Bound as a wildcard: PropertyGet exposes a PropertyInfo on Rust but the
+    // bare name on the other targets, and this test is about DerivedPatterns.
+    | PropertyGet _ -> "col"
+    | Value _ -> "?"
+    | _ -> "<unsupported>"
 
 let tests =
   testList "Quotations" [
@@ -272,4 +294,10 @@ let tests =
         // Thoth Auto format: ["Call", ...]
         parsed[0] |> unbox<string> |> equal "Call"
 #endif
+    testCase "DerivedPatterns AndAlso, OrElse and SpecificCall work" <| fun () ->
+        dpToSql <@ fun (c: DpRec) -> c.Country = "UK" @> |> equal "(col = ?)"
+        dpToSql <@ fun (c: DpRec) -> c.Country = "UK" && c.Balance > 100.0 @>
+        |> equal "((col = ?) AND (col > ?))"
+        dpToSql <@ fun (c: DpRec) -> c.Id < 5 || c.Balance > 1.0 @>
+        |> equal "((col < ?) OR (col > ?))"
   ]

--- a/tests/Rust/tests/src/QuotationTests.fs
+++ b/tests/Rust/tests/src/QuotationTests.fs
@@ -3,6 +3,7 @@ module Fable.Tests.QuotationTests
 open Util.Testing
 open Microsoft.FSharp.Quotations
 open Microsoft.FSharp.Quotations.Patterns
+open Microsoft.FSharp.Quotations.DerivedPatterns
 open Microsoft.FSharp.Linq.RuntimeHelpers
 
 // NOTE: quotations are deconstructed through an untyped `Expr` parameter (helpers below
@@ -405,3 +406,59 @@ let ``Quotation Substitute replaces variables`` () =
     | Lambda(_, Call(_, _, [ Value(value, _); _ ])) ->
         unbox<int> value |> equal 42
     | _ -> failwith "Expected the lambda variable to be substituted"
+
+// DerivedPatterns: AndAlso and OrElse recover the shape `&&` and `||` desugar
+// into, and SpecificCall matches a call by the identity of a template quotation
+// rather than by its compiled name. All three previously reported
+// "not supported by Fable".
+type private DpRec = { Country: string; Balance: float; Id: int }
+
+let rec private dpToSql (e: Expr) : string =
+    match e with
+    | Lambda(_, body) -> dpToSql body
+    | AndAlso(l, r) -> "(" + dpToSql l + " AND " + dpToSql r + ")"
+    | OrElse(l, r) -> "(" + dpToSql l + " OR " + dpToSql r + ")"
+    | SpecificCall <@ (=) @> (_, _, [ l; r ]) -> "(" + dpToSql l + " = " + dpToSql r + ")"
+    | SpecificCall <@ (>) @> (_, _, [ l; r ]) -> "(" + dpToSql l + " > " + dpToSql r + ")"
+    | SpecificCall <@ (<) @> (_, _, [ l; r ]) -> "(" + dpToSql l + " < " + dpToSql r + ")"
+    // Bound as a wildcard: PropertyGet exposes a PropertyInfo on Rust but the
+    // bare name on the other targets, and this test is about DerivedPatterns.
+    | PropertyGet _ -> "col"
+    | Value _ -> "?"
+    | _ -> "<unsupported>"
+
+[<Fact>]
+let ``DerivedPatterns AndAlso, OrElse and SpecificCall work`` () =
+    dpToSql <@ fun (c: DpRec) -> c.Country = "UK" @> |> equal "(col = ?)"
+
+    dpToSql <@ fun (c: DpRec) -> c.Country = "UK" && c.Balance > 100.0 @>
+    |> equal "((col = ?) AND (col > ?))"
+
+    dpToSql <@ fun (c: DpRec) -> c.Id < 5 || c.Balance > 1.0 @>
+    |> equal "((col < ?) OR (col > ?))"
+
+// A local captured by a quotation is spliced in by .NET as a Value node holding
+// its value. It used to come through as a Var carrying only a name, because the
+// emitter treated every identifier as a quotation variable -- and the binding was
+// then inlined away underneath it, since neither reference counting nor the
+// inliner looked inside a Quote.
+[<Fact>]
+let ``a captured local is a Value, not a Var`` () =
+    let captured = "SE"
+
+    let describe (e: Expr) =
+        match e with
+        | Lambda(_, body) ->
+            match body with
+            | Value(v, _) -> "Value:" + unbox<string> v
+            | Var v -> "Var:" + v.Name
+            | _ -> "other"
+        | _ -> "not a lambda"
+
+    describe <@ fun (_: int) -> captured @> |> equal "Value:SE"
+    describe <@ fun (_: int) -> "SE" @> |> equal "Value:SE"
+    // a variable genuinely bound by the quotation stays a Var
+    (match <@ fun (x: string) -> x @> with
+     | Lambda(_, Var v) -> v.Name
+     | _ -> "?")
+    |> equal "x"


### PR DESCRIPTION
- AndAlso, OrElse and SpecificCall are mapped, with an implementation in each
  runtime that has a quotation module. They were the last patterns still
  reporting "not supported by Fable", and && and || desugar into IfThenElse, so
  without them a consumer has to re-derive that shape by hand
- a local captured by a quotation is now spliced in as a Value holding its
  value, the way .NET does, instead of a Var carrying only a name. That needed
  three changes together: the emitter tracks which names the quotation binds,
  getSubExpressions lets analysis see into a Quote, and canInlineArg stops
  removing a binding whose only reference lives inside one