### PR TITLE
fix: report Fable's own logs from the Fable.Compiler API

### DIFF
--- a/src/Fable.Cli/Main.fs
+++ b/src/Fable.Cli/Main.fs
@@ -12,6 +12,7 @@ open Fable
 open Fable.AST
 open Fable.Transforms
 open Fable.Transforms.State
+open Fable.Compiler
 open Fable.Compiler.ProjectCracker
 open Fable.Compiler.Util
 
@@ -87,35 +88,6 @@ module private Util =
         logs
         |> Seq.filter (fun log -> log.Severity = Severity.Error)
         |> Seq.iter (fun log -> Log.error (formatLog rootDir log))
-
-    let getFSharpDiagnostics (diagnostics: FSharpDiagnostic array) =
-        diagnostics
-        |> Array.map (fun er ->
-            let severity =
-                match er.Severity with
-                | FSharpDiagnosticSeverity.Hidden
-                | FSharpDiagnosticSeverity.Info -> Severity.Info
-                | FSharpDiagnosticSeverity.Warning -> Severity.Warning
-                | FSharpDiagnosticSeverity.Error -> Severity.Error
-
-            let range =
-                SourceLocation.Create(
-                    start =
-                        {
-                            line = er.StartLine
-                            column = er.StartColumn + 1
-                        },
-                    ``end`` =
-                        {
-                            line = er.EndLine
-                            column = er.EndColumn + 1
-                        }
-                )
-
-            let msg = $"%s{er.Message} (code %i{er.ErrorNumber})"
-
-            LogEntry.Make(severity, msg, fileName = er.FileName, range = range, tag = "FSHARP")
-        )
 
     let getOutPath (cliArgs: CliArgs) pathResolver file =
         match cliArgs.CompilerOptions.Language with
@@ -672,7 +644,7 @@ and FableCompiler(checker: InteractiveChecker, projCracked: ProjectCracked, fabl
 
                         let state =
                             { state with
-                                FSharpLogs = getFSharpDiagnostics results.Diagnostics
+                                FSharpLogs = CodeServices.getFSharpDiagnostics results.Diagnostics
                                 HasFSharpCompilationFinished = true
                             }
 
@@ -1590,7 +1562,7 @@ let private compilationCycle (state: State) (changes: ISet<string>) =
 
                             match result with
                             | Some ex ->
-                                getFSharpDiagnostics diagnostics |> logErrors cliArgs.RootDir
+                                CodeServices.getFSharpDiagnostics diagnostics |> logErrors cliArgs.RootDir
                                 Log.error (ex.Message)
                                 return 1
                             | None ->

--- a/src/Fable.Compiler/Library.fs
+++ b/src/Fable.Compiler/Library.fs
@@ -17,12 +17,24 @@ type TypeCheckProjectResult =
         ProjectCheckResults: FSharpCheckProjectResults
     }
 
+type FableASTResult =
+    {
+        /// The current file transformed into the Fable AST
+        FableAST: AST.Fable.File
+        /// Everything the compiler reported: the diagnostics of the F# project as checked up to
+        /// the current file, tagged "FSHARP", followed by the logs Fable raised while
+        /// transforming that file, tagged "FABLE".
+        Logs: LogEntry array
+    }
+
 type CompileResult =
     {
         /// A map of absolute file path to transpiled JavaScript code
         CompiledFiles: Map<string, string>
-        /// Diagnostics of the entire checked F# project
-        Diagnostics: FSharpDiagnostic array
+        /// Everything the compiler reported: the diagnostics of the entire checked F# project,
+        /// tagged "FSHARP", followed by the logs Fable raised while translating the compiled
+        /// files, tagged "FABLE".
+        Logs: LogEntry array
     }
 
 type BabelWriter
@@ -94,6 +106,35 @@ type BabelWriter
 
 module CodeServices =
 
+    let getFSharpDiagnostics (diagnostics: FSharpDiagnostic array) =
+        diagnostics
+        |> Array.map (fun er ->
+            let severity =
+                match er.Severity with
+                | FSharpDiagnosticSeverity.Hidden
+                | FSharpDiagnosticSeverity.Info -> Severity.Info
+                | FSharpDiagnosticSeverity.Warning -> Severity.Warning
+                | FSharpDiagnosticSeverity.Error -> Severity.Error
+
+            let range =
+                AST.SourceLocation.Create(
+                    start =
+                        {
+                            line = er.StartLine
+                            column = er.StartColumn + 1
+                        },
+                    ``end`` =
+                        {
+                            line = er.EndLine
+                            column = er.EndColumn + 1
+                        }
+                )
+
+            let msg = $"%s{er.Message} (code %i{er.ErrorNumber})"
+
+            LogEntry.Make(severity, msg, fileName = er.FileName, range = range, tag = "FSHARP")
+        )
+
     let compileFileToJs
         (com: Compiler)
         (pathResolver: PathResolver)
@@ -145,7 +186,7 @@ module CodeServices =
         (cliArgs: CliArgs)
         (crackerResponse: CrackerResponse)
         (currentFile: string)
-        : Async<AST.Fable.File>
+        : Async<FableASTResult>
         =
         async {
             let! assemblies = checker.GetImportedAssemblies()
@@ -173,7 +214,7 @@ module CodeServices =
 
             let fableLibDir = Path.getRelativePath currentFile crackerResponse.FableLibDir
 
-            let compiler: Compiler =
+            let compiler: CompilerImpl =
                 CompilerImpl(
                     currentFile,
                     fableProj,
@@ -185,10 +226,14 @@ module CodeServices =
 
             // TODO: make it configurable if FableTransforms.transformFile is applied?
             let fableAST =
-                FSharp2Fable.Compiler.transformFile compiler
-                |> FableTransforms.transformFile compiler
+                FSharp2Fable.Compiler.transformFile (compiler :> Compiler)
+                |> FableTransforms.transformFile (compiler :> Compiler)
 
-            return fableAST
+            return
+                {
+                    FableAST = fableAST
+                    Logs = Array.append (getFSharpDiagnostics checkProjectResult.Diagnostics) compiler.Logs
+                }
         }
 
     let compileMultipleFilesToJavaScript
@@ -214,13 +259,13 @@ module CodeServices =
 
             let opts = cliArgs.CompilerOptions
 
-            let! compiledFiles =
+            let! results =
                 inputFiles
                 |> Seq.map (fun currentFile ->
                     async {
                         let fableLibDir = Path.getRelativePath currentFile crackerResponse.FableLibDir
 
-                        let compiler: Compiler =
+                        let compiler: CompilerImpl =
                             CompilerImpl(
                                 currentFile,
                                 fableProj,
@@ -234,17 +279,28 @@ module CodeServices =
                             Path.ChangeExtension(currentFile, cliArgs.CompilerOptions.FileExtension)
 
                         let! js =
-                            compileFileToJs compiler pathResolver outputPath cliArgs.CompilerOptions.FileExtension
+                            compileFileToJs
+                                (compiler :> Compiler)
+                                pathResolver
+                                outputPath
+                                cliArgs.CompilerOptions.FileExtension
 
-                        return currentFile, js
+                        // `AddLog` is not thread-safe, so every file keeps its own compiler and
+                        // the logs are gathered once all files are done.
+                        return (currentFile, js), compiler.Logs
                     }
                 )
                 |> Async.Parallel
 
+            let compiledFiles, fableLogs = Array.unzip results
+
             return
                 {
                     CompiledFiles = Map.ofArray compiledFiles
-                    Diagnostics = typeCheckProjectResult.ProjectCheckResults.Diagnostics
+                    Logs =
+                        Array.append
+                            (getFSharpDiagnostics typeCheckProjectResult.ProjectCheckResults.Diagnostics)
+                            (Array.concat fableLogs)
                 }
         }
 
@@ -305,14 +361,14 @@ module CodeServices =
 
             let opts = cliArgs.CompilerOptions
 
-            let! compiledFiles =
+            let! results =
                 dependentFiles
                 |> Array.filter (fun filePath -> not (filePath.EndsWith(".fsi", StringComparison.Ordinal)))
                 |> Array.map (fun currentFile ->
                     async {
                         let fableLibDir = Path.getRelativePath currentFile crackerResponse.FableLibDir
 
-                        let compiler: Compiler =
+                        let compiler: CompilerImpl =
                             CompilerImpl(
                                 currentFile,
                                 fableProj,
@@ -325,16 +381,24 @@ module CodeServices =
                         let outputPath = Path.ChangeExtension(currentFile, ".js")
 
                         let! js =
-                            compileFileToJs compiler pathResolver outputPath cliArgs.CompilerOptions.FileExtension
+                            compileFileToJs
+                                (compiler :> Compiler)
+                                pathResolver
+                                outputPath
+                                cliArgs.CompilerOptions.FileExtension
 
-                        return currentFile, js
+                        // `AddLog` is not thread-safe, so every file keeps its own compiler and
+                        // the logs are gathered once all files are done.
+                        return (currentFile, js), compiler.Logs
                     }
                 )
                 |> Async.Parallel
 
+            let compiledFiles, fableLogs = Array.unzip results
+
             return
                 {
                     CompiledFiles = Map.ofArray compiledFiles
-                    Diagnostics = checkProjectResult.Diagnostics
+                    Logs = Array.append (getFSharpDiagnostics checkProjectResult.Diagnostics) (Array.concat fableLogs)
                 }
         }

--- a/src/Fable.Compiler/Library.fsi
+++ b/src/Fable.Compiler/Library.fsi
@@ -4,15 +4,28 @@ open FSharp.Compiler.SourceCodeServices
 open FSharp.Compiler.Diagnostics
 open FSharp.Compiler.CodeAnalysis
 open Fable
+open Fable.Transforms.State
 open Fable.Compiler.Util
 open Fable.Compiler.ProjectCracker
+
+type FableASTResult =
+    {
+        /// The current file transformed into the Fable AST
+        FableAST: AST.Fable.File
+        /// Everything the compiler reported: the diagnostics of the F# project as checked up to
+        /// the current file, tagged "FSHARP", followed by the logs Fable raised while
+        /// transforming that file, tagged "FABLE".
+        Logs: LogEntry array
+    }
 
 type CompileResult =
     {
         /// A map of absolute file path to transpiled JavaScript
         CompiledFiles: Map<string, string>
-        /// Diagnostics of the entire checked F# project
-        Diagnostics: FSharpDiagnostic array
+        /// Everything the compiler reported: the diagnostics of the entire checked F# project,
+        /// tagged "FSHARP", followed by the logs Fable raised while translating the compiled
+        /// files, tagged "FABLE".
+        Logs: LogEntry array
     }
 
 type TypeCheckProjectResult =
@@ -23,6 +36,10 @@ type TypeCheckProjectResult =
 
 [<RequireQualifiedAccess>]
 module CodeServices =
+
+    /// Convert the diagnostics of the F# compiler into log entries tagged "FSHARP".
+    /// The error number is folded into the message, as `Fable.Cli` prints it.
+    val getFSharpDiagnostics: diagnostics: FSharpDiagnostic array -> LogEntry array
 
     /// Type check a project using the InteractiveChecker
     val typeCheckProject:
@@ -39,7 +56,7 @@ module CodeServices =
         cliArgs: CliArgs ->
         crackerResponse: CrackerResponse ->
         currentFile: string ->
-            Async<AST.Fable.File>
+            Async<FableASTResult>
 
     /// And compile multiple files of a project to JavaScript.
     /// The expected usage of this function is either every file in the project or only the user files.

--- a/tests/Integration/Compiler/CodeServicesProject/.gitignore
+++ b/tests/Integration/Compiler/CodeServicesProject/.gitignore
@@ -1,0 +1,1 @@
+Program.fs

--- a/tests/Integration/Compiler/CodeServicesProject/CodeServicesProject.fsproj
+++ b/tests/Integration/Compiler/CodeServicesProject/CodeServicesProject.fsproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <RollForward>Major</RollForward>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../../../src/Fable.Core/Fable.Core.fsproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Integration/Compiler/CodeServicesTests.fs
+++ b/tests/Integration/Compiler/CodeServicesTests.fs
@@ -1,0 +1,157 @@
+module Fable.Tests.Compiler.CodeServicesApi
+
+open System
+open Expecto
+open Fable
+open Fable.Compiler.Util
+open Fable.Compiler.ProjectCracker
+open Fable.Transforms.State
+open FSharp.Compiler.SourceCodeServices
+
+/// Drives `Fable.Compiler.CodeServices` directly, the way a host embedding the compiler does,
+/// instead of going through `Fable.Cli.Main`.
+module private Fixture =
+
+    let private projDir =
+        IO.Path.Join(__SOURCE_DIRECTORY__, "CodeServicesProject") |> Path.normalizeFullPath
+
+    let private projFile =
+        IO.Path.Join(projDir, "CodeServicesProject.fsproj") |> Path.normalizeFullPath
+
+    let private sourceFile = IO.Path.Join(projDir, "Program.fs") |> Path.normalizeFullPath
+
+    let private cliArgs =
+        {
+            CliArgs.ProjectFile = projFile
+            // These tests only look at what the compiler reports, they never run the emitted
+            // JavaScript, so point at a fixed directory instead of depending on a fable-library
+            // build being present.
+            FableLibraryPath = Some(IO.Path.Join(projDir, "fable_modules", "fable-library-js"))
+            RootDir = projDir
+            Configuration = "Debug"
+            OutDir = None
+            IsWatch = false
+            Precompile = false
+            PrecompiledLib = None
+            PrintAst = false
+            SourceMaps = false
+            SourceMapsRoot = None
+            NoRestore = false
+            NoCache = false
+            NoGitignore = false
+            NoParallelTypeCheck = false
+            Exclude = [ "Fable.Core" ]
+            Replace = Map.empty
+            RunProcess = None
+            CompilerOptions = CompilerOptionsHelper.Make()
+            Verbosity = Verbosity.Silent
+        }
+
+    /// Cracking is expensive and the project options never change, only the source does.
+    let private crackerResponse =
+        lazy
+            (let resolver: ProjectCrackerResolver = Fable.Compiler.MSBuildCrackerResolver()
+             CrackerOptions(cliArgs, false) |> getFullProjectOpts resolver)
+
+    let private pathResolver =
+        { new PathResolver with
+            member _.TryPrecompiledOutPath(_sourceDir, _relativePath) = None
+            member _.GetOrAddDeduplicateTargetDir(_importDir, _addTargetDir) = ""
+        }
+
+    /// Writes `source` as the single file of the project and hands back what the compiler needs.
+    /// NOTE: NOT threadsafe, that file is rewritten on every call.
+    let private prepare (source: string) =
+        IO.File.WriteAllText(sourceFile, source)
+        let crackerResponse = crackerResponse.Value
+
+        let _, sourceReader =
+            crackerResponse.ProjectOptions.SourceFiles
+            |> Array.map Fable.Compiler.File
+            |> Fable.Compiler.File.MakeSourceReader
+
+        let checker = InteractiveChecker.Create(crackerResponse.ProjectOptions)
+        crackerResponse, sourceReader, checker
+
+    let compile (source: string) =
+        let crackerResponse, sourceReader, checker = prepare source
+
+        async {
+            let! typeCheckResult =
+                Fable.Compiler.CodeServices.typeCheckProject sourceReader checker cliArgs crackerResponse
+
+            return!
+                Fable.Compiler.CodeServices.compileMultipleFilesToJavaScript
+                    pathResolver
+                    cliArgs
+                    crackerResponse
+                    typeCheckResult
+                    [ sourceFile ]
+        }
+        |> Async.RunSynchronously
+
+    let compileToFableAST (source: string) =
+        let crackerResponse, sourceReader, checker = prepare source
+
+        Fable.Compiler.CodeServices.compileFileToFableAST
+            sourceReader
+            checker
+            cliArgs
+            crackerResponse
+            sourceFile
+        |> Async.RunSynchronously
+
+/// `Async.RunSynchronously` type-checks fine but has no translation, so Fable reports it through
+/// `addErrorAndReturnNull` and emits `return null`.
+let private unsupportedByFable =
+    """module Program
+
+let blocking () = Async.RunSynchronously(async { return 42 })
+"""
+
+let private fsharpTypeError =
+    """module Program
+
+let wrong: int = "not an int"
+"""
+
+let tests =
+    testList
+        "CodeServices"
+        [
+            testCase "Fable errors are reported"
+            <| fun _ ->
+                let result = Fixture.compile unsupportedByFable
+
+                let errors =
+                    result.Logs |> Array.filter (fun log -> log.Severity = Severity.Error)
+
+                Expect.exists
+                    errors
+                    (fun log -> log.Tag = "FABLE" && log.Message.Contains "not supported by Fable")
+                    "Fable should report that Async.RunSynchronously is not supported"
+
+            testCase "F# errors are reported"
+            <| fun _ ->
+                let result = Fixture.compile fsharpTypeError
+
+                let errors =
+                    result.Logs |> Array.filter (fun log -> log.Severity = Severity.Error)
+
+                Expect.exists
+                    errors
+                    (fun log -> log.Tag = "FSHARP")
+                    "The F# type error should be reported"
+
+            testCase "Fable errors are reported when only transforming to the Fable AST"
+            <| fun _ ->
+                let result = Fixture.compileToFableAST unsupportedByFable
+
+                let errors =
+                    result.Logs |> Array.filter (fun log -> log.Severity = Severity.Error)
+
+                Expect.exists
+                    errors
+                    (fun log -> log.Tag = "FABLE" && log.Message.Contains "not supported by Fable")
+                    "Fable should report that Async.RunSynchronously is not supported"
+        ]

--- a/tests/Integration/Compiler/Fable.Tests.Compiler.fsproj
+++ b/tests/Integration/Compiler/Fable.Tests.Compiler.fsproj
@@ -23,6 +23,7 @@
     <!-- Link the pure-managed inflate source so its (internal) module is testable -->
     <Compile Include="../../../src/fcs-fable/Inflate.fs" />
     <Compile Include="CompilerMessagesTests.fs" />
+    <Compile Include="CodeServicesTests.fs" />
     <Compile Include="AnonRecordInInterfaceTests.fs" />
     <Compile Include="CompilerHelpersTests.fs" />
     <Compile Include="InflateTests.fs" />

--- a/tests/Integration/Compiler/Main.fs
+++ b/tests/Integration/Compiler/Main.fs
@@ -6,6 +6,7 @@ open Expecto
 let allTests =
     [
         CompilerMessages.tests
+        CodeServicesApi.tests
         AnonRecordInInterface.tests
         CompilerHelpers.tests
         Inflate.tests


### PR DESCRIPTION
`CodeServices.compileMultipleFilesToJavaScript` and `compileFileToJavaScript` filled `CompileResult.Diagnostics` from the FCS type-check results only. The `CompilerImpl` that holds Fable's own logs was upcast to the `Compiler` interface at the binding and then discarded, so every error Fable raised while translating a file was dropped. Code that type-checks but that Fable cannot translate compiled "successfully" into JavaScript that silently does the wrong thing, and a host built on `Fable.Compiler` had no way to find out.

This surfaced while working on [vite-plugin-fable](https://github.com/fable-compiler/vite-plugin-fable), which drives `compileMultipleFilesToJavaScript` from a compiler daemon. On the repro in the issue, `vite build` printed no diagnostic, exited 0, and put `return null` in the production bundle. Silent wrong output rather than a crash, which is why it went unnoticed for so long and why it is worth a breaking change to fix properly.

Both functions now keep the concrete compiler and return everything that went wrong as `LogEntry array`, tagged `FABLE` or `FSHARP`, which is the representation `Fable.Cli` already uses. `compileFileToFableAST` reports the same way. The conversion from FCS diagnostics to `LogEntry` moves out of `Fable.Cli` into `Fable.Compiler`, so there is one implementation of it rather than two that can drift.

Logs are collected per file and concatenated afterwards, because `AddLog` takes no lock and the files are compiled under `Async.Parallel`.

Nothing drove `CodeServices` from a test, which is a large part of why this went unnoticed, so this adds coverage that calls the library API directly: the `Async.RunSynchronously` snippet from the issue (it type-checks, but Fable has no translation for it) has to come back as a `Severity.Error` tagged `FABLE`, and an ordinary F# type error as one tagged `FSHARP`.

### Breaking change

`CompileResult.Diagnostics: FSharpDiagnostic array` is replaced by `CompileResult.Logs: LogEntry array`, and `compileFileToFableAST` now returns `FableASTResult` instead of `AST.Fable.File`.

Adding `Logs` alongside `Diagnostics` would have been non-breaking, and that is its whole appeal, but it leaves the default wrong: a consumer reading `Diagnostics`, a field named as though it were the complete answer, would still see nothing. "Nobody knew there was somewhere else to look" is precisely the bug being fixed.

Since this is marked `fix!`, `shipit` will bump the affected packages to a new major. Happy to reshape this into a non-breaking `Logs` addition first and drop `Diagnostics` in the next major instead, if that suits the release plan better.

### Follow-up: `Fable.Cli`

`Fable.Cli` still collects `com.Logs` in its own compile pipeline. Only the duplicated FCS-diagnostic conversion moved out of it here.

Making the CLI consume `CodeServices` outright would leave one implementation of "compile a project and report what went wrong" rather than two, and the CLI would keep that implementation honest. It is not in this PR because `CodeServices` would first have to grow watch mode, precompiled info, inline expression collection, watch dependencies and the non-JavaScript targets, which is a much larger change than this fix. Worth discussing before anyone starts on it.

### Verification

`dotnet fable` output is unchanged by this PR for both a Fable error and an F# error: the reported diagnostics and the emitted JavaScript were compared before and after, since the CLI is being rewired to a new source for the same data. `./build.sh test javascript` and the `tests/Integration/Compiler` suite are green.

Fixes #4922.
