### PR TITLE
fix(rust): let a string be enumerated

### DIFF
--- a/src/Fable.Transforms/Rust/Replacements.fs
+++ b/src/Fable.Transforms/Rust/Replacements.fs
@@ -1375,6 +1375,11 @@ let getEnumerator com r t i (expr: Expr) =
     // | IsEntity (Types.regexCaptureCollection) _
     | Array _ -> Helper.LibCall(com, "Seq", "Enumerable::ofArray", t, [ expr ], ?loc = r)
     | List _ -> Helper.LibCall(com, "Seq", "Enumerable::ofList", t, [ expr ], ?loc = r)
+    // A string is enumerable in F# but `string` is `LrcStr` in Rust, with no
+    // GetEnumerator to fall through to -- so `for ch in s do` did not compile.
+    | String ->
+        let ar = Helper.LibCall(com, "String", "toCharArray", t, [ expr ])
+        Helper.LibCall(com, "Seq", "Enumerable::ofArray", t, [ ar ], ?loc = r)
     | IsEntity (Types.hashset) _
     | IsEntity (Types.iset) _ ->
         let ar = Helper.LibCall(com, "HashSet", "entries", t, [ expr ])

--- a/tests/Rust/tests/src/StringTests.fs
+++ b/tests/Rust/tests/src/StringTests.fs
@@ -1590,3 +1590,31 @@ let ``String.filter with Char.IsDigit as a predicate doesn't hang`` () =
 //     let s3: FormattableString = $"""I have no holes"""
 //     s3.GetStrings() |> equal [|"I have no holes"|]
 // #endif
+
+// A string is enumerable in F#, but `string` is `LrcStr` in Rust with no
+// GetEnumerator to fall through to, so `for ch in s do` did not compile.
+[<Fact>]
+let ``for-in over a string works`` () =
+    let mutable count = 0
+    let mutable upper = ""
+
+    for ch in "abc" do
+        count <- count + 1
+        upper <- upper + string (System.Char.ToUpper ch)
+
+    count |> equal 3
+    upper |> equal "ABC"
+
+[<Fact>]
+let ``for-in over an empty string does nothing`` () =
+    let mutable count = 0
+
+    for _ in "" do
+        count <- count + 1
+
+    count |> equal 0
+
+[<Fact>]
+let ``a string works with the Seq functions`` () =
+    "hello" |> Seq.filter (fun c -> c = 'l') |> Seq.length |> equal 2
+    "hello" |> Seq.toList |> List.length |> equal 5


### PR DESCRIPTION
`for ch in someString do` did not compile: a string is enumerable in F#, but `string` is `LrcStr` in Rust and `getEnumerator` fell through to a `GetEnumerator` instance call that does not exist on it.

Routed through `String_::toCharArray` and `Seq::Enumerable::ofArray`, the same shape the HashSet and Dictionary cases directly above already use. The library function was already there.