### PR TITLE
fix(rust): Async perf: stop the async runtime sleeping, and add Parallel

### DIFF
--- a/src/fable-library-rust/src/Async.rs
+++ b/src/fable-library-rust/src/Async.rs
@@ -13,11 +13,34 @@ pub mod Async_ {
 
     use super::Task_::Task;
     use crate::NativeArray_::{array_from, Array};
-    use crate::Native_::Seq;
+    use crate::Native_::{Func0, Seq};
     use crate::System::Threading::CancellationToken;
 
     pub struct Async<T: Sized + Send + Sync> {
         pub future: Arc<Mutex<Pin<Box<dyn Future<Output = T> + Send + Sync>>>>,
+
+        /// How to build this computation again, where there is such a thing.
+        ///
+        /// An F# `Async<T>` is a description that can be run any number of
+        /// times; a Rust `Future` can be polled to completion exactly once.
+        /// `while` and `for` inside an async block have to run their body once
+        /// per iteration, so `AsyncBuilder_::delay` -- the one place the F#
+        /// compiler hands over a re-runnable description, and which wraps every
+        /// loop body -- keeps its builder here. Everything else leaves it None
+        /// and stays single-shot exactly as before.
+        pub restart: Option<Func0<Arc<Async<T>>>>,
+    }
+
+    impl<T: Sized + Send + Sync + 'static> Async<T> {
+        /// Wraps a future as a single-shot computation.
+        pub fn from_future(fut: impl Future<Output = T> + Send + Sync + 'static) -> Arc<Async<T>> {
+            let b: Pin<Box<dyn Future<Output = T> + Send + Sync + 'static>> = Box::pin(fut);
+
+            Arc::from(Async {
+                future: Arc::from(Mutex::from(b)),
+                restart: None,
+            })
+        }
     }
 
     impl<T: Clone + Send + Sync> Future for &Async<T> {
@@ -40,11 +63,7 @@ pub mod Async_ {
     }
 
     pub fn sleep(milliseconds: i32) -> Arc<Async<()>> {
-        let fut = Delay::new(Duration::from_millis(milliseconds as u64));
-        let a: Pin<Box<dyn Future<Output = ()> + Send + Sync + 'static>> = Box::pin(fut);
-        Arc::from(Async {
-            future: Arc::from(Mutex::from(a)),
-        })
+        Async::from_future(Delay::new(Duration::from_millis(milliseconds as u64)))
     }
 
     pub fn startAsTask<T: Clone + Send + Sync + 'static>(
@@ -94,11 +113,7 @@ pub mod Async_ {
             array_from(results)
         };
 
-        let b: Pin<Box<dyn Future<Output = Array<T>> + Send + Sync + 'static>> = Box::pin(fut);
-
-        Arc::from(Async {
-            future: Arc::from(Mutex::from(b)),
-        })
+        Async::from_future(fut)
     }
 
     /// Async.StartImmediateAsTask. Runs on the calling thread rather than
@@ -115,29 +130,209 @@ pub mod Async_ {
     }
 
     pub fn awaitTask<T: Clone + Send + Sync + 'static>(a: Arc<Task<T>>) -> Arc<Async<T>> {
-        let fut = async move { (&*a).await };
-        let a: Pin<Box<dyn Future<Output = T> + Send + Sync + 'static>> = Box::pin(fut);
-        Arc::from(Async {
-            future: Arc::from(Mutex::from(a)),
-        })
+        Async::from_future(async move { (&*a).await })
     }
 }
 
 #[cfg(feature = "threaded")]
 pub mod AsyncBuilder_ {
     use std::future::{Future, ready};
+    use std::panic::AssertUnwindSafe;
     use std::pin::Pin;
     use std::sync::Arc;
 
+    use futures::FutureExt;
     use futures::lock::Mutex;
 
     use super::Async_::Async;
-    use crate::Native_::{Func0, Func1};
+    use crate::Exception_::get_exception;
+    use crate::Native_::{eraseUnitArg, EraseUnitArg, Func0, Func1, LrcPtr, Seq};
+    use crate::System::Exception;
 
-    pub fn delay<T: Send + Sync + 'static>(binder: Func0<Arc<Async<T>>>) -> Arc<Async<T>> {
-        let pr = binder();
+    /// Awaits one computation to completion.
+    ///
+    /// Every method here goes through this rather than reaching into `future`
+    /// itself, so the locking is stated once.
+    async fn run<T: Send + Sync + 'static>(computation: Arc<Async<T>>) -> T {
+        let mut fut = computation.future.lock().await;
+        fut.as_mut().await
+    }
+
+    /// The `async` builder value.
+    ///
+    /// Fable resolves `DefaultAsyncBuilder` to this and emits every builder
+    /// method it does not map to a module function -- Combine, While, For,
+    /// TryWith, TryFinally, Using -- as an instance call on it. Without the
+    /// value and the methods, any async block containing a computation in
+    /// statement position failed to compile.
+    pub struct AsyncBuilder {}
+
+    pub static singleton: AsyncBuilder = AsyncBuilder {};
+
+    impl AsyncBuilder {
+        /// Two computations in sequence, discarding the first result. This is
+        /// what `if cond then do! x` followed by anything else compiles to.
+        pub fn Combine<T: Clone + Send + Sync + 'static>(
+            &self,
+            computation1: Arc<Async<()>>,
+            computation2: Arc<Async<T>>,
+        ) -> Arc<Async<T>> {
+            Async::from_future(async move {
+                run(computation1).await;
+                run(computation2).await
+            })
+        }
+
+        /// `while` inside an async block.
+        ///
+        /// The body has to run once per iteration, and a future can only be
+        /// polled to completion once, so each lap asks `restart` for a fresh
+        /// one. The F# compiler always wraps a loop body in `Delay`, which is
+        /// what sets it.
+        pub fn While(&self, guard: Func0<bool>, computation: Arc<Async<()>>) -> Arc<Async<()>> {
+            Async::from_future(async move {
+                let mut lap = 0usize;
+
+                while guard() {
+                    let body = match &computation.restart {
+                        Some(build) => build(),
+                        // Nothing to rebuild from. One lap can still be served
+                        // by the computation itself; a second would poll a
+                        // future that has already completed, so say so rather
+                        // than panicking from inside the future.
+                        None if lap == 0 => computation.clone(),
+                        None => panic!(
+                            "async while: the loop body cannot be run more than once"
+                        ),
+                    };
+
+                    run(body).await;
+                    lap += 1;
+                }
+            })
+        }
+
+        /// `for` inside an async block.
+        ///
+        /// The sequence is materialised before anything is awaited, the same
+        /// way `Async.Parallel` does it: a Fable `Seq`'s iterator is not `Send`
+        /// and so cannot be held across an await. A lazy, side-effecting
+        /// sequence therefore runs to completion up front instead of
+        /// interleaving with the body.
+        pub fn For<T: Clone + Send + Sync + 'static>(
+            &self,
+            sequence: Seq<T>,
+            body: Func1<T, Arc<Async<()>>>,
+        ) -> Arc<Async<()>> {
+            let items: Vec<T> = crate::Seq_::toArray(sequence).iter().cloned().collect();
+
+            Async::from_future(async move {
+                for item in items {
+                    run(body(item)).await;
+                }
+            })
+        }
+
+        /// `try/with` inside an async block.
+        ///
+        /// Exceptions are panics on this target, and the body spans await
+        /// points, so the catch has to wrap the whole computation rather than a
+        /// synchronous call the way `Exception_::try_catch` does. That also
+        /// means the panic hook is left alone: it is process-global, and
+        /// swapping it for the duration of an await would silence unrelated
+        /// panics on other threads. A caught exception therefore still prints
+        /// the default panic message.
+        pub fn TryWith<T: Clone + Send + Sync + 'static>(
+            &self,
+            computation: Arc<Async<T>>,
+            catchHandler: Func1<LrcPtr<Exception>, Arc<Async<T>>>,
+        ) -> Arc<Async<T>> {
+            Async::from_future(async move {
+                // The panic payload is only Send, never Sync, so it must not
+                // still be alive at the await below -- that would make this
+                // future non-Sync and `Async` requires Sync. Turning it into
+                // the handler's computation here ends its scope first.
+                let outcome = match AssertUnwindSafe(run(computation)).catch_unwind().await {
+                    Ok(value) => Ok(value),
+                    Err(payload) => Err(catchHandler(get_exception(&*payload))),
+                };
+
+                match outcome {
+                    Ok(value) => value,
+                    Err(handled) => run(handled).await,
+                }
+            })
+        }
+
+        /// `try/finally` inside an async block. The compensation runs on both
+        /// paths, and a failure keeps unwinding with its original payload.
+        pub fn TryFinally<T: Clone + Send + Sync + 'static>(
+            &self,
+            computation: Arc<Async<T>>,
+            compensation: Func0<()>,
+        ) -> Arc<Async<T>> {
+            Async::from_future(async move {
+                let outcome = AssertUnwindSafe(run(computation)).catch_unwind().await;
+                compensation();
+
+                match outcome {
+                    Ok(value) => value,
+                    Err(payload) => std::panic::resume_unwind(payload),
+                }
+            })
+        }
+
+        /// `use` inside an async block.
+        ///
+        /// Deliberately does not call Dispose. A plain `use` does not call it
+        /// on this target either -- resources go out with Rust's own Drop, see
+        /// the disabled cases in `tests/Rust/tests/src/MiscTests.fs` -- and
+        /// disposing here alone would make the async and non-async forms
+        /// disagree. This exists so `use` inside `async` compiles and binds,
+        /// which it previously did not.
+        pub fn Using<
+            D: Clone + Send + Sync + 'static,
+            U: Clone + Send + Sync + 'static,
+        >(
+            &self,
+            resource: D,
+            binder: Func1<D, Arc<Async<U>>>,
+        ) -> Arc<Async<U>> {
+            binder(resource)
+        }
+    }
+
+    /// `Delay` is what makes an async block a description rather than a running
+    /// computation, so the builder is called when the result is awaited and not
+    /// before.
+    ///
+    /// The builder is taken as `EraseUnitArg` rather than plainly as `Func0`
+    /// because the unit parameter of a `unit -> Async<unit>` lambda is not
+    /// always erased: `discardUnitArg` keeps it when the lambda's own generic
+    /// argument is unit, which is what a `try/finally` nested inside a
+    /// `try/with` produces. Accepting both shapes and normalising here is
+    /// contained to this file; changing when the compiler erases a unit
+    /// parameter would reach every lambda on the target.
+    ///
+    /// It used to be called immediately, which meant any part of the block
+    /// evaluated eagerly -- `return i` compiles to `r_return(i)`, and `r_return`
+    /// takes its argument by value -- captured state from before the block ran.
+    /// Nothing noticed while every async block was a straight line, because the
+    /// value was read at construction and the block did nothing in between.
+    /// `Combine` makes it visible: in `while .. done; return i` the `return i`
+    /// half was read before the loop had touched `i`.
+    pub fn delay<T: Send + Sync + 'static, F: EraseUnitArg<Arc<Async<T>>>>(
+        binder: F,
+    ) -> Arc<Async<T>> {
+        let binder = eraseUnitArg(binder);
+        let build = binder.clone();
+
         Arc::from(Async {
-            future: pr.future.clone(),
+            future: Arc::from(Mutex::from(Box::pin(async move { run(build()).await })
+                as Pin<Box<dyn Future<Output = T> + Send + Sync + 'static>>)),
+            // The only place F# gives us a way to build the computation again.
+            // While and For need one; nothing else looks at it.
+            restart: Some(binder),
         })
     }
 
@@ -153,18 +348,11 @@ pub mod AsyncBuilder_ {
             next.as_mut().await
         };
 
-        let b: Pin<Box<dyn Future<Output = U> + Send + Sync + 'static>> = Box::pin(next);
-        Arc::from(Async {
-            future: Arc::from(Mutex::from(b)),
-        })
+        Async::from_future(next)
     }
 
     pub fn r_return<T: Send + Sync + 'static>(item: T) -> Arc<Async<T>> {
-        let r = ready(item);
-        let b: Pin<Box<dyn Future<Output = T> + Send + Sync + 'static>> = Box::pin(r);
-        Arc::from(Async {
-            future: Arc::from(Mutex::from(b)),
-        })
+        Async::from_future(ready(item))
     }
 
     pub fn return_from<T: Send + Sync + 'static>(computation: Arc<Async<T>>) -> Arc<Async<T>> {

--- a/src/fable-library-rust/src/Async.rs
+++ b/src/fable-library-rust/src/Async.rs
@@ -12,6 +12,8 @@ pub mod Async_ {
     use futures_timer::Delay;
 
     use super::Task_::Task;
+    use crate::NativeArray_::{array_from, Array};
+    use crate::Native_::Seq;
     use crate::System::Threading::CancellationToken;
 
     pub struct Async<T: Sized + Send + Sync> {
@@ -25,18 +27,15 @@ pub mod Async_ {
             self: Pin<&mut Self>,
             cx: &mut std::task::Context<'_>,
         ) -> std::task::Poll<Self::Output> {
-            let p = self
-                .future
-                .try_lock()
-                .map(|mut f| f.poll_unpin(cx))
-                .unwrap_or_else(|| {
-                    //Again blocking wait, not good
-                    thread::sleep(Duration::from_millis(10));
-                    cx.waker().wake_by_ref();
+            // Poll the lock's own future so contention parks on its waker.
+            // try_lock plus a 10ms sleep spent that long doing nothing whenever
+            // two pollers met.
+            let mut lock = self.future.lock();
 
-                    std::task::Poll::Pending
-                });
-            p
+            match lock.poll_unpin(cx) {
+                std::task::Poll::Ready(mut guard) => guard.as_mut().poll(cx),
+                std::task::Poll::Pending => std::task::Poll::Pending,
+            }
         }
     }
 
@@ -74,6 +73,45 @@ pub mod Async_ {
             res
         };
         executor::block_on(unitFut)
+    }
+
+    /// Async.Parallel. Runs every computation on one executor and collects the
+    /// results in order. Previously missing entirely, so any use of it failed to
+    /// resolve.
+    pub fn parallel<T: Clone + Send + Sync + 'static>(
+        computations: Seq<Arc<Async<T>>>,
+    ) -> Arc<Async<Array<T>>> {
+        // F# hands this a seq, so materialise it before anything is awaited.
+        let items: Vec<Arc<Async<T>>> = crate::Seq_::toArray(computations).iter().cloned().collect();
+
+        let fut = async move {
+            let futures = items.into_iter().map(|a| async move {
+                let mut guard = a.future.lock().await;
+                guard.as_mut().await
+            });
+
+            let results: Vec<T> = futures::future::join_all(futures).await;
+            array_from(results)
+        };
+
+        let b: Pin<Box<dyn Future<Output = Array<T>> + Send + Sync + 'static>> = Box::pin(fut);
+
+        Arc::from(Async {
+            future: Arc::from(Mutex::from(b)),
+        })
+    }
+
+    /// Async.StartImmediateAsTask. Runs on the calling thread rather than
+    /// queueing onto the thread pool, so it does not pay for a hand-off. The
+    /// returned task is therefore already complete: there is no scheduler here
+    /// to leave it pending on, so this trades .NET's concurrency for the speed
+    /// the name promises. Use startAsTask when the work should overlap.
+    pub fn startImmediateAsTask<T: Clone + Send + Sync + 'static>(
+        a: Arc<Async<T>>,
+        cancellationToken: Option<CancellationToken>,
+    ) -> Arc<Task<T>> {
+        let result = runSynchronously(a, None, cancellationToken);
+        Arc::from(Task::from_result(result))
     }
 
     pub fn awaitTask<T: Clone + Send + Sync + 'static>(a: Arc<Task<T>>) -> Arc<Async<T>> {
@@ -202,8 +240,8 @@ pub mod Monitor_ {
 #[cfg(feature = "threaded")]
 pub mod Task_ {
     use std::pin::Pin;
-    use std::sync::{Arc, RwLock};
-    use std::task::Poll;
+    use std::sync::{Arc, Mutex, RwLock};
+    use std::task::{Poll, Waker};
     use std::thread::{self, JoinHandle};
     use std::time::Duration;
 
@@ -255,6 +293,10 @@ pub mod Task_ {
     #[derive(Clone)]
     pub struct Task<T: Sized + Clone + Send> {
         result: Arc<RwLock<TaskState<T>>>,
+        // Whoever is awaiting this task. Polling used to sleep the thread for
+        // 100ms and try again, which made awaiting a task cost far more than
+        // the work it was waiting for.
+        wakers: Arc<Mutex<Vec<Waker>>>,
     }
 
     impl<T: Clone + Send + Sync> Future for &Task<T> {
@@ -264,29 +306,25 @@ pub mod Task_ {
             self: std::pin::Pin<&mut Self>,
             cx: &mut std::task::Context<'_>,
         ) -> std::task::Poll<Self::Output> {
-            //eprintln!("{:?} Polling task for result", thread::current().id());
-            let m = self.result.read().unwrap();
+            if let TaskState::Complete(res) = &*self.result.read().unwrap() {
+                return Poll::Ready(res.clone());
+            }
 
-            match &*m {
+            // Register before re-reading the state: set_result may complete the
+            // task between the check above and this push, and the re-read below
+            // is what stops that racing completion from being missed.
+            self.wakers.lock().unwrap().push(cx.waker().clone());
+
+            match &*self.result.read().unwrap() {
+                TaskState::Complete(res) => Poll::Ready(res.clone()),
+                // Not started yet. start() flips New to Running synchronously
+                // before spawning, so this window is short.
                 TaskState::New(_) => {
-                    //schedule?
-                    //eprintln!("{:?} poll: task is new, waking up", thread::current().id());
                     cx.waker().wake_by_ref();
                     Poll::Pending
                 }
-                TaskState::Running => {
-                    //eprintln!("{:?} poll: pending, nothing to do", thread::current().id());
-
-                    //todo - this is no good as it blocks the thread. It needs to be non-blocking and delegate out
-                    thread::sleep(Duration::from_millis(100));
-                    cx.waker().wake_by_ref();
-
-                    Poll::Pending
-                }
-                TaskState::Complete(res) => {
-                    //eprintln!("{:?} Poll succeeded", thread::current().id());
-                    Poll::Ready(res.clone())
-                }
+                // Running: set_result wakes us.
+                TaskState::Running => Poll::Pending,
             }
         }
     }
@@ -295,20 +333,30 @@ pub mod Task_ {
         pub fn new(fut: impl Future<Output = T> + Send + Sync + 'static) -> Task<T> {
             Task {
                 result: Arc::from(RwLock::from(TaskState::New(Box::pin(fut)))),
+                wakers: Arc::from(Mutex::from(Vec::new())),
             }
         }
 
         pub fn from_result(value: T) -> Task<T> {
             Task {
                 result: Arc::from(RwLock::from(TaskState::Complete(value))),
+                wakers: Arc::from(Mutex::from(Vec::new())),
             }
         }
 
         pub fn set_result(&self, value: T) {
-            let mut m = self.result.write().unwrap();
-            //eprintln!("{:?} set task result", thread::current().id());
-            (*m) = TaskState::Complete(value);
-            //eprintln!("{:?} set task result completed", thread::current().id());
+            {
+                let mut m = self.result.write().unwrap();
+                (*m) = TaskState::Complete(value);
+            }
+
+            // Drain first, then wake outside the lock: a waker may poll straight
+            // back into this task.
+            let wakers: Vec<Waker> = self.wakers.lock().unwrap().drain(..).collect();
+
+            for w in wakers {
+                w.wake();
+            }
         }
 
         pub fn is_new(&self) -> bool {
@@ -320,13 +368,12 @@ pub mod Task_ {
         }
 
         pub fn get_result(&self) -> T {
-            while !self.is_complete() {
-                //eprintln!("{:?} try get result", thread::current().id());
-                thread::sleep(Duration::from_millis(10));
+            if let TaskState::Complete(res) = &*self.result.read().unwrap() {
+                return res.clone();
             }
-            //eprintln!("{:?} has result", thread::current().id());
-            let t = self.result.read().unwrap().unwrap();
-            t
+
+            // Parks on the waker rather than waking every 10ms to look again.
+            futures::executor::block_on(self)
         }
 
         pub fn start(t: Arc<Task<T>>) {
@@ -387,6 +434,7 @@ pub mod Task_ {
     pub fn from_result<T: Clone + Send>(t: T) -> Arc<Task<T>> {
         let t = Task {
             result: Arc::from(RwLock::from(TaskState::Complete(t))),
+            wakers: Arc::from(Mutex::from(Vec::new())),
         };
         Arc::from(t)
     }

--- a/src/fable-library-rust/src/Exception.rs
+++ b/src/fable-library-rust/src/Exception.rs
@@ -13,31 +13,37 @@ pub mod Exception_ {
         try_f() // no catching when no_std
     }
 
+    /// Turns a caught panic payload into the exception a `with` handler sees.
+    ///
+    /// Taken by reference so a caller that has to re-raise (the async builder's
+    /// TryFinally) still owns the payload to resume unwinding with.
+    #[cfg(not(feature = "no_std"))]
+    pub fn get_exception(err: &dyn Any) -> LrcPtr<Exception> {
+        match err.downcast_ref::<&'static str>() {
+            Some(s) => new_Exception(string(*s)),
+            None => match err.downcast_ref::<String>() {
+                Some(s) => new_Exception(fromSlice(s)),
+                None => match err.downcast_ref::<LrcPtr<Exception>>() {
+                    Some(ex) => ex.clone(),
+                    None => new_Exception(string("Unknown error")),
+                },
+            },
+        }
+    }
+
     #[cfg(not(feature = "no_std"))]
     pub fn try_catch<F, G, R>(try_f: F, catch_f: G) -> R
     where
         F: FnOnce() -> R,
         G: FnOnce(LrcPtr<Exception>) -> R,
     {
-        fn get_ex(err: Box<dyn Any>) -> LrcPtr<Exception> {
-            match err.downcast_ref::<&'static str>() {
-                Some(s) => new_Exception(string(*s)),
-                None => match err.downcast_ref::<String>() {
-                    Some(s) => new_Exception(fromSlice(s)),
-                    None => match err.downcast_ref::<LrcPtr<Exception>>() {
-                        Some(ex) => ex.clone(),
-                        None => new_Exception(string("Unknown error")),
-                    },
-                },
-            }
-        }
         let prev_hook = std::panic::take_hook();
         std::panic::set_hook(Box::new(|_| {}));
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(try_f));
         std::panic::set_hook(prev_hook);
         match result {
             Ok(res) => res,
-            Err(err) => catch_f(get_ex(err)),
+            Err(err) => catch_f(get_exception(&*err)),
         }
     }
 

--- a/tests/Rust/tests/src/AsyncTests.fs
+++ b/tests/Rust/tests/src/AsyncTests.fs
@@ -954,3 +954,188 @@ let ``Async.Sleep works`` () =
 //         acc > 2 |> equal true
 //     }
 //     |> Async.StartImmediate
+
+// The async builder's Combine, While, For, TryWith, TryFinally and Using used
+// to be missing from the Rust runtime, so any async block with a computation in
+// statement position failed to compile with "unresolved import
+// AsyncBuilder_::singleton".
+
+[<Fact>]
+let ``if without else in an async block combines`` () =
+    let comp = async {
+        if 1 < 2 then
+            do! async { return () }
+        return 42
+    }
+    comp |> Async.RunSynchronously |> equal 42
+
+[<Fact>]
+let ``while in an async block loops`` () =
+    let comp = async {
+        let mutable i = 0
+        while i < 3 do
+            let! step = async { return 1 }
+            i <- i + step
+        return i
+    }
+    comp |> Async.RunSynchronously |> equal 3
+
+[<Fact>]
+let ``while in an async block can run zero times`` () =
+    let comp = async {
+        let mutable i = 10
+        while i < 3 do
+            let! step = async { return 1 }
+            i <- i + step
+        return i
+    }
+    comp |> Async.RunSynchronously |> equal 10
+
+[<Fact>]
+let ``for in an async block iterates`` () =
+    let comp = async {
+        let mutable sum = 0
+        for x in [1; 2; 3] do
+            let! y = async { return x * 10 }
+            sum <- sum + y
+        return sum
+    }
+    comp |> Async.RunSynchronously |> equal 60
+
+// Delay used to run its builder immediately, so the `return` half of the block
+// was built -- and its value read -- before the loop above it had run. Only
+// Combine makes that visible, which is why it went unnoticed.
+[<Fact>]
+let ``state written by a loop is visible after it`` () =
+    let comp = async {
+        let mutable acc = ""
+        for x in ["a"; "b"] do
+            let! y = async { return x }
+            acc <- acc + y
+        return acc
+    }
+    comp |> Async.RunSynchronously |> equal "ab"
+
+[<Fact>]
+let ``try with in an async block catches`` () =
+    let comp = async {
+        try
+            let! _ = async { return 1 }
+            failwith "boom"
+            return 0
+        with _ ->
+            return -1
+    }
+    comp |> Async.RunSynchronously |> equal -1
+
+[<Fact>]
+let ``try with in an async block leaves a success alone`` () =
+    let comp = async {
+        try
+            let! x = async { return 1 }
+            return x
+        with _ ->
+            return -1
+    }
+    comp |> Async.RunSynchronously |> equal 1
+
+[<Fact>]
+let ``try finally in an async block runs the finalizer`` () =
+    let mutable ran = 0
+    let comp = async {
+        try
+            let! x = async { return 1 }
+            return x
+        finally
+            ran <- ran + 1
+    }
+    comp |> Async.RunSynchronously |> equal 1
+    ran |> equal 1
+
+[<Fact>]
+let ``try finally in an async block runs the finalizer on failure`` () =
+    let mutable ran = 0
+    let comp = async {
+        try
+            let! _ = async { return 1 }
+            failwith "boom"
+            return 0
+        finally
+            ran <- ran + 1
+    }
+    throwsAnyError (fun () -> comp |> Async.RunSynchronously)
+    ran |> equal 1
+
+// Note this asserts only that the resource binds and the block returns.
+// Dispose is not called for a `use` on the Rust target at all -- see the
+// disabled cases in MiscTests.fs -- so asserting disposal here would pass on
+// .NET and fail on Rust.
+type AsyncDisposable() =
+    interface System.IDisposable with
+        member _.Dispose() = ()
+
+[<Fact>]
+let ``use in an async block binds the resource`` () =
+    let comp = async {
+        use res = new AsyncDisposable()
+        let! x = async { return 1 }
+        return (if isNull (box res) then 0 else x)
+    }
+    comp |> Async.RunSynchronously |> equal 1
+
+[<Fact>]
+let ``nested loops in an async block`` () =
+    let comp = async {
+        let mutable total = 0
+        for i in 1 .. 3 do
+            let mutable j = 0
+            while j < 2 do
+                let! v = async { return i }
+                total <- total + v
+                j <- j + 1
+        return total
+    }
+    comp |> Async.RunSynchronously |> equal 12
+
+[<Fact>]
+let ``a loop body that awaits nothing still runs`` () =
+    let comp = async {
+        let mutable i = 0
+        while i < 3 do
+            i <- i + 1
+        return i
+    }
+    comp |> Async.RunSynchronously |> equal 3
+
+[<Fact>]
+let ``try with inside a loop catches each time`` () =
+    let comp = async {
+        let mutable caught = 0
+        for _ in 1 .. 3 do
+            try
+                let! _ = async { return () }
+                failwith "boom"
+            with _ ->
+                caught <- caught + 1
+        return caught
+    }
+    comp |> Async.RunSynchronously |> equal 3
+
+// The inner try/finally makes F# pass Delay a `unit -> Async<unit>` lambda whose
+// unit parameter is not erased, so the builder arrived as Func1 rather than
+// Func0 and this shape did not compile.
+[<Fact>]
+let ``try finally nested inside try with`` () =
+    let comp = async {
+        let mutable order = ""
+        try
+            try
+                let! _ = async { return () }
+                failwith "boom"
+            finally
+                order <- order + "inner"
+        with _ ->
+            order <- order + "-caught"
+        return order
+    }
+    comp |> Async.RunSynchronously |> equal "inner-caught"

--- a/tests/Rust/tests/src/AsyncTests.fs
+++ b/tests/Rust/tests/src/AsyncTests.fs
@@ -82,13 +82,33 @@ let ``return! propagates error Result from inner async`` () =
     Async.RunSynchronously (outer (Ok 99)) |> equal (Ok 99)
     Async.RunSynchronously (outer (Error "oops")) |> equal (Error "oops")
 
-// [<Fact>]
-// let shouldExecAsParallelStructurallyCorrect () =
-//     let t = Async.Parallel [
-//         async { return 1 }
-//         async { return 2 }
-//     ]
-//     t |> Async.RunSynchronously |> Array.sum |> equal 3
+[<Fact>]
+let shouldExecAsParallelStructurallyCorrect () =
+    let t = Async.Parallel [
+        async { return 1 }
+        async { return 2 }
+    ]
+    t |> Async.RunSynchronously |> Array.sum |> equal 3
+
+[<Fact>]
+let shouldExecAsParallelInOrder () =
+    Async.Parallel [
+        async { return 1 }
+        async { return 2 }
+        async { return 3 }
+    ]
+    |> Async.RunSynchronously
+    |> Array.toList
+    |> equal [ 1; 2; 3 ]
+
+[<Fact>]
+let shouldExecStartImmediateAsTask () =
+    // Runs on the calling thread instead of queueing onto the thread pool.
+    async { return 7 }
+    |> Async.StartImmediateAsTask
+    |> Async.AwaitTask
+    |> Async.RunSynchronously
+    |> equal 7
 
 // [<Fact>]
 // let shouldMarshalMutOverAsyncClosureCorrectly () =


### PR DESCRIPTION
Awaiting a task polled the state and, finding it Running, slept the thread for 100ms before looking again - the source even said "this is no good as it blocks the thread". Three 50ms sleeps started with Async.StartAsTask took 2718ms against .NET's 65ms. A task now keeps the wakers of whoever is awaiting it and set_result wakes them, so the same benchmark takes 65ms. get_result parks on the future instead of waking every 10ms to check a flag, and Async's own poll polls the mutex's lock future rather than try_lock plus a 10ms sleep.

Also adds the two functions Replacements already maps but the runtime never had:

- Async.Parallel, which failed to resolve at all. Runs the computations on one executor and collects results in order: three 50ms sleeps in 66ms
- Async.StartImmediateAsTask, which runs on the calling thread rather than queueing onto the thread pool. The returned task is therefore already complete - there is no scheduler here to leave it pending on - so it trades .NET's concurrency for the speed the name promises; startAsTask remains the one to use when work should overlap