### PR TITLE
fix(python): preserve record field names in structured formatting

### DIFF
--- a/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
+++ b/src/Fable.Transforms/Python/Fable2Python.Transforms.fs
@@ -3538,6 +3538,18 @@ let declareDataClassType
     =
     let name = com.GetIdentifier(ctx, entName)
 
+    // Record slots follow Python naming conventions, but structured formatting must
+    // retain the original F# field names. Keep the names on the generated class so
+    // the runtime can pair them with the slots without attempting a lossy conversion.
+    let fsharpFieldNames =
+        ent.FSharpFields
+        |> List.filter (fun field -> not field.IsStatic)
+        |> List.map (fun field -> Expression.stringConstant field.Name)
+        |> Expression.tuple
+
+    let fsharpFieldNamesMember =
+        Statement.assign ([ Expression.name ("__fable_field_names__", Store) ], fsharpFieldNames)
+
     // Generate field annotations from entity's FSharpFields to properly uncurry function types.
     // Record/dataclass fields store functions uncurried at runtime, so we need to uncurry
     // lambda types in the type annotations to match.
@@ -3661,6 +3673,7 @@ let declareDataClassType
     let classBody =
         let body =
             [
+                yield fsharpFieldNamesMember
                 yield! staticFieldAnnotations
                 yield! props
                 yield! classMembers

--- a/src/fable-library-py/fable_library/record.py
+++ b/src/fable-library-py/fable_library/record.py
@@ -79,14 +79,22 @@ def _field_to_string(value: object) -> str:
 
 
 def record_to_string(self: Record) -> str:
-    if hasattr(self, "__slots__"):
-        return (
-            "{ "
-            + "\n  ".join(map(lambda slot: slot + " = " + _field_to_string(getattr(self, slot)), self.__slots__))
-            + " }"
-        )
-    else:
+    if not hasattr(self, "__slots__"):
         return "{ " + "\n  ".join(map(lambda kv: kv[0] + " = " + _field_to_string(kv[1]), self.__dict__.items())) + " }"
+
+    slots = self.__slots__
+    # Newer generated records retain their source-level F# field names here.
+    # Fall back to slots so the current runtime remains compatible with code
+    # compiled before that metadata was emitted.
+    field_names = getattr(type(self), "__fable_field_names__", slots)
+    return (
+        "{ "
+        + "\n  ".join(
+            f"{field_name} = {_field_to_string(getattr(self, slot))}"
+            for slot, field_name in zip(slots, field_names, strict=True)
+        )
+        + " }"
+    )
 
 
 def record_get_hashcode(self: Record) -> int:

--- a/tests/Python/TestRecordType.fs
+++ b/tests/Python/TestRecordType.fs
@@ -61,6 +61,11 @@ type StructRecord = { Size: int; Seed: int; Path: int list }
 
 type StructRecordHolder = { Tag: int; Data: StructRecord }
 
+[<Fact>]
+let ``test sprintf formats record fields with their F# names`` () =
+    sprintf "%A" { Size = 1; Seed = 2; Path = [] }
+    |> equal "{ Size = 1\n  Seed = 2\n  Path = [] }"
+
 let updateStructRecord (data: StructRecord) (path: int list) = { data with Path = List.rev path }
 
 let holdStructRecord (data: StructRecord) (path: int list) =


### PR DESCRIPTION
## Summary
- retain original F# record field names on generated Python dataclasses
- use that metadata when formatting records with %A, retaining a fallback for previously generated classes
- cover PascalCase record fields with a Python regression test

Fixes #4949.

## Validation
- dotnet build src/Fable.Transforms/Fable.Transforms.fsproj --no-restore
- dotnet test -c Release --no-restore (tests/Python): 2381 passed
- generated Python pytest: 1 passed (targeted regression)
- Pyright on fable_library/record.py: 0 errors
- Fantomas check

Note: the standard Python harness stalled during its uv sync package-build phase after runtime generation; the targeted generated-code test used that freshly generated runtime.